### PR TITLE
bootstrap-driver: add NOCOMPILER flags for cmsBuild

### DIFF
--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -1,4 +1,6 @@
 ### RPM external bootstrap-driver 20.0
+## NOCOMPILER
+
 Source: bootstrap
 
 Requires: apt


### PR DESCRIPTION
The current bootstrap-driver still brings in GCC, the biggest
depenendency. The patch removes it, by adding NOCOMPILER flag.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
