### PR TITLE
c-ares support for curl. (py)curl updates.

### DIFF
--- a/c-ares.spec
+++ b/c-ares.spec
@@ -1,0 +1,23 @@
+### RPM external c-ares 1.10.0
+Source: http://c-ares.haxx.se/download/%n-%realversion.tar.gz
+Provides: libcares.2.so()(64bit)   
+%prep
+%setup -n %n-%{realversion}
+
+%build
+./configure --prefix=%i 
+make %makeprocesses
+
+%install
+make install
+
+# Remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
+# which we neither need nor use at this time.
+rm -rf %i/lib/pkgconfig
+
+# Strip libraries, we are not going to debug them.
+%define strip_files %i/lib
+# Read documentation online.
+%define drop_files %i/share
+
+%post

--- a/curl.spec
+++ b/curl.spec
@@ -1,6 +1,7 @@
-### RPM external curl 7.28.0
+### RPM external curl 7.35.0
 Source: http://curl.haxx.se/download/%n-%realversion.tar.gz
 Provides: libcurl.so.3()(64bit) 
+Requires: c-ares
 Requires: openssl
 Requires: zlib
    
@@ -10,7 +11,7 @@ Requires: zlib
 %build
 export OPENSSL_ROOT
 export ZLIB_ROOT
-./configure --prefix=%i --disable-static --without-libidn --disable-ldap --with-ssl=${OPENSSL_ROOT} --with-zlib=${ZLIB_ROOT}
+./configure --prefix=%i --disable-static --without-libidn --disable-ldap --with-ssl=${OPENSSL_ROOT} --with-zlib=${ZLIB_ROOT} --enable-ares=${C_ARES_ROOT}
 # This should change link from "-lz" to "-lrt -lz", needed by gold linker
 # This is a fairly ugly way to do it, however.
 perl -p -i -e "s!\(LIBS\)!(LIBCURL_LIBS)!" src/Makefile

--- a/py2-pycurl.spec
+++ b/py2-pycurl.spec
@@ -1,14 +1,14 @@
-### RPM external py2-pycurl 7.19.0
+### RPM external py2-pycurl 7.19.3
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 Source: http://pycurl.sourceforge.net/download/pycurl-%realversion.tar.gz
 Requires: python curl
 
 %prep
 %setup -n pycurl-%realversion
-perl -p -i -e '/--static-libs/ && s/^(\s+)/$1"") #/' setup.py
+perl -p -i -e 's/,\s+"--static-libs"]/]/' setup.py
 
 %build
-python setup.py build
+python setup.py build --with-ssl
 
 %install
 python setup.py install --prefix=%i


### PR DESCRIPTION
Hi Diego,

as discussed via email, the DBS 3 Migration Service has some problems with pycurl and multi-threading. pycurl itself is thread-safe, however the DNS lookup is not. The suggestion on http://linux.die.net/man/3/libcurl-tutorial is to disable signals, which I did for DBS 3. The disadvantage is, that DNS timeouts are not caught anymore in that case. The solution is to use c-ares for the DNS lookup. I have added a c-ares.spec and configured curl to build against c-ares.

In addition, I have upgraded curl and pycurl to the latest release to enable shared SSL session id caches between different threads, to reduce the load on cmsweb through authentication during migration requests. 

I have tested DBS 3 Server, DBS 3 Migration Service and DBS 3 Client, everything seems to be fine.

Could you review and merge, please?

Thanks,
Manuel
