### PR TITLE
comp.pre slc5_amd64_gcc461 PHEDEX-combined-web

### DIFF
--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -1,8 +1,10 @@
-### RPM cms PHEDEX-admin PHEDEX_4_1_2
+### RPM cms PHEDEX-admin PHEDEX_4_1_3pre1
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-Source: cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e&module=%{downloadn}&export=%{downloadn}&&tag=-r%{v}&output=/%{downloadn}-admin.tar.gz
+%define gittag PHEDEX-%(echo %realversion | tr . _)
+Source: git://github.com/dmwm/PHEDEX?obj=master/788560654b78555c96b71aa66c99e59e2b30581d&export=%n&output=/%{downloadn}-admin.tar.gz
+
 # Oracle libs
 Requires: oracle oracle-env 
 # perl libs
@@ -24,7 +26,7 @@ Provides: perl(XML::LibXML)
 Provides: perl(Net::Twitter::Lite)
 
 %prep
-%setup -n %{downloadn}
+%setup -n %{downloadn}-admin
 rm -rf Toolkit/DBS
 
 %build

--- a/PHEDEX-combined-agents.spec
+++ b/PHEDEX-combined-agents.spec
@@ -1,7 +1,8 @@
 ### RPM cms PHEDEX-combined-agents 1
 
-# This is a fake spec whose only job is to build PHEDEX-web and
-# PHEDEX-datasvc on a combined platform of dependencies
+# This is a fake spec whose only job is to build PHEDEX,
+# PHEDEX-admin and PHEDEX-micro on a combined platform
+# of dependencies
 
 Requires: PHEDEX PHEDEX-admin PHEDEX-micro
 

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-datasvc 2.3.16pre1
+### RPM cms PHEDEX-datasvc 2.3.16
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag PHEDEX-datasvc%(echo %realversion | tr . _)

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag PHEDEX-datasvc%(echo %realversion | tr . _)
-Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/a8a85d7413f45c08473049927078a62b7b0b39ef&export=%n&output=/%n.tar.gz
+Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/62874fa45c9a73c78d9600beb41c8cbe7661fda4&export=%n&output=/%n.tar.gz
 
 # For DB Access
 Requires: oracle oracle-env p5-dbi p5-dbd-oracle

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,9 +1,8 @@
-### RPM cms PHEDEX-datasvc 2.3.15
+### RPM cms PHEDEX-datasvc 2.3.16pre1
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define cvsversion DATASVC_%(echo %realversion | tr . _)
-%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
-Source: %cvsserver&strategy=export&module=%{downloadn}&export=%{downloadn}&&tag=-r%{cvsversion}&output=/%{n}.tar.gz
+%define gittag PHEDEX-datasvc%(echo %realversion | tr . _)
+Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/a60c3d6c3301fca2864710ac25712a9b3d9203fb&export=%n&output=/%n.tar.gz
 
 # For DB Access
 Requires: oracle oracle-env p5-dbi p5-dbd-oracle
@@ -27,7 +26,7 @@ Provides: perl(XML::LibXML)
 Provides: perl(URI::Escape)
 
 %prep
-%setup -n PHEDEX
+%setup -n PHEDEX-datasvc
 
 %build
 %install

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,7 +1,6 @@
 ### RPM cms PHEDEX-datasvc 2.3.17
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag PHEDEX-datasvc%(echo %realversion | tr . _)
 Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/f4f8c2b470201dd47b31845e434e7756f64b8f32&export=%n&output=/%n.tar.gz
 
 # For DB Access

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,8 +1,8 @@
-### RPM cms PHEDEX-datasvc 2.3.16
+### RPM cms PHEDEX-datasvc 2.3.17
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag PHEDEX-datasvc%(echo %realversion | tr . _)
-Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/62874fa45c9a73c78d9600beb41c8cbe7661fda4&export=%n&output=/%n.tar.gz
+Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/f4f8c2b470201dd47b31845e434e7756f64b8f32&export=%n&output=/%n.tar.gz
 
 # For DB Access
 Requires: oracle oracle-env p5-dbi p5-dbd-oracle

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag PHEDEX-datasvc%(echo %realversion | tr . _)
-Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/a60c3d6c3301fca2864710ac25712a9b3d9203fb&export=%n&output=/%n.tar.gz
+Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/a8a85d7413f45c08473049927078a62b7b0b39ef&export=%n&output=/%n.tar.gz
 
 # For DB Access
 Requires: oracle oracle-env p5-dbi p5-dbd-oracle

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -1,34 +1,29 @@
-### RPM cms PHEDEX-lifecycle 1.1.0
+### RPM cms PHEDEX-lifecycle 1.2.0
 ## INITENV +PATH PERL5LIB %i/perl_lib
 ## INITENV +PATH PERL5LIB %i/T0/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-#%define cvsversion LIFECYCLE_%(echo %realversion | tr . _)
