### PR TITLE
[CMSSW_7_0_X] XROOTD add XrdClient/XrdClientProtocol.hh to private headers

### DIFF
--- a/xrootd-3.3.3-add-private-XrdClientProtocol.hh.patch
+++ b/xrootd-3.3.3-add-private-XrdClientProtocol.hh.patch
@@ -1,0 +1,20 @@
+diff --git a/src/XrdHeaders.cmake b/src/XrdHeaders.cmake
+index 6402a32..eeed5b9 100644
+--- a/src/XrdHeaders.cmake
++++ b/src/XrdHeaders.cmake
+@@ -95,6 +95,7 @@ set( XROOTD_PRIVATE_HEADERS
+   XrdClient/XrdClientPhyConnection.hh
+   XrdClient/XrdClientReadCache.hh
+   XrdClient/XrdClientSock.hh
++  XrdClient/XrdClientProtocol.hh
+   XrdNet/XrdNetPeer.hh
+   XrdNet/XrdNetBuffer.hh
+   XrdOfs/XrdOfs.hh
+@@ -102,7 +103,6 @@ set( XROOTD_PRIVATE_HEADERS
+   XrdOfs/XrdOfsHandle.hh
+   XrdOfs/XrdOfsTrace.hh
+   XrdSys/XrdSysPriv.hh
+-
+   XrdOss/XrdOssApi.hh
+   XrdOss/XrdOssConfig.hh
+   XrdOss/XrdOssError.hh

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -10,6 +10,7 @@ Patch4: xrootd-3.3.3-rc1-add-GetHandle-XrdClientAbs-header
 Patch5: xrootd-3.1.0-narrowing-conversion
 Patch6: xrootd-3.3.3-rc1-rename-macos-to-apple
 Patch7: xrootd-3.3.3-rc1-gcc47
+Patch8: xrootd-3.3.3-add-private-XrdClientProtocol.hh
 
 BuildRequires: cmake
 %if "%online" != "true"
@@ -32,6 +33,7 @@ Requires: gcc openssl
 %patch5 -p1
 %patch6 -p1
 %patch7 -p1
+%patch8 -p1 
 
 # need to fix these from xrootd git
 perl -p -i -e 's|^#!.*perl(.*)|#!/usr/bin/env perl$1|' src/XrdMon/cleanup.pl


### PR DESCRIPTION
CMSSW depends on XrdClient/XrdClientProtocol.hh private header.
Starting 3.3.3 header is no more deployed for public.
