### PR TITLE
scram-project-build: use of new config tag V05-01-15

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-14
+%define configtag       V05-01-15
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
already tested for mic IB and looks like logs are properly generated.
