### PR TITLE
Update to V05-01-03-01 to enable MISSING_SYMBOL_FLAGS on Fedora

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-03
+%define configtag       V05-01-03-01
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
Signed-off-by: David Abdurachmanov davidlt@cern.ch
