### PR TITLE
DQMGUI 7.4.0

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 7.3.0
+### RPM cms dqmgui 7.4.0
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
@@ -9,12 +9,14 @@
 %define cvs cvs://:pserver:anonymous@cmscvs.cern.ch:2401/cvs_server/repositories/CMSSW?passwd=AA_:yZZ3e
 %define flavors '' 128 
 
-Source0: git+https://github.com/rovere/dqmgui.git?obj=master/6.4.0&export=Monitoring&output=/Monitoring.tar.gz
+Source0: git+https://github.com/rovere/dqmgui.git?obj=master/6.5.0&export=Monitoring&output=/Monitoring.tar.gz
+#Source0: git+:///build1/rovere/GUIDevelopment/GHM?obj=RovereDevelopment&export=Monitoring&output=/Monitoring.tar.gz
 #Source0: %{svn}?scheme=svn+ssh&strategy=export&module=Monitoring&output=/src.tar.gz
 Source1: %{cvs}&strategy=export&module=CMSSW/DQMServices/Core&export=DQMServices/Core&tag=-rV03-15-19&output=/DQMCore.tar.gz
 Source2: svn://rotoglup-scratchpad.googlecode.com/svn/trunk/rtgu/image?module=image&revision=10&scheme=http&output=/rtgu.tar.gz
 Source3: http://opensource.adobe.com/wiki/download/attachments/3866769/numeric.tar.gz
-Source4: git+https://github.com/rovere/dqmgui.git?obj=index128/7.3.0&export=Monitoring&output=/Monitoring128.tar.gz
+Source4: git+https://github.com/rovere/dqmgui.git?obj=index128/7.4.0&export=Monitoring&output=/Monitoring128.tar.gz
+#Source4: git+:///build1/rovere/GUIDevelopment/GHM?obj=Develop128&export=Monitoring&output=/Monitoring128.tar.gz
 Patch0: dqmgui-rtgu
 
 Requires: cherrypy py2-cheetah yui extjs gmake pcre boost root libpng libjpg classlib rotatelogs py2-pycurl py2-cjson libuuid d3 protobuf


### PR DESCRIPTION
Ciao Diego,
this pull request will include DQMGUI 7.4.0 with the following fix:
1. Fix the StreamerInfo problem that we spotted during the transition from ROOT 5.32 to 5.34
2. Code to properly patch the current indices in order to push the correct streamerinfo for all the samples that have already been indexed: this will have to be taken care of as per our discussion, during the upgrade, after the post action, w/o any service running.
3. visDQMExport daemon to perform the index migration in the Offline server. It will use intermediate ProtocolBuffer messages to transfer ROOT information from the current to the extended index (128-bits keys). It is customizable and currently it is configured to only migrate runs taken from 2012 onward. This behavior can be customized and will be changed depending on available disk space on the production server. It will be quite aggressive in CPU usage.
4. make the DQM GUI able to digest Run Dependent Monte Carlo samples, which are ordinary Monte Carlo production spread across many runs, to better simulate the real conditions of the detector during data taking.

Again, thanks for this extra effort.

Ciao,
Marco.
