### PR TITLE
new scram version, config tag, html log zip instead of tar gz

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_5_pre4
+### RPM lcg SCRAMV1 V2_2_5_pre5
 ## NOCOMPILER
 %define GitHubVersion %(echo SCRAM-%realversion | sed 's|-V|-|')
 

--- a/cmssw-ib.spec
+++ b/cmssw-ib.spec
@@ -18,32 +18,31 @@ mkdir -p %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION
 du -sh $CMSSW_ROOT/lib/%cmsplatf > %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/library_size.txt
 case %cmsplatf in
   *_mic_*)
-    PYTHON_CMD="/usr/bin/python"
+DOW=`/usr/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%a').lower()"`
+HOUR=`/usr/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%H').lower()"`
   ;;
   *)
-    PYTHON_CMD="$PYTHON_ROOT/bin/python"
+DOW=`$PYTHON_ROOT/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%a').lower()"`
+HOUR=`$PYTHON_ROOT/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%H').lower()"`
   ;;
 esac
-DOW=`$PYTHON_CMD -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%a').lower()"`
-HOUR=`$PYTHON_CMD -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%H').lower()"`
-
 eval `%scram runtime -sh`
 CMSSW_MAJOR_MINOR=`echo $CMSSW_VERSION | sed -e 's/CMSSW_\([0-9]*\)_\([0-9]*\).*/\1.\2/g'`
 pushd %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/logs/src
   tar xzf src-logs.tgz
 popd
-$PYTHON_CMD %_builddir/IntBuild/IB/buildLogAnalyzer.py \
+%_builddir/IntBuild/IB/buildLogAnalyzer.py \
             -r $CMSSW_VERSION \
             -p $CMSSW_ROOT/src/PackageList.cmssw \
             --logDir %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/logs/src \
             --topURL "http://cern.ch/cms-sdt/rc/%cmsplatf/www/$DOW/$CMSSW_MAJOR_MINOR-$DOW-$HOUR/new/"
 
 cd %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/logs/html
-tar czf ../html-logs.tgz ./
+zip -r ../html-logs.zip ./
 cd ..
 rm -rf src html
 mkdir -p html
-mv html-logs.tgz html
+mv html-logs.zip html
 
 rm -rf %i/*
 %install

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-12
+%define configtag       V05-01-14
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
SCRAMV1: V2_2_5_pre5
- Force set PATH environment for scram runtime (no need to run rehash)
- SCRAM now complains if 'file' attribute is missing in test/BuildFile.xml
- Always exit with non-zero code if there are build errors (even if -k is used). Also print an error message at the end to remind that there were compilaton errors.

Config tag V05-01-13:
- Exit with non-zero even if -k is passed to scram build
- print error message at the end jsut to remind the developer that there were build errors
- error messages for wrong/missing tag/attributes errors in BuildFile
