### PR TITLE
Cleanup CRAB3 runtime generation

### DIFF
--- a/crabtaskworker-setup.patch
+++ b/crabtaskworker-setup.patch
@@ -1,40 +1,14 @@
---- setup_dependencies.py
-+++ setup_dependencies.py
-@@ -114,27 +114,33 @@ 
-                         'statics': ['src/couchapps/Agent+'],
+--- setup_dependencies.py.orig	2013-12-19 22:33:38.000000000 +0100
++++ setup_dependencies.py	2013-12-19 22:50:03.000000000 +0100
+@@ -130,9 +130,9 @@
                          },
-                 'crabserver':{
--                        'packages': ['WMCore.WMSpec', 'WMCore.ACDC',
-+                        'packages':['WMCore.WMSpec', 'WMCore.ACDC',
-                                      'WMCore.Storage+', 'WMCore.HTTPFrontEnd.RequestManager+',
-                                      'WMCore.RequestManager+', 'WMComponent.DBSUpload',
-                                      'WMCore.ProcessPool'],
-                         'systems': ['wmc-web'],
+                 'crabtaskworker':{
+                         'packages':['WMCore..WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
+-                                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+', 'WMCore.Services.UserFileCache+'],
++                                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+', 'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+'],
+                         'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
+-                        'systems': ['wmc-database'],
++                        'systems': ['wmc-database', 'wmc-runtime'],
                          },
-                 'crabclient':{
--                        'packages': ['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks',
-+                        'packages':['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks',
-                                      'WMCore.Services.UserFileCache'],
-                         'systems': ['wmc-base'],
-                         'modules': ['WMCore.FwkJobReport.FileInfo', 'WMCore.Services.Requests',
-                                     'WMCore.Services.Service', 'WMCore.Services.pycurl_manager'],
-                         },
-+                'crabtaskworker':{
-+                        'packages':['WMCore..WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+',
-+                                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+'],
-+                        'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
-+                        'systems': ['wmc-database'],
-+                        },
                  'wmclient':{
                          'systems': ['wmc-runtime', 'wmc-database']
-                         },
-                 'reqmon':{
--                        'statics': ['src/couchapps/WMStats+', 
-+                        'statics': ['src/couchapps/WMStats+',
-                                     'src/couchapps/WorkloadSummary+'],
-                         },
--                'alertscollector': 
-+                'alertscollector':
-                 {
-                         'statics': ['src/couchapps/AlertsCollector+'],
-                 },

--- a/crabtaskworker-setup.patch
+++ b/crabtaskworker-setup.patch
@@ -1,5 +1,14 @@
 --- setup_dependencies.py.orig	2013-12-19 22:33:38.000000000 +0100
-+++ setup_dependencies.py	2013-12-19 22:50:03.000000000 +0100
++++ setup_dependencies.py	2013-12-19 23:14:45.000000000 +0100
+@@ -28,7 +28,7 @@
+                         'systems':['wmc-base']
+                         },
+                 'wmc-runtime':{
+-                        'packages': ['WMCore.WMRuntime', 'WMCore.WMSpec+', 'PSetTweaks', 'WMCore.FwkJobReport', 'WMCore.Storage+'],
++                        'packages': ['WMCore.WMRuntime+', 'WMCore.WMSpec+', 'PSetTweaks', 'WMCore.FwkJobReport', 'WMCore.Storage+'],
+                         'modules' : ['WMCore.Algorithms.ParseXMLFile'],
+                         'systems':['wmc-base']
+                         },
 @@ -130,9 +130,9 @@
                          },
                  'crabtaskworker':{

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,20 +1,23 @@
-### RPM cms crabtaskworker 3.3.0.rc16
+### RPM cms crabtaskworker 3.3.1.pre8
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 ## INITENV +PATH PYTHONPATH %i/x$PYTHON_LIB_SITE_PACKAGES
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.84.htcondor2
+%define wmcver 0.9.86
 
-Source0: git://github.com/bbockelm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
+Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Requires: python  dbs-client dls-client dbs3-client py2-pycurl py2-httplib2  condor
+Patch0: crabtaskworker-setup
+
+Requires: python  dbs-client dls-client dbs3-client py2-pycurl py2-httplib2 cherrypy condor
 BuildRequires: py2-sphinx
 
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
 %setup -T -b 0 -n WMCore-%{wmcver}
+%patch0 -p0
 
 %build
 touch $PWD/condor_config
@@ -29,7 +32,9 @@ python setup.py build_system -s TaskWorker
 
 sed -i 's|CRAB3_VERSION=.*|CRAB3_VERSION=%{realversion}|' bin/htcondor_make_runtime.sh
 sed -i 's|CRABSERVERVER=.*|CRABSERVERVER=%{realversion}|' bin/htcondor_make_runtime.sh
-./bin/htcondor_make_runtime.sh
+sed -i 's|WMCOREVER=.*|WMCOREVER=%{wmcver}|' bin/htcondor_make_runtime.sh
+
+RPM_RELEASE=1 ./bin/htcondor_make_runtime.sh
 
 %install
 mkdir -p %i/etc/profile.d %i/{x,}{bin,lib,data,doc} %i/{x,}$PYTHON_LIB_SITE_PACKAGES


### PR DESCRIPTION
This is the first set of improvements of the CRAB3 runtime generation.  With this patch, all dependencies except one are now taken from the build RPM environment instead of external servers.
