### PR TITLE
[IB/CMSSW_6_2_X/stable] SWIG and LHAPDF.

### DIFF
--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -28,6 +28,11 @@ Requires: gfortran-macosx
 %patch3 -p2
 
 touch src/gzio.inc ; touch src/gzio.F ; touch src/ftn_gzio.c 
+
+# Remove wrapper generated w/ SWIG 1.3* version. Makefile will
+# regenerate it w/ our SWIG version.
+rm ./pyext/lhapdf_wrap.cc
+
 %patch1 -p2
 
 cd share/lhapdf/PDFsets

--- a/swig-2.0.10-fix-gcc47-cxx11.patch
+++ b/swig-2.0.10-fix-gcc47-cxx11.patch
@@ -1,9 +1,9 @@
 diff --git a/Source/Modules/php.cxx b/Source/Modules/php.cxx
-index fbfa5e0..225c6dc 100644
+index 3cae483..de828fe 100644
 --- a/Source/Modules/php.cxx
 +++ b/Source/Modules/php.cxx
 @@ -1714,7 +1714,7 @@ public:
- 	      Printf(output, "\t\t\treturn new $c($r);\n");
+ 	      Printf(output, "\t\t\treturn new %s%s($r);\n", prefix, Getattr(classLookup(d), "sym:name"));
  	    } else {
  	      Printf(output, "\t\t\t$c = new stdClass();\n");
 -	      Printf(output, "\t\t\t$c->"SWIG_PTR" = $r;\n");

--- a/swig.spec
+++ b/swig.spec
@@ -1,10 +1,10 @@
-### RPM external swig 2.0.4
+### RPM external swig 2.0.10
 ## INITENV SET SWIG_HOME %i
 ## INITENV SET SWIG_LIB  %i/share/swig/%realversion
 
 Source: http://downloads.sourceforge.net/sourceforge/swig/swig/%n-%realversion.tar.gz
 
-Patch0: swig-2.0.4-fix-gcc47-cxx11
+Patch0: swig-2.0.10-fix-gcc47-cxx11
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
@@ -17,13 +17,7 @@ Patch0: swig-2.0.4-fix-gcc47-cxx11
 %prep
 %setup -n %n-%realversion
 
-# Apply C++11 / gcc 4.7.x fixes only if using a 47x architecture.
-# See http://gcc.gnu.org/gcc-4.7/porting_to.html
-case %cmsplatf in
-  *gcc4[789]*)
 %patch0 -p1
-  ;;
-esac
 
 %build
 ./configure --without-pcre --prefix=%i \


### PR DESCRIPTION
The following pull request should resolve LHAPDF compilation issues on newer systems and compilers.
