### PR TITLE
[CMSSW_6_2_X] frontier_client 2.8.8

### DIFF
--- a/frontier_client.spec
+++ b/frontier_client.spec
@@ -1,4 +1,4 @@
-### RPM external frontier_client 2.8.7
+### RPM external frontier_client 2.8.8
 Source: http://frontier.cern.ch/dist/%{n}__%{realversion}__src.tar.gz
 %define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
 


### PR DESCRIPTION
Fix issue where frontier_client terminates with 1 (non-zero)
return code on success. It's a mininmal change comparing to
2.8.7.

Discussion:
  https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1876.html

Signed-off-by: David Abdurachmanov davidlt@cern.ch
