### PR TITLE
[CMSSW_7_0_X] root: bump version to 5.34.10; apply 6 thread safety patches

### DIFF
--- a/0001-Use-meta-data-mutex-for-the-proxy-initialization.patch
+++ b/0001-Use-meta-data-mutex-for-the-proxy-initialization.patch
@@ -1,0 +1,61 @@
+From ba443df888664becb07009f785ae5c94c0171ffa Mon Sep 17 00:00:00 2001
+From: David Abdurachmanov <David.Abdurachmanov@cern.ch>
+Date: Tue, 22 Oct 2013 14:14:31 +0200
+Subject: [PATCH 1/2] Use meta-data mutex for the proxy initialization.
+
+This avoid nesting the collection and the meta-data mutex.
+
+Backport: 0c40533fe73f8312944ae0f2636ede51b2a33cfb
+
+Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>
+---
+ io/io/src/TEmulatedCollectionProxy.cxx |    3 ++-
+ io/io/src/TGenCollectionProxy.cxx      |    4 +++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/io/io/src/TEmulatedCollectionProxy.cxx b/io/io/src/TEmulatedCollectionProxy.cxx
+index 0eb85d6..d6e3acf 100644
+--- a/io/io/src/TEmulatedCollectionProxy.cxx
++++ b/io/io/src/TEmulatedCollectionProxy.cxx
+@@ -32,6 +32,7 @@
+ #include "Riostream.h"
+ 
+ #include "TVirtualMutex.h" // For R__LOCKGUARD
++#include "TInterpreter.h"  // For gCINTMutex
+ 
+ //
+ // Utility function to allow the creation of a TClass for a std::pair without
+@@ -110,7 +111,7 @@ void TEmulatedCollectionProxy::DeleteArray(void* p, Bool_t dtorOnly) const
+ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
+ {
+    // Proxy initializer
+-   R__LOCKGUARD2(gCollectionMutex);
++   R__LOCKGUARD2(gCINTMutex);
+    if (fClass) return this;
+ 
+ 
+diff --git a/io/io/src/TGenCollectionProxy.cxx b/io/io/src/TGenCollectionProxy.cxx
+index 4c2a9fa..44009e4 100644
+--- a/io/io/src/TGenCollectionProxy.cxx
++++ b/io/io/src/TGenCollectionProxy.cxx
+@@ -36,6 +36,8 @@
+ #include "TStreamerInfoActions.h"
+ #include <stdlib.h>
+ 
++#include "TInterpreter.h" // For gCINTMutex
++
+ #define MESSAGE(which,text)
+ 
+ std::vector<TVirtualCollectionProxy*> gSlowIterator__Proxy;
+@@ -771,7 +773,7 @@ static TGenCollectionProxy::Value *R__CreateValue(const std::string &name, Bool_
+ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
+ {
+    // Proxy initializer
+-   R__LOCKGUARD2(gCollectionMutex);
++   R__LOCKGUARD2(gCINTMutex);
+    if (fValue) return this;
+ 
+    TClass *cl = fClass ? fClass.GetClass() : TClass::GetClass(fTypeinfo,kTRUE,silent);
+-- 
+1.7.4.1
+

--- a/0002-Fix-thread-safety-of-TThread-TThread-Long_t-id.patch
+++ b/0002-Fix-thread-safety-of-TThread-TThread-Long_t-id.patch
@@ -1,0 +1,35 @@
+From ca4eea119f2c5fed85665d7e2386cde843fbb554 Mon Sep 17 00:00:00 2001
+From: Philippe Canal <pcanal@fnal.gov>
+Date: Thu, 17 Oct 2013 05:07:29 -0500
+Subject: [PATCH] Fix thread safety of TThread::TThread(Long_t id)
+
+Changing fId is a common ressource (see TThread::GetThread)
+and thus its update must be locked.
+
+(cherry picked from commit c85bd1176dee1629ac1beb0d7f57003198dd281a)
+---
+ core/thread/src/TThread.cxx |    5 +++++
+ 1 files changed, 5 insertions(+), 0 deletions(-)
+
+diff --git a/core/thread/src/TThread.cxx b/core/thread/src/TThread.cxx
+index 0fc81bb..bfb1851 100644
+--- a/core/thread/src/TThread.cxx
++++ b/core/thread/src/TThread.cxx
+@@ -246,9 +246,14 @@ TThread::TThread(Long_t id)
+    fPriority  = kNormalPriority;
+    fThreadArg = 0;
+    Constructor();
++
++   // Changing the id must be protected as it will be look at by multiple
++   // threads (see TThread::GetThread)
++   ThreadInternalLock();
+    fNamed     = kFALSE;
+    fId = (id ? id : SelfId());
+    fState = kRunningState;
++   ThreadInternalUnLock();
+ 
+    if (gDebug)
+       Info("TThread::TThread", "TThread attached to running thread");
+-- 
+1.7.4.1
+

--- a/0003-Reduce-lifetime-of-lock-in-TFile-TFile-to-avoid-lock.patch
+++ b/0003-Reduce-lifetime-of-lock-in-TFile-TFile-to-avoid-lock.patch
@@ -1,0 +1,32 @@
+From b5bdb586635f61817bfa14b0eba07ac5014fe602 Mon Sep 17 00:00:00 2001
+From: Philippe Canal <pcanal@fnal.gov>
+Date: Fri, 18 Oct 2013 06:08:54 -0500
+Subject: [PATCH] Reduce lifetime of lock in TFile::~TFile to avoid lock nesting.
+
+No need to hold the gROOTMutex while executing ResetGlobalVar.
+---
+ io/io/src/TFile.cxx |    8 +++++---
+ 1 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/io/io/src/TFile.cxx b/io/io/src/TFile.cxx
+index 56295da..866ec71 100644
+--- a/io/io/src/TFile.cxx
++++ b/io/io/src/TFile.cxx
+@@ -514,9 +514,11 @@ TFile::~TFile()
+    SafeDelete(fInfoCache);
+    SafeDelete(fOpenPhases);
+ 
+-   R__LOCKGUARD2(gROOTMutex);
+-   gROOT->GetListOfClosedObjects()->Remove(this);
+-   gROOT->GetUUIDs()->RemoveUUID(GetUniqueID());
++   {
++      R__LOCKGUARD2(gROOTMutex);
++      gROOT->GetListOfClosedObjects()->Remove(this);
++      gROOT->GetUUIDs()->RemoveUUID(GetUniqueID());
++   }
+ 
+    if (IsOnHeap()) {
+       // Delete object from CINT symbol table so it can not be used anymore.
+-- 
+1.7.4.1
+

--- a/0004-Reduce-lock-lifetime-in-TCollection-GarbageCollect.patch
+++ b/0004-Reduce-lock-lifetime-in-TCollection-GarbageCollect.patch
@@ -1,0 +1,43 @@
+From 2563f5f047c24201257be3077b1ccaab6117a166 Mon Sep 17 00:00:00 2001
+From: Philippe Canal <pcanal@fnal.gov>
+Date: Fri, 18 Oct 2013 05:21:16 -0500
+Subject: [PATCH] Reduce lock lifetime in TCollection::GarbageCollect
+
+This avoid the potential for unnecessary nested locks
+when/if the routine actually deletes the object.
+---
+ core/cont/src/TCollection.cxx |   18 ++++++++++--------
+ 1 files changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/core/cont/src/TCollection.cxx b/core/cont/src/TCollection.cxx
+index c632446..8fe4b74 100644
+--- a/core/cont/src/TCollection.cxx
++++ b/core/cont/src/TCollection.cxx
+@@ -581,14 +581,16 @@ void TCollection::GarbageCollect(TObject *obj)
+ {
+    // Add to the list of things to be cleaned up.
+ 
+-   R__LOCKGUARD2(gCollectionMutex);
+-   if (fgGarbageCollection) {
+-      if (!fgEmptyingGarbage) {
+-         fgGarbageCollection->Add(obj);
+-      } else
+-         delete obj;
+-   } else
+-      delete obj;
++   {
++      R__LOCKGUARD2(gCollectionMutex);
++      if (fgGarbageCollection) {
++         if (!fgEmptyingGarbage) {
++            fgGarbageCollection->Add(obj);
++            return;
++         }
++      }
++   }
++   delete obj;
+ }
+ 
+ //______________________________________________________________________________
+-- 
+1.7.4.1
+

--- a/0005-Remove-unnecessary-global-variable-and-lock.patch
+++ b/0005-Remove-unnecessary-global-variable-and-lock.patch
@@ -1,0 +1,199 @@
+From 9651eb210234ae6fd048f74f9bc4d29989c79f2f Mon Sep 17 00:00:00 2001
+From: Philippe Canal <pcanal@fnal.gov>
+Date: Fri, 18 Oct 2013 04:43:11 -0500
+Subject: [PATCH] Remove unnecessary global variable and lock
+
+gUtmpContents was used only as a data passing mechanism
+between related routines and its content had a short lifetime.
+
+This avoids having to put a lock in TUnixSystem::SetDisplay
+and (trivially) avoid introducing a possible dead-lock with the lock
+being taken as part of 'Warning'.
+
+Conflicts:
+	core/unix/inc/TUnixSystem.h
+---
+ core/unix/inc/TUnixSystem.h   |    3 -
+ core/unix/src/TUnixSystem.cxx |  129 +++++++++++++++++++++-------------------
+ 2 files changed, 68 insertions(+), 64 deletions(-)
+
+diff --git a/core/unix/inc/TUnixSystem.h b/core/unix/inc/TUnixSystem.h
+index 9e8814e..0cc6e4a 100644
+--- a/core/unix/inc/TUnixSystem.h
++++ b/core/unix/inc/TUnixSystem.h
+@@ -78,9 +78,6 @@ protected:
+    static void         UnixDynListSymbols(const char *lib, const char *re = "");
+    static void         UnixDynListLibs(const char *lib = "");
+ 
+-   static void        *SearchUtmpEntry(int nentries, const char *tty);
+-   static int          ReadUtmpFile();
+-
+ public:
+    TUnixSystem();
+    virtual ~TUnixSystem();
+diff --git a/core/unix/src/TUnixSystem.cxx b/core/unix/src/TUnixSystem.cxx
+index 0fc491b8..979a0df 100644
+--- a/core/unix/src/TUnixSystem.cxx
++++ b/core/unix/src/TUnixSystem.cxx
+@@ -304,8 +304,72 @@ enum {
+ // End FPE handling includes
+ 
+ 
+-static STRUCT_UTMP *gUtmpContents;
++struct TUtmpContent {
++   STRUCT_UTMP *fUtmpContents;
++   UInt_t       fEntries; // Number of entries in utmp file.
++   
++   TUtmpContent() : fUtmpContents(0) {}
++   ~TUtmpContent() { free(fUtmpContents); }
++   
++   STRUCT_UTMP *SearchUtmpEntry(const char *tty)
++   {
++      // Look for utmp entry which is connected to terminal tty.
++      
++      STRUCT_UTMP *ue = fUtmpContents;
++      
++      UInt_t n = fEntries;
++      while (n--) {
++         if (ue->ut_name[0] && !strncmp(tty, ue->ut_line, sizeof(ue->ut_line)))
++            return ue;
++         ue++;
++      }
++      return 0;
++   }
++   
++   int ReadUtmpFile()
++   {
++      // Read utmp file. Returns number of entries in utmp file.
++      
++      FILE  *utmp;
++      struct stat file_stats;
++      size_t n_read, size;
++      
++      fEntries = 0;
++      
++      R__LOCKGUARD2(gSystemMutex);
++      
++      utmp = fopen(UTMP_FILE, "r");
++      if (!utmp)
++         return 0;
++      
++      fstat(fileno(utmp), &file_stats);
++      size = file_stats.st_size;
++      if (size <= 0) {
++         fclose(utmp);
++         return 0;
++      }
++      
++      fUtmpContents = (STRUCT_UTMP *) malloc(size);
++      if (!fUtmpContents) {
++         fclose(utmp);
++         return 0;
++      }
++      
++      n_read = fread(fUtmpContents, 1, size, utmp);
++      if (!ferror(utmp)) {
++         if (fclose(utmp) != EOF && n_read == size) {
++            fEntries = size / sizeof(STRUCT_UTMP);
++            return fEntries;
++         }
++      } else
++         fclose(utmp);
++      
++      free(fUtmpContents);
++      fUtmpContents = 0;
++      return 0;
++   }
+ 
++};
+ 
+ const char *kServerPath     = "/tmp";
+ const char *kProtocolName   = "tcp";
+@@ -618,9 +682,10 @@ void TUnixSystem::SetDisplay()
+       if (tty) {
+          tty += 5;               // remove "/dev/"
+ 
+-         R__LOCKGUARD2(gSystemMutex);
++         TUtmpContent utmp;
++         utmp.ReadUtmpFile();
+ 
+-         STRUCT_UTMP *utmp_entry = (STRUCT_UTMP *)SearchUtmpEntry(ReadUtmpFile(), tty);
++         STRUCT_UTMP *utmp_entry = utmp.SearchUtmpEntry(tty);
+          if (utmp_entry) {
+             if (utmp_entry->ut_host[0]) {
+                if (strchr(utmp_entry->ut_host, ':')) {
+@@ -649,7 +714,6 @@ void TUnixSystem::SetDisplay()
+             }
+ #endif
+          }
+-         free(gUtmpContents);
+       }
+    }
+ }
+@@ -4892,63 +4956,6 @@ void TUnixSystem::UnixDynUnload(const char *lib)
+ #endif
+ }
+ 
+-//______________________________________________________________________________
+-int TUnixSystem::ReadUtmpFile()
+-{
+-   // Read utmp file. Returns number of entries in utmp file.
+-
+-   FILE  *utmp;
+-   struct stat file_stats;
+-   size_t n_read, size;
+-
+-   R__LOCKGUARD2(gSystemMutex);
+-
+-   gUtmpContents = 0;
+-
+-   utmp = fopen(UTMP_FILE, "r");
+-   if (!utmp)
+-      return 0;
+-
+-   fstat(fileno(utmp), &file_stats);
+-   size = file_stats.st_size;
+-   if (size <= 0) {
+-      fclose(utmp);
+-      return 0;
+-   }
+-
+-   gUtmpContents = (STRUCT_UTMP *) malloc(size);
+-   if (!gUtmpContents) {
+-      fclose(utmp);
+-      return 0;
+-   }
+-
+-   n_read = fread(gUtmpContents, 1, size, utmp);
+-   if (!ferror(utmp)) {
+-      if (fclose(utmp) != EOF && n_read == size)
+-         return size / sizeof(STRUCT_UTMP);
+-   } else
+-      fclose(utmp);
+-
+-   free(gUtmpContents);
+-   gUtmpContents = 0;
+-   return 0;
+-}
+-
+-//______________________________________________________________________________
+-void *TUnixSystem::SearchUtmpEntry(int n, const char *tty)
+-{
+-   // Look for utmp entry which is connected to terminal tty.
+-
+-   STRUCT_UTMP *ue = gUtmpContents;
+-
+-   while (n--) {
+-      if (ue->ut_name[0] && !strncmp(tty, ue->ut_line, sizeof(ue->ut_line)))
+-         return ue;
+-      ue++;
+-   }
+-   return 0;
+-}
+-
+ //---- System, CPU and Memory info ---------------------------------------------
+ 
+ #if defined(R__MACOSX)
+-- 
+1.7.4.1
+

--- a/0006-Fix-thread-safety-of-TGenCollectionProxy-s-iterator-.patch
+++ b/0006-Fix-thread-safety-of-TGenCollectionProxy-s-iterator-.patch
@@ -1,0 +1,392 @@
+From f6d7496a63ab3e4a1f847e6c36791692f93b6a5f Mon Sep 17 00:00:00 2001
+From: David Abdurachmanov <David.Abdurachmanov@cern.ch>
+Date: Tue, 22 Oct 2013 14:19:05 +0200
+Subject: [PATCH 2/2] Fix thread safety of TGenCollectionProxy's iterator creation.
+
+The major change is that the utility routine returned by
+TVirtualCollectionProxy::GetFunctionCreateIterators
+now has the prototype:
+
+typedef void (*CreateIterators_t)(void *collection, void **begin_arena, void **end_arena, TVirtualCollectionProxy *proxy);
+
+i.e. adding a new pointer to the virtual collection proxy so
+that in the case where the routine can not hard code all
+the information (for example in the case of emulated collection
+proxy) it can now get the information from a the CollectionProxy
+without relying on the calls to PushProxy (which we are trying
+to deprecate in general as it is somewhat thread adverse).
+
+Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>
+---
+ cint/reflex/inc/Reflex/Builder/CollectionProxy.h |   15 +++++++++------
+ core/cont/inc/TCollectionProxyInfo.h             |   14 +++++++-------
+ core/cont/inc/TVirtualCollectionProxy.h          |    4 ++--
+ io/io/inc/TVirtualCollectionIterators.h          |   10 +++++-----
+ io/io/src/TGenCollectionProxy.cxx                |   20 +++++---------------
+ io/io/src/TStreamerInfoActions.cxx               |   12 ++++++------
+ tree/tree/src/TBranchElement.cxx                 |    8 ++++----
+ 7 files changed, 38 insertions(+), 45 deletions(-)
+
+diff --git a/cint/reflex/inc/Reflex/Builder/CollectionProxy.h b/cint/reflex/inc/Reflex/Builder/CollectionProxy.h
+index 34a540e..ce1eb10 100644
+--- a/cint/reflex/inc/Reflex/Builder/CollectionProxy.h
++++ b/cint/reflex/inc/Reflex/Builder/CollectionProxy.h
+@@ -22,6 +22,9 @@
+ #define REFLEX_COLLECTIONPROXY_VERSION 3
+ 
+ // Forward declarations
++
++class TVirtualCollectionProxy;
++
+ namespace std {
+    template <class T, class A> class deque;
+    template <class T, class A> class vector;
+@@ -141,7 +144,7 @@ namespace Reflex  {
+          typedef Cont_t *PCont_t;
+          typedef typename Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy *) {
+             PCont_t c = PCont_t(coll);
+             new (*begin_arena) iterator(c->begin());
+             new (*end_arena) iterator(c->end());
+@@ -182,7 +185,7 @@ namespace Reflex  {
+          typedef Cont_t *PCont_t;
+          typedef typename Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy *) {
+             PCont_t c = PCont_t(coll);
+             if (c->empty()) {
+                *begin_arena = 0;
+@@ -219,7 +222,7 @@ namespace Reflex  {
+          typedef Cont_t *PCont_t;
+          typedef Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy *) {
+             PCont_t c = PCont_t(coll);
+             new (*begin_arena) iterator(c->begin());
+             new (*end_arena) iterator(c->end());
+@@ -255,7 +258,7 @@ namespace Reflex  {
+          typedef Cont_t *PCont_t;
+          typedef typename Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy *) {
+             PCont_t  c = PCont_t(coll);
+             *begin_arena = new iterator(c->begin());
+             *end_arena = new iterator(c->end());        
+@@ -563,7 +566,7 @@ namespace Reflex  {
+       void*  (*create_env)();
+ 
+       // Set of function of direct iteration of the collections.
+-      void (*fCreateIterators)(void *collection, void **begin_arena, void **end_arena); 
++      void (*fCreateIterators)(void *collection, void **begin_arena, void **end_arena, TVirtualCollectionProxy *proxy);
+       // begin_arena and end_arena should contain the location of memory arena  of size fgIteratorSize. 
+       // If the collection iterator are of that size or less, the iterators will be constructed in place in those location (new with placement)
+       // Otherwise the iterators will be allocated via a regular new and their address returned by modifying the value of begin_arena and end_arena.
+@@ -912,7 +915,7 @@ namespace Reflex  {
+          // In the other iterator we store the index
+          // and the value.
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy *) {
+             iterator *begin = new (*begin_arena) iterator;
+             begin->first.fIndex = 0;
+             begin->second = false;
+diff --git a/core/cont/inc/TCollectionProxyInfo.h b/core/cont/inc/TCollectionProxyInfo.h
+index d2ac21d..d56b758 100644
+--- a/core/cont/inc/TCollectionProxyInfo.h
++++ b/core/cont/inc/TCollectionProxyInfo.h
+@@ -78,7 +78,7 @@ namespace ROOT {
+          typedef Cont_t *PCont_t;
+          typedef typename Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy*) {
+             PCont_t c = PCont_t(coll);
+             new (*begin_arena) iterator(c->begin());
+             new (*end_arena) iterator(c->end());
+@@ -119,7 +119,7 @@ namespace ROOT {
+          typedef Cont_t *PCont_t;
+          typedef typename Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy*) {
+             PCont_t c = PCont_t(coll);
+             if (c->empty()) {
+                *begin_arena = 0;
+@@ -155,7 +155,7 @@ namespace ROOT {
+          typedef Cont_t *PCont_t;
+          typedef typename Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy*) {
+             PCont_t  c = PCont_t(coll);
+             *begin_arena = new iterator(c->begin());
+             *end_arena = new iterator(c->end());        
+@@ -442,7 +442,7 @@ namespace ROOT {
+       void*  (*fCreateEnv)();
+       
+       // Set of function of direct iteration of the collections.
+-      void (*fCreateIterators)(void *collection, void **begin_arena, void **end_arena); 
++      void (*fCreateIterators)(void *collection, void **begin_arena, void **end_arena, TVirtualCollectionProxy *proxy);
+       // begin_arena and end_arena should contain the location of memory arena  of size fgIteratorSize. 
+       // If the collection iterator are of that size or less, the iterators will be constructed in place in those location (new with placement)
+       // Otherwise the iterators will be allocated via a regular new and their address returned by modifying the value of begin_arena and end_arena.
+@@ -478,7 +478,7 @@ namespace ROOT {
+                            void*  (*feed_func)(void*,void*,size_t),
+                            void*  (*collect_func)(void*,void*),
+                            void*  (*create_env)(),
+-                           void   (*getIterators)(void *collection, void **begin_arena, void **end_arena) = 0,
++                           void   (*getIterators)(void *collection, void **begin_arena, void **end_arena, TVirtualCollectionProxy *proxy) = 0,
+                            void*  (*copyIterator)(void *dest, const void *source) = 0,
+                            void*  (*next)(void *iter, const void *end) = 0,
+                            void   (*deleteSingleIterator)(void *iter) = 0,
+@@ -617,7 +617,7 @@ namespace ROOT {
+          typedef Cont_t *PCont_t;
+          typedef Cont_t::iterator iterator;
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy*) {
+             PCont_t c = PCont_t(coll);
+             new (*begin_arena) iterator(c->begin());
+             new (*end_arena) iterator(c->end());
+@@ -759,7 +759,7 @@ namespace ROOT {
+          // In the other iterator we store the index
+          // and the value.
+ 
+-         static void create(void *coll, void **begin_arena, void **end_arena) {
++         static void create(void *coll, void **begin_arena, void **end_arena, TVirtualCollectionProxy*) {
+             iterator *begin = new (*begin_arena) iterator;
+             begin->first.fIndex = 0;
+             begin->second = false;
+diff --git a/core/cont/inc/TVirtualCollectionProxy.h b/core/cont/inc/TVirtualCollectionProxy.h
+index f761e5a..8a495b2 100644
+--- a/core/cont/inc/TVirtualCollectionProxy.h
++++ b/core/cont/inc/TVirtualCollectionProxy.h
+@@ -1,4 +1,4 @@
+-// @(#)root/cont:$Id$
++// @(#)root/cont:$Id: f761e5ab393bb556962776de666bc9dd0b6e738b $
+ // Author: Philippe Canal 20/08/2003
+ 
+ /*************************************************************************
+@@ -159,7 +159,7 @@ public:
+    // Set of functions to iterate easily throught the collection
+    static const Int_t fgIteratorArenaSize = 16; // greater than sizeof(void*) + sizeof(UInt_t)
+ 
+-   typedef void (*CreateIterators_t)(void *collection, void **begin_arena, void **end_arena);
++   typedef void (*CreateIterators_t)(void *collection, void **begin_arena, void **end_arena, TVirtualCollectionProxy *proxy);
+    virtual CreateIterators_t GetFunctionCreateIterators(Bool_t read = kTRUE) = 0; 
+    // begin_arena and end_arena should contain the location of a memory arena of size fgIteratorSize. 
+    // If the collection iterator are of that size or less, the iterators will be constructed in place in those location (new with placement)
+diff --git a/io/io/inc/TVirtualCollectionIterators.h b/io/io/inc/TVirtualCollectionIterators.h
+index e00edea..8f5fc7f 100644
+--- a/io/io/inc/TVirtualCollectionIterators.h
++++ b/io/io/inc/TVirtualCollectionIterators.h
+@@ -1,4 +1,4 @@
+-// @(#)root/cont:$Id$
++// @(#)root/cont:$Id: e00edea30f17233d3f97a85eba14e20c201eb980 $
+ // Author: Philippe Canal 20/08/2010
+ 
+ /*************************************************************************
+@@ -63,11 +63,11 @@ public:
+    {
+    }
+    
+-   inline void CreateIterators(void *collection)
++   inline void CreateIterators(void *collection, TVirtualCollectionProxy *proxy)
+    {
+       // Initialize the fBegin and fEnd iterators.
+       
+-      fCreateIterators(collection, &fBegin, &fEnd);
++      fCreateIterators(collection, &fBegin, &fEnd, proxy);
+    }
+    
+    inline ~TVirtualCollectionIterators() 
+@@ -143,13 +143,13 @@ public:
+       }
+    }
+    
+-   inline void CreateIterators(void *collection)
++   inline void CreateIterators(void *collection, TVirtualCollectionProxy *proxy)
+    {
+       // Initialize the fBegin and fEnd iterators.
+       
+       fBegin = &(fRawBeginBuffer[0]);
+       fEnd = &(fRawEndBuffer[0]);
+-      fCreateIterators(collection, &fBegin, &fEnd);
++      fCreateIterators(collection, &fBegin, &fEnd, proxy);
+       if (fBegin != &(fRawBeginBuffer[0])) {
+          // The iterator where too large to buffer in the  buffer
+          fAllocated = kTRUE;
+diff --git a/io/io/src/TGenCollectionProxy.cxx b/io/io/src/TGenCollectionProxy.cxx
+index 44009e4..451bc08 100644
+--- a/io/io/src/TGenCollectionProxy.cxx
++++ b/io/io/src/TGenCollectionProxy.cxx
+@@ -40,8 +40,6 @@
+ 
+ #define MESSAGE(which,text)
+ 
+-std::vector<TVirtualCollectionProxy*> gSlowIterator__Proxy;
+-
+ //////////////////////////////////////////////////////////////////////////
+ //                                                                      //
+ //  class TGenVectorProxy
+@@ -1121,8 +1119,6 @@ void TGenCollectionProxy::PushProxy(void *objstart)
+ {
+    // Add an object.
+ 
+-   gSlowIterator__Proxy.push_back(this);
+-
+    if ( !fValue ) Initialize(kFALSE);
+    if ( !fProxyList.empty() ) {
+       EnvironBase_t* back = fProxyList.back();
+@@ -1158,8 +1154,6 @@ void TGenCollectionProxy::PopProxy()
+ {
+    // Remove the last object.
+ 
+-   gSlowIterator__Proxy.pop_back();
+-   
+    if ( !fProxyList.empty() ) {
+       EnvironBase_t* e = fProxyList.back();
+       if ( --e->fRefCount <= 0 ) {
+@@ -1277,10 +1271,10 @@ struct TGenCollectionProxy__SlowIterator {
+ };
+ 
+ //______________________________________________________________________________
+-void TGenCollectionProxy__SlowCreateIterators(void * /* collection */, void **begin_arena, void **end_arena) 
++void TGenCollectionProxy__SlowCreateIterators(void * /* collection */, void **begin_arena, void **end_arena, TVirtualCollectionProxy *proxy)
+ {
+-   new (*begin_arena) TGenCollectionProxy__SlowIterator(gSlowIterator__Proxy.back());
+-   *(UInt_t*)*end_arena = gSlowIterator__Proxy.back()->Size();
++   new (*begin_arena) TGenCollectionProxy__SlowIterator(proxy);
++   *(UInt_t*)*end_arena = proxy->Size();
+ }
+ 
+ //______________________________________________________________________________
+@@ -1317,7 +1311,7 @@ void TGenCollectionProxy__SlowDeleteTwoIterators(void *, void *)
+ 
+ 
+ //______________________________________________________________________________
+-void TGenCollectionProxy__VectorCreateIterators(void *obj, void **begin_arena, void **end_arena) 
++void TGenCollectionProxy__VectorCreateIterators(void *obj, void **begin_arena, void **end_arena, TVirtualCollectionProxy*)
+ {
+    // We can safely assume that the std::vector layout does not really depend on
+    // the content!
+@@ -1335,10 +1329,6 @@ void TGenCollectionProxy__VectorCreateIterators(void *obj, void **begin_arena, v
+    *end_arena = &(*vec->end());
+ #endif
+    
+-   // The following is a safer way but require the caller to have called TPushPop
+-   //   TVirtualCollectionProxy *proxy = gSlowIterator__Proxy.back();
+-   //   void *good_begin_arena = proxy->At(0);
+-   //   void *good_end_arena = ((char*)proxy->At(0)) + proxy->Size() * proxy->GetIncrement();
+ }
+ 
+ //______________________________________________________________________________
+@@ -1371,7 +1361,7 @@ void TGenCollectionProxy__VectorDeleteTwoIterators(void *, void *)
+ 
+ 
+ //______________________________________________________________________________
+-void TGenCollectionProxy__StagingCreateIterators(void *obj, void **begin_arena, void **end_arena) 
++void TGenCollectionProxy__StagingCreateIterators(void *obj, void **begin_arena, void **end_arena, TVirtualCollectionProxy *)
+ {
+    TGenCollectionProxy::TStaging * s = (TGenCollectionProxy::TStaging*)obj;
+    *begin_arena = s->GetContent();
+diff --git a/io/io/src/TStreamerInfoActions.cxx b/io/io/src/TStreamerInfoActions.cxx
+index f64f861..15cc5e8 100644
+--- a/io/io/src/TStreamerInfoActions.cxx
++++ b/io/io/src/TStreamerInfoActions.cxx
+@@ -490,7 +490,7 @@ namespace TStreamerInfoActions
+             char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+             void *begin = &(startbuf[0]);
+             void *end = &(endbuf[0]);
+-            config->fCreateIterators(alternative, &begin, &end );
++            config->fCreateIterators(alternative, &begin, &end, oldProxy);
+             // We can not get here with a split vector of pointer, so we can indeed assume
+             // that actions->fConfiguration != null.
+             buf.ApplySequence(*actions, begin, end);
+@@ -565,7 +565,7 @@ namespace TStreamerInfoActions
+                char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                void *begin = &(startbuf[0]);
+                void *end = &(endbuf[0]);
+-               config->fCreateIterators(alternative, &begin, &end );
++               config->fCreateIterators(alternative, &begin, &end, oldProxy);
+                // We can not get here with a split vector of pointer, so we can indeed assume
+                // that actions->fConfiguration != null.
+                buf.ApplySequence(*actions, begin, end);
+@@ -643,7 +643,7 @@ namespace TStreamerInfoActions
+             char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+             void *begin = &(startbuf[0]);
+             void *end = &(endbuf[0]);
+-            config->fCreateIterators( alternative, &begin, &end );
++            config->fCreateIterators( alternative, &begin, &end, newProxy);
+             // We can not get here with a split vector of pointer, so we can indeed assume
+             // that actions->fConfiguration != null.
+             buf.ApplySequence(*actions, begin, end);
+@@ -692,7 +692,7 @@ namespace TStreamerInfoActions
+                char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                void *begin = &(startbuf[0]);
+                void *end = &(endbuf[0]);
+-               config->fCreateIterators( alternative, &begin, &end );
++               config->fCreateIterators( alternative, &begin, &end, newProxy);
+                // We can not get here with a split vector of pointer, so we can indeed assume
+                // that actions->fConfiguration != null.
+                buf.ApplySequence(*actions, begin, end);
+@@ -1516,7 +1516,7 @@ namespace TStreamerInfoActions
+             char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+             void *begin = &(startbuf[0]);
+             void *end = &(endbuf[0]);
+-            config->fCreateIterators(alternative, &begin, &end );
++            config->fCreateIterators(alternative, &begin, &end, newProxy);
+             // We can not get here with a split vector of pointer, so we can indeed assume
+             // that actions->fConfiguration != null.
+ 
+@@ -1871,7 +1871,7 @@ namespace TStreamerInfoActions
+             char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+             void *begin = &(startbuf[0]);
+             void *end = &(endbuf[0]);
+-            config->fCreateIterators(alternative, &begin, &end );
++            config->fCreateIterators(alternative, &begin, &end, newProxy);
+             // We can not get here with a split vector of pointer, so we can indeed assume
+             // that actions->fConfiguration != null.
+             
+diff --git a/tree/tree/src/TBranchElement.cxx b/tree/tree/src/TBranchElement.cxx
+index 2615eca..7de358b 100644
+--- a/tree/tree/src/TBranchElement.cxx
++++ b/tree/tree/src/TBranchElement.cxx
+@@ -1409,7 +1409,7 @@ void TBranchElement::FillLeavesCollection(TBuffer& b)
+    b << n;
+ 
+    if(fSTLtype != TClassEdit::kVector && proxy->HasPointers() && fSplitLevel > TTree::kSplitCollectionOfPointers ) {
+-      fPtrIterators->CreateIterators(fObject);
++      fPtrIterators->CreateIterators(fObject, proxy);
+    } else {
+       //NOTE: this does not work for not vectors since the CreateIterators expects a TGenCollectionProxy::TStaging as its argument!
+       //NOTE: and those not work in general yet, since the TStaging object is neither created nor passed.
+@@ -1417,7 +1417,7 @@ void TBranchElement::FillLeavesCollection(TBuffer& b)
+       if (proxy->GetProperties() & TVirtualCollectionProxy::kIsAssociative) {
+          // do nothing for now ...
+       } else {
+-         fIterators->CreateIterators(fObject);
++         fIterators->CreateIterators(fObject, proxy);
+       }
+    }
+ 
+@@ -3708,9 +3708,9 @@ void TBranchElement::ReadLeavesCollection(TBuffer& b)
+    TVirtualCollectionProxy::TPushPop helper(proxy, fObject);
+    void* alternate = proxy->Allocate(fNdata, true);
+    if(fSTLtype != TClassEdit::kVector && proxy->HasPointers() && fSplitLevel > TTree::kSplitCollectionOfPointers ) {
+-      fPtrIterators->CreateIterators(alternate);
++      fPtrIterators->CreateIterators(alternate, proxy);
+    } else {
+-      fIterators->CreateIterators(alternate);
++      fIterators->CreateIterators(alternate, proxy);
+    }
+ 
+    Int_t nbranches = fBranches.GetEntriesFast();
+-- 
+1.7.4.1
+

--- a/root.spec
+++ b/root.spec
@@ -1,4 +1,4 @@
-### RPM lcg root 5.34.09
+### RPM lcg root 5.34.10
 ## INITENV +PATH PYTHONPATH %i/lib/python
 ## INITENV SET ROOTSYS %i  
 #Source: ftp://root.cern.ch/%n/%{n}_v%{realversion}.source.tar.gz
@@ -19,7 +19,12 @@ Patch3: root-5.32.00-detect-arch
 Patch4: root-5.30.02-fix-gcc46
 Patch5: root-5.30.02-fix-isnan-again
 Patch6: root-5.34.05-cintex-armv7a-port
-Patch7: root-5.34.09-ROOT-5437
+Patch7: 0001-Use-meta-data-mutex-for-the-proxy-initialization
+Patch8: 0002-Fix-thread-safety-of-TThread-TThread-Long_t-id
+Patch9: 0003-Reduce-lifetime-of-lock-in-TFile-TFile-to-avoid-lock
+Patch10: 0004-Reduce-lock-lifetime-in-TCollection-GarbageCollect
+Patch11: 0005-Remove-unnecessary-global-variable-and-lock
+Patch12: 0006-Fix-thread-safety-of-TGenCollectionProxy-s-iterator-
 
 Requires: gccxml gsl libjpg libpng libtiff pcre python fftw3 xz xrootd libxml2 openssl
 
@@ -44,11 +49,17 @@ Requires: freetype
 %patch3 -p1
 %patch4 -p1
 %patch5 -p1
-%patch7 -p1
 
 %if %isarmv7
 %patch6 -p1
 %endif
+
+%patch7 -p1
+%patch8 -p1
+%patch9 -p1
+%patch10 -p1
+%patch11 -p1
+%patch12 -p1
 
 # The following patch can only be applied on SLC5 or later (extra linker
 # options only available with the SLC5 binutils)


### PR DESCRIPTION
Thread safe patches from v5-34-00-patches branch:
- 98c0d99cf2999575502ed1cd2c5cb233c9062a37
- ca4eea119f2c5fed85665d7e2386cde843fbb554
- 9651eb210234ae6fd048f74f9bc4d29989c79f2f
- 2563f5f047c24201257be3077b1ccaab6117a166
- 0c40533fe73f8312944ae0f2636ede51b2a33cfb
- b5bdb586635f61817bfa14b0eba07ac5014fe602

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
