### PR TITLE
rivet2: fix configure cannot find boost headers needed by yaml-cpp

### DIFF
--- a/rivet2.spec
+++ b/rivet2.spec
@@ -20,7 +20,7 @@ Requires: python cython
             --with-yaml-cpp=${YAML_CPP_ROOT} \
             --disable-doxygen --disable-pdfmanual --with-pic \
             PYTHONPATH=${CYTHON_ROOT}/lib/python@PYTHONV@/site-packages \
-            CXX="$(which %cms_cxx)" CXXFLAGS="%cms_cxxflags"
+            CXX="$(which %cms_cxx)" CXXFLAGS="%cms_cxxflags" CPPFLAGS="-I${BOOST_ROOT}/include"
 
 # The following hack insures that the bins with the library linked explicitly
 # rather than indirectly, as required by the gold linker


### PR DESCRIPTION
Ritve2 failed on armv7hl:

```
yaml-cpp API version could not be determined
```

yaml-cpp depends on Boost, but configure script executed GCC without
passing -I option for Boost includes. Hack it by adding Boost
include path in CPPFLAGS.

Previously it was taking Boost headers from standard system location and
Boost is not installed on armv7hl machines.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
