### PR TITLE
task summary view add use 0.9.79c from ticoann private repository

### DIFF
--- a/reqmon.spec
+++ b/reqmon.spec
@@ -1,7 +1,11 @@
-### RPM cms reqmon 0.9.79
+### RPM cms reqmon 0.9.79c
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 
-Source0: git://github.com/dmwm/WMCore?obj=master/%realversion&export=%n&output=/%n.tar.gz
+#Source0: git://github.com/dmwm/WMCore?obj=master/%realversion&export=%n&output=/%n.tar.gz
+
+#from private repository
+Source: git://github.com/ticoann/WMCore?obj=wmstats_task_summary/%realversion&export=%n&output=/%n.tar.gz
+
 Requires: python rotatelogs
 BuildRequires: py2-setuptools py2-sphinx couchskel
 


### PR DESCRIPTION
Hi Diego, Alan told me that you could update wmstats this time. This patch is created by ops request.
Once successful job filter is applied in the agents they will loose some success job information per task.
This patch will compensate that. Please deploy on the testbed.
Sorry for the hassle.

This takes WMCore 0.9.79c tag from my private repository
