### PR TITLE
[CMSSW_7_0_X][48][ARM] Misc. fixes

### DIFF
--- a/classlib-3.1.3-fix-unwind-x86_64.patch
+++ b/classlib-3.1.3-fix-unwind-x86_64.patch
@@ -1,0 +1,35 @@
+diff --git a/src/utils/DebugAids.cpp b/src/utils/DebugAids.cpp
+index 894c8a0..f014b1b 100644
+--- a/src/utils/DebugAids.cpp
++++ b/src/utils/DebugAids.cpp
+@@ -83,7 +83,7 @@ GetLogicalAddress (PVOID addr, PTSTR name, DWORD length,
+ }
+ #endif
+ 
+-#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) // FIXME: Check
++#if (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) && defined(__x86_64__) // FIXME: Check
+ extern "C" {
+     typedef unsigned _Unwind_Ptr __attribute__((__mode__(__pointer__)));
+     struct _Unwind_Context;
+@@ -168,7 +168,7 @@ unwindWalkStack (_Unwind_Context *ctx, void *data)
+     writev (fd, bufs, nbufs);
+     return _URC_NO_REASON;
+ }
+-#endif // GCC 3.4+
++#endif // (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) && defined(__x86_64__)
+ 
+ 
+ #if __hpux
+@@ -868,10 +868,10 @@ DebugAids::stacktrace (IOFD fd /* = IOFD_INVALID */)
+     sprintf (buffer, PSTACK_COMMAND, (unsigned long) getpid (), fd);
+     system (buffer);
+ 
+-#elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
++#elif (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) && defined(__x86_64__)
+     // FIXME: Check for _Unwind*, compilers other than GCC support this API
+     _Unwind_Backtrace (unwindWalkStack, &fd);
+-#endif
++#endif // (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) && defined(__x86_64__)
+ 
+     // FIXME: mpatrol has some generic unix unwind code.
+     // FIXME: from unix faq: ask debugger to dump stack trace

--- a/classlib.spec
+++ b/classlib.spec
@@ -4,6 +4,7 @@ Source: http://cmsrep.cern.ch/cmssw/cms/SOURCES/slc5_amd64_gcc472/external/class
 Patch0: classlib-3.1.3-gcc46
 Patch1: classlib-3.1.3-sl6
 Patch2: classlib-3.1.3-fix-gcc47-cxx11
+Patch3: classlib-3.1.3-fix-unwind-x86_64
 
 Requires: bz2lib 
 Requires: pcre 
@@ -28,6 +29,7 @@ Requires: onlinesystemtools
 %patch0 -p1
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 
 %build
 ./configure --prefix=%i                         \

--- a/ncurses.spec
+++ b/ncurses.spec
@@ -14,7 +14,9 @@ Source: http://ftp.gnu.org/pub/gnu/%{n}/%{n}-%{realversion}.tar.gz
             --enable-static \
             --without-debug \
             --without-ada \
-            --without-manpages
+            --without-manpages \
+            --disable-database \
+            --enable-termcap
 
 make %{makeprocesses} CFLAGS="-O2 -fPIC" CXXFLAGS="-O2 -fPIC -std=c++11"
 

--- a/pcre.spec
+++ b/pcre.spec
@@ -1,13 +1,19 @@
-### RPM external pcre 7.9
-Source: http://downloads.sourceforge.net/%n/%n-%{realversion}.tar.bz2
+### RPM external pcre 7.9__8.33
+%define generic_version 7.9
+%define fc_version 8.33
+Source0: http://downloads.sourceforge.net/%{n}/%{n}-%{generic_version}.tar.bz2
+Source1: http://downloads.sourceforge.net/%{n}/%{n}-%{fc_version}.tar.bz2
+
 Requires: bz2lib
 
-%define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
+%define isonline %(case %{cmsplatf} in (*onl_*_*) echo 1 ;; (*) echo 0 ;; esac)
+%define isfc %(case %{cmsplatf} in (fc*) echo 1 ;; (*) echo 0 ;; esac)
 
-%if "%online" != "true"
-Requires: zlib
-%else
+
+%if %isonline
 Requires: onlinesystemtools
+%else
+Requires: zlib
 %endif
 
 %if "%{?cms_cxx:set}" != "set"
@@ -15,7 +21,12 @@ Requires: onlinesystemtools
 %endif
 
 %prep
-%setup -n %n-%{realversion}
+%if %isfc
+%setup -b 1 -n %{n}-%{fc_version}
+%else
+%setup -b 0 -n %{n}-%{generic_version}
+%endif
+
 %build
 CPPFLAGS="-I${BZ2LIB_ROOT}/include -I${ZLIB_ROOT}/include"
 LDFLAGS="-L${BZ2LIB_ROOT}/lib -L${ZLIB_ROOT}/lib"


### PR DESCRIPTION
**ChangeLog**
- Fix undefined symbols coming from _classlib_ on GCC 4.8.1 ARM targets. _classlib_ tries to use private symbols from _libgcc_s_ (GCC)
- Disable  _ncurses_ terminfo database and enable termcap as a fallback mechanism. This removes terminfo database from `./share` path and prevents having RPM with hard links.
- Use 8.33 _pcre_ on Fedora to be compatible with system. Warnings were produced by linker while compiling CMSSW about possible conflicts. 
