### PR TITLE
[CMSSW_7_0_X][48] Fix armv7hl gcc and binutils; update bootstrap-driver

### DIFF
--- a/autotools.spec
+++ b/autotools.spec
@@ -8,15 +8,21 @@ Source0: http://ftpmirror.gnu.org/autoconf/autoconf-%autoconf_version.tar.gz
 Source1: http://ftpmirror.gnu.org/automake/automake-%automake_version.tar.gz
 Source2: http://ftpmirror.gnu.org/libtool/libtool-%libtool_version.tar.gz
 Source3: http://ftp.gnu.org/gnu/m4/m4-%m4_version.tar.bz2
+Patch0: m4-1.4.16-fix-gets
 
 %prep
 %setup -D -T -b 0 -n autoconf-%{autoconf_version}
 %setup -D -T -b 1 -n automake-%{automake_version}
 %setup -D -T -b 2 -n libtool-%{libtool_version}
 %setup -D -T -b 3 -n m4-%{m4_version}
+%patch0 -p1
 
 %build
 export PATH=%i/bin:$PATH
+pushd %_builddir/m4-%{m4_version} 
+  ./configure --disable-dependency-tracking --prefix %i
+  make %makeprocesses && make install
+popd
 pushd %_builddir/autoconf-%{autoconf_version}
   ./configure --disable-dependency-tracking --prefix %i
   make %makeprocesses && make install
@@ -27,10 +33,6 @@ pushd %_builddir/automake-%{automake_version}
 popd
 pushd %_builddir/libtool-%{libtool_version} 
   ./configure --disable-dependency-tracking --prefix %i --enable-ltdl-install
-  make %makeprocesses && make install
-popd
-pushd %_builddir/m4-%{m4_version} 
-  ./configure --disable-dependency-tracking --prefix %i
   make %makeprocesses && make install
 popd
 

--- a/binutils-2.23.2-0000-PR-gas-14987-14887.patch
+++ b/binutils-2.23.2-0000-PR-gas-14987-14887.patch
@@ -1,0 +1,24 @@
+diff --git a/gas/config/tc-arm.c b/gas/config/tc-arm.c
+index 48316a5..7d4c3de 100644
+--- a/gas/config/tc-arm.c
++++ b/gas/config/tc-arm.c
+@@ -885,6 +885,9 @@ const char FLT_CHARS[] = "rRsSfFdDxXeEpP";
+ static inline int
+ skip_past_char (char ** str, char c)
+ {
++  /* PR gas/14987: Allow for whitespace before the expected character.  */
++  skip_whitespace (*str);
++
+   if (**str == c)
+     {
+       (*str)++;
+@@ -5168,6 +5171,9 @@ parse_address_main (char **str, int i, int group_relocations,
+       return PARSE_OPERAND_SUCCESS;
+     }
+ 
++  /* PR gas/14887: Allow for whitespace after the opening bracket.  */
++  skip_whitespace (p);
++
+   if ((reg = arm_reg_parse (&p, REG_TYPE_RN)) == FAIL)
+     {
+       inst.error = _(reg_expected_msgs[REG_TYPE_RN]);

--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -177,7 +177,7 @@ slc*)
   ;;
 fc*)
   fc18_armv7hl_platformSeeds="glibc coreutils bash tcsh zsh perl tcl tk readline openssl 
-                              ncurses e2fsprogs krb5-libs freetype fontconfig libstdc++-4.7.2 
+                              ncurses e2fsprogs krb5-libs freetype fontconfig libstdc++
                               libidn libX11 libXmu libSM libICE libXcursor libXext libXrandr 
                               libXft mesa-libGLU mesa-libGL e2fsprogs-libs libXi libXinerama 
                               libXft libXrender libXpm gcc-c++ libcom_err libXpm-devel libXft-devel

--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -182,7 +182,8 @@ fc*)
                               libXft mesa-libGLU mesa-libGL e2fsprogs-libs libXi libXinerama 
                               libXft libXrender libXpm gcc-c++ libcom_err libXpm-devel libXft-devel
                               libX11-devel libXext-devel mesa-libGLU mesa-libGLU-devel libGLEW
-                              glew perl-Digest-MD5 perl-ExtUtils-MakeMaker patch perl-libwww-perl"
+                              glew perl-Digest-MD5 perl-ExtUtils-MakeMaker patch perl-libwww-perl
+                              krb5-libs krb5-devel"
   ;;
 esac
 

--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -182,7 +182,7 @@ fc*)
                               libXft mesa-libGLU mesa-libGL e2fsprogs-libs libXi libXinerama 
                               libXft libXrender libXpm gcc-c++ libcom_err libXpm-devel libXft-devel
                               libX11-devel libXext-devel mesa-libGLU mesa-libGLU-devel libGLEW
-                              glew perl-Digest-MD5"
+                              glew perl-Digest-MD5 perl-ExtUtils-MakeMaker patch perl-libwww-perl"
   ;;
 esac
 

