### PR TITLE
scram-project-file: updated config tag to V05-01-16 which should fix the inkDef file compilation

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-15
+%define configtag       V05-01-16
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
updated config tag to V05-01-16 which should fix the inkDef file compilation when BUILD_LOG env is set
