### PR TITLE
[CMSSW_7_0_X] DMTCP; CGAL; gmp-static; mpfr-static; fix data package permissions

### DIFF
--- a/cgal-toolfile.spec
+++ b/cgal-toolfile.spec
@@ -1,5 +1,5 @@
-### RPM external CGAL-toolfile 1.0
-Requires: CGAL
+### RPM external cgal-toolfile 1.0
+Requires: cgal
 %prep
 
 %build
@@ -7,8 +7,8 @@ Requires: CGAL
 %install
 
 mkdir -p %{i}/etc/scram.d
-cat << \EOF_TOOLFILE >%{i}/etc/scram.d/CGAL.xml
-<tool name="CGAL" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cgal.xml
+<tool name="cgal" version="@TOOL_VERSION@">
   <info url="http://www.cgal.org/"/>
   <lib name="CGAL_Core"/>
   <lib name="CGAL_ImageIO"/>
@@ -18,6 +18,8 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/CGAL.xml
     <environment name="LIBDIR" default="$CGAL_BASE/lib"/>
     <environment name="INCLUDE" default="$CGAL_BASE/include"/>
   </client>
+  <use name="zlib"/>
+  <use name="boost_system"/>
 </tool>
 EOF_TOOLFILE
 

--- a/cgal.spec
+++ b/cgal.spec
@@ -1,10 +1,10 @@
-### RPM external CGAL 4.2
+### RPM external cgal 4.2
 
 Source: https://gforge.inria.fr/frs/download.php/32360/%{n}-%{realversion}.tar.bz2
 
-BuildRequires: cmake
+BuildRequires: cmake gmp-static mpfr-static
 
-Requires: boost gcc zlib
+Requires: boost zlib
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
@@ -21,22 +21,14 @@ Requires: boost gcc zlib
 
 %build
 
-SOLIB_EXT=so
-case "%{cmsplatf}" in
-  osx*)
-    SOLIB_EXT=dylib
-    ;;
-esac
-
-export MPFR_LIB_DIR="${GCC_ROOT}/lib"
-export MPFR_INC_DIR="${GCC_ROOT}/include"
-export GMP_LIB_DIR="${GCC_ROOT}/lib"
-export GMP_INC_DIR="${GCC_ROOT}/include"
+export MPFR_LIB_DIR="${MPFR_STATIC_ROOT}/lib"
+export MPFR_INC_DIR="${MPFR_STATIC_ROOT}/include"
+export GMP_LIB_DIR="${GMP_STATIC_ROOT}/lib"
+export GMP_INC_DIR="${GMP_STATIC_ROOT}/include"
 
 cmake . \
   -DCMAKE_CXX_COMPILER:STRING="%{cms_cxx}" \
-  -DCMAKE_CXX_FLAGS:STRING="%{cms_cxxflags} -I${GCC_ROOT}/include" \
-  -DCMAKE_SHARED_LINKER_FLAGS:STRING="-L${GCC_ROOT}/lib" \
+  -DCMAKE_CXX_FLAGS:STRING="%{cms_cxxflags}" \
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
   -DCMAKE_SKIP_RPATH:BOOL=YES \
   -DWITH_BLAS:BOOL=OFF \
@@ -64,8 +56,7 @@ cmake . \
   -DWITH_ZLIB:BOOL=ON \
   -DWITH_demos:BOOL=OFF \
   -DWITH_examples:BOOL=OFF \
-  -DZLIB_INCLUDE_DIR:PATH="${ZLIB_ROOT}/include" \
-  -DZLIB_LIBRARY:FILEPATH="${ZLIB_ROOT}/lib/libz.${SOLIB_EXT}" \
+  -DZLIB_ROOT="${ZLIB_ROOT}" \
   -DCGAL_ENABLE_PRECONFIG:BOOL=NO \
   -DCGAL_IGNORE_PRECONFIGURED_GMP:BOOL=YES \
   -DCGAL_IGNORE_PRECONFIGURED_MPFR:BOOL=YES \

--- a/cgal.spec
+++ b/cgal.spec
@@ -17,7 +17,7 @@ Requires: boost zlib
 %define drop_files %{i}/{share,bin} %{i}/lib/CGAL
 
 %prep
-%setup -n %{n}-%{realversion}
+%setup -n CGAL-%{realversion}
 
 %build
 

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -128,6 +128,7 @@ Requires: python-ldap-toolfile
 Requires: gdb-toolfile
 Requires: google-perftools-toolfile
 Requires: igprof-toolfile
