### PR TITLE
[CMSSW_5_3_X] Backport CGAL from CMSSW_7_0_X

### DIFF
--- a/cgal-toolfile.spec
+++ b/cgal-toolfile.spec
@@ -1,0 +1,26 @@
+### RPM external cgal-toolfile 1.0
+Requires: cgal
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cgal.xml
+<tool name="cgal" version="@TOOL_VERSION@">
+  <info url="http://www.cgal.org/"/>
+  <lib name="CGAL_Core"/>
+  <lib name="CGAL_ImageIO"/>
+  <lib name="CGAL"/>
+  <client>
+    <environment name="CGAL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CGAL_BASE/lib"/>
+    <environment name="INCLUDE" default="$CGAL_BASE/include"/>
+  </client>
+  <use name="zlib"/>
+  <use name="boost_system"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/cgal.spec
+++ b/cgal.spec
@@ -1,0 +1,69 @@
+### RPM external cgal 4.2
+
+Source: https://gforge.inria.fr/frs/download.php/32360/%{n}-%{realversion}.tar.bz2
+
+BuildRequires: cmake gmp-static mpfr-static
+
+Requires: boost zlib
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx g++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -std=c++0x
+%endif
+
+%define drop_files %{i}/{share,bin} %{i}/lib/CGAL
+
+%prep
+%setup -n CGAL-%{realversion}
+
+%build
+
+export MPFR_LIB_DIR="${MPFR_STATIC_ROOT}/lib"
+export MPFR_INC_DIR="${MPFR_STATIC_ROOT}/include"
+export GMP_LIB_DIR="${GMP_STATIC_ROOT}/lib"
+export GMP_INC_DIR="${GMP_STATIC_ROOT}/include"
+
+cmake . \
+  -DCMAKE_CXX_COMPILER:STRING="%{cms_cxx}" \
+  -DCMAKE_CXX_FLAGS:STRING="%{cms_cxxflags}" \
+  -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
+  -DCMAKE_SKIP_RPATH:BOOL=YES \
+  -DWITH_BLAS:BOOL=OFF \
+  -DWITH_CGAL_Core:BOOL=ON \
+  -DWITH_CGAL_ImageIO:BOOL=ON \
+  -DWITH_CGAL_Qt3:BOOL=OFF \
+  -DWITH_CGAL_Qt4:BOOL=OFF \
+  -DWITH_Coin3D:BOOL=OFF \
+  -DWITH_ESBTL:BOOL=OFF \
+  -DWITH_Eigen3:BOOL=OFF \
+  -DWITH_GMP:BOOL=ON \
+  -DWITH_GMPXX:BOOL=OFF \
+  -DWITH_IPE:BOOL=OFF \
+  -DWITH_LAPACK:BOOL=OFF \
+  -DWITH_LEDA:BOOL=OFF \
+  -DWITH_MPFI:BOOL=OFF \
+  -DWITH_MPFR:BOOL=ON \
+  -DWITH_NTL:BOOL=OFF \
+  -DWITH_OpenGL:BOOL=OFF \
+  -DWITH_OpenNL:BOOL=OFF \
+  -DWITH_QGLViewer:BOOL=OFF \
+  -DWITH_RS:BOOL=OFF \
+  -DWITH_RS3:BOOL=OFF \
+  -DWITH_TAUCS:BOOL=OFF \
+  -DWITH_ZLIB:BOOL=ON \
+  -DWITH_demos:BOOL=OFF \
+  -DWITH_examples:BOOL=OFF \
+  -DZLIB_ROOT="${ZLIB_ROOT}" \
+  -DCGAL_ENABLE_PRECONFIG:BOOL=NO \
+  -DCGAL_IGNORE_PRECONFIGURED_GMP:BOOL=YES \
+  -DCGAL_IGNORE_PRECONFIGURED_MPFR:BOOL=YES \
+  -DBoost_NO_SYSTEM_PATHS:BOOL=TRUE \
+  -DBOOST_ROOT:PATH="${BOOST_ROOT}"
+
+make VERBOSE=1
+
+%install
+make install VERBOSE=1

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -106,6 +106,7 @@ Requires: protobuf-toolfile
 Requires: llvm-gcc-toolfile
 Requires: icc-gcc-toolfile
 Requires: cvs2git-toolfile
+Requires: cgal-toolfile
 
 %if "%isslc" == "true"
 Requires: openldap-toolfile

--- a/gmp-static.spec
+++ b/gmp-static.spec
@@ -1,0 +1,34 @@
+### RPM external gmp-static 5.0.2
+
+Source: ftp://ftp.gnu.org/gnu/gmp/gmp-%{realversion}.tar.bz2
+
+%define keep_archives true
+%define drop_files %{i}/share
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx g++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -std=c++0x
+%endif
+
+%prep
+%setup -n gmp-%{realversion}
+
+%build
+./configure \
+  --prefix=%{i} \
+  --disable-shared \
+  --enable-static \
+  --enable-cxx \
+  --with-pic \
+  CXX="%{cms_cxx}" \
+  CXXFLAGS="%{cms_cxxflags}"
+
+make %{makeprocesses}
+
+%install
+
+make install
+find %{i}/lib -name '*.la' -delete

--- a/mpfr-static.spec
+++ b/mpfr-static.spec
@@ -1,0 +1,26 @@
+### RPM external mpfr-static 3.0.1
+
+Source: http://www.mpfr.org/mpfr-%{realversion}/mpfr-%{realversion}.tar.bz2
+
+BuildRequires: gmp-static
+
+%define keep_archives true
+%define drop_files %{i}/share
+
+%prep
+%setup -n mpfr-%{realversion}
+
+%build
+./configure \
+  --enable-static \
+  --disable-shared \
+  --prefix=%{i} \
+  --with-gmp=${GMP_STATIC_ROOT} \
+  --with-pic \
+
+make %{makeprocesses}
+
+%install
+
+make install
+find %{i}/lib -name '*.la' -delete


### PR DESCRIPTION
The following backports _CGAL_ (new external) incl. its build-time dependencies from `CMSSW_7_0_X` to `CMSSW_5_3_X`.
