### PR TITLE
Build PhEDEx on SLC6 with https git-access. Also updated lifecycle-dataprovider and some p5-* modules

### DIFF
--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -27,6 +27,8 @@ Provides: perl(Net::Twitter::Lite)
 
 %prep
 %setup -n %{downloadn}-admin
+rm -rf Build
+rm -rf Contrib
 rm -rf Documentation/ACAT2008
 rm -rf Documentation/DC04PostMortem
 rm -rf Documentation/DC04Stats
@@ -36,6 +38,9 @@ rm -rf Documentation/WebConfig
 rm -rf Documentation/WebSite
 rm -rf Documentation/WhitePapers
 rm -rf Migration
+rm -rf perl_lib/DMWMMON
+rm -rf perl_lib/PHEDEX/Testbed
+rm -rf perl_lib/PHEDEX/Web
 rm -rf PhEDExWeb
 rm -rf Testbed
 rm -rf Toolkit/DBS

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -27,7 +27,22 @@ Provides: perl(Net::Twitter::Lite)
 
 %prep
 %setup -n %{downloadn}-admin
+rm -rf Documentation/ACAT2008
+rm -rf Documentation/DC04PostMortem
+rm -rf Documentation/DC04Stats
+rm -rf Documentation/Grid2005
+rm -rf Documentation/Updates
+rm -rf Documentation/WebConfig
+rm -rf Documentation/WebSite
+rm -rf Documentation/WhitePapers
+rm -rf Migration
+rm -rf PhEDExWeb
+rm -rf Testbed
 rm -rf Toolkit/DBS
+rm -rf Toolkit/Management
+rm -rf Toolkit/Peers
+rm -rf Toolkit/Test
+rm -rf Utilities/testSpace
 
 %build
 

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -24,7 +24,7 @@ Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
 
 # Fake for obsolete CLI/SiteDataInfo.pm
-Provides: (XML::Twig)
+Provides: perl(XML::Twig)
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
 

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -1,9 +1,9 @@
-### RPM cms PHEDEX-admin PHEDEX_4_1_3pre1
+### RPM cms PHEDEX-admin PHEDEX_4_1_3pre2
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag PHEDEX-%(echo %realversion | tr . _)
-Source: git://github.com/dmwm/PHEDEX?obj=master/788560654b78555c96b71aa66c99e59e2b30581d&export=%n&output=/%{downloadn}-admin.tar.gz
+%define gittag 788560654b78555c96b71aa66c99e59e2b30581d
+Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-admin.tar.gz
 
 # Oracle libs
 Requires: oracle oracle-env 

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -1,9 +1,14 @@
-### RPM cms PHEDEX-admin PHEDEX_4_1_3
+### RPM cms PHEDEX-admin 4.1.3
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
-Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-admin.tar.gz
+%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadt %(echo %realversion | tr '.' '_')
+%define setupdir  %{downloadn}-%{downloadn}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadn}_%{downloadt}.tar.gz
+
+#%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
+#Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-admin.tar.gz
 
 # Oracle libs
 Requires: oracle oracle-env 
@@ -27,7 +32,7 @@ Provides: perl(XML::LibXML)
 Provides: perl(Net::Twitter::Lite)
 
 %prep
-%setup -n %{downloadn}-admin
+%setup -n %{setupdir}
 rm -rf Build
 rm -rf Contrib
 rm -rf Documentation/ACAT2008

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -12,6 +12,7 @@ Requires: p5-time-hires p5-text-glob p5-compress-zlib p5-dbi
 Requires: p5-dbd-oracle p5-xml-parser p5-poe p5-poe-component-child
 Requires: p5-log-log4perl p5-log-dispatch p5-log-dispatch-filerotate
 Requires: p5-params-validate p5-monalisa-apmon
+Requires p5-clone p5-json-xs p5-mail-rfc822-address
 # Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
 # This is so it gets into our dependencies-setup.sh
 Requires: expat
@@ -22,6 +23,8 @@ Provides: perl(DB_File)
 Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
 
+# Fake for obsolete CLI/SiteDataInfo.pm
+Provides: (XML::Twig)
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
 
@@ -40,7 +43,9 @@ rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
 rm -rf perl_lib/PHEDEX/Testbed
-rm -rf perl_lib/PHEDEX/Web
+rm -rf perl_lib/PHEDEX/Web/API
+rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*
+rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpacw,TH}.pm
 rm -rf PhEDExWeb
 rm -rf Testbed
 rm -rf Toolkit/DBS
@@ -48,6 +53,7 @@ rm -rf Toolkit/Management
 rm -rf Toolkit/Peers
 rm -rf Toolkit/Test
 rm -rf Utilities/testSpace
+rm -f  Utilities/WebServiceWrite.pl
 
 %build
 

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -42,10 +42,11 @@ rm -rf Documentation/WebSite
 rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
+rm -f  perl_lib/PHEDEX/CLI/FakeAgent.pm
 rm -rf perl_lib/PHEDEX/Testbed
 rm -rf perl_lib/PHEDEX/Web/API
 rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*
-rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpacw,TH}.pm
+rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpace}.pm
 rm -rf PhEDExWeb
 rm -rf Testbed
 rm -rf Toolkit/DBS

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -2,7 +2,7 @@
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag d5e9c8c85bc015c321617ac31638c196a929981e
+%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
 Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-admin.tar.gz
 
 # Oracle libs

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -1,8 +1,8 @@
-### RPM cms PHEDEX-admin PHEDEX_4_1_3pre2
+### RPM cms PHEDEX-admin PHEDEX_4_1_3
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag 788560654b78555c96b71aa66c99e59e2b30581d
+%define gittag d5e9c8c85bc015c321617ac31638c196a929981e
 Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-admin.tar.gz
 
 # Oracle libs

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -12,7 +12,7 @@ Requires: p5-time-hires p5-text-glob p5-compress-zlib p5-dbi
 Requires: p5-dbd-oracle p5-xml-parser p5-poe p5-poe-component-child
 Requires: p5-log-log4perl p5-log-dispatch p5-log-dispatch-filerotate
 Requires: p5-params-validate p5-monalisa-apmon
-Requires p5-clone p5-json-xs p5-mail-rfc822-address
+Requires: p5-clone p5-json-xs p5-mail-rfc822-address
 # Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
 # This is so it gets into our dependencies-setup.sh
 Requires: expat

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -4,8 +4,8 @@
 %define downloadn %(echo %n | cut -f1 -d-)
 %define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
 %define downloadt %(echo %realversion | tr '.' '_')
-%define setupdir  %{downloadn}-%{downloadn}_%{downloadt}
-Source: https://github.com/dmwm/PHEDEX/archive/%{downloadn}_%{downloadt}.tar.gz
+%define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
 
 #%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
 #Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-admin.tar.gz

--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -23,8 +23,6 @@ Provides: perl(DB_File)
 Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
 
-# Fake for obsolete CLI/SiteDataInfo.pm
-Provides: perl(XML::Twig)
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
 
@@ -43,16 +41,30 @@ rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
 rm -f  perl_lib/PHEDEX/CLI/FakeAgent.pm
+rm -f  perl_lib/PHEDEX/CLI/SiteDataInfo.pm
 rm -rf perl_lib/PHEDEX/Testbed
 rm -rf perl_lib/PHEDEX/Web/API
 rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*
-rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpace}.pm
+rm -rf perl_lib/PHEDEX/Web/S{pooler,QLSpace}.pm
 rm -rf PhEDExWeb
+rm -f  Schema/GenPartitions.pl
+rm -f  Schema/Oracle{Init,}Spacemon.sql
+rm -f  Schema/Setup-Role-Access.pl
 rm -rf Testbed
 rm -rf Toolkit/DBS
 rm -rf Toolkit/Management
 rm -rf Toolkit/Peers
 rm -rf Toolkit/Test
+rm -f  Utilities/AuthMapper.pl
+rm -f  Utilities/CheckPhEDExContactUsercert.py
+rm -f  Utilities/GetNodeIds
+rm -f  Utilities/RequestAdministartion.pl
+rm -f  Utilities/RequestPhEDExContactUsercert.py
+rm -f  Utilities/RoleMap.txt
+rm -f  Utilities/RoleMapper.pl
+rm -f  Utilities/RouterControl
+rm -f  Utilities/spacecount
+rm -f  Utilities/stacc
 rm -rf Utilities/testSpace
 rm -f  Utilities/WebServiceWrite.pl
 

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,6 +1,6 @@
 ### RPM cms PHEDEX-datasvc 2.3.17
 ## INITENV +PATH PERL5LIB %i/perl_lib
-%define downloadn %(echo %n | cut -f1 -d-)
+#%define downloadn %(echo %n | cut -f1 -d-)
 %define gittag f4f8c2b470201dd47b31845e434e7756f64b8f32
 Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/%gittag&export=%n&output=/%n.tar.gz
 

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,8 +1,14 @@
 ### RPM cms PHEDEX-datasvc 2.3.17
 ## INITENV +PATH PERL5LIB %i/perl_lib
-#%define downloadn %(echo %n | cut -f1 -d-)
-%define gittag f4f8c2b470201dd47b31845e434e7756f64b8f32
-Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/%gittag&export=%n&output=/%n.tar.gz
+
+%define downloadn %(echo %n | cut -f1 -d-)
+%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadt %(echo %realversion | tr '.' '_')
+%define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
+
+#%define gittag f4f8c2b470201dd47b31845e434e7756f64b8f32
+#Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/%gittag&export=%n&output=/%n.tar.gz
 
 # For DB Access
 Requires: oracle oracle-env p5-dbi p5-dbd-oracle
@@ -26,7 +32,7 @@ Provides: perl(XML::LibXML)
 Provides: perl(URI::Escape)
 
 %prep
-%setup -n PHEDEX-datasvc
+%setup -n %{setupdir}
 
 %build
 %install

--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,8 +1,8 @@
-### RPM cms PHEDEX-datasvc 2.3.16
+### RPM cms PHEDEX-datasvc 2.3.17
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag PHEDEX-datasvc%(echo %realversion | tr . _)
-Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/62874fa45c9a73c78d9600beb41c8cbe7661fda4&export=%n&output=/%n.tar.gz
+%define gittag f4f8c2b470201dd47b31845e434e7756f64b8f32
+Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-datasvc/%gittag&export=%n&output=/%n.tar.gz
 
 # For DB Access
 Requires: oracle oracle-env p5-dbi p5-dbd-oracle

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -37,6 +37,7 @@ Provides: perl(T0::Util)
 %prep
 %setup -n %{setupdir}
 tar zxf %_sourcedir/T0.tar.gz
