### PR TITLE
[IB/CMSSW_6_2_X/osx108_amd64_gcc472] Change WeightContainer::size_type to unsigned long long

### DIFF
--- a/hepmc-2.06.07-WeightContainer-fix-size_type.patch
+++ b/hepmc-2.06.07-WeightContainer-fix-size_type.patch
@@ -1,0 +1,13 @@
+diff --git a/HepMC/WeightContainer.h b/HepMC/WeightContainer.h
+index 980f75b..93f5e3b 100644
+--- a/HepMC/WeightContainer.h
++++ b/HepMC/WeightContainer.h
+@@ -31,7 +31,7 @@ namespace HepMC {
+ 
+     public:
+         /// defining the size type used by vector and map
+-	typedef std::size_t size_type;
++	typedef unsigned long long size_type;
+         /// iterator for the weight container
+ 	typedef std::vector<double>::iterator iterator;
+         /// const iterator for the weight container

--- a/hepmc.spec
+++ b/hepmc.spec
@@ -1,6 +1,7 @@
 ### RPM external hepmc 2.06.07
 Source: http://lcgapp.cern.ch/project/simu/HepMC/download/HepMC-%realversion.tar.gz
 Patch0: hepmc-2.03.06-reflex
+Patch1: hepmc-2.06.07-WeightContainer-fix-size_type
 Requires: autotools
 
 %define keep_archives true
@@ -20,6 +21,7 @@ Requires: gfortran-macosx
 %prep
 %setup -q -n HepMC-%{realversion}
 %patch0 -p0
+%patch1 -p1
 
 case %cmsplatf in
   slc5_*_gcc4[01234]*) 


### PR DESCRIPTION
Currently WeightContainer::size_type is set to std::size_t, which
is a different type depending on platform. Change it to unsigned
long long to make type cross-platofrm friendly. Solves issue with
Reflex dictionary checksum.

Signed-off-by: David Abdurachmanov david.abdurachmanov@gmail.com
