### PR TITLE
git: set GIT_EXEC_PATH

### DIFF
--- a/git-toolfile.spec
+++ b/git-toolfile.spec
@@ -28,6 +28,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/git.xml
   <runtime name="PATH" value="$GIT_BASE/libexec/git-core" type="path"/>
   <runtime name="GIT_TEMPLATE_DIR" value="$GIT_BASE/share/git-core/templates" type="path"/>
   <runtime name="GIT_SSL_CAINFO" value="$GIT_BASE/share/ssl/certs/ca-bundle.crt" type="path"/>
+  <runtime name="GIT_EXEC_PATH" value="$GIT_BASE/libexec/git-core" type="path"/>
   <runtime name="PERL5LIB" value="$GIT_BASE@PERL5LIB_PATH@" type="path"/>
 </tool>
 EOF_TOOLFILE

--- a/git.spec
+++ b/git.spec
@@ -3,6 +3,7 @@
 ## INITENV +PATH PATH %{i}/libexec/git-core
 ## INITENV SET GIT_TEMPLATE_DIR %{i}/share/git-core/templates
 ## INITENV SET GIT_SSL_CAINFO %{i}/share/ssl/certs/ca-bundle.crt
+## INITENV SET GIT_EXEC_PATH %{i}/libexec/git-core
 
 %define isDarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
 


### PR DESCRIPTION
Some git commands are failing, because git --exec-path reports
non-reallocated path.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
