### PR TITLE
Decouple real commits from RPM name.

### DIFF
--- a/cmssw.spec
+++ b/cmssw.spec
@@ -6,6 +6,7 @@ Requires: cmssw-tool-conf python cms-git-tools
 %define useCmsTC        yes
 %define saveDeps        yes
 %define branch          CMSSW_7_0_X
+%define gitcommit       %{realversion}
 
 %if "%(case %realversion in (*_COVERAGE_X*) echo true ;; (*) echo false ;; esac)" == "true"
 %define branch		%(echo %realversion | sed -e 's|_COVERAGE_X.*|_X|')
@@ -34,6 +35,6 @@ Requires: cmssw-tool-conf python cms-git-tools
 %define branch		%(echo %realversion | sed -e 's|_X.*|_X|')
 %endif
 
-%define source1         git://github.com/cms-sw/cmssw.git?protocol=https&obj=%{branch}/%{realversion}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
+%define source1         git://github.com/cms-sw/cmssw.git?protocol=https&obj=%{branch}/%{gitcommit}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
 
 ## IMPORT scram-project-build


### PR DESCRIPTION
- Allows for building a release before tagging it.
- Allows for reusing uploaded sources between IBs that do not change.
