### PR TITLE
IB/CMSSW_6_2_X/fc18_armv7hl_gcc480: bring it up to date w/ other archs.

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_5_pre1
+### RPM lcg SCRAMV1 V2_2_5_pre2
 ## NOCOMPILER
 
 %define cvsrepo  cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e

--- a/herwig.spec
+++ b/herwig.spec
@@ -1,8 +1,9 @@
-### RPM external herwig 6.520
-Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}-%{realversion}-src.tgz
+### RPM external herwig 6.521
+Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
 Requires: lhapdf photos 
 Patch1: herwig-6.520-tauoladummy
 
+%define isDarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
 %define keep_archives true
 
 %prep
@@ -33,8 +34,8 @@ make install
 # then hack include area as jimmy depends on missing header file..
 # but only on slc*. On macosx HERWIG65.INC == herwig65.inc
 # what is actually needed is a link to herwig6510.inc
-%ifos darwin
-ln -sf herwig6520.inc %{i}/include/herwig65.inc
+%if %isDarwin
+ln -sf herwig6521.inc %{i}/include/herwig65.inc
 %else
 ln -sf HERWIG65.INC %{i}/include/herwig65.inc
 %endif

--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,8 +1,8 @@
-### RPM external pythia8 165 
+### RPM external pythia8 175 
 
 Requires: hepmc
 
-Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}-%{realversion}-src.tgz
+Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
 
 %if "%{?cms_cxxflags:set}" != "set"
 %define cms_cxxflags -std=c++0x


### PR DESCRIPTION
The following brings the latest external requests already available on the other architectures.
