### PR TITLE
[CMSSW_7_0_X] Add autotools to Bison (System M4 is not supported on SLC6)

### DIFF
--- a/bison.spec
+++ b/bison.spec
@@ -1,6 +1,8 @@
 ### RPM external bison 2.7.1
 Source: http://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
 
+BuildRequires: autotools
+
 %define drop_files %{i}/share/{man,locale,info}
 
 %prep


### PR DESCRIPTION
M4 version on SLC6 is too old or is unsupported. Add autotools
package as BuildRequires to Bison.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
