### PR TITLE
[CMSSW_7_0_X] xrootd add XrdClient/XrdClientSid.hh private header

### DIFF
--- a/xrootd-3.3.3-add-private-headers.patch
+++ b/xrootd-3.3.3-add-private-headers.patch
@@ -1,16 +1,17 @@
 diff --git a/src/XrdHeaders.cmake b/src/XrdHeaders.cmake
-index 6402a32..eeed5b9 100644
+index 6402a32..08c0cf2 100644
 --- a/src/XrdHeaders.cmake
 +++ b/src/XrdHeaders.cmake
-@@ -95,6 +95,7 @@ set( XROOTD_PRIVATE_HEADERS
+@@ -95,6 +95,8 @@ set( XROOTD_PRIVATE_HEADERS
    XrdClient/XrdClientPhyConnection.hh
    XrdClient/XrdClientReadCache.hh
    XrdClient/XrdClientSock.hh
 +  XrdClient/XrdClientProtocol.hh
++  XrdClient/XrdClientSid.hh
    XrdNet/XrdNetPeer.hh
    XrdNet/XrdNetBuffer.hh
    XrdOfs/XrdOfs.hh
-@@ -102,7 +103,6 @@ set( XROOTD_PRIVATE_HEADERS
+@@ -102,7 +104,6 @@ set( XROOTD_PRIVATE_HEADERS
    XrdOfs/XrdOfsHandle.hh
    XrdOfs/XrdOfsTrace.hh
    XrdSys/XrdSysPriv.hh

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -10,7 +10,7 @@ Patch4: xrootd-3.3.3-rc1-add-GetHandle-XrdClientAbs-header
 Patch5: xrootd-3.1.0-narrowing-conversion
 Patch6: xrootd-3.3.3-rc1-rename-macos-to-apple
 Patch7: xrootd-3.3.3-rc1-gcc47
-Patch8: xrootd-3.3.3-add-private-XrdClientProtocol.hh
+Patch8: xrootd-3.3.3-add-private-headers
 
 BuildRequires: cmake
 %if "%online" != "true"


### PR DESCRIPTION
Another xrootd private header XrdClient/XrdClientSid.hh is being used
by CMSSW and no more distributed. Adding it to ./include/xrootd/private
