### PR TITLE
[CMSW_7_0_X] Enable Perl and add CA certificates bundle in GIT

### DIFF
--- a/git-toolfile.spec
+++ b/git-toolfile.spec
@@ -16,6 +16,8 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/git.xml
   <runtime name="PATH" value="$GIT_BASE/bin" type="path"/>
   <runtime name="PATH" value="$GIT_BASE/libexec/git-core" type="path"/>
   <runtime name="GIT_TEMPLATE_DIR" value="$GIT_BASE/share/git-core/templates" type="path"/>
+  <runtime name="GIT_SSL_CAINFO" value="$GIT_BASE/share/ssl/certs/ca-bundle.crt" type="path"/>
+  <runtime name="PERL5LIB" value="$GIT_BASE/lib/perl5/site_perl" type="path"/>
 </tool>
 EOF_TOOLFILE
 

--- a/git.spec
+++ b/git.spec
@@ -2,11 +2,10 @@
 
 %define isDarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
 
-%define curl_tag curl-7_31_0
-
 Source0: https://github.com/git/git/archive/v%{realversion}.tar.gz
 Patch1: git-1.8.3.1-no-symlink
 
+%define curl_tag curl-7_31_0
 Source1: https://raw.github.com/bagder/curl/%{curl_tag}/lib/mk-ca-bundle.pl
 
 Requires: curl expat openssl zlib pcre
@@ -20,6 +19,8 @@ Provides: perl(SVN::Core)
 Provides: perl(SVN::Delta)
 Provides: perl(SVN::Ra)
 Provides: perl(YAML::Any)
+
+%define drop_files %{i}/share/man
 
 %prep
 %setup -b 0 -n %{n}-%{realversion}


### PR DESCRIPTION
The following adds CA certificates bundle into GIT, which is not available by default on Darwin platform. GIT now can verify HTTPS connection. Tested on `slc5_amd64_gcc472` and `osx108_amd64_gcc472` with github and CERN GIT.

In addition enabled Perl, which allows at least `git add --interactive` to work. Tested on  `slc5_amd64_gcc472` and `osx108_amd64_gcc472`.
