### PR TITLE
use system python for mic

### DIFF
--- a/cmssw-ib.spec
+++ b/cmssw-ib.spec
@@ -16,22 +16,20 @@ cd $CMSSW_ROOT
 export CMSSW_VERSION
 mkdir -p %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION
 du -sh $CMSSW_ROOT/lib/%cmsplatf > %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/library_size.txt
+PYTHON_CMD="$PYTHON_ROOT/bin/python"
 case %cmsplatf in
   *_mic_*)
-DOW=`/usr/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%a').lower()"`
-HOUR=`/usr/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%H').lower()"`
-  ;;
-  *)
-DOW=`$PYTHON_ROOT/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%a').lower()"`
-HOUR=`$PYTHON_ROOT/bin/python -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%H').lower()"`
+    PYTHON_CMD="/usr/bin/python"
   ;;
 esac
+DOW=`$PYTHON_CMD -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%a').lower()"`
+HOUR=`$PYTHON_CMD -c "import os;from datetime import datetime;print datetime.strptime(os.environ['CMSSW_VERSION'].rsplit('_X_')[1], '%Y-%m-%d-%H00').strftime('%H').lower()"`
 eval `%scram runtime -sh`
 CMSSW_MAJOR_MINOR=`echo $CMSSW_VERSION | sed -e 's/CMSSW_\([0-9]*\)_\([0-9]*\).*/\1.\2/g'`
 pushd %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/logs/src
   tar xzf src-logs.tgz
 popd
-%_builddir/IntBuild/IB/buildLogAnalyzer.py \
+$PYTHON_CMD %_builddir/IntBuild/IB/buildLogAnalyzer.py \
             -r $CMSSW_VERSION \
             -p $CMSSW_ROOT/src/PackageList.cmssw \
             --logDir %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/logs/src \


### PR DESCRIPTION
mic IBs were failing as cmssw-ib was using cross compiled python. This patch should allow to use system python for mic build and PYTHON_ROOT/bin/python for rest.
