### PR TITLE
GEANT4 10.00 - ParFullCMS

### DIFF
--- a/geant4-bench.spec
+++ b/geant4-bench.spec
@@ -1,0 +1,34 @@
+### RPM external geant4-bench 1.0.0
+
+BuildRequires: geant4-parfullcms
+BuildRequires: geant4data
+
+%prep
+# NOP
+
+%build
+# NOP
+
+%install
+
+mkdir -p %{i}
+cd %{i}
+
+# Copy required files
+cp -r ${GEANT4_PARFULLCMS_ROOT}/share/ParFullCMS .
+
+# Set number of threads
+export G4FORCENUMBEROFTHREADS=max
+
+# export GEANT4 data files
+export G4LEDATA
+export G4LEVELGAMMADATA
+export G4SAIDXSDATA
+export G4NEUTRONXSDATA
+
+# Adjust event size
+sed -ibak 's;\(/run/beamOn \).*;\1800;' ParFullCMS/mt.g4
+
+# Launch bechmark
+cd ParFullCMS
+ParFullCMS mt.g4 2>&1 | tee run.log

--- a/geant4-data-rpm.file
+++ b/geant4-data-rpm.file
@@ -24,7 +24,9 @@ tar -C %i/data -zxvf %_sourcedir/%{G4DataTool}.%{realversion}.tar.gz
 %post
 if [ "X$CMS_INSTALL_PREFIX" = "X" ] ; then CMS_INSTALL_PREFIX=$RPM_INSTALL_PREFIX; export CMS_INSTALL_PREFIX; fi
 echo "%{BaseTool}_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
-echo "%{BaseTool}_RUNTIME='%G4RunTime'"                >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
+echo "%{BaseTool}_RUNTIME='%G4RunTime'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
+echo "%{G4RunTime}='$CMS_INSTALL_PREFIX/%{pkgrel}/data/%{G4DataTool}%{realversion}'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
 
 echo "set %{BaseTool}_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
-echo "set %{BaseTool}_RUNTIME='%G4RunTime'"                >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
+echo "set %{BaseTool}_RUNTIME='%G4RunTime'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
+echo "set %{G4RunTime}='$CMS_INSTALL_PREFIX/%{pkgrel}/data/%{G4DataTool}%{realversion}'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh

--- a/geant4-parfullcms.spec
+++ b/geant4-parfullcms.spec
@@ -1,0 +1,34 @@
+### RPM external geant4-parfullcms 2014.01.27
+
+%define realname ParFullCMS
+
+Source0: http://davidlt.web.cern.ch/davidlt/vault/%{realname}.%{realversion}.tar.bz2
+
+BuildRequires: cmake
+Requires: geant4
+Requires: geant4data
+
+%prep
+%setup -n %{realname}
+
+%build
+
+mkdir build-ParFullCMS
+cd build-ParFullCMS
+
+cmake .. \
+  -DCMAKE_CXX_COMPILER="g++" \
+  -DCMAKE_CXX_FLAGS="-std=c++11" \
+  -DCMAKE_INSTALL_PREFIX:PATH="%i" \
+  -DCMAKE_INSTALL_LIBDIR="lib" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_STATIC_LIBS=ON \
+  -DGeant4_USE_FILE=${GEANT4_ROOT}
+
+make %{makeprocesses} VERBOSE=1
+
+%install
+
+cd build-ParFullCMS
+make install


### PR DESCRIPTION
The following adds ParFullCMS to CMSDIST and requires GEANT4 10.00 or newer. `geant4-bench` provides example how to run ParFullCMS from in RPM environment.