+rm Testbed/AutomatedTesting/check_API.pl
 
 %build
 %install

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-lifecycle 1.2.0
+### RPM cms PHEDEX-lifecycle 1.2.1
 ## INITENV +PATH PERL5LIB %i/perl_lib
 ## INITENV +PATH PERL5LIB %i/T0/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -1,10 +1,14 @@
 ### RPM cms PHEDEX-lifecycle 1.2.0
 ## INITENV +PATH PERL5LIB %i/perl_lib
 ## INITENV +PATH PERL5LIB %i/T0/perl_lib
-#%define downloadn %(echo %n | cut -f1 -d-)
+%define downloadn %(echo %n | cut -f1 -d-)
+%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadt %(echo %realversion | tr '.' '_')
+%define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
 
-%define gittag 58f3eed1c98b8edaae10f6befe9d0343c0abc38b
-Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%gittag&export=%n&output=/%n.tar.gz
+#%define gittag 58f3eed1c98b8edaae10f6befe9d0343c0abc38b
+#Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%gittag&export=%n&output=/%n.tar.gz
 
 # TODO Need to get this from somewhere else...
 %define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
@@ -31,7 +35,7 @@ Provides: perl(T0::Util)
 #Requires:  expat
 
 %prep
-%setup -n PHEDEX-lifecycle
+%setup -n %{setupdir}
 tar zxf %_sourcedir/T0.tar.gz
 
 %build

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -1,14 +1,14 @@
 ### RPM cms PHEDEX-lifecycle 1.2.0
 ## INITENV +PATH PERL5LIB %i/perl_lib
 ## INITENV +PATH PERL5LIB %i/T0/perl_lib
-%define downloadn %(echo %n | cut -f1 -d-)
+#%define downloadn %(echo %n | cut -f1 -d-)
+
+%define gittag 58f3eed1c98b8edaae10f6befe9d0343c0abc38b
+Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%gittag&export=%n&output=/%n.tar.gz
 
 # TODO Need to get this from somewhere else...
 %define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
 Source1: %cvsserver&strategy=export&module=T0&export=T0&&tag=-rPHEDEX_LIFECYCLE_1_0_0&output=/T0.tar.gz
-
-%define gittag 58f3eed1c98b8edaae10f6befe9d0343c0abc38b
-Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%gittag&export=%n&output=/%n.tar.gz
 
 Requires: p5-poe p5-poe-component-child p5-clone p5-time-hires p5-text-glob
 Requires: p5-compress-zlib p5-log-log4perl p5-json-xs p5-xml-parser p5-monalisa-apmon

--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -1,14 +1,14 @@
-### RPM cms PHEDEX-lifecycle 1.1.0
+### RPM cms PHEDEX-lifecycle 1.2.0
 ## INITENV +PATH PERL5LIB %i/perl_lib
 ## INITENV +PATH PERL5LIB %i/T0/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-#%define cvsversion LIFECYCLE_%(echo %realversion | tr . _)
-#%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
-#Source0: %cvsserver&strategy=export&module=%{downloadn}&export=%{downloadn}&&tag=-r%{cvsversion}&output=/%{n}.tar.gz
+
+# TODO Need to get this from somewhere else...
+%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
 Source1: %cvsserver&strategy=export&module=T0&export=T0&&tag=-rPHEDEX_LIFECYCLE_1_0_0&output=/T0.tar.gz
 
-%define realversion LIFECYCLE_1_2_0
-Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%realversion&export=%n&output=/%n.tar.gz
+%define gittag 58f3eed1c98b8edaae10f6befe9d0343c0abc38b
+Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%gittag&export=%n&output=/%n.tar.gz
 
 Requires: p5-poe p5-poe-component-child p5-clone p5-time-hires p5-text-glob
 Requires: p5-compress-zlib p5-log-log4perl p5-json-xs p5-xml-parser p5-monalisa-apmon

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -3,7 +3,8 @@
 ## INITENV +PATH PATH %i/Utilities:%i/Toolkit/DBS:%i/Toolkit/DropBox:%i/Toolkit/Request
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-Source: git://github.com/dmwm/PHEDEX?obj=master/788560654b78555c96b71aa66c99e59e2b30581d&export=%n&output=/%{downloadn}-micro.tar.gz
+$define gittag 788560654b78555c96b71aa66c99e59e2b30581d
+Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-micro.tar.gz
 
 # Oracle libs
 Requires: oracle oracle-env

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -33,13 +33,32 @@ Provides: perl(Net::Twitter::Lite)
 %prep
 
 %setup -n %{downloadn}-micro
