### PR TITLE
Prepared for CMSSW_4_1_10

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -98,6 +98,7 @@ Requires: lapack-toolfile
 Requires: pyminuit2-toolfile
 Requires: professor-toolfile
 Requires: py2-ipython-toolfile
+Requires: py2-pycurl-toolfile
 
 %if "%isslc" == "true"
 Requires: gdb-toolfile

--- a/cmssw.spec
+++ b/cmssw.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw CMSSW_4_1_9
+### RPM cms cmssw CMSSW_4_1_10
 Requires: cmssw-tool-conf python
 
 %define runGlimpse      yes

--- a/py2-pycurl-toolfile.spec
+++ b/py2-pycurl-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external py2-pycurl-toolfile 1.0
+Requires: py2-pycurl
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/py2-pycurl.xml
+<tool name="py2-pycurl" version="@TOOL_VERSION@">
+  <client>
+    <environment name="PY2_PYCURL_BASE" default="@TOOL_ROOT@"/>
+  </client>
+  <runtime name="PYTHONPATH" value="$PY2_PYCURL_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
+  <use name="python"/>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post
+

--- a/py2-pycurl.spec
+++ b/py2-pycurl.spec
@@ -1,0 +1,17 @@
+### RPM external py2-pycurl 7.19.0
+## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
+Source: http://pycurl.sourceforge.net/download/pycurl-%realversion.tar.gz
+Requires: python curl
+
+%prep
+%setup -n pycurl-%realversion
+perl -p -i -e '/--static-libs/ && s/^(\s+)/$1"") #/' setup.py
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
+# Remove documentation.
+%define drop_files %i/share


### PR DESCRIPTION
IB/CMSSW_4_1_8/slc5_amd64_gcc434 + py2-pycurl.spec,
py2-pycurl-toolfile.spec and update cmssw-tool-conf.spec to
depend on py2-pycurl-toolfile and cmssw.spec to have the correct
CMSSW tag
