### PR TITLE
Added rivet-2.8.2-disable-doc patch to fix python crashes on OSX108

### DIFF
--- a/rivet2.spec
+++ b/rivet2.spec
@@ -4,6 +4,9 @@ Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rive
 Requires: hepmc boost fastjet gsl yaml-cpp yoda
 Requires: python cython
 
+Patch0: rivet-1.4.0
+Patch1: rivet-1.8.2-disable-doc
+
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
 %endif
@@ -14,6 +17,8 @@ Requires: python cython
 
 %prep
 %setup -n rivet/%{realversion}
+%patch0 -p0
+%patch1 -p1
 
 ./configure --disable-silent-rules --prefix=%i --with-boost=${BOOST_ROOT} --with-hepmc=$HEPMC_ROOT \
             --with-fastjet=$FASTJET_ROOT --with-gsl=$GSL_ROOT --with-yoda=${YODA_ROOT} \


### PR DESCRIPTION
I also added rivet-1.4.0 which still applied. The other ones did not apply anymore. 
