### PR TITLE
scram-project-build: use of new config tag V05-01-15

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-14
+%define configtag       V05-01-15
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
This new tag should avoid the missing log issue of IB.
Lets try it for mic IBs and if worked then we shall merge it in stable.