+rm -rf Build
 rm -rf Custom/Template/*
 rm -rf Custom/DCache
 rm -rf Custom/Castor
 rm -rf Custom/SRM
+rm -rf Documentation/ACAT2008
+rm -rf Documentation/DC04PostMortem
+rm -rf Documentation/DC04Stats
+rm -rf Documentation/Grid2005
+rm -rf Documentation/Updates
+rm -rf Documentation/WebConfig
+rm -rf Documentation/WebSite
+rm -rf Documentation/WhitePapers
+rm -rf Migration
+rm -rf perl_lib/DMWMMON
+rm -rf perl_lib/PHEDEX/Testbed
+rm -rf perl_lib/PHEDEX/Schema
+rm -rf perl_lib/PHEDEX/Web
+rm -rf PhEDExWeb
 rm -rf Schema
+rm -rf Testbed
 rm -rf Toolkit/Infrastructure
+rm -rf Toolkit/Management
 rm -rf Toolkit/Monitoring
+rm -rf Toolkit/Peers
+rm -rf Toolkit/Test
 rm -rf Toolkit/Transfer
 rm -rf Toolkit/Workflow
 rm -rf Toolkit/Verify
@@ -53,6 +72,7 @@ rm -rf Utilities/DropStatus
 rm -rf Utilities/FillNames
 rm -rf Utilities/GrepSites
 rm -rf Utilities/ping-watchdog.pl
+rm -rf Utilities/testSpace
 rm -rf Utilities/stagercp
 rm -rf Utilities/WordMunger
 rm -rf Utilities/wrapper_rfcp

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -50,6 +50,7 @@ rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
 rm -f  perl_lib/PHEDEX/CLI/FakeAgent.pm
+rm -f  perl_lib/PHEDEX/CLI/SiteDataInfo.pm
 rm -rf perl_lib/PHEDEX/Testbed
 rm -rf perl_lib/PHEDEX/Web/API
 rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -1,9 +1,9 @@
-### RPM cms PHEDEX-micro PHEDEX_4_1_3pre1
+### RPM cms PHEDEX-micro PHEDEX_4_1_3
 
 ## INITENV +PATH PATH %i/Utilities:%i/Toolkit/DBS:%i/Toolkit/DropBox:%i/Toolkit/Request
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-$define gittag 788560654b78555c96b71aa66c99e59e2b30581d
+%define gittag d5e9c8c85bc015c321617ac31638c196a929981e
 Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-micro.tar.gz
 
 # Oracle libs

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -5,8 +5,8 @@
 %define downloadn %(echo %n | cut -f1 -d-)
 %define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
 %define downloadt %(echo %realversion | tr '.' '_')
-%define setupdir  %{downloadn}-%{downloadn}_%{downloadt}
-Source: https://github.com/dmwm/PHEDEX/archive/%{downloadn}_%{downloadt}.tar.gz
+%define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
 
 #%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
 #Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-micro.tar.gz

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -27,6 +27,8 @@ Provides: perl(DB_File)
 Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
 
+# Fake for obsolete CLI/SiteDataInfo.pm
+Provides: perl(XML::Twig)
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
 
@@ -49,9 +51,12 @@ rm -rf Documentation/WebSite
 rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
+rm -f  perl_lib/PHEDEX/CLI/FakeAgent.pm
 rm -rf perl_lib/PHEDEX/Testbed
 rm -rf perl_lib/PHEDEX/Schema
-rm -rf perl_lib/PHEDEX/Web
+rm -rf perl_lib/PHEDEX/Web/API
+rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*
+rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpace}.pm
 rm -rf PhEDExWeb
 rm -rf Schema
 rm -rf Testbed

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -27,8 +27,6 @@ Provides: perl(DB_File)
 Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
 
-# Fake for obsolete CLI/SiteDataInfo.pm
-Provides: perl(XML::Twig)
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
 
@@ -70,15 +68,26 @@ rm -rf Toolkit/Verify
 rm -rf Toolkit/DropBox
 rm -rf Utilities/AgentFactory.pl
 rm -rf Utilities/AgentMon.pl                                                
+rm -f  Utilities/AuthMap.txt
+rm -f  Utilities/AuthMapper.pl
+rm -f  Utilities/CheckPhEDExContactUsercert.py
 rm -rf Utilities/CMSSWMigrate
 rm -rf Utilities/DBDump
 rm -rf Utilities/DBLoad
 rm -rf Utilities/DropStatus
 rm -rf Utilities/FillNames
+rm -f  Utilities/GetNodeIds
 rm -rf Utilities/GrepSites
 rm -rf Utilities/ping-watchdog.pl
-rm -rf Utilities/testSpace
+rm -f  Utilities/RequestAdministartion.pl
+rm -f  Utilities/RequestPhEDExContactUsercert.py
+rm -f  Utilities/RoleMap.txt
+rm -f  Utilities/RoleMapper.pl
+rm -f  Utilities/RouterControl
+rm -f  Utilities/spacecount
+rm -f  Utilities/stacc
 rm -rf Utilities/stagercp
+rm -rf Utilities/testSpace
 rm -rf Utilities/WordMunger
 rm -rf Utilities/wrapper_rfcp
 rm -f  Utilities/WebServiceWrite.pl

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -53,7 +53,6 @@ rm -rf Migration
 rm -rf perl_lib/DMWMMON
 rm -f  perl_lib/PHEDEX/CLI/FakeAgent.pm
 rm -rf perl_lib/PHEDEX/Testbed
-rm -rf perl_lib/PHEDEX/Schema
 rm -rf perl_lib/PHEDEX/Web/API
 rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*
 rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpace}.pm
@@ -82,6 +81,7 @@ rm -rf Utilities/testSpace
 rm -rf Utilities/stagercp
 rm -rf Utilities/WordMunger
 rm -rf Utilities/wrapper_rfcp
+rm -f  Utilities/WebServiceWrite.pl
 
 %build
 

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -34,6 +34,7 @@ Provides: perl(Net::Twitter::Lite)
 
 %setup -n %{downloadn}-micro
 rm -rf Build
+rm -rf Contrib
 rm -rf Custom/Template/*
 rm -rf Custom/DCache
 rm -rf Custom/Castor

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -3,7 +3,7 @@
 ## INITENV +PATH PATH %i/Utilities:%i/Toolkit/DBS:%i/Toolkit/DropBox:%i/Toolkit/Request
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag d5e9c8c85bc015c321617ac31638c196a929981e
+%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
 Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-micro.tar.gz
 
 # Oracle libs

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -1,10 +1,15 @@
-### RPM cms PHEDEX-micro PHEDEX_4_1_3
+### RPM cms PHEDEX-micro 4.1.3
 
 ## INITENV +PATH PATH %i/Utilities:%i/Toolkit/DBS:%i/Toolkit/DropBox:%i/Toolkit/Request
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
-Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-micro.tar.gz
+%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadt %(echo %realversion | tr '.' '_')
+%define setupdir  %{downloadn}-%{downloadn}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadn}_%{downloadt}.tar.gz
+
+#%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
+#Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%{downloadn}-micro.tar.gz
 
 # Oracle libs
 Requires: oracle oracle-env
@@ -32,7 +37,7 @@ Provides: perl(Net::Twitter::Lite)
 
 %prep
 
-%setup -n %{downloadn}-micro
+%setup -n %{setupdir}
 rm -rf Build
 rm -rf Contrib
 rm -rf Custom/Template/*

--- a/PHEDEX-web.spec
+++ b/PHEDEX-web.spec
@@ -1,8 +1,14 @@
 ### RPM cms PHEDEX-web 4.2.9
 ## INITENV +PATH PERL5LIB %i/perl_lib
-#%define downloadn %(echo %n | cut -f1 -d-)
-%define gittag 1cf6be60c2447feb33c8394e047b2b8a1285983a
-Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-web/%gittag&export=%n&output=/%n.tar.gz
+
+%define downloadn %(echo %n | cut -f1 -d-)
+%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadt %(echo %realversion | tr '.' '_')
+%define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
+
+#%define gittag 1cf6be60c2447feb33c8394e047b2b8a1285983a
+#Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-web/%gittag&export=%n&output=/%n.tar.gz
 
 # This allows me to not pull everything in here, which duplicates code
 Requires: PHEDEX-datasvc
@@ -29,7 +35,7 @@ Provides: perl(DB_File)
 Provides: perl(XML::LibXML)
 
 %prep
-%setup -n PHEDEX-web
+%setup -n %{setupdir}
 
 %build
 %install

--- a/PHEDEX-web.spec
+++ b/PHEDEX-web.spec
@@ -1,8 +1,8 @@
 ### RPM cms PHEDEX-web 4.2.9
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define gittag PHEDEX-web_%(echo %realversion | tr . _)
-Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-web/1cf6be60c2447feb33c8394e047b2b8a1285983a&export=%n&output=/%n.tar.gz
+%define gittag 1cf6be60c2447feb33c8394e047b2b8a1285983a
+Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-web/%gittag&export=%n&output=/%n.tar.gz
 
 # This allows me to not pull everything in here, which duplicates code
 Requires: PHEDEX-datasvc

--- a/PHEDEX-web.spec
+++ b/PHEDEX-web.spec
@@ -1,6 +1,6 @@
 ### RPM cms PHEDEX-web 4.2.9
 ## INITENV +PATH PERL5LIB %i/perl_lib
-%define downloadn %(echo %n | cut -f1 -d-)
+#%define downloadn %(echo %n | cut -f1 -d-)
 %define gittag 1cf6be60c2447feb33c8394e047b2b8a1285983a
 Source: git://github.com/dmwm/PHEDEX?obj=PHEDEX-web/%gittag&export=%n&output=/%n.tar.gz
 

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-webapp 1.3.13
+### RPM cms PHEDEX-webapp 1.3.14
 ## INITENV +PATH PERL5LIB %i/perl_lib
 
 %define downloadn %(echo %n | cut -f1 -d-)

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -3,7 +3,9 @@
 %define downloadn %(echo %n | cut -f1 -d-)
 %define gittag WEBAPP_%(echo %realversion | tr . _)
 %define yuicompressorversion 2.4.6
-Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/5c0b49edc0b9ec4285ac87f12bea39e4638aa9da&export=%n&output=/%n.tar.gz
+
+%define gittag 5c0b49edc0b9ec4285ac87f12bea39e4638aa9da
+Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/%gittag&export=%n&output=/%n.tar.gz
 Source1: http://yui.zenfs.com/releases/yuicompressor/yuicompressor-%{yuicompressorversion}.zip
 Requires: protovis yui
 BuildRequires: java-jdk

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -1,11 +1,10 @@
 ### RPM cms PHEDEX-webapp 1.3.13
 ## INITENV +PATH PERL5LIB %i/perl_lib
-%define downloadn %(echo %n | cut -f1 -d-)
-%define gittag WEBAPP_%(echo %realversion | tr . _)
-%define yuicompressorversion 2.4.6
-
+#%define downloadn %(echo %n | cut -f1 -d-)
 %define gittag 5c0b49edc0b9ec4285ac87f12bea39e4638aa9da
 Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/%gittag&export=%n&output=/%n.tar.gz
+
+%define yuicompressorversion 2.4.6
 Source1: http://yui.zenfs.com/releases/yuicompressor/yuicompressor-%{yuicompressorversion}.zip
 Requires: protovis yui
 BuildRequires: java-jdk

--- a/PHEDEX-webapp.spec
+++ b/PHEDEX-webapp.spec
@@ -1,8 +1,14 @@
 ### RPM cms PHEDEX-webapp 1.3.13
 ## INITENV +PATH PERL5LIB %i/perl_lib
-#%define downloadn %(echo %n | cut -f1 -d-)
-%define gittag 5c0b49edc0b9ec4285ac87f12bea39e4638aa9da
-Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/%gittag&export=%n&output=/%n.tar.gz
+
+%define downloadn %(echo %n | cut -f1 -d-)
+%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadt %(echo %realversion | tr '.' '_')
+%define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
+
+#%define gittag 5c0b49edc0b9ec4285ac87f12bea39e4638aa9da
+#Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-webapp/%gittag&export=%n&output=/%n.tar.gz
 
 %define yuicompressorversion 2.4.6
 Source1: http://yui.zenfs.com/releases/yuicompressor/yuicompressor-%{yuicompressorversion}.zip
@@ -11,15 +17,15 @@ BuildRequires: java-jdk
 
 %prep
 %setup -T -b 1 -n yuicompressor-%{yuicompressorversion}
-%setup -D -T -b 0 -n PHEDEX-webapp
+%setup -D -T -b 0 -n %{setupdir}
 
 %build
 export YUICOMPRESSOR_PATH=%_builddir/yuicompressor-%{yuicompressorversion}/build/yuicompressor-%{yuicompressorversion}.jar
 cd %_builddir
-sh %_builddir/PHEDEX-webapp/PhEDExWeb/ApplicationServer/util/phedex-minify.sh
-rm -rf %_builddir/PHEDEX-webapp/PhEDExWeb/{ApplicationServer/{js,css,util},yuicompressor*}
-mv %_builddir/PHEDEX-webapp/PhEDExWeb/ApplicationServer/{build/*,}
-rmdir %_builddir/PHEDEX-webapp/PhEDExWeb/ApplicationServer/build
+sh %_builddir/%{setupdir}/PhEDExWeb/ApplicationServer/util/phedex-minify.sh
+rm -rf %_builddir/%{setupdir}/PhEDExWeb/{ApplicationServer/{js,css,util},yuicompressor*}
+mv %_builddir/%{setupdir}/PhEDExWeb/ApplicationServer/{build/*,}
+rmdir %_builddir/%{setupdir}/PhEDExWeb/ApplicationServer/build
 
 %install
 mkdir -p %i/etc/{env,profile}.d

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -1,7 +1,7 @@
 ### RPM cms PHEDEX PHEDEX_4_1_3
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
-%define gittag d5e9c8c85bc015c321617ac31638c196a929981e
+%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
 Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%n.tar.gz
 
 # Oracle libs

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -42,9 +42,9 @@ rm -rf Documentation/WebSite
 rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
-rm -rf perl_lib/Schema
-rm -rf perl_lib/Testbed
-rm -rf perl_lib/Web
+rm -rf perl_lib/PHEDEX/Schema
+rm -rf perl_lib/PHEDEX/Testbed
+rm -rf perl_lib/PHEDEX/Web
 rm -rf PhEDExWeb
 rm -rf Schema
 rm -rf Testbed

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -22,8 +22,6 @@ Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
 Provides: perl(CGI)
 
-# Fake for obsolete CLI/SiteDataInfo.pm
-Provides: perl(XML::Twig)
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
 
@@ -45,10 +43,11 @@ rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
 rm -f  perl_lib/PHEDEX/CLI/FakeAgent.pm
+rm -f  perl_lib/PHEDEX/CLI/SiteDataInfo.pm
 rm -rf perl_lib/PHEDEX/Testbed
 rm -rf perl_lib/PHEDEX/Web/API
 rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*
-rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpace}.pm
+rm -rf perl_lib/PHEDEX/Web/S{pooler,QLSpace}.pm
 rm -rf PhEDExWeb
 rm -rf Schema
 rm -rf Testbed
@@ -59,10 +58,14 @@ rm -rf Toolkit/Monitoring
 rm -rf Toolkit/Workflow
 rm -rf Toolkit/Peers
 rm -rf Toolkit/Test
+rm -f  Utilities/AuthMap.txt
+rm -f  Utilities/AuthMapper.pl
+rm -f  Utilities/CheckPhEDExContactUsercert.py
 rm -f  Utilities/CMSSWMigrate
 rm -f  Utilities/DBDump
 rm -f  Utilities/DBLoad
 rm -f  Utilities/DBSCheck
+rm -f  Utilities/GetNodeIds
 rm -f  Utilities/GrepSites
 rm -f  Utilities/FileDeleteTMDB
 rm -f  Utilities/LinkNew
@@ -72,7 +75,14 @@ rm -f  Utilities/MakeDailyStats
 rm -f  Utilities/netmon
 rm -f  Utilities/NodeNew
 rm -f  Utilities/NodeRemove
+rm -f  Utilities/RequestAdministartion.pl
+rm -f  Utilities/RequestPhEDExContactUsercert.py
+rm -f  Utilities/RoleMap.txt
+rm -f  Utilities/RoleMapper.pl
+rm -f  Utilities/RouterControl
 rm -f  Utilities/RunTest
+rm -f  Utilities/spacecount
+rm -f  Utilities/stacc
 rm -rf Utilities/testSpace
 rm -f  Utilities/WordMunger
 rm -f  Utilities/WebServiceWrite.pl

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -1,7 +1,7 @@
-### RPM cms PHEDEX PHEDEX_4_1_3pre3
+### RPM cms PHEDEX PHEDEX_4_1_3
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
-%define gittag 04558e10774408d7acd47b4779c9491fb8396071
+%define gittag d5e9c8c85bc015c321617ac31638c196a929981e
 Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%n.tar.gz
 
 # Oracle libs

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -20,6 +20,7 @@ Provides: perl(HTML::Entities)
 Provides: perl(DB_File)
 Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
+Provides: perl(CGI)
 
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
@@ -31,11 +32,19 @@ rm -rf Contrib
 rm -f  Custom/Template/Config.Micro
 rm -f  Custom/Template/ConfigPart.CERN*
 rm -f  Custom/Template/ConfigPart.Management
+rm -rf Documentation/ACAT2008
+rm -rf Documentation/DC04PostMortem
+rm -rf Documentation/DC04Stats
+rm -rf Documentation/Grid2005
 rm -rf Documentation/Updates
+rm -rf Documentation/WebConfig
 rm -rf Documentation/WebSite
 rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
+rm -rf perl_lib/Schema
+rm -rf perl_lib/Testbed
+rm -rf perl_lib/Web
 rm -rf PhEDExWeb
 rm -rf Schema
 rm -rf Testbed

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -22,6 +22,8 @@ Provides: perl(Date::Manip)
 Provides: perl(XML::LibXML)
 Provides: perl(CGI)
 
+# Fake for obsolete CLI/SiteDataInfo.pm
+Provides: perl(XML::Twig)
 # Fake provide of twitter client; needs to be installed manually
 Provides: perl(Net::Twitter::Lite)
 
@@ -42,9 +44,11 @@ rm -rf Documentation/WebSite
 rm -rf Documentation/WhitePapers
 rm -rf Migration
 rm -rf perl_lib/DMWMMON
-rm -rf perl_lib/PHEDEX/Schema
+rm -f  perl_lib/PHEDEX/CLI/FakeAgent.pm
 rm -rf perl_lib/PHEDEX/Testbed
-rm -rf perl_lib/PHEDEX/Web
+rm -rf perl_lib/PHEDEX/Web/API
+rm -rf perl_lib/PHEDEX/Web/{C,D,F,U}*
+rm -rf perl_lib/PHEDEX/Web/S{pooler,SLSpace}.pm
 rm -rf PhEDExWeb
 rm -rf Schema
 rm -rf Testbed

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -1,8 +1,14 @@
-### RPM cms PHEDEX PHEDEX_4_1_3
+### RPM cms PHEDEX 4.1.3
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
-%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
-Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%n.tar.gz
+%define downloadn %(echo %n | cut -f1 -d-)
+%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadt %(echo %realversion | tr '.' '_')
+%define setupdir  %{downloadn}-%{downloadn}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadn}_%{downloadt}.tar.gz
+
+#%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
+#Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%n.tar.gz
 
 # Oracle libs
 Requires: oracle oracle-env
@@ -26,7 +32,7 @@ Provides: perl(CGI)
 Provides: perl(Net::Twitter::Lite)
 
 %prep
-%setup -n %n
+%setup -n %{setupdir}
 rm -rf Build
 rm -rf Contrib
 rm -f  Custom/Template/Config.Micro

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -1,7 +1,8 @@
-### RPM cms PHEDEX PHEDEX_4_1_3pre1
+### RPM cms PHEDEX PHEDEX_4_1_3pre3
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
-Source: git://github.com/dmwm/PHEDEX?obj=master/788560654b78555c96b71aa66c99e59e2b30581d&export=%n&output=/%n.tar.gz
+%define gittag 04558e10774408d7acd47b4779c9491fb8396071
+Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%n.tar.gz
 
 # Oracle libs
 Requires: oracle oracle-env

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -2,10 +2,10 @@
 
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
-%define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
+%define downloadp %(echo %downloadn)
 %define downloadt %(echo %realversion | tr '.' '_')
-%define setupdir  %{downloadn}-%{downloadn}_%{downloadt}
-Source: https://github.com/dmwm/PHEDEX/archive/%{downloadn}_%{downloadt}.tar.gz
+%define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
+Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
 
 #%define gittag 7572e79f0925d593180e1b6a62e2ae1ae29c0f39
 #Source: git://github.com/dmwm/PHEDEX?obj=master/%gittag&export=%n&output=/%n.tar.gz

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -26,14 +26,26 @@ Provides: perl(Net::Twitter::Lite)
 
 %prep
 %setup -n %n
+rm -rf Build
+rm -rf Contrib
 rm -f  Custom/Template/Config.Micro
 rm -f  Custom/Template/ConfigPart.CERN*
 rm -f  Custom/Template/ConfigPart.Management
+rm -rf Documentation/Updates
+rm -rf Documentation/WebSite
+rm -rf Documentation/WhitePapers
+rm -rf Migration
+rm -rf perl_lib/DMWMMON
+rm -rf PhEDExWeb
 rm -rf Schema
+rm -rf Testbed
+rm -rf Toolkit/DBS
 rm -rf Toolkit/Infrastructure
+rm -rf Toolkit/Management
 rm -rf Toolkit/Monitoring
 rm -rf Toolkit/Workflow
-rm -rf Toolkit/DBS
+rm -rf Toolkit/Peers
+rm -rf Toolkit/Test
 rm -f  Utilities/CMSSWMigrate
 rm -f  Utilities/DBDump
 rm -f  Utilities/DBLoad
@@ -48,6 +60,7 @@ rm -f  Utilities/netmon
 rm -f  Utilities/NodeNew
 rm -f  Utilities/NodeRemove
 rm -f  Utilities/RunTest
+rm -rf Utilities/testSpace
 rm -f  Utilities/WordMunger
 
 %build

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -75,6 +75,7 @@ rm -f  Utilities/NodeRemove
 rm -f  Utilities/RunTest
 rm -rf Utilities/testSpace
 rm -f  Utilities/WordMunger
+rm -f  Utilities/WebServiceWrite.pl
 
 %build
 

--- a/lifecycle-dataprovider.spec
+++ b/lifecycle-dataprovider.spec
@@ -3,13 +3,14 @@
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
 %define pkg DataProvider
 #%define svnserver svn://svn.cern.ch/reps/CMSDMWM
-Source0: git://github.com/dmwm/LifeCycle?obj=master/%realversion&export=%pkg&output=/%pkg.tar.gz
+Source0: https://github.com/dmwm/LifeCycle/archive/%{realversion}.tar.gz
+#Source0: git://github.com/dmwm/LifeCycle?obj=master/%realversion&export=%pkg&output=/%pkg.tar.gz
 #Source0: %svnserver/LifeCycle/tags/%{realversion}/DataProvider/?scheme=svn+ssh&strategy=export&module=DataProvider&output=/dataprovider.tar.gz
 Requires: python
 BuildRequires: py2-sphinx
 
 %prep
-%setup -D -T -b 0 -n DataProvider
+%setup -D -T -b 0 -n LifeCycle-%{realversion}
 
 %build
 pwd

--- a/lifecycle-dataprovider.spec
+++ b/lifecycle-dataprovider.spec
@@ -1,4 +1,4 @@
-### RPM cms lifecycle-dataprovider 1.0.5
+### RPM cms lifecycle-dataprovider 1.0.7
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
 %define pkg DataProvider

--- a/p5-cgi-session.spec
+++ b/p5-cgi-session.spec
@@ -8,6 +8,7 @@ Requires: p5-extutils-makemaker p5-cgi
 Provides:  perl(DBD::Pg)
 Provides:  perl(DBI)
 Provides:  perl(FreezeThaw)
+Provides:  perl(Test::More)
 
 %prep
 %setup -n %downloadn-%{realversion}

--- a/p5-clone.spec
+++ b/p5-clone.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-clone 0.31
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn Clone
 Source: http://search.cpan.org/CPAN/authors/id/R/RD/RDF/%{downloadn}-%{realversion}.tar.gz
 Requires: p5-extutils-makemaker

--- a/p5-compress-zlib.spec
+++ b/p5-compress-zlib.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-compress-zlib 1.42
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn Compress-Zlib
 Source: http://search.cpan.org/CPAN/authors/id/P/PM/PMQS/%{downloadn}-%{realversion}.tar.gz
 Requires: zlib p5-extutils-makemaker

--- a/p5-dbd-oracle.spec
+++ b/p5-dbd-oracle.spec
@@ -1,6 +1,7 @@
 ### RPM external p5-dbd-oracle 1.23
 ## INITENV +PATH PERL5LIB %i/lib/perl5
 ## BUILDIF case $(uname):$(uname -m) in Linux:i*86 | Linux:x86_64 | Darwin:* ) true ;; * ) false ;; esac
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn DBD-Oracle
 %define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
 

--- a/p5-dbi.spec
+++ b/p5-dbi.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-dbi 1.609
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn DBI
 ## Let's fake the provides of windows stuff for the time being.
 Provides: perl(RPC::PlClient)

--- a/p5-json-xs.spec
+++ b/p5-json-xs.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-json-xs 2.3
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn JSON-XS
 Source: http://search.cpan.org/CPAN/authors/id/M/ML/MLEHMANN/%{downloadn}-%{realversion}.tar.gz
 Requires: p5-extutils-makemaker p5-common-sense

--- a/p5-linux-pid.spec
+++ b/p5-linux-pid.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-linux-pid 0.04
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn Linux-Pid
 Source: http://search.cpan.org/CPAN/authors/id/R/RG/RGARCIA/%{downloadn}-%{realversion}.tar.gz
 Requires: p5-extutils-makemaker

--- a/p5-params-validate.spec
+++ b/p5-params-validate.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-params-validate 1.00
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn Params-Validate
 Source: http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/%{downloadn}-%{realversion}.tar.gz
 Requires: p5-extutils-makemaker p5-module-build p5-test-simple p5-attribute-handlers p5-extutils-cbuilder

--- a/p5-time-hires.spec
+++ b/p5-time-hires.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-time-hires 1.9715
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn Time-HiRes
 Source: http://search.cpan.org/CPAN/authors/id/J/JH/JHI/%{downloadn}-%{realversion}.tar.gz
 Requires: p5-extutils-makemaker

--- a/p5-version.spec
+++ b/p5-version.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-version 0.91
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn version
 Source: http://search.cpan.org/CPAN/authors/id/J/JP/JPEACOCK/%{downloadn}-%{realversion}.tar.gz
 Requires: p5-extutils-makemaker

--- a/p5-xml-parser.spec
+++ b/p5-xml-parser.spec
@@ -1,5 +1,6 @@
 ### RPM external p5-xml-parser 2.41
 ## INITENV +PATH PERL5LIB %i/lib/perl5
+# Dummy comment: forcing the compiling for SLC6
 %define downloadn XML-Parser
 %define expatversion 2.0.0
 Source0: http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/%{downloadn}-%{realversion}.tar.gz


### PR DESCRIPTION
This includes a few minor bugfixes for PhEDEx, but the main feature is the changes for building on SLC6. 

This means getting the code from git via HTTPS, because of the zlib problem with native git commands. This applies to the PhEDEx spec files but also to the lifecycle-dataprovider.

To build on SLC6, a number of perl modules needed to be recompiled too. These have had a dummy line added to the spec file to trigger a rebuild.

So, could this request be merged please, and a build made in the comp repository?
