### PR TITLE
Remove `VerboseLevel:' parameter from TMVA weight files

### DIFF
--- a/data-RecoParticleFlow-PFProducer.spec
+++ b/data-RecoParticleFlow-PFProducer.spec
@@ -1,9 +1,9 @@
-### RPM cms data-RecoParticleFlow-PFProducer V14-08-05
+### RPM cms data-RecoParticleFlow-PFProducer V14-08-05-01
 
 %prep
 
 # Base URL, where to find the files
-%define base_url "http://cmsdoc.cern.ch/cms/data/CMSSW"
+%define base_url "http://davidlt.web.cern.ch/davidlt/vault/cmsdata"
 
 cat << CMS_EOF >> ./sources
 RecoParticleFlow/PFProducer/data/MVAnalysis_BDT.weights_finalID_hzz-pions.txt

--- a/data-RecoParticleFlow-PFTracking.spec
+++ b/data-RecoParticleFlow-PFTracking.spec
@@ -1,9 +1,9 @@
-### RPM cms data-RecoParticleFlow-PFTracking V12-03-03
+### RPM cms data-RecoParticleFlow-PFTracking V12-03-03-01
 
 %prep
 
 # Base URL, where to find the files
-%define base_url "http://cmsdoc.cern.ch/cms/data/CMSSW"
+%define base_url "http://davidlt.web.cern.ch/davidlt/vault/cmsdata"
 
 cat << CMS_EOF >> ./sources
 RecoParticleFlow/PFTracking/data/BDT_weights_21.txt


### PR DESCRIPTION
`VerboseLevel:' parameter is not supported by newer versions of
ROOT5 and ROOT6. This blocks ROOT6 RelVals from running.

This was reported in OfflineComputingPlanningMeeting2013121.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
