### PR TITLE
Backport python event reader patch.

### DIFF
--- a/condor.spec
+++ b/condor.spec
@@ -5,6 +5,7 @@
 
 Source: git://github.com/htcondor/htcondor.git?obj=master/%{condortag}&export=condor-%{realversion}&output=/condor-%{realversion}.tar.gz
 Patch0: cms-htcondor-build
+Patch1: htcondor-python-event-reader
 
 Requires: openssl zlib expat pcre libtool python boost p5-archive-tar curl libxml2
 BuildRequires: cmake gcc
@@ -12,6 +13,7 @@ BuildRequires: cmake gcc
 %prep 
 %setup -n %n-%{realversion}
 %patch0 -p1
+%patch1 -p1
 sed -i "s,P5_ARCHIVE_TAR_ROOT,$P5_ARCHIVE_TAR_ROOT," externals/bundles/globus/5.2.1/CMakeLists.txt
 sed -i "s,P5_IO_ZLIB_ROOT,$P5_IO_ZLIB_ROOT," externals/bundles/globus/5.2.1/CMakeLists.txt
 sed -i "s,P5_PACKAGE_CONSTANTS_ROOT,$P5_PACKAGE_CONSTANTS_ROOT," externals/bundles/globus/5.2.1/CMakeLists.txt

