### PR TITLE
[CMSSW_7_0_X][48] Misc. updates

### DIFF
--- a/cascade-toolfile.spec
+++ b/cascade-toolfile.spec
@@ -17,6 +17,9 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cascade.xml
   <architecture name="slc[^_]*_[^_]*_gcc4[4-9]">
     <lib name="cascade_merged"/>
   </architecture>
+  <architecture name="^fc">
+    <lib name="cascade_merged"/>
+  </architecture>
   <architecture name="osx">
     <lib name="cascade_merged"/>
   </architecture>

--- a/coral-tool-conf.spec
+++ b/coral-tool-conf.spec
@@ -15,6 +15,7 @@ Requires: openssl-toolfile
 Requires: sqlite-toolfile
 Requires: libuuid-toolfile
 Requires: zlib-toolfile
+Requires: bz2lib-toolfile
 Requires: cppunit-toolfile
 Requires: xerces-c-toolfile
 %if %isamd64

--- a/gdb.spec
+++ b/gdb.spec
@@ -1,4 +1,4 @@
-### RPM external gdb 7.6
+### RPM external gdb 7.6.1
 Source: http://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.bz2
 Patch0: gdb-7.6-fix-pythonhome
 Requires: python ncurses zlib xz expat

--- a/tauolapp-toolfile.spec
+++ b/tauolapp-toolfile.spec
@@ -19,6 +19,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/tauolapp.xml
   </client>
   <use name="hepmc"/>
   <use name="f77compiler"/>
+  <use name="pythia8"/>
+  <use name="lhapdf"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
**ChangeLog**
- In _cascade-toolfile_ for Fedora Core we were not linking to any cascade library. Fix it for architectures starting with `fc`.
- GDB bump version to 7.6.1
- _coral-tool-conf_ needs _bz2lib_ depedency as _pcre_ links to bz2lib. Otherwise we receive SCRAM warning about missing toolfile.
- Tauolapp 1.3.3 added dependencies for _lhapdf_ and _pythia8_, but such dependencies were never reflected in tauolapp toolfile. Add them.
