### PR TITLE
[CMSSW_7_0_X] geant4,geant4-toolfile: do not relocate GEANT4 include paths

### DIFF
--- a/geant4-toolfile.spec
+++ b/geant4-toolfile.spec
@@ -40,7 +40,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4core.xml
     <environment name="GEANT4CORE_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$GEANT4CORE_BASE/lib"/>
     <environment name="G4LIB" value="$LIBDIR"/>
-    <environment name="INCLUDE" default="$GEANT4CORE_BASE/include"/>
+    <environment name="INCLUDE" default="$GEANT4CORE_BASE/include/Geant4"/>
   </client>
   <flags cppdefines="GNU_GCC G4V9"/>
   <use name="clhep"/>

--- a/geant4.spec
+++ b/geant4.spec
@@ -52,7 +52,3 @@ make %makeprocesses VERBOSE=1
 
 cd ../build
 make install
-
-# Move headers from ../include/Geant4 to ../include
-tar -C %i/include/Geant4 -cf - . | tar -C %i/include -xf -
-rm -rf %i/include/Geant4


### PR DESCRIPTION
Do no relocate GEANT4 paths and modify GEATN4 toolfile to adapt
to the change. Set INCLUDE to $GEANT4CORE_BASE/include/Geant4

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
