### PR TITLE
llvm,llvm-gcc-toolfile: update to work with GCC 4.8.1

### DIFF
--- a/llvm-3.3-add-triplet-x86_64-redhat-linux-gnu.patch
+++ b/llvm-3.3-add-triplet-x86_64-redhat-linux-gnu.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/Driver/ToolChains.cpp b/lib/Driver/ToolChains.cpp
+index fffba0e..fac6ff2 100644
+--- a/lib/Driver/ToolChains.cpp
++++ b/lib/Driver/ToolChains.cpp
+@@ -1099,7 +1099,8 @@ Generic_GCC::GCCInstallationDetector::GCCInstallationDetector(
+     "x86_64-suse-linux",
+     "x86_64-manbo-linux-gnu",
+     "x86_64-linux-gnu",
+-    "x86_64-slackware-linux"
++    "x86_64-slackware-linux",
++    "x86_64-redhat-linux-gnu"
+   };
+   static const char *const X86LibDirs[] = { "/lib32", "/lib" };
+   static const char *const X86Triples[] = {

--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -46,6 +46,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags REM_CXXFLAGS="-Werror=format-contains-nul"/>
     <flags REM_CXXFLAGS="-Werror=maybe-uninitialized"/>
     <flags REM_CXXFLAGS="-Werror=unused-but-set-variable"/>
+    <flags REM_CXXFLAGS="-Wno-unused-local-typedefs"/>
     <flags CXXFLAGS="-Wno-c99-extensions"/>
     <flags CXXFLAGS="-Wno-c++11-narrowing"/>
     <flags CXXFLAGS="-D__STRICT_ANSI__"/>

--- a/llvm.spec
+++ b/llvm.spec
@@ -16,6 +16,7 @@ Source1: svn://llvm.org/svn/llvm-project/cfe/branches/release_%llvmBranch/?schem
 #Source1: svn://llvm.org/svn/llvm-project/cfe/trunk/?scheme=http&revision=%clangRevision&module=clang-%realversion-%clangRevision&output=/clang-%realversion-%clangRevision.tgz
 Patch0: llvm-3.1-fix-requires
 Patch1: llvm-3.2-getGCCToolchainDir
+Patch2: llvm-3.3-add-triplet-x86_64-redhat-linux-gnu
 %define keep_archives true
 
 %prep
@@ -25,6 +26,7 @@ mv clang-%realversion-%clangRevision clang
 cd clang
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 %setup -T -D -n llvm-%realversion-%llvmRevision
 
 %build


### PR DESCRIPTION
Remove `-Wno-unused-local-typedefs' GCC option on LLVM/Clang, it's
not supported. Our (SLC{5,6}) triplet is x86_64-redhat-linux-gnu,
which is not available in Clang. Add it.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
