### PR TITLE
ACDC server spec

### DIFF
--- a/acdcserver.spec
+++ b/acdcserver.spec
@@ -1,31 +1,28 @@
-### RPM cms reqmgr 0.9.57b
+### RPM cms acdcserver 0.9.65
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 ## INITENV +PATH PYTHONPATH %i/x$PYTHON_LIB_SITE_PACKAGES
 
-Source: git://github.com/dmwm/WMCore?obj=size-per-evt-fix/%realversion&export=%n&output=/%n.tar.gz
-#Source: git://github.com/dmwm/WMCore?obj=master/%realversion&export=%n&output=/%n.tar.gz
-
-Requires: py2-simplejson py2-sqlalchemy py2-httplib2 cherrypy py2-cheetah py2-cx-oracle yui rotatelogs couchdb py2-cjson py2-sphinx acdcserver
+Source: git://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=%n&output=/%n.tar.gz
+Requires: python py2-httplib2 rotatelogs couchdb py2-cjson py2-sphinx
 
 %prep
-%setup -b 0 -n %n 
+%setup -b 0 -n %n
 
 %build
-python setup.py build_system -s reqmgr
+python setup.py build_system -s acdcserver
 
 %install
 mkdir -p %i/{x,}{bin,lib,data,doc} %i/{x,}$PYTHON_LIB_SITE_PACKAGES
-python setup.py install_system -s reqmgr --prefix=%i
+python setup.py install_system -s acdcserver --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
 
 mkdir -p %i/bin
-cp -pf %_builddir/%n/bin/[[:lower:]]* %i/bin
+cp -pf %_builddir/%n/bin/acdcserver-tools %i/bin
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+rm -rf %i/etc/profile.d
 mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
 for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
   root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
   if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then


### PR DESCRIPTION
Define a spec for ACDC server which packs the dependencies
as defined in WMCore/setup_dependencies for the ACDC server
app. Add a dependency on reqmgr for the acdcserver.

Related to: dmwm/deployment#63
