### PR TITLE
Add CUDA 5.5 toolfile

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -119,6 +119,7 @@ Requires: doxygen-toolfile
 Requires: py2-python-dateutil-toolfile
 Requires: yaml-cpp-toolfile
 Requires: fastjet-contrib-toolfile
+Requires: cuda-toolfile
 
 # Only for Linux platform.
 %if %islinux
@@ -146,7 +147,7 @@ Requires: igprof-toolfile
 %endif
 %endif
 
-%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler boost_serialization boost_iostreams
+%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler boost_serialization boost_iostreams cuda
 
 ## IMPORT scramv1-tool-conf
 

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -1,0 +1,36 @@
+### RPM external cuda-toolfile 5.5
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
+<tool name="cuda" version="%{realversion}">
+  <info url="https://developer.nvidia.com/cuda-toolkit"/>
+  <lib name="cublas"/>
+  <lib name="cublas_device"/>
+  <lib name="cudadevrt"/>
+  <lib name="cudart"/>
+  <lib name="cudart_static"/>
+  <lib name="cufft"/>
+  <lib name="cufftw"/>
+  <lib name="cuinj64"/>
+  <lib name="curand"/>
+  <lib name="cusparse"/>
+  <lib name="nppc"/>
+  <lib name="nppi"/>
+  <lib name="npps"/>
+  <lib name="nvToolsExt"/>
+  <client>
+    <environment name="CUDA_BASE" default="/usr/local/cuda-%{realversion}"/>
+    <environment name="BINDIR" default="$CUDA_BASE/bin"/>
+    <environment name="LIBDIR" default="$CUDA_BASE/lib64"/>
+    <environment name="INCLUDE" default="$CUDA_BASE/include"/>
+  </client>
+  <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post


### PR DESCRIPTION
CUDA toolfile will be distributed in standard CMSSW distribution. CUDA must be enabled explicitly via `scram setup cuda`. It will make `NVCC` (uses our C++ compiler) available in CMSSW environment and also allow linking to CUDA in CMSSW packages. We might want to split `cuda-toolfile` into several different ones in future.