-#%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
-#Source0: %cvsserver&strategy=export&module=%{downloadn}&export=%{downloadn}&&tag=-r%{cvsversion}&output=/%{n}.tar.gz
+
+# TODO Need to get this from somewhere else...
+%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
 Source1: %cvsserver&strategy=export&module=T0&export=T0&&tag=-rPHEDEX_LIFECYCLE_1_0_0&output=/T0.tar.gz
 
-%define realversion LIFECYCLE_1_2_0
-Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%realversion&export=%n&output=/%n.tar.gz
+%define commit 58f3eed1c98b8edaae10f6befe9d0343c0abc38b
+Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%commit&export=%n&output=/%n.tar.gz
 
 Requires: p5-poe p5-poe-component-child p5-clone p5-time-hires p5-text-glob
 Requires: p5-compress-zlib p5-log-log4perl p5-json-xs p5-xml-parser p5-monalisa-apmon
 Requires: p5-common-sense
 Requires: mod_perl2 
 Requires: lifecycle-dataprovider
-# This is temporary, for the examples
-Requires: dbs3-client
-# The lifecycle doesn't require Oracle itself, but setting up a DB will!
-Requires: oracle oracle-env p5-dbi p5-dbd-oracle
+## This is temporary, for the examples
+#Requires: dbs3-client
+## The lifecycle doesn't require Oracle itself, but setting up a DB will!
+#Requires: oracle oracle-env p5-dbi p5-dbd-oracle
 
-#Provides: perl(XML::LibXML)
 Provides: perl(XML::Twig)
 Provides: perl(T0::FileWatcher)
 Provides: perl(T0::Logger::Sender)
 Provides: perl(T0::Util)
-
-# Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
-# This is so it gets into our dependencies-setup.sh
-#Requires:  expat
 
 %prep
 %setup -n PHEDEX-lifecycle
@@ -47,8 +42,7 @@ cp -p Testbed/FakeFTS.pl %i/bin
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
 : > %i/etc/profile.d/dependencies-setup.sh
 : > %i/etc/profile.d/dependencies-setup.csh
-#echo export LIFECYCLE=%instroot/Testbed/LifeCycle >> %i/etc/profile.d/dependencies-setup.sh
-#echo setenv LIFECYCLE %instroot/Testbed/LifeCycle >> %i/etc/profile.d/dependencies-setup.csh
+
 for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
   root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
   if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -1,0 +1,61 @@