--- a/htcondor-python-event-reader.patch
+++ b/htcondor-python-event-reader.patch
@@ -1,0 +1,159 @@
+diff --git a/src/python-bindings/CMakeLists.txt b/src/python-bindings/CMakeLists.txt
+index 8b5035a..ccf5ff1 100644
+--- a/src/python-bindings/CMakeLists.txt
++++ b/src/python-bindings/CMakeLists.txt
+@@ -32,7 +32,7 @@ if ( WITH_PYTHON_BINDINGS AND PYTHONLIBS_FOUND AND Boost_PYTHON_LIBRARY AND NOT
+   set_target_properties(classad_module PROPERTIES SUFFIX ".so" )
+ 
+   set_source_files_properties(config.cpp collector.cpp secman.cpp dc_tool.cpp schedd.cpp classad.cpp classad_module.cpp PROPERTIES COMPILE_FLAGS "-Wno-strict-aliasing -Wno-cast-qual -Wno-deprecated")
+-  add_library( htcondor SHARED htcondor.cpp collector.cpp config.cpp daemon_and_ad_types.cpp dc_tool.cpp export_headers.h old_boost.h schedd.cpp secman.cpp )
++  add_library( htcondor SHARED htcondor.cpp collector.cpp config.cpp daemon_and_ad_types.cpp dc_tool.cpp export_headers.h old_boost.h schedd.cpp secman.cpp event.cpp )
+   target_link_libraries( htcondor pyclassad condor_utils -lboost_python ${PYTHON_LIBRARIES} )
+   set_target_properties( htcondor PROPERTIES PREFIX "" )
+   set_target_properties( htcondor PROPERTIES SUFFIX ".so" )
+diff --git a/src/python-bindings/event.cpp b/src/python-bindings/event.cpp
+new file mode 100644
+index 0000000..11c81d9
+--- /dev/null
++++ b/src/python-bindings/event.cpp
+@@ -0,0 +1,86 @@
++
++// Note - pyconfig.h must be included before condor_common to avoid
++// re-definition warnings.
++# include <pyconfig.h>
++
++#include "read_user_log.h"
++
++#include <memory>
++#include <boost/python.hpp>
++
++#include "old_boost.h"
++#include "event.h"
++using namespace boost::python;
++EventIterator::EventIterator(FILE *source, bool is_xml)
++  : m_done(false), m_source(source), m_reader(new ReadUserLog(source, is_xml))
++{}
++
++boost::shared_ptr<ClassAdWrapper>
++EventIterator::next()
++{
++    if (m_done) THROW_EX(StopIteration, "All events processed");
++
++    boost::shared_ptr<ULogEvent> new_event;
++    boost::shared_ptr<ClassAdWrapper> output(new ClassAdWrapper());
++    ULogEventOutcome retval;
++    ULogEvent *tmp_event = NULL;
++    retval = m_reader->readEvent(tmp_event);
++    //printf("Read an event.\n");
++    new_event.reset(tmp_event);
++    classad::ClassAd *tmp_ad;
++
++    // Bug workaround: the last event generates ULOG_RD_ERROR on line 0.
++    ReadUserLog::ErrorType error;
++    const char *error_str = NULL;
++    unsigned line_num;
++    switch (retval) {
++        case ULOG_OK:
++            tmp_ad = reinterpret_cast<classad::ClassAd*>(new_event->toClassAd());
++            if (tmp_ad)
++            {
++                output->CopyFrom(*tmp_ad);
++                delete tmp_ad;
++            }
++            return output;
++        // NOTE: ULOG_RD_ERROR is always done on the last event with an error on line 0
++        // How do we differentiate "empty file" versus a real parse error on line 0?
++        case ULOG_NO_EVENT:
++            m_done = true;
++            THROW_EX(StopIteration, "All events processed");
++            break;
++        case ULOG_RD_ERROR:
++        case ULOG_MISSED_EVENT:
++        case ULOG_UNK_ERROR:
++        default:
++            THROW_EX(ValueError, "Unable to parse input stream into a HTCondor event.");
++    }
++    return output;
++}
++
++EventIterator
++readEventsFile(FILE * file, bool is_xml)
++{
++    return EventIterator(file, is_xml);
++}
++
++EventIterator
++readEventsFile2(FILE *file)
++{
++    return readEventsFile(file);
++}
++
++void export_event_reader()
++{
++    boost::python::class_<EventIterator>("EventIterator", boost::python::no_init)
++        .def("next", &EventIterator::next)
++        .def("__iter__", &EventIterator::pass_through)
++        ;
++
++    def("readEvents", readEventsFile, boost::python::with_custodian_and_ward_postcall<0, 1>());
++    def("readEvents", readEventsFile2, boost::python::with_custodian_and_ward_postcall<0, 1>(),
++        "Parse input HTCondor event log into an iterator of ClassAds.\n"
++        ":param input: A file pointer.\n"
++        ":param is_xml: Set to true if the log file is XML-formatted (defaults to false).\n"
++        ":return: A iterator which produces ClassAd objects.");
++}
++
+diff --git a/src/python-bindings/event.h b/src/python-bindings/event.h
+new file mode 100644
+index 0000000..158f3de
+--- /dev/null
++++ b/src/python-bindings/event.h
+@@ -0,0 +1,23 @@
++
++#include <boost/python.hpp>
++
++#include "classad_wrapper.h"
++
++class EventIterator
++{
++public:
++
++    EventIterator(FILE * fp, bool is_xml);
++
++    inline static boost::python::object pass_through(boost::python::object const& o) { return o; };
++
++    boost::shared_ptr<ClassAdWrapper> next();
++
++private:
++    bool m_done;
++    FILE * m_source;
++    boost::shared_ptr<ReadUserLog> m_reader;
++};
++
++EventIterator readEventsFile(FILE * file, bool is_xml=false);
++
+diff --git a/src/python-bindings/htcondor.cpp b/src/python-bindings/htcondor.cpp
+index 2646f88..1a5e1bb 100644
+--- a/src/python-bindings/htcondor.cpp
++++ b/src/python-bindings/htcondor.cpp
+@@ -23,4 +23,5 @@
+     export_schedd();
+     export_dc_tool();
+     export_secman();
++    export_event_reader();
+ }
+diff --git a/src/python-bindings/export_headers.h b/src/python-bindings/export_headers.h
+index 401f917..6c9b65a 100644
+--- a/src/python-bindings/export_headers.h
++++ b/src/python-bindings/export_headers.h
+@@ -1,7 +1,10 @@
+ 
+ void export_collector();
++//void export_negotiator();
+ void export_schedd();
+ void export_dc_tool();
+ void export_daemon_and_ad_types();
+ void export_config();
+ void export_secman();
++void export_event_reader();
++


### PR DESCRIPTION
This backports a patch to the 8.0.4 release which exposes the event reader API to the python bindings.
