### PR TITLE
Ib/cmssw 6 2 x/slc5 amd64 gcc472

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V2_2_5_pre2
+### RPM lcg SCRAMV1 V2_2_5_pre3
 ## NOCOMPILER
+%define GitHubVersion %(echo SCRAM-%realversion | sed 's|-V|-|')
 
-%define cvsrepo  cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
-Source0: %{cvsrepo}&tag=-r%{realversion}&module=SCRAM&output=/source.tar.gz
+Source0: https://github.com/cms-sw/SCRAM/archive/%{realversion}.tar.gz
 
 %define OldDB /%{cmsplatf}/lcg/SCRAMV1/scramdb/project.lookup
 %define SCRAM_ALL_VERSIONS   V[0-9][0-9]*_[0-9][0-9]*_[0-9][0-9]*
@@ -38,7 +38,7 @@ if [ "X%{SCRAM_REL_MINOR}" == "X" ] ; then
   exit 1
 fi
 
-%setup -n SCRAM
+%setup -n %GitHubVersion
 %build
 %install
 tar -cf - . | tar -C %i -xvvf -

--- a/cmssw-toolfile.spec
+++ b/cmssw-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-toolfile 2.0
+### RPM cms cmssw-toolfile 2.1
 Requires: cmssw
 %prep
 
@@ -15,11 +15,18 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cmssw.xml
     <environment name="CMSSW_BINDIR" default="$CMSSW_BASE/bin/$SCRAM_ARCH"/>
     <environment name="INCLUDE" default="$CMSSW_BASE/src"/>
   </client>
-  <runtime name="LD_LIBRARY_PATH" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHONPATH" value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHONPATH" value="$LIBDIR" type="path"/>
 </tool>
 EOF_TOOLFILE
+
+export OS_RUNTIME_LDPATH_NAME="LD_LIBRARY_PATH"
+case %cmsplatf in
+  osx* )
+    export OS_RUNTIME_LDPATH_NAME="DYLD_FALLBACK_LIBRARY_PATH"
+  ;;
+esac
 
 ## IMPORT scram-tools-post

--- a/online-toolfile.spec
+++ b/online-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM cms online-toolfile 2.0
+### RPM cms online-toolfile 2.1
 Requires: online
 %prep
 
@@ -15,11 +15,17 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cmssw.xml
     <environment name="CMSSW_BINDIR" default="$CMSSW_BASE/bin/$SCRAM_ARCH"/>
     <environment name="INCLUDE" default="$CMSSW_BASE/src"/>
   </client>
-  <runtime name="LD_LIBRARY_PATH" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHONPATH" value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHONPATH" value="$LIBDIR" type="path"/>
 </tool>
 EOF_TOOLFILE
 
+export OS_RUNTIME_LDPATH_NAME="LD_LIBRARY_PATH"
+case %cmsplatf in
+  osx* )
+    export OS_RUNTIME_LDPATH_NAME="DYLD_FALLBACK_LIBRARY_PATH"
+  ;;
+esac
 ## IMPORT scram-tools-post


### PR DESCRIPTION
Please include it for 6.2.X all archs. It contains new SCRAM version V2_2_5_pre3 and updated cmssw-toolfile and online-toolfile to properly set library paths of base release in patch releases.