+### RPM cms PHEDEX-lifecycle 1.1.0
+## INITENV +PATH PERL5LIB %i/perl_lib
+## INITENV +PATH PERL5LIB %i/T0/perl_lib
+%define downloadn %(echo %n | cut -f1 -d-)
+#%define cvsversion LIFECYCLE_%(echo %realversion | tr . _)
+#%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
+#Source0: %cvsserver&strategy=export&module=%{downloadn}&export=%{downloadn}&&tag=-r%{cvsversion}&output=/%{n}.tar.gz
+Source1: %cvsserver&strategy=export&module=T0&export=T0&&tag=-rPHEDEX_LIFECYCLE_1_0_0&output=/T0.tar.gz
+
+%define realversion LIFECYCLE_1_2_0
+Source0: git://github.com/dmwm/LifeCycle?obj=master/%realversion&export=%pkg&output=/%pkg.tar.gz
+
+Requires: p5-poe p5-poe-component-child p5-clone p5-time-hires p5-text-glob
+Requires: p5-compress-zlib p5-log-log4perl p5-json-xs p5-xml-parser p5-monalisa-apmon
+Requires: p5-common-sense
+Requires: mod_perl2 
+Requires: lifecycle-dataprovider
+# This is temporary, for the examples
+Requires: dbs3-client
+# The lifecycle doesn't require Oracle itself, but setting up a DB will!
+Requires: oracle oracle-env p5-dbi p5-dbd-oracle
+
+#Provides: perl(XML::LibXML)
+Provides: perl(XML::Twig)
+Provides: perl(T0::FileWatcher)
+Provides: perl(T0::Logger::Sender)
+Provides: perl(T0::Util)
+
+# Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
+# This is so it gets into our dependencies-setup.sh
+#Requires:  expat
+
+%prep
+%setup -n PHEDEX
+tar zxf %_sourcedir/T0.tar.gz
+
+%build
+%install
+mkdir -p %i/etc/{env,profile}.d %i/bin
+tar -cf - * | (cd %i && tar -xf -)
+cp -p Testbed/LifeCycle/Lifecycle.pl %i/bin
+cp -p Testbed/LifeCycle/CheckProxy.pl %i/bin
+cp -p Testbed/LifeCycle/fake-delete.pl %i/bin
+cp -p Testbed/LifeCycle/fake-validate.pl %i/bin
+cp -p Testbed/FakeFTS.pl %i/bin
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+#echo export LIFECYCLE=%instroot/Testbed/LifeCycle >> %i/etc/profile.d/dependencies-setup.sh
+#echo setenv LIFECYCLE %instroot/Testbed/LifeCycle >> %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$$root != X || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -8,7 +8,7 @@
 Source1: %cvsserver&strategy=export&module=T0&export=T0&&tag=-rPHEDEX_LIFECYCLE_1_0_0&output=/T0.tar.gz
 
 %define realversion LIFECYCLE_1_2_0
-Source0: git://github.com/dmwm/LifeCycle?obj=master/%realversion&export=%pkg&output=/%pkg.tar.gz
+Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%realversion&export=%n&output=/%n.tar.gz
 
 Requires: p5-poe p5-poe-component-child p5-clone p5-time-hires p5-text-glob
 Requires: p5-compress-zlib p5-log-log4perl p5-json-xs p5-xml-parser p5-monalisa-apmon
@@ -31,7 +31,7 @@ Provides: perl(T0::Util)
 #Requires:  expat
 
 %prep
-%setup -n PHEDEX
+%setup -n PHEDEX-lifecycle
 tar zxf %_sourcedir/T0.tar.gz
 
 %build

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -1,9 +1,10 @@
-### RPM cms PHEDEX-micro PHEDEX_4_1_2
+### RPM cms PHEDEX-micro PHEDEX_4_1_3pre1
 
 ## INITENV +PATH PATH %i/Utilities:%i/Toolkit/DBS:%i/Toolkit/DropBox:%i/Toolkit/Request
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-Source: cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e&module=%{downloadn}&export=%{downloadn}&&tag=-r%{v}&output=/%{downloadn}-micro.tar.gz
+Source: git://github.com/dmwm/PHEDEX?obj=master/788560654b78555c96b71aa66c99e59e2b30581d&export=%n&output=/%{downloadn}-micro.tar.gz
+
 # Oracle libs
 Requires: oracle oracle-env
 # perl libs
@@ -30,7 +31,7 @@ Provides: perl(Net::Twitter::Lite)
 
 %prep
 
