### PR TITLE
[CMSSW_7_0_X] dmtcp: bump revision to 2212

### DIFF
--- a/dmtcp.spec
+++ b/dmtcp.spec
@@ -1,4 +1,4 @@
-### RPM external dmtcp 2.0-2208
+### RPM external dmtcp 2.0-2212
 
 %define pkg_version %(echo "%{realversion}" | cut -d- -f 1)
 %define pkg_revision %(echo "%{realversion}" | cut -d- -f 2)


### PR DESCRIPTION
This versions resolves the problem, where checkpointed application
has huge arguments and environment size.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
