### PR TITLE
[CMSSW_6_2_X] Fix GIT PERL5LIB path for SLC6.

### DIFF
--- a/git-toolfile.spec
+++ b/git-toolfile.spec
@@ -6,6 +6,17 @@ Requires: git
 
 %install
 
+case "%{cmsplatf}" in
+  slc6*)
+    PERL5LIB_PATH=/share/perl5
+    ;;
+  *)
+    PERL5LIB_PATH=/lib/perl5/site_perl
+    ;;
+esac
+
+export PERL5LIB_PATH
+
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/git.xml
 <tool name="git" version="@TOOL_VERSION@">
@@ -17,7 +28,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/git.xml
   <runtime name="PATH" value="$GIT_BASE/libexec/git-core" type="path"/>
   <runtime name="GIT_TEMPLATE_DIR" value="$GIT_BASE/share/git-core/templates" type="path"/>
   <runtime name="GIT_SSL_CAINFO" value="$GIT_BASE/share/ssl/certs/ca-bundle.crt" type="path"/>
-  <runtime name="PERL5LIB" value="$GIT_BASE/lib/perl5/site_perl" type="path"/>
+  <runtime name="PERL5LIB" value="$GIT_BASE@PERL5LIB_PATH@" type="path"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
On SLC6 distribution a different PERL5LIB path is picked.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
