### PR TITLE
rpm,apt: use new bootstrap-bundle and make gcc a build require

### DIFF
--- a/bootstrap-bundle.spec
+++ b/bootstrap-bundle.spec
@@ -1,0 +1,53 @@
+### RPM external bootstrap-bundle 1.0
+## INITENV SET MAGIC %{i}/share/magic.mgc
+## NOCOMPILER
+
+BuildRequires: gcc
+BuildRequires: bz2lib-bootstrap db4-bootstrap file-bootstrap libxml2-bootstrap lua-bootstrap nspr-bootstrap nss-bootstrap
+BuildRequires: openssl-bootstrap popt-bootstrap sqlite-bootstrap zlib-bootstrap
+
+%define keep_archives true
+%define isamd64 %(case %{cmsplatf} in (*amd64*|*_mic_*) echo 1 ;; (*) echo 0 ;; esac)
+%define ismac   %(case %{cmsplatf} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
+
+%define soname so
+%if %ismac
+%define soname dylib
+%endif
+
+%define libdir lib
+%if %isamd64
+%define libdir lib64
+%endif
+
+%prep
+%build
+%install
+mkdir %{i}/bin %{i}/lib %{i}/include %{i}/share %{i}/tmp
+for tool in `echo %{buildrequiredtools} | tr ' ' '\n' | grep '\-bootstrap$'`; do
+  toolcap=`echo $tool | tr a-z- A-Z_`
+  toolbase=`eval echo \\$${toolcap}_ROOT`
+  for sdir in bin lib include ; do
+    [ -d ${toolbase}/${sdir} ] || continue
+    rsync -r --links --ignore-existing ${toolbase}/${sdir}/ %{i}/${sdir}/
+  done
+done
+cp -r ${FILE_BOOTSTRAP_ROOT}/share/misc/magic.mgc %{i}/share
+rm -f %{i}/bin/xml2-config %{i}/lib/xml2Conf.sh
+
+#Bundle libstd and libgcc_s and libelf
+%if %ismac
+cp -P $GCC_ROOT/lib/lib{stdc++,gcc_s}*.%{soname} %{i}/lib
+%else
+cp -P $GCC_ROOT/%{libdir}/lib{stdc++,gcc_s}.%{soname}* %{i}/lib
+cp -P $GCC_ROOT/lib/libelf.%{soname}* %{i}/lib
+cp -P $GCC_ROOT/lib/libelf-*.%{soname} %{i}/lib
+%endif
+
+find %{i}/bin -type f -perm -a+x -exec %strip {} \;
+find %{i}/lib -type f -perm -a+x -exec %strip {} \;
+
+mv %{i}/lib/lib{lua,magic}.a %{i}/tmp
+rm -f %{i}/lib/*.{l,}a
+mv %{i}/tmp/lib* %{i}/lib/
+rm -rf %{i}/tmp

--- a/bz2lib-bootstrap.spec
+++ b/bz2lib-bootstrap.spec
@@ -1,0 +1,50 @@
+### RPM external bz2lib-bootstrap 1.0.5
+# Build system patches by Lassi A. Tuura <lat@iki.fi>
+Source: http://www.bzip.org/%{realversion}/bzip2-%{realversion}.tar.gz
+%define cpu %(echo "%{cmsplatf}" | cut -f2 -d_)
+Provides: libbz2.so.1
+%if "%{cpu}" == "amd64"
+Provides: libbz2.so.1()(64bit)
+%endif
+
+%define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
+
+%prep
+%setup -n bzip2-%{realversion}
+sed -e 's/ -shared/ -dynamiclib/' \
+    -e 's/ -Wl,-soname -Wl,[^ ]*//' \
+    -e 's/libbz2\.so/libbz2.dylib/g' \
+    < Makefile-libbz2_so > Makefile-libbz2_dylib
+
+%build
+%if %isdarwin
+so=dylib
+%else
+so=so
+%endif
+make %{makeprocesses} -f Makefile-libbz2_$so
+
+%install
+%if %isdarwin
+so=dylib
+%else
+so=so
+%endif
+make install PREFIX=%{i}
+# For bzip2 1.0.5, the library appears to retain the name libbz2.so.1.0.4
+# rather than libbz2.so.1.0.5 as one would expect, so use this "tmpversion"
+# instead of realversion
+%define tmpversion 1.0.4
+cp libbz2.${so}.%{tmpversion} %{i}/lib
+ln -s libbz2.${so}.%{tmpversion} %{i}/lib/libbz2.$so
+ln -s libbz2.${so}.%{tmpversion} %{i}/lib/libbz2.${so}.`echo %{tmpversion} | cut -d. -f 1,2`
+ln -s libbz2.${so}.%{tmpversion} %{i}/lib/libbz2.${so}.`echo %{tmpversion} | cut -d. -f 1`
+ln -sf bzdiff %{i}/bin/bzcmp
+ln -sf bzgrep %{i}/bin/bzegrep
+ln -sf bzgrep %{i}/bin/bzfgrep
+ln -sf bzmore %{i}/bin/bzless
+
+# Strip libraries, we are not going to debug them.
+%define strip_files %{i}/lib
+# Look up documentation online.
+%define drop_files %{i}/man

--- a/db4-bootstrap.spec
+++ b/db4-bootstrap.spec
@@ -1,0 +1,18 @@
+### RPM external db4-bootstrap 4.4.20
+Source: http://download.oracle.com/berkeley-db/db-%{realversion}.NC.tar.gz
+%define drop_files %i/docs
+%define strip_files %i/lib
+
+%prep
+%setup -n db-%{realversion}.NC
+
+%build
+mkdir obj
+cd obj
+../dist/configure --prefix=%{i} --build="%{_build}" --host="%{_host}" \
+                  --disable-java --disable-tcl --disable-static
+make %{makeprocesses}
+
+%install
+cd obj
+make install

--- a/file-bootstrap.spec
+++ b/file-bootstrap.spec
@@ -1,0 +1,15 @@
+### RPM external file-bootstrap 5.13
+## INITENV SET MAGIC %{i}/share/misc/magic.mgc
+
+Source: ftp://ftp.fu-berlin.de/unix/tools/file/file-%{realversion}.tar.gz
+
+%define keep_archives true
+%define drop_files %{i}/share/man
+
+%prep  
+%setup -n file-%{realversion}
+
+%build
+./configure --prefix=%{i} --build="%{_build}" --host="%{_host}" \
+            --enable-static --disable-shared CFLAGS="-fPIC"
+make %{makeprocesses}

--- a/libxml2-bootstrap.spec
+++ b/libxml2-bootstrap.spec
@@ -1,0 +1,24 @@
+### RPM external libxml2-bootstrap 2.7.7
+%define downloadv %(echo %{realversion} | cut -d"_" -f1)
+Source: ftp://xmlsoft.org/libxml2/libxml2-%{downloadv}.tar.gz
+%define strip_files %{i}/lib/lib* %{i}/bin/{xmlcatalog,xmllint}
+%define drop_files %{i}/share/{man,doc,gtk-doc}
+
+Requires: zlib-bootstrap
+
+%prep
+%setup -n libxml2-%{downloadv}
+
+%build
+./configure --disable-static --prefix=%{i} --build="%{_build}" \
+            --host="%{_host}" --with-zlib="${ZLIB_BOOTSTRAP_ROOT}" --without-python
+make %{makeprocesses}
+
+%install
+make install
+rm -rf %{i}/lib/pkgconfig
+rm -rf %{i}/lib/*.{l,}a
+
+%post
+%{relocateConfig}bin/xml2-config
+%{relocateConfig}lib/xml2Conf.sh

--- a/lua-bootstrap.spec
+++ b/lua-bootstrap.spec
@@ -1,0 +1,15 @@
+### RPM external lua-bootstrap 5.1.5
+Source0: http://www.lua.org/ftp/lua-%{realversion}.tar.gz
+
+%define keep_archives true
+%define strip_files %{i}/{lib,bin}
+%define drop_files %{i}/{share,man}
+
+%prep  
+%setup -n lua-%{realversion}
+
+%build
+make -C src all MYLIBS="-ldl" MYCFLAGS="-fPIC -DLUA_USE_POSIX -DLUA_USE_DLOPEN"
+
+%install
+make install INSTALL_TOP=%{i}

--- a/nspr-bootstrap.spec
+++ b/nspr-bootstrap.spec
@@ -1,0 +1,23 @@
+### RPM external nspr-bootstrap 4.9.5
+Source: https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v%{realversion}/src/nspr-%{realversion}.tar.gz
+%define strip_files %{i}/lib
+
+%define isamd64 %(case %{cmsplatf} in (*amd64*|*_mic_*) echo 1 ;; (*) echo 0 ;; esac)
+%prep  
+%setup -n nspr-%{realversion}
+
+%build
+pushd mozilla/nsprpub
+CONF_OPTS="--disable-static --prefix=%{i} --build=%{_build} --host=%{_host}"
+%if %isamd64
+CONF_OPTS="${CONF_OPTS} --enable-64bit"
+%endif
+
+./configure ${CONF_OPTS}
+make %{makeprocesses}
+popd
+
+%install
+pushd mozilla/nsprpub
+make install
+popd

--- a/nss-bootstrap.spec
+++ b/nss-bootstrap.spec
@@ -1,0 +1,51 @@
+### RPM external nss-bootstrap 3.14.3
+%define release_version %(echo "%{realversion}" | tr . _)_RTM
+Source: https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_%{release_version}/src/nss-%{realversion}.tar.gz
+Requires: nspr-bootstrap sqlite-bootstrap
+Patch0: nss-3.14.3-add-SQLITE-LIBS-DIR
+Patch1: nss-3.14.3-add-ZLIB-LIBS-DIR-and-ZLIB-INCLUDE-DIR
+
+%define isamd64 %(case %{cmsplatf} in (*amd64*|*_mic_*) echo 1 ;; (*) echo 0 ;; esac)
+
+Requires: zlib-bootstrap
+
+%prep
+%setup -n nss-%{realversion}
+%patch0 -p1
+%patch1 -p1
+
+%build
+export NSPR_INCLUDE_DIR="${NSPR_BOOTSTRAP_ROOT}/include/nspr"
+export NSPR_LIB_DIR="${NSPR_BOOTSTRAP_ROOT}/lib"
+export USE_SYSTEM_ZLIB=1
+export ZLIB_INCLUDE_DIR="${ZLIB_BOOTSTRAP_ROOT}/include"
+export ZLIB_LIBS_DIR="${ZLIB_BOOTSTRAP_ROOT}/lib"
+export NSS_USE_SYSTEM_SQLITE=1
+export SQLITE_INCLUDE_DIR="${SQLITE_BOOTSTRAP_ROOT}/include"
+export SQLITE_LIBS_DIR="${SQLITE_BOOTSTRAP_ROOT}/lib"
+%if %isamd64
+export USE_64=1
+%endif
+
+make -C ./mozilla/security/coreconf clean
+make -C ./mozilla/security/dbm clean
+make -C ./mozilla/security/nss clean
+make -C ./mozilla/security/coreconf
+make -C ./mozilla/security/dbm
+make -C ./mozilla/security/nss
+
+%install
+case %{cmsplatf} in
+  osx*)
+    soname=dylib ;;
+  *)
+    soname=so ;;
+esac
+rm -rf %{i}/lib/libsoftokn3*
+rm -rf %{i}/lib/libsql*
+
+install -d %{i}/include/nss3
+install -d %{i}/lib
+find mozilla/dist/public/nss -name '*.h' -exec install -m 644 {} %{i}/include/nss3 \;
+find . -path "*/mozilla/dist/*.OBJ/lib/*.${soname}" -exec install -m 755 {} %{i}/lib \;
+%define strip_files %{i}/lib

--- a/openssl-bootstrap.spec
+++ b/openssl-bootstrap.spec
@@ -1,0 +1,101 @@
+### RPM external openssl-bootstrap 0.9.8e__1.0.1
+%define slc_version 0.9.8e
+%define generic_version 1.0.1
+Source0: http://www.openssl.org/source/openssl-%{generic_version}.tar.gz
+Source1: http://cmsrep.cern.ch/cmssw/openssl-sources/openssl-fips-%{slc_version}-usa.tar.bz2
+Patch0: openssl-0.9.8e-rh-0.9.8e-12.el5_4.6
+Patch1: openssl-x86-64-gcc420
+
+%define ismac %(case %{cmsplatf} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
+%define isfc %(case %{cmsplatf} in (fc*) echo 1 ;; (*) echo 0 ;; esac)
+%define isslc %(case %{cmsplatf} in (slc*) echo 1 ;; (*) echo 0 ;; esac)
+
+%prep
+%if %ismac
+%setup -b 0 -n openssl-%{generic_version}
+%endif
+%if %isfc
+%setup -b 0 -n openssl-%{generic_version}
+%endif
+%if %isslc
+%setup -b 1 -n openssl-fips-%{slc_version}
+%patch0 -p1
+%patch1 -p1
+%endif
+
+%build
+# Looks like rpmbuild passes its own sets of flags via the
+# RPM_OPT_FLAGS environment variable and those flags include
+# -m64 (probably since rpmbuild processor detection is not
+# fooled by linux32). A quick fix is to just set the variable
+# to "" but we should probably understand how rpm determines
+# those flags and use them for our own good.
+RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
+               -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
+               -fstack-protector --param=ssp-buffer-size=4"
+
+case "%{cmsplatf}" in
+  *armv7*)
+    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic-armv7-a"
+    ;;
+  *)
+    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic"
+    ;;
+esac
+
+export RPM_OPT_FLAGS
+
+case "%{cmsplatf}" in
+  osx*)
+    export KERNEL_BITS=64 # used by config to decide 64-bit build
+    cfg_args="-DOPENSSL_USE_NEW_FUNCTIONS"
+    ;;
+  fc*)
+    cfg_args="--with-krb5-flavor=MIT enable-krb5"
+    ;;
+  *)
+    cfg_args="--with-krb5-flavor=MIT enable-krb5 fipscanisterbuild"
+    ;;
+esac
+
+./config --prefix=%{i} ${cfg_args} enable-seed enable-tlsext enable-rfc3779 no-asm \
+                       no-idea no-mdc2 no-rc5 no-ec no-ecdh no-ecdsa shared
+
+case "%{cmsplatf}" in
+  fc*|osx*)
+    make depend
+    ;;
+esac
+
+make
+
+%install
+RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
+               -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
+               -fstack-protector --param=ssp-buffer-size=4"
+
+case "%{cmsplatf}" in
+  *armv7*)
+    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic-armv7-a"
+    ;;
+  *)
+    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic"
+    ;;
+esac
+
+export RPM_OPT_FLAGS
+
+make install
+
+rm -rf %{i}/lib/pkgconfig
+# We remove archive libraries because otherwise we need to propagate everywhere
+# their dependency on kerberos.
+rm -rf %{i}/lib/*.a
+
+# MacOSX is case insensitive and the man page structure has case sensitive logic
+case %cmsplatf in
+  osx* ) 
+    rm -rf %{i}/ssl/man
+    ;;
+esac
+perl -p -i -e "s|^#!.*perl|#!/usr/bin/env perl|" %{i}/ssl/misc/CA.pl %{i}/ssl/misc/der_chop %{i}/bin/c_rehash

--- a/popt-bootstrap.spec
+++ b/popt-bootstrap.spec
@@ -1,0 +1,13 @@
+### RPM external popt-bootstrap 1.16
+Source: http://rpm5.org/files/popt/popt-%{realversion}.tar.gz
+%define drop_files %{i}/share
+
+%prep  
+%setup -n popt-%{realversion}
+
+%build
+./configure --disable-static --disable-nls \
+            --prefix %{i} --build="%{_build}" --host="%{_host}" \
+            CFLAGS="-fPIC" \
+            CXXFLAGS="-fPIC"  
+make

--- a/sqlite-bootstrap.spec
+++ b/sqlite-bootstrap.spec
@@ -1,0 +1,15 @@
+### RPM external sqlite-bootstrap 3.7.17
+Source: http://www.sqlite.org/2013/sqlite-autoconf-3071700.tar.gz
+
+%prep
+%setup -n sqlite-autoconf-3071700
+
+%build
+./configure --build="%{_build}" --host="%{_host}" --prefix=%{i} \
+            --disable-tcl --disable-static
+make %{makeprocesses}
+
+%install
+make install
+rm -rf %{i}/lib/pkgconfig
+%define strip_files %{i}/lib

--- a/zlib-bootstrap.spec
+++ b/zlib-bootstrap.spec
@@ -1,0 +1,28 @@
+### RPM external zlib-bootstrap 1.2.8
+Source: http://zlib.net/zlib-%{realversion}.tar.gz
+
+%prep
+%setup -n zlib-%{realversion}
+
+%build
+
+case %{cmsplatf} in
+   *_amd64_gcc4[56789]*|*_mic_* )
+     CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1 -msse3" \
+     ./configure --prefix=%{i}
+     ;;
+   *_armv7hl_gcc4[56789]* )
+     CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1" \
+     ./configure --prefix=%{i}
+     ;;
+   * )
+     ./configure --prefix=%{i}
+     ;;
+esac
+
+make %{makeprocesses}
+
+# Strip libraries, we are not going to debug them.
+%define strip_files %{i}/lib
+# Look up documentation online.
+%define drop_files %{i}/share


### PR DESCRIPTION
This allows us to bundle all the needed externals of rpm/apt into one rpm (bootstrap-bundle) and make gcc a build time dependency. This reduces the bootstrap size to 35MB from 560MB.

Note, this just touches apt.spec and rpm.spec (plus new *-bootstraps.spec) only. So it is safe to merge it in to stable branch of 70X. This is not going to trigger a re-built or any thing (unless one explicitly build apt/rpm or bootstrap-driver).

I have tested it for slc6_amd64_gcc481, slc5_amd64_gcc481, osx108_amd64_gcc481, fc18_armv7hl_gcc481 and slc6_mic_gcc481.

NOTE: I am having problems forking the cmsdist repo. So I have created a branch in cms-sw/cmsdist. Feel free to delete this branch once merge is done.