--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -183,7 +183,7 @@ fc*)
                               libXft libXrender libXpm gcc-c++ libcom_err libXpm-devel libXft-devel
                               libX11-devel libXext-devel mesa-libGLU mesa-libGLU-devel libGLEW
                               glew perl-Digest-MD5 perl-ExtUtils-MakeMaker patch perl-libwww-perl
-                              krb5-libs krb5-devel"
+                              krb5-libs krb5-devel perl-Data-Dumper"
   ;;
 esac
 

--- a/flex.spec
+++ b/flex.spec
@@ -1,6 +1,8 @@
 ### RPM external flex 2.5.37
 Source: http://switch.dl.sourceforge.net/project/%{n}/%{n}-%{realversion}.tar.bz2
 
+BuildRequires: autotools
+
 %prep
 %setup -q -n %{n}-%{realversion}
 

--- a/gcc-4.8.1-0000-pr-57748.patch
+++ b/gcc-4.8.1-0000-pr-57748.patch
@@ -1,0 +1,15 @@
+diff --git a/gcc/stor-layout.c b/gcc/stor-layout.c
+index 3381fcf..e720d01 100644
+--- a/gcc/stor-layout.c
++++ b/gcc/stor-layout.c
+@@ -1618,7 +1618,9 @@ compute_record_mode (tree type)
+ 		   && integer_zerop (TYPE_SIZE (TREE_TYPE (field)))))
+ 	  || ! host_integerp (bit_position (field), 1)
+ 	  || DECL_SIZE (field) == 0
+-	  || ! host_integerp (DECL_SIZE (field), 1))
++	  || ! host_integerp (DECL_SIZE (field), 1)
++	  || (TREE_CODE (TREE_TYPE (field)) == ARRAY_TYPE
++	      && tree_low_cst (DECL_SIZE (field), 1) == 0))
+ 	return;
+ 
+       /* If this field is the whole struct, remember its mode so

--- a/gcc-4.8.1-0001-pr-58065.patch
+++ b/gcc-4.8.1-0001-pr-58065.patch
@@ -1,0 +1,13 @@
+diff --git a/gcc/config/arm/arm.h b/gcc/config/arm/arm.h
+index 05aea35..48e0f21 100644
+--- a/gcc/config/arm/arm.h
++++ b/gcc/config/arm/arm.h
+@@ -630,6 +630,8 @@ extern int arm_arch_thumb_hwdiv;
+ 
+ #define BIGGEST_ALIGNMENT (ARM_DOUBLEWORD_ALIGN ? DOUBLEWORD_ALIGNMENT : 32)
+ 
++#define MALLOC_ABI_ALIGNMENT  BIGGEST_ALIGNMENT
++
+ /* XXX Blah -- this macro is used directly by libobjc.  Since it
+    supports no vector modes, cut out the complexity and fall back
+    on BIGGEST_FIELD_ALIGNMENT.  */

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -156,7 +156,7 @@ case %cmsplatf in
      COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++11 -msse3 -ftree-vectorize -Wno-strict-overflow"
    ;;
    *_armv7hl_* )
-    COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++11 -mfpu=neon -ftree-vectorize -Wno-strict-overflow -fsigned-char -fsigned-bitfields"
+    COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++11 -ftree-vectorize -Wno-strict-overflow -fsigned-char -fsigned-bitfields"
    ;;
 esac
 

--- a/gcc.spec
+++ b/gcc.spec
@@ -6,6 +6,8 @@
 %define gccRevision 199526
 %define gccBranch gcc-%(echo %{realversion} | cut -f1,2 -d. | tr . _)-branch
 Source0: svn://gcc.gnu.org/svn/gcc/branches/%{gccBranch}?module=gcc-%{gccBranch}-%{gccRevision}&revision=%{gccRevision}&output=/gcc-%{gccBranch}-%{gccRevision}.tar.gz
+Patch0: gcc-4.8.1-0000-pr-57748
+Patch1: gcc-4.8.1-0001-pr-58065
 
 %define islinux %(case %{cmsos} in (slc*|fc*) echo 1 ;; (*) echo 0 ;; esac)
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
@@ -28,22 +30,25 @@ Source6: ftp://gcc.gnu.org/pub/gcc/infrastructure/cloog-%{cloogVersion}.tar.gz
 
 %if %islinux
 %define bisonVersion 2.7
-%define binutilsv 2.23.2
+%define binutilsVersion 2.23.2
 %define elfutilsVersion 0.156
 %define m4Version 1.4.16
 %define flexVersion 2.5.37
 Source7: http://ftp.gnu.org/gnu/bison/bison-%{bisonVersion}.tar.gz
-Source8: http://ftp.gnu.org/gnu/binutils/binutils-%binutilsv.tar.bz2
+Source8: http://ftp.gnu.org/gnu/binutils/binutils-%{binutilsVersion}.tar.bz2
+Patch2: binutils-2.23.2-0000-PR-gas-14987-14887
 Source9: https://fedorahosted.org/releases/e/l/elfutils/%{elfutilsVersion}/elfutils-%{elfutilsVersion}.tar.bz2
