### PR TITLE
Generate runtime tarball for TaskWorker.

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,14 +1,14 @@
-### RPM cms crabclient 3.3.0.pre3
+### RPM cms crabclient 3.3.0.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 ## INITENV +PATH PYTHONPATH %i/x$PYTHON_LIB_SITE_PACKAGES
 
-%define wmcver 0.9.83
+%define wmcver 0.9.84.htcondor2
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define crabserver 3.3.0.pre30
+%define crabserver 3.3.0.rc6
 
 
-Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
+Source0: git://github.com/bbockelm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABClient.git?obj=htcondor_poc/%{realversion}&export=CRABClient-%{realversion}&output=/CRABClient-%{realversion}.tar.gz
 Source2: git://github.com/dmwm/CRABServer.git?obj=htcondor_poc/%{crabserver}&export=CRABServer-%{crabserver}&output=/CRABServer-%{crabserver}.tar.gz
 

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,12 +1,12 @@
-### RPM cms crabtaskworker 3.3.0.rc5
+### RPM cms crabtaskworker 3.3.0.rc16
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 ## INITENV +PATH PYTHONPATH %i/x$PYTHON_LIB_SITE_PACKAGES
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.82
+%define wmcver 0.9.84.htcondor2
 
-Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
+Source0: git://github.com/bbockelm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
 Requires: python  dbs-client dls-client dbs3-client py2-pycurl py2-httplib2  condor
@@ -27,6 +27,10 @@ cd ../CRABServer-%{realversion}
 perl -p -i -e "s{<VERSION>}{%{realversion}}g" doc/taskworker/conf.py
 python setup.py build_system -s TaskWorker
 
+sed -i 's|CRAB3_VERSION=.*|CRAB3_VERSION=%{realversion}|' bin/htcondor_make_runtime.sh
+sed -i 's|CRABSERVERVER=.*|CRABSERVERVER=%{realversion}|' bin/htcondor_make_runtime.sh 
+./bin/htcondor_make_runtime.sh
+
 %install
 mkdir -p %i/etc/profile.d %i/{x,}{bin,lib,data,doc} %i/{x,}$PYTHON_LIB_SITE_PACKAGES
 touch $PWD/condor_config
@@ -35,7 +39,8 @@ cd ../WMCore-%{wmcver}
 python setup.py install_system -s  crabtaskworker --prefix=%i
 cd ../CRABServer-%{realversion}
 python setup.py install_system -s TaskWorker  --prefix=%i
-
+cp TaskManagerRun-%{realversion}.tar.gz  %i/data/TaskManagerRun.tar.gz
+cp CMSRunAnalysis-%{realversion}.tar.gz  %i/data/CMSRunAnalysis.tar.gz
 find %i -name '*.egg-info' -exec rm {} \;
 
 # Generate .pyc files.


### PR DESCRIPTION
Generate runtime tarball during the TaskWorker RPM generation.  This allows the TaskWorker to be self-contained and not rely on an external server.
