### PR TITLE
Backport patch allowing the HTCondor python bindings to directly renew proxies

### DIFF
--- a/condor.spec
+++ b/condor.spec
@@ -6,6 +6,7 @@
 Source: git://github.com/htcondor/htcondor.git?obj=master/%{condortag}&export=condor-%{realversion}&output=/condor-%{realversion}.tar.gz
 Patch0: cms-htcondor-build
 Patch1: htcondor-python-event-reader
+Patch2: htcondor-python-renew-proxy
 
 Requires: openssl zlib expat pcre libtool python boost p5-archive-tar curl libxml2
 BuildRequires: cmake gcc
@@ -14,6 +15,7 @@ BuildRequires: cmake gcc
 %setup -n %n-%{realversion}
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 sed -i "s,P5_ARCHIVE_TAR_ROOT,$P5_ARCHIVE_TAR_ROOT," externals/bundles/globus/5.2.1/CMakeLists.txt
 sed -i "s,P5_IO_ZLIB_ROOT,$P5_IO_ZLIB_ROOT," externals/bundles/globus/5.2.1/CMakeLists.txt
 sed -i "s,P5_PACKAGE_CONSTANTS_ROOT,$P5_PACKAGE_CONSTANTS_ROOT," externals/bundles/globus/5.2.1/CMakeLists.txt

--- a/htcondor-python-renew-proxy.patch
+++ b/htcondor-python-renew-proxy.patch
@@ -1,0 +1,68 @@
+--- a/src/python-bindings/schedd.cpp
++++ b/src/python-bindings/schedd.cpp
+@@ -16,6 +16,7 @@
+ #include "classad_helpers.h"
+ #include "condor_config.h"
+ #include "condor_holdcodes.h"
++#include "globus_utils.h"
+ #include "basename.h"
+ 
+ #include <classad/operators.h>
+@@ -492,6 +493,40 @@
+             THROW_EX(RuntimeError, errstack.getFullText(true).c_str());
+     }
+ 
++    int refreshGSIProxy(int cluster, int proc, std::string proxy_filename, int lifetime=-1)
++    {
++        time_t now = time(NULL);
++        time_t result_expiration;
++        CondorError errstack;
++
++        if (lifetime < 0)
++        {
++            lifetime = param_integer("DELEGATE_JOB_GSI_CREDENTIALS_LIFETIME", 0);
++        }
++
++        DCSchedd schedd(m_addr.c_str());
++        bool do_delegation = param_boolean("DELEGATE_JOB_GSI_CREDENTIALS", true);
++        if (do_delegation && !schedd.delegateGSIcredential(cluster, proc, proxy_filename.c_str(), lifetime ? now+lifetime : 0,
++                                                           &result_expiration, &errstack))
++        {
++            THROW_EX(RuntimeError, errstack.getFullText(true).c_str());
++        }
++        else if (!do_delegation)
++        {
++            if (!schedd.updateGSIcredential(cluster, proc, proxy_filename.c_str(), &errstack))
++            {
++                THROW_EX(RuntimeError, errstack.getFullText(true).c_str());
++            }
++            // Note: x509_error_string() is not thread-safe; hence, we are not using the HTCondor-generated
++            // error handling.
++            int result = x509_proxy_seconds_until_expire(proxy_filename.c_str());
++            if (result < 0) {THROW_EX(RuntimeError, "Unable to determine proxy expiration time");}
++            return result;
++        }
++        return result_expiration - now;
++    }
++
++
+     void edit(object job_spec, std::string attr, object val)
+     {
+         std::vector<int> clusters;
+@@ -634,6 +669,15 @@
+             ":param job_spec: Either a list of jobs (CLUSTER.PROC) or a string containing a constraint to match jobs against.\n"
+             ":param attr: Attribute name to edit.\n"
+             ":param value: The new value of the job attribute; should be a string (which will be converted to a ClassAds expression) or a ClassAds expression.")
+-        .def("reschedule", &Schedd::reschedule, "Send reschedule command to the schedd.\n");
++        .def("reschedule", &Schedd::reschedule, "Send reschedule command to the schedd.\n")
++        .def("refreshGSIProxy", &Schedd::refreshGSIProxy, "Refresh the GSI proxy for a given job\n"
++            ":param cluster: Job cluster.\n"
++            ":param proc: Job proc.\n"
++            ":param filename: Filename of proxy to delegate or upload to job.\n"
++            ":param lifetime: Desired lifetime (in seconds) of delegated proxy; 0 indicates to not shorten"
++            " the job lifetime.  -1 indicates to use the value of parameter DELEGATE_JOB_GSI_CREDENTIALS_LIFETIME."
++            " NOTE: depending on the lifetime of the proxy in `filename`, the resulting lifetime may be shorter"
++            " than the desired lifetime.\n"
++            ":return: Lifetime of the resulting job proxy in seconds.")
+         ;
+ }


### PR DESCRIPTION
This client-only change (really, just exposing existing C++ to python) is essential for CRAB3 proxy renewal.