+Requires: dmtcp-toolfile
 %endif
 
 %if "%isslc6" == "true"

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -119,7 +119,7 @@ Requires: sloccount-toolfile
 Requires: cvs2git-toolfile
 Requires: pacparser-toolfile
 Requires: git-toolfile
-Requires: CGAL-toolfile
+Requires: cgal-toolfile
 Requires: doxygen-toolfile
 
 %if "%isslc" == "true"

--- a/data-package-build.file
+++ b/data-package-build.file
@@ -8,24 +8,29 @@
 DOWNLOAD_TOOL=$(basename $(which curl || which wget || echo "none"))
 
 for FILE in $(cat ./sources); do
- DEST_FILE=%{i}/${FILE}
- case "${DOWNLOAD_TOOL}" in
-   curl)
-     curl --create-dirs -k -L -s -S -o "${DEST_FILE}" "%{base_url}/${FILE}"
-     ;;
-   wget)
-     DEST_DIR=$(dirname "${DEST_FILE}")
-     mkdir -p ${DEST_DIR}
-     pushd ${DEST_DIR}
-       wget --no-check-certificate --no-verbose "%{base_url}/${FILE}"
-     popd
-     ;;
-   none)
-     echo "Unsupported download tool. Could not locate curl or wget. Contact package maintainer."
-     exit 1
-     ;;
- esac
+  DEST_FILE=%{i}/${FILE}
+  DEST_DIR=$(dirname "${DEST_FILE}")
+  mkdir -p ${DEST_DIR}
+  case "${DOWNLOAD_TOOL}" in
+    curl)
+      # cURL does not download empty files, touch file before downloading
+      touch ${DEST_FILE}
+      curl --create-dirs -k -L -s -S -o "${DEST_FILE}" "%{base_url}/${FILE}"
+      ;;
+    wget)
+      pushd ${DEST_DIR}
+        wget --no-check-certificate --no-verbose "%{base_url}/${FILE}"
+      popd
+      ;;
+    none)
+      echo "Unsupported download tool. Could not locate curl or wget. Contact package maintainer."
+      exit 1
+      ;;
+  esac
 done
+
+find %{i} -type d -exec chmod 0755 {} \;
+find %{i} -type f -exec chmod 0644 {} \;
 
 %post
 %define base_tool %(echo "%{n}" | tr '[a-z-]' '[A-Z_]')

--- a/dmtcp-toolfile.spec
+++ b/dmtcp-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external dmtcp-toolfile 1.0
+Requires: dmtcp
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/dmtcp.xml
+<tool name="dmtcp" version="@TOOL_VERSION@">
+  <info url="http://dmtcp.sourceforge.net/"/>
+  <client>
+    <environment name="DMTCP_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$DMTCP_BASE/lib"/>
+    <environment name="LIBDIR" default="$DMTCP_BASE/lib/dmtcp"/>
+  </client>
+  <runtime name="PATH" value="$DMTCP_BASE/bin" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/dmtcp.spec
+++ b/dmtcp.spec
@@ -1,0 +1,33 @@
+### RPM external dmtcp 2.0-2060
+
+%define pkg_version %(echo "%{realversion}" | cut -d- -f 1)
+%define pkg_revision %(echo "%{realversion}" | cut -d- -f 2)
+
+Source: svn://svn.code.sf.net/p/dmtcp/code/trunk?scheme=svn&revision=%{pkg_revision}&module=%{n}&output=/%{n}.tar.gz
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx g++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -std=c++11
+%endif
+
+%define drop_files %{i}/share
+
+%prep
+%setup -n %{n}
+
+%build
+./configure \
+  --prefix=%{i} \
+  --disable-test-suite \
+  --disable-dependency-tracking \
+  CXX="%{cms_cxx}" \
+  CXXFLAGS="%{cms_cxxflags}"
+
+make %{makeprocesses}
+
+%install
+
+make install

--- a/gmp-static.spec
+++ b/gmp-static.spec
@@ -1,0 +1,34 @@
+### RPM external gmp-static 5.0.2
+
+Source: ftp://ftp.gnu.org/gnu/gmp/gmp-%{realversion}.tar.bz2
+
+%define keep_archives true
+%define drop_files %{i}/share
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx g++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -std=c++11
+%endif
+
+%prep
+%setup -n gmp-%{realversion}
+
+%build
+./configure \
+  --prefix=%{i} \
+  --disable-shared \
+  --enable-static \
+  --enable-cxx \
+  --with-pic \
+  CXX="%{cms_cxx}" \
+  CXXFLAGS="%{cms_cxxflags}"
+
+make %{makeprocesses}
+
+%install
+
+make install
+find %{i}/lib -name '*.la' -delete

