### PR TITLE
root: add support for C++11 mode for `linuxarm' target

### DIFF
--- a/root-5.34.17-linuxarm-cxx11.patch
+++ b/root-5.34.17-linuxarm-cxx11.patch
@@ -1,0 +1,23 @@
+diff --git a/config/Makefile.linuxarm b/config/Makefile.linuxarm
+index 5586220..a6520d2 100644
+--- a/config/Makefile.linuxarm
++++ b/config/Makefile.linuxarm
+@@ -14,13 +14,16 @@ else
+ OPT           = $(OPTFLAGS)
+ NOOPT         =
+ endif
++ifeq ($(CXX11),yes)
++CXX11FLAGS    = -std=c++11 -Wno-deprecated-declarations
++endif
+
+ # Compiler:
+ CXX           = g++
+ CC            = gcc
+-CXXFLAGS      = -Wall -fsigned-char -fPIC $(EXTRA_CXXFLAGS)
++CXXFLAGS      = -Wall -fsigned-char -fPIC $(EXTRA_CXXFLAGS) $(CXX11FLAGS)
+ CFLAGS        = -Wall -fsigned-char -fPIC $(EXTRA_CFLAGS)
+-CINTCXXFLAGS  = -Wall -fsigned-char -fPIC $(EXTRA_CXXFLAGS) \
++CINTCXXFLAGS  = -Wall -fsigned-char -fPIC $(EXTRA_CXXFLAGS) $(CXX11FLAGS) \
+                 -DG__REGEXP -DG__UNIX -DG__SHAREDLIB \
+                 -DG__OSFDLL -DG__ROOT -DG__REDIRECTIO
+ CINTCFLAGS    = -Wall -fsigned-char -fPIC $(EXTRA_CFLAGS) \

--- a/root.spec
+++ b/root.spec
@@ -30,6 +30,7 @@ Patch14: https://github.com/Dr15Jones/root/commit/97b24fb57166a105d3912ee0ac0c3b
 Patch15: https://github.com/Dr15Jones/root/commit/e04ab19e95c14665a2b5e464f30c54d226b490e0.patch
 Patch16: https://github.com/Dr15Jones/root/commit/386c35244cd8901c243bbc8dd10ac1643e44b589.patch
 Patch17: https://github.com/Dr15Jones/root/commit/285552177b57fa931d4e2f6e67ea3cb0414c736b.patch
+Patch18: root-5.34.17-linuxarm-cxx11
 
 Requires: gccxml gsl libjpg libpng libtiff pcre python fftw3 xz xrootd libxml2 openssl
 
@@ -70,6 +71,7 @@ Requires: freetype
 %patch15 -p1
 %patch16 -p1
 %patch17 -p1
+%patch18 -p1
 
 # The following patch can only be applied on SLC5 or later (extra linker
 # options only available with the SLC5 binutils)
@@ -136,16 +138,6 @@ CONFIG_ARGS="--enable-table
              --with-cint-longline=4096
              --disable-hdfs
              --disable-oracle ${EXTRA_CONFIG_ARGS}"
-
-# Add support for GCC 4.6
-sed -ibak 's/\-std=c++11/-std=c++0x/g' \
-  configure \
-  Makefile \
-  config/Makefile.macosx64 \
-  config/Makefile.macosx \
-  config/Makefile.linux \
-  config/root-config.in \
-  config/Makefile.linuxx8664gcc 
 
 %if %isarmv7
 cp ./cint/iosenum/iosenum.linux3 ./cint/iosenum/iosenum.linuxarm3


### PR DESCRIPTION
Add missing fragments to `linuxarm' target Makefile to support C++11
mode.

Cleanup unneeded parts in SPEC.

Also filed as ROOT-6110 in Jira.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
