### PR TITLE
[IB/CMSSW_6_2_X/stable] online_build_set,online_application_set: add Geometry/GEMGeometry

### DIFF
--- a/online_application_set.file
+++ b/online_application_set.file
@@ -461,6 +461,7 @@ Geometry/FP420SimData
 Geometry/ForwardCommonData
 Geometry/ForwardGeometry
 Geometry/ForwardSimData
+Geometry/GEMGeometry
 Geometry/GlobalTrackingGeometryBuilder
 Geometry/HcalAlgo
 Geometry/HcalCommonData

--- a/online_build_set.file
+++ b/online_build_set.file
@@ -449,6 +449,7 @@ Geometry/FP420SimData
 Geometry/ForwardCommonData
 Geometry/ForwardGeometry
 Geometry/ForwardSimData
+Geometry/GEMGeometry
 Geometry/GlobalTrackingGeometryBuilder
 Geometry/HcalAlgo
 Geometry/HcalCommonData


### PR DESCRIPTION
Add Geometry/GEMGeometry to ONLINE build set. It's a new dependency
introduced by Geometry/GlobalTrackingGeometryBuilder.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