-Patch1: https://fedorahosted.org/releases/e/l/elfutils/%{elfutilsVersion}/elfutils-portability.patch
+Patch3: https://fedorahosted.org/releases/e/l/elfutils/%{elfutilsVersion}/elfutils-portability.patch
 Source10: http://ftp.gnu.org/gnu/m4/m4-%m4Version.tar.gz
-Patch2: m4-1.4.16-fix-gets
+Patch4: m4-1.4.16-fix-gets
 Source11: http://garr.dl.sourceforge.net/project/flex/flex-%{flexVersion}.tar.bz2
 %endif
 
 %prep
 
 %setup -T -b 0 -n gcc-%gccBranch-%gccRevision
+%patch0 -p1
+%patch1 -p1
 
 # Filter out private stuff from RPM requires headers.
 cat << \EOF > %{name}-req
@@ -99,11 +104,12 @@ EOF_CMS_H
 
 %if %islinux
 %setup -D -T -b 7 -n bison-%{bisonVersion}
-%setup -D -T -b 8 -n binutils-%binutilsv
-%setup -D -T -b 9 -n elfutils-%{elfutilsVersion}
-%patch1 -p1
-%setup -D -T -b 10 -n m4-%{m4Version}
+%setup -D -T -b 8 -n binutils-%{binutilsVersion}
 %patch2 -p1
+%setup -D -T -b 9 -n elfutils-%{elfutilsVersion}
+%patch3 -p1
+%setup -D -T -b 10 -n m4-%{m4Version}
+%patch4 -p1
 %setup -D -T -b 11 -n flex-%{flexVersion}
 %endif
 
@@ -165,7 +171,7 @@ CXX="$CXX -fPIC"
   export PATH=%{i}/tmp/bison/bin:$PATH
 
   # Build binutils
-  cd ../binutils-%{binutilsv}
+  cd ../binutils-%{binutilsVersion}
   ./configure --disable-static --prefix=%{i} ${CONF_BINUTILS_OPTS} --disable-werror \
               --build=%{_build} --host=%{_host} --disable-nls --with-zlib=no --enable-targets=all \
               CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" CFLAGS="-I%{i}/include" \

--- a/git-toolfile.spec
+++ b/git-toolfile.spec
@@ -7,7 +7,7 @@ Requires: git
 %install
 
 case "%{cmsplatf}" in
-  slc6*)
+  slc6*|fc18*)
     PERL5LIB_PATH=/share/perl5
     ;;
   *)

--- a/gmp-static.spec
+++ b/gmp-static.spec
@@ -2,6 +2,8 @@
 
 Source: ftp://ftp.gnu.org/gnu/gmp/gmp-%{realversion}.tar.bz2
 
+BuildRequires: autotools
+
 %define keep_archives true
 %define drop_files %{i}/share
 

--- a/openssl.spec
+++ b/openssl.spec
@@ -61,6 +61,12 @@ esac
 ./config --prefix=%{i} ${cfg_args} enable-seed enable-tlsext enable-rfc3779 no-asm \
                        no-idea no-mdc2 no-rc5 no-ec no-ecdh no-ecdsa shared
 
+case "%{cmsplatf}" in
+  fc*|osx*)
+    make depend
+    ;;
+esac
+
 make
 
 %install

--- a/sigcpp.spec
+++ b/sigcpp.spec
@@ -2,6 +2,8 @@
 %define majorv %(echo %realversion | cut -d. -f1,2) 
 Source: http://ftp.gnome.org/pub/GNOME/sources/libsigc++/%{majorv}/libsigc++-%{realversion}.tar.bz2
 
+BuildRequires: autotools
+
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx c++ -std=c++0x
 %endif

--- a/vdt.spec
+++ b/vdt.spec
@@ -6,6 +6,7 @@ BuildRequires: cmake
 
 %define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
 %define isarmv7 %(case %{cmsplatf} in (*armv7*) echo 1 ;; (*) echo 0 ;; esac)
+%define iscpu_marvell %(cat /proc/cpuinfo | grep 'Marvell PJ4Bv7' 2>&1 >/dev/null && echo 1 || echo 0)
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
@@ -26,12 +27,19 @@ cmake . \
 %endif
 
 %if %isarmv7
+# Select NEON or VFPv3/VFPv3-D16
+%if %iscpu_marvell
+%define neon_support OFF
+%else
+%define neon_support ON
+%endif
+
 cmake . \
   -DCMAKE_CXX_COMPILER="%{cms_cxx}" \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DPRELOAD:BOOL=ON \
   -DSSE:BOOL=OFF \
-  -DNEON:BOOL=ON
+  -DNEON:BOOL=%{neon_support}
 %endif
 
 make %{makeprocesses} VERBOSE=1


### PR DESCRIPTION
- Add fix for PR gas/14987 [binutils]
- Add fix for PR gas/14887 [binutils]
- Add fix for PR middle-end/57748 [gcc] // not yet merged to gcc trunk, just pinged gcc-patches.
- Add fix for PR target/58065 [gcc]
- Add missing bootstrap-driver prerequisites needed for GIT and Dell servers