--- a/mpfr-static.spec
+++ b/mpfr-static.spec
@@ -1,0 +1,26 @@
+### RPM external mpfr-static 3.0.1
+
+Source: http://www.mpfr.org/mpfr-%{realversion}/mpfr-%{realversion}.tar.bz2
+
+BuildRequires: gmp-static
+
+%define keep_archives true
+%define drop_files %{i}/share
+
+%prep
+%setup -n mpfr-%{realversion}
+
+%build
+./configure \
+  --enable-static \
+  --disable-shared \
+  --prefix=%{i} \
+  --with-gmp=${GMP_STATIC_ROOT} \
+  --with-pic \
+
+make %{makeprocesses}
+
+%install
+
+make install
+find %{i}/lib -name '*.la' -delete

--- a/xrootd-toolfile.spec
+++ b/xrootd-toolfile.spec
@@ -14,6 +14,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/xrootd.xml
   <client>
     <environment name="XROOTD_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$XROOTD_BASE/include/xrootd"/>
+    <environment name="INCLUDE" default="$XROOTD_BASE/include/xrootd/private"/>
     <environment name="LIBDIR" default="$XROOTD_BASE/lib"/>
   </client>
   <runtime name="PATH" value="$XROOTD_BASE/bin" type="path"/>

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,16 +1,15 @@
-### RPM external xrootd 3.2.4
+### RPM external xrootd 3.3.3
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 %define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
 
-Source: http://xrootd.cern.ch/cgi-bin/cgit.cgi/xrootd/snapshot/%n-%{realversion}.tar.gz
-Patch0: xrootd-gcc44
+Source: http://xrootd.org/download/v%{realversion}/%{n}-%{realversion}.tar.gz
 Patch1: xrootd-5.30.00-fix-gcc46
-Patch3: xrootd-3.1.0-fixed-library-location-all-os
-Patch4: xrootd-3.1.0-client-send-moninfo
-Patch5: xrootd-3.1.0-gcc-470-literals-whitespace
-Patch6: xrootd-3.1.0-add-GetHandle-XrdClientAbs-header
-Patch7: xrootd-3.1.0-narrowing-conversion
-Patch8: xrootd-3.2.3-rename-macos-to-apple
+Patch2: xrootd-3.1.0-fixed-library-location-all-os
+Patch3: xrootd-3.1.0-client-send-moninfo
+Patch4: xrootd-3.3.3-rc1-add-GetHandle-XrdClientAbs-header
+Patch5: xrootd-3.1.0-narrowing-conversion
+Patch6: xrootd-3.3.3-rc1-rename-macos-to-apple
+Patch7: xrootd-3.3.3-rc1-gcc47
 
 BuildRequires: cmake
 %if "%online" != "true"
@@ -26,14 +25,13 @@ Requires: gcc openssl
 
 %prep 
 %setup -n %n-%{realversion}
-%patch0 -p1
 %patch1 -p1
-%patch3 -p0
+%patch2 -p0
+%patch3 -p1
 %patch4 -p1
 %patch5 -p1
 %patch6 -p1
 %patch7 -p1
-%patch8 -p1
 
 # need to fix these from xrootd git
 perl -p -i -e 's|^#!.*perl(.*)|#!/usr/bin/env perl$1|' src/XrdMon/cleanup.pl


### PR DESCRIPTION
**ChangeLog**
- In CMSSW_7_0_0_pre1 _data-MagneticField-Interpolation_ package had wrong permissions. People outside cms/zh group could not see files. Set all directories on 0755 and all files on 0644.
- In data packages _cURL_ does not download empty files. Touch files before downloading. No issues if wget is used.
- Add _DTMCP_ for SLC5, SLC6 and FC18. Checkpoint/restore implementation.
- Add _gmp-static_ package. GMP static library (w/ PIC) for CGAL (build-time dependency).
- Add _mpfr-static_ package. MPFR static library (w/ PIC) for CGAL (build-time dependency).
- Rename _CGAL_ to _cgal_.
- Second attempt to add_xrootd_ 3.3.3.
- Add `./include/xrootd/private` path to include search path. Needed for CMSSW, but should be removed in future.