-%setup -n %{downloadn}
+%setup -n %{downloadn}-micro
 rm -rf Custom/Template/*
 rm -rf Custom/DCache
 rm -rf Custom/Castor

--- a/PHEDEX-web.spec
+++ b/PHEDEX-web.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-web 4.2.9pre1
+### RPM cms PHEDEX-web 4.2.9
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag PHEDEX-web_%(echo %realversion | tr . _)

--- a/PHEDEX-web.spec
+++ b/PHEDEX-web.spec
@@ -1,7 +1,6 @@
 ### RPM cms PHEDEX-web 4.2.9
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag PHEDEX-web_%(echo %realversion | tr . _)
 Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-web/1cf6be60c2447feb33c8394e047b2b8a1285983a&export=%n&output=/%n.tar.gz
 
 # This allows me to not pull everything in here, which duplicates code

--- a/PHEDEX-web.spec
+++ b/PHEDEX-web.spec
@@ -1,9 +1,8 @@
-### RPM cms PHEDEX-web 4.2.8
+### RPM cms PHEDEX-web 4.2.9pre1
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define cvsversion WEB_%(echo %realversion | tr . _)
-%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
-Source: %cvsserver&strategy=export&module=%{downloadn}&export=%{downloadn}&&tag=-r%{cvsversion}&output=/%{n}.tar.gz
+%define gittag PHEDEX-web_%(echo %realversion | tr . _)
+Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-web/1cf6be60c2447feb33c8394e047b2b8a1285983a&export=%n&output=/%n.tar.gz
 
 # This allows me to not pull everything in here, which duplicates code
 Requires: PHEDEX-datasvc
@@ -30,7 +29,7 @@ Provides: perl(DB_File)
 Provides: perl(XML::LibXML)
 
 %prep
-%setup -n PHEDEX
+%setup -n PHEDEX-web
 
 %build
 %install

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-webapp 1.3.13pre1
+### RPM cms PHEDEX-webapp 1.3.13
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag WEBAPP_%(echo %realversion | tr . _)

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -1,9 +1,9 @@
-### RPM cms PHEDEX-webapp 1.3.13
+### RPM cms PHEDEX-webapp 1.3.14
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag WEBAPP_%(echo %realversion | tr . _)
 %define yuicompressorversion 2.4.6
-Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/5c0b49edc0b9ec4285ac87f12bea39e4638aa9da&export=%n&output=/%n.tar.gz
+Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/c75584405e9792eba20051b183539ef47ec2ced6&export=%n&output=/%n.tar.gz
 Source1: http://yui.zenfs.com/releases/yuicompressor/yuicompressor-%{yuicompressorversion}.zip
 Requires: protovis yui
 BuildRequires: java-jdk

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -1,7 +1,6 @@
 ### RPM cms PHEDEX-webapp 1.3.14
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag WEBAPP_%(echo %realversion | tr . _)
 %define yuicompressorversion 2.4.6
 Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/c75584405e9792eba20051b183539ef47ec2ced6&export=%n&output=/%n.tar.gz
 Source1: http://yui.zenfs.com/releases/yuicompressor/yuicompressor-%{yuicompressorversion}.zip

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -1,25 +1,24 @@
-### RPM cms PHEDEX-webapp 1.3.12
+### RPM cms PHEDEX-webapp 1.3.13pre1
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define cvsversion WEBAPP_%(echo %realversion | tr . _)
-%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
+%define gittag WEBAPP_%(echo %realversion | tr . _)
 %define yuicompressorversion 2.4.6
-Source0: %cvsserver&strategy=export&module=%{downloadn}&export=%{downloadn}&&tag=-r%{cvsversion}&output=/%{n}.tar.gz
+Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/5c0b49edc0b9ec4285ac87f12bea39e4638aa9da&export=%n&output=/%n.tar.gz
 Source1: http://yui.zenfs.com/releases/yuicompressor/yuicompressor-%{yuicompressorversion}.zip
 Requires: protovis yui
 BuildRequires: java-jdk
 
 %prep
 %setup -T -b 1 -n yuicompressor-%{yuicompressorversion}
-%setup -D -T -b 0 -n PHEDEX
+%setup -D -T -b 0 -n PHEDEX-webapp
 
 %build
 export YUICOMPRESSOR_PATH=%_builddir/yuicompressor-%{yuicompressorversion}/build/yuicompressor-%{yuicompressorversion}.jar
 cd %_builddir
-sh %_builddir/PHEDEX/PhEDExWeb/ApplicationServer/util/phedex-minify.sh
-rm -rf %_builddir/PHEDEX/PhEDExWeb/{ApplicationServer/{js,css,util},yuicompressor*}
-mv %_builddir/PHEDEX/PhEDExWeb/ApplicationServer/{build/*,}
-rmdir %_builddir/PHEDEX/PhEDExWeb/ApplicationServer/build
+sh %_builddir/PHEDEX-webapp/PhEDExWeb/ApplicationServer/util/phedex-minify.sh
+rm -rf %_builddir/PHEDEX-webapp/PhEDExWeb/{ApplicationServer/{js,css,util},yuicompressor*}
+mv %_builddir/PHEDEX-webapp/PhEDExWeb/ApplicationServer/{build/*,}
+rmdir %_builddir/PHEDEX-webapp/PhEDExWeb/ApplicationServer/build
 
 %install
 mkdir -p %i/etc/{env,profile}.d

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -1,7 +1,8 @@
-### RPM cms PHEDEX PHEDEX_4_1_2
+### RPM cms PHEDEX PHEDEX_4_1_3pre1
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
-Source: cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e&module=%n&export=%n&&tag=-r%{v}&output=/%n.tar.gz
+Source: git://github.com/dmwm/PHEDEX?obj=master/788560654b78555c96b71aa66c99e59e2b30581d&export=%n&output=/%n.tar.gz
+
 # Oracle libs
 Requires: oracle oracle-env
 # perl libs

--- a/lifecycle-dataprovider.spec
+++ b/lifecycle-dataprovider.spec
@@ -1,10 +1,10 @@
-### RPM cms lifecycle-dataprovider 1.0.5
+### RPM cms lifecycle-dataprovider 1.0.7
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
 %define pkg DataProvider
-#%define svnserver svn://svn.cern.ch/reps/CMSDMWM
+
 Source0: git://github.com/dmwm/LifeCycle?obj=master/%realversion&export=%pkg&output=/%pkg.tar.gz
-#Source0: %svnserver/LifeCycle/tags/%{realversion}/DataProvider/?scheme=svn+ssh&strategy=export&module=DataProvider&output=/dataprovider.tar.gz
+
 Requires: python
 BuildRequires: py2-sphinx
 

--- a/lifecycle-dataprovider.spec
+++ b/lifecycle-dataprovider.spec
@@ -1,0 +1,59 @@
+### RPM cms lifecycle-dataprovider 1.0.5
+## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
+%define webdoc_files %{installroot}/%{pkgrel}/doc/
+%define pkg DataProvider
+#%define svnserver svn://svn.cern.ch/reps/CMSDMWM
+Source0: git://github.com/dmwm/LifeCycle?obj=master/%realversion&export=%pkg&output=/%pkg.tar.gz
+#Source0: %svnserver/LifeCycle/tags/%{realversion}/DataProvider/?scheme=svn+ssh&strategy=export&module=DataProvider&output=/dataprovider.tar.gz
+Requires: python
+BuildRequires: py2-sphinx
+
+%prep
+%setup -D -T -b 0 -n DataProvider
+
+%build
+pwd
+cd DataProvider
+
+# setup version
+cat src/python/DataProvider/__init__.py | sed "s,development,%{realversion},g" > init.tmp
+mv -f init.tmp src/python/DataProvider/__init__.py
+
+python setup.py build
+
+# build DataProvider sphinx documentation
+PYTHONPATH=$PWD/src/python:$PYTHONPATH
+cd doc
+cat sphinx/conf.py | sed "s,development,%{realversion},g" > sphinx/conf.py.tmp
+mv sphinx/conf.py.tmp sphinx/conf.py
+mkdir -p build
+make html
+cd -
+
+%install
+pwd
+cd DataProvider
+python setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
+mkdir -p %i/doc
+tar --exclude '.buildinfo' -C doc/build/html -cf - . | tar -C %i/doc -xvf -
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$$root != X || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh
+
+%files
+%{installroot}/%{pkgrel}/
+%exclude %{installroot}/%{pkgrel}/doc
+## SUBPACKAGE webdoc


### PR DESCRIPTION
Updates PhEDEx datasvc and webapp for new shifter APIs.
Also adds LifeCycle and lifecycle-dataprovider specs, which had been omitted in the migration from CVS.

Git claims it can't merge this pull automatically, which is rubbish, I'm only changing files I own.

It also appears to be pulling in changes which were already merged. Don't ask me why, I don't have a clue...
