### PR TITLE
Add support for OpenCL 1.1 C and C++ API

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 30.0
+### RPM cms cmssw-tool-conf 31.0
 ## NOCOMPILER
 # with cmsBuild, change the above version only when a new
 # tool is added
@@ -121,6 +121,8 @@ Requires: yaml-cpp-toolfile
 Requires: fastjet-contrib-toolfile
 Requires: cuda-toolfile
 Requires: rivet2-toolfile
+Requires: opencl-toolfile
+Requires: opencl-cpp-toolfile
 
 # Only for Linux platform.
 %if %islinux
@@ -148,7 +150,7 @@ Requires: igprof-toolfile
 %endif
 %endif
 
-%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler boost_serialization boost_iostreams cuda rivet2
+%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler boost_serialization boost_iostreams cuda rivet2 opencl opencl-cpp
 
 ## IMPORT scramv1-tool-conf
 

--- a/opencl-cpp-toolfile.spec
+++ b/opencl-cpp-toolfile.spec
@@ -1,0 +1,25 @@
+### RPM external opencl-cpp-toolfile 1.0
+
+Requires: opencl-cpp
+
+%prep
+# NOP
+
+%build
+# NOP
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/opencl-cpp.xml
+<tool name="opencl-cpp" version="@TOOL_VERSION@">
+  <info url="http://www.khronos.org/registry/cl/"/>
+  <client>
+    <environment name="OPENCL_CPP_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$OPENCL_CPP_BASE/include"/>
+  </client>
+  <use name="opencl"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/opencl-cpp.spec
+++ b/opencl-cpp.spec
@@ -1,0 +1,16 @@
+### RPM external opencl-cpp 1.1
+## NOCOMPILER
+
+Source0: http://www.khronos.org/registry/cl/api/%{realversion}/cl.hpp
+
+Requires: opencl
+
+%prep
+# NOP
+
+%build
+# NOP
+
+%install
+mkdir -p %{i}/include/CL
+cp %{SOURCE0} %{i}/include/CL

--- a/opencl-toolfile.spec
+++ b/opencl-toolfile.spec
@@ -1,0 +1,26 @@
+### RPM external opencl-toolfile 1.0
+
+Requires: opencl
+
+%prep
+# NOP
+
+%build
+# NOP
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/opencl.xml
+<tool name="opencl" version="@TOOL_VERSION@">
+  <info url="https://www.khronos.org/opencl/"/>
+  <lib name="OpenCL"/>
+  <client>
+    <environment name="OPENCL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$OPENCL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$OPENCL_BASE/include"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/opencl.spec
+++ b/opencl.spec
@@ -1,0 +1,15 @@
+### RPM external opencl 1.1
+## NOCOMPILER
+
+%prep
+# NOP
+
+%build
+# NOP
+
+%install
+# NOP
+
+%post
+ln -s /usr/lib64/nvidia ${RPM_INSTALL_PREFIX}/%{pkgrel}/lib64
+ln -s /usr/local/cuda/include ${RPM_INSTALL_PREFIX}/%{pkgrel}/include


### PR DESCRIPTION
By default OpenCL is configured for NVIDIA CUDA. <PKG>/include and
<PKG>/lib64 are symlinks, which can me modified to point to
alternative implementation.

`opencl` and `opencl-cpp` are optional toolfiles and must be loaded
explicitly.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
