### PR TITLE
blackhat: fix compile on armv7hl; add dependency on openssl

### DIFF
--- a/blackhat-0.9.9-armv7hl.patch
+++ b/blackhat-0.9.9-armv7hl.patch
@@ -1,0 +1,1002 @@
+diff --git a/src/trees_eval/A0_1phi_Q_massive.cpp b/src/trees_eval/A0_1phi_Q_massive.cpp
+index a6d95c7..1dfe83b 100755
+--- a/src/trees_eval/A0_1phi_Q_massive.cpp
++++ b/src/trees_eval/A0_1phi_Q_massive.cpp
+@@ -615,7 +615,7 @@ template <int i0, int i1, int i2, int i3,  class T> complex<T>  A1ph2q2QM2fm_16_
+ 	//_MESSAGE8("16m: Q+,q+,q2+,Q2+ : ",i0,", ",i1,", ",i2,", ",i3);
+ 	return -_HIGGS_SCALAR_SCALAR_PARAM*mass*complex<T>(0,-1)*(f1.Lt()*ep.p(i1)->Lt())*(ep.p(i2)->Lt()*fn.Lt())/(T(8)*ep.sp(i0,i1)*ep.sp(i2,i3));}
+ 
+-template <class T, int QMPOS, int QPOS, int QPOS2, int QMPOS2> complex<T> (*A1ph2q2QM_Tree_Ptr_non_higgs_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int QMPOS, int QPOS, int QPOS2, int QMPOS2> complex<T> (*A1ph2q2QM_Tree_Ptr_non_higgs_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ //	cout << hex << " hqQq2Q2:" << hc << dec << endl;
+ 	switch(hc){
+ 		case 0x07090805: //8631://(Q+,q3+,qb3-,Qb+)
+@@ -1659,7 +1659,7 @@ template <class T, int QMPOS, int QPOS, int QPOS2, int QMPOS2> complex<T> (*A1ph
+ 	}
+ }
+ 
+-template <class T> complex<T> (*A1ph2q2QM_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2q2QM_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	// We first extract the position of the higgs and then analyse the colour ordered particles in the next level down
+ 	long rem=hc;
+ 	long newhc=0;
+@@ -2010,7 +2010,7 @@ template <int i0, int i2, int i3, class T> complex<T>  A1ph2QM1g15p_eval(const e
+ 									   -(ep.ref()->Lt()*ep.p(i2)->Lt())*(ep.p(i2)->L()*f4.L())*fac1/((rf.L()*ep.p(i2)->L())*(f1.Lt()*ep.ref()->Lt())));
+ }
+ 
+-template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_simp_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_simp_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	//	cout << hex << hc << dec << endl;
+ 	
+ 	switch (hc) {
+@@ -2088,7 +2088,7 @@ template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_sim
+ 	}
+ }
+ 	
+-template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_simp_dag_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_simp_dag_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	//	cout << hex << hc << dec << endl;
+ 	
+ 	switch (hc) {
+@@ -2166,7 +2166,7 @@ template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_sim
+ }
+ 			
+ 			
+-template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_simp_full_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_simp_full_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	//	cout << hex << hc << dec << endl;
+ 	
+ 	switch (hc) {
+@@ -2311,7 +2311,7 @@ template <class T, int QPOS, int GLUE, int QPOS2> complex<T> (*A1ph2QM1g_phi_sim
+ 	}
+ }
+ 	
+-template <class T> complex<T> (*A1ph2QM1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2QM1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	// We first extract the position of the higgs and then analyse the colour ordered particles in the next level down
+ 	long rem=hc;
+ 	long newhc=0;
+@@ -2405,17 +2405,17 @@ template <class T> complex<T> (*A1ph2QM1g_Tree_Ptr_eval(long hc))(const eval_par
+ }
+ 
+ 
+-template complex<R> (*A1ph2q2QM_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2q2QM_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2q2QM_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2q2QM_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2q2QM_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2q2QM_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A1ph2QM1g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2QM1g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2QM1g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2QM1g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2QM1g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2QM1g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ #if BH_USE_GMP
+-template complex<RGMP> (*A1ph2q2QM_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2QM1g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2q2QM_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2QM1g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ 
+ #endif
+ 
+diff --git a/src/trees_eval/A0_1phi_eval.cpp b/src/trees_eval/A0_1phi_eval.cpp
+index edfb599..39b95a2 100644
+--- a/src/trees_eval/A0_1phi_eval.cpp
++++ b/src/trees_eval/A0_1phi_eval.cpp
+@@ -42,7 +42,7 @@ template <int i0, int i1, int i2, class T> complex<T>  A1ph2g2_eval(const eval_p
+ 	return complex<T>(0,-1)*_HIGGS_GLUON_GLUON_PARAM_D*pow(ep.spb(i1,i2),2);
+ }
+ 
+-template <class T> complex<T> (*A1ph2g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {
+ 	case 0x900://ph--
+ 		return &A1ph2g1_eval<0,1,2>;
+@@ -117,7 +117,7 @@ template <int i0, int i1, int i2, int i3, class T> complex<T>  A1ph3g4_eval(cons
+ }
+ 
+ 
+-template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_Ptr_higgs_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_Ptr_higgs_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {
+ 		case 0x001://ph--+
+ 			return &A1ph3g1_eval<G1,G2,G3>;
+@@ -140,7 +140,7 @@ template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_P
+ 	}
+ }
+ 
+-template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_Ptr_higgs_dag_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_Ptr_higgs_dag_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {			
+ 		case 0x110://phd++-
+ 			return &A1ph3g3_eval<G1,G2,G3>;
+@@ -164,7 +164,7 @@ template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_P
+ }
+ 	
+ 	
+-template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_Ptr_higgs_full_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_Ptr_higgs_full_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {
+ 		case 0x001://H--+
+ 			return &A1ph3g1_eval<G1,G2,G3>;
+@@ -205,7 +205,7 @@ template <class T, int HIGGS, int G1, int G2, int G3> complex<T> (*A1ph3g_Tree_P
+ 
+ 	
+ 	
+-template <class T> complex<T> (*A1ph3g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph3g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	long rem=hc;
+ 	long newhc=0;
+ 	int epos;
+@@ -339,7 +339,7 @@ template <int i0, int i1, int i2, int i3, class T> complex<T>  A1ph1g2q8_eval(co
+ 	return complex<T>(0,-1)*ep.spb(i2,i1)*ep.spb(i2,i1)/ep.spb(i3,i1);
+ }
+ 
+-template <class T> complex<T> (*A1ph1g2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph1g2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {
+ 	case 0x9230://phq-q+-
+ 		return &A1ph1g2q1_eval<0,1,2,3>;
+@@ -517,7 +517,7 @@ template <class T> complex<T> (*A1ph1g2q_Tree_Ptr_eval(long hc))(const eval_para
+ //	return complex<T>(0,1)*ep.spb(i1,i2)*ep.spb(i1,i2);
+ //}
+ 
+-template <class T> complex<T> (*A1ph2g2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2g2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {
+ 
+ 	default:// We return zero for all other helicity combinations
+@@ -593,7 +593,7 @@ template <int i0, int i1, int i2, int i3, int i4, class T> complex<T>  A1ph2q2Q1
+ }
+ 
+ 
+-template <class T> complex<T> (*A1ph2q2Q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2q2Q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ //	cout << hex << hc << dec << endl;
+ 	switch (hc) {
+ 	case 0x0E02030908://ph,qm,qp,q2p,q2m
+@@ -1118,38 +1118,38 @@ template <class T> complex<T> (*A1ph2q2Q_Tree_Ptr_eval(long hc))(const eval_para
+ 	
+ 
+ 
+-template complex<R> (*A1ph2g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ 
+ 
+-template complex<R> (*A1ph3g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph3g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph3g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph3g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph3g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph3g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ 
+ 
+-template complex<R> (*A1ph1g2q_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph1g2q_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph1g2q_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph1g2q_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph1g2q_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph1g2q_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ 
+ 
+-template complex<R> (*A1ph2g2q_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2g2q_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2g2q_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2g2q_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2g2q_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2g2q_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A1ph2q2Q_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2q2Q_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2q2Q_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2q2Q_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2q2Q_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2q2Q_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ #if BH_USE_GMP
+-template complex<RGMP> (*A1ph2g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph3g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph1g2q_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2g2q_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2q2Q_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph3g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph1g2q_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2g2q_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2q2Q_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ 
+ #endif
+ 		
+diff --git a/src/trees_eval/A0_1phi_scalar.cpp b/src/trees_eval/A0_1phi_scalar.cpp
+index d1bc981..cc1db63 100644
+--- a/src/trees_eval/A0_1phi_scalar.cpp
++++ b/src/trees_eval/A0_1phi_scalar.cpp
+@@ -328,7 +328,7 @@ template <int i0, int i1, int i2, class T> complex<T>  A1ph2sc6_eval(const eval_
+ 
+ 
+     
+-template <class T> complex<T> (*A1ph2sc_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2sc_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {
+ 	case 0x944://phss
+         case 0xA44://phdss
+@@ -1127,7 +1127,7 @@ template <int i0, int i1, int i2, int i3, class T> complex<T>  A1ph2sc1g12_eval(
+     
+ 
+ 
+-template <class T> complex<T> (*A1ph2sc1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ //		cout << hex << hc << dec << endl;
+ 	switch (hc) {
+ 			
+@@ -2170,17 +2170,17 @@ template <class T> complex<T> (*A1ph2sc1g_Tree_Ptr_eval(long hc))(const eval_par
+ }
+ 
+ 	
+-template complex<R> (*A1ph2sc_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2sc_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2sc_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2sc_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2sc_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2sc_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A1ph2sc1g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2sc1g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2sc1g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 			
+ #if BH_USE_GMP
+-template complex<RGMP> (*A1ph2sc_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2sc1g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2sc_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ }	
+diff --git a/src/trees_eval/A0_1phi_scalar_2.cpp b/src/trees_eval/A0_1phi_scalar_2.cpp
+index 96dba27..be495ce 100644
+--- a/src/trees_eval/A0_1phi_scalar_2.cpp
++++ b/src/trees_eval/A0_1phi_scalar_2.cpp
+@@ -191,7 +191,7 @@ template <int i0, int i1, int i2, class T> complex<T>  A1ph1QM1sc1q8p_eval(const
+ }
+ 
+ 
+-template <class T, int SPOS, int QPOS, int QMPOS> complex<T> (*A1ph1QM1sc1q_phi_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int SPOS, int QPOS, int QMPOS> complex<T> (*A1ph1QM1sc1q_phi_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	//	cout << hex << hc << dec << endl;
+ 	switch (hc) {
+ 		case 0xd28: //258: //(s,q3-,Qb+)
+@@ -338,7 +338,7 @@ template <class T, int SPOS, int QPOS, int QMPOS> complex<T> (*A1ph1QM1sc1q_phi_
+ 	}
+ }
+ 
+-template <class T> complex<T> (*A1ph1QM1sc1q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph1QM1sc1q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	// We first extract the position of the higgs and then analyse the colour ordered particles in the next level down
+ 	long rem=hc;
+ 	long newhc=0;
+@@ -527,7 +527,7 @@ template <int i1, int i2, int i3, int i4, int i5, class T> complex<T>  A1ph2sc2q
+ 	
+ }
+ 
+-template <class T> complex<T> (*A1ph2sc2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A1ph2sc2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+ 	switch (hc) {
+ 		case 0x94234: //2169: //(ph,s,qb-,q+,s)
+@@ -1071,17 +1071,17 @@ template <class T> complex<T> (*A1ph2sc2q_Tree_Ptr_eval(long hc))(const eval_par
+ 	}
+ }
+ 
+-template complex<R> (*A1ph1QM1sc1q_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph1QM1sc1q_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph1QM1sc1q_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph1QM1sc1q_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph1QM1sc1q_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph1QM1sc1q_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A1ph2sc2q_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2sc2q_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2sc2q_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2sc2q_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2sc2q_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2sc2q_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ #if BH_USE_GMP
+-template complex<RGMP> (*A1ph1QM1sc1q_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2sc2q_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph1QM1sc1q_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2sc2q_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ }	
+diff --git a/src/trees_eval/A0_1phi_scalar_massive.cpp b/src/trees_eval/A0_1phi_scalar_massive.cpp
+index db1de55..d3bb83f 100644
+--- a/src/trees_eval/A0_1phi_scalar_massive.cpp
++++ b/src/trees_eval/A0_1phi_scalar_massive.cpp
+@@ -67,7 +67,7 @@ template <int i0, int i1, int i2, int i3, class T> complex<T>  A1ph2sc1gM3_eval(
+ 	
+ 
+ 
+-template <class T> complex<T> (*A1ph2sc1gM_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2sc1gM_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	//	cout << hex << hc << dec << endl;
+ 	switch (hc) {
+ 			
+@@ -345,7 +345,7 @@ template <int i1, int i2, int i3, int i4, int i5, class T> complex<T>  A1ph2sc2q
+ 
+ }
+ 
+-template <class T> complex<T> (*A1ph2sc2qM_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A1ph2sc2qM_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+     switch (hc) {
+ 		case 0x94234: //2169: //(ph,s,qb-,q+,s)
+@@ -619,17 +619,17 @@ template <class T> complex<T> (*A1ph2sc2qM_Tree_Ptr_eval(long hc))(const eval_pa
+ 	}
+ }
+ 	
+-template complex<R> (*A1ph2sc1gM_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2sc1gM_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2sc1gM_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2sc1gM_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2sc1gM_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2sc1gM_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A1ph2sc2qM_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2sc2qM_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2sc2qM_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2sc2qM_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2sc2qM_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2sc2qM_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 			
+ #if BH_USE_GMP
+-template complex<RGMP> (*A1ph2sc1gM_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2sc2qM_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2sc1gM_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2sc2qM_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ 
+ #endif
+ 
+diff --git a/src/trees_eval/A0_2Gsc_eval.cpp b/src/trees_eval/A0_2Gsc_eval.cpp
+index 817a271..9a7fecd 100644
+--- a/src/trees_eval/A0_2Gsc_eval.cpp
++++ b/src/trees_eval/A0_2Gsc_eval.cpp
+@@ -566,7 +566,7 @@ template <int i0, int i1, int i2, class T> complex<T>  A2Gsc1g8_eval(const eval_
+ 
+ 
+ 
+-template <class T> complex<T> (*A2Gsc1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A2Gsc1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ //    cout << "Found massive three-point vertex:" << hex << hc << dec << endl;
+ 	switch (hc) {// Note that the labels are in the reverse order of the respective process
+ 	case 0x413://G+g+G-
+@@ -703,13 +703,13 @@ template <class T> complex<T> (*A2Gsc1g_Tree_Ptr_eval(long hc))(const eval_param
+ 
+ 
+ 
+-template complex<R> (*A2Gsc1g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2Gsc1g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2Gsc1g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2Gsc1g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2Gsc1g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2Gsc1g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ #if BH_USE_GMP
+ 
+-template complex<RGMP> (*A2Gsc1g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2Gsc1g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ 
+diff --git a/src/trees_eval/A0_2q2Gl1y_eval.cpp b/src/trees_eval/A0_2q2Gl1y_eval.cpp
+index 48aeb0c..6c345b0 100644
+--- a/src/trees_eval/A0_2q2Gl1y_eval.cpp
++++ b/src/trees_eval/A0_2q2Gl1y_eval.cpp
+@@ -186,7 +186,7 @@ SPA(5,1)*SPA(5,4))
+ 
+ 
+ 
+-template <class T> complex<T>  (*A2q2G1y_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T>  (*A2q2G1y_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 
+    switch (hc) {
+ 
+@@ -225,13 +225,13 @@ template <class T> complex<T>  (*A2q2G1y_Tree_Ptr_eval(long hc))(const eval_para
+ }
+ }
+ 
+-template complex<R>  (*A2q2G1y_Tree_Ptr_eval(long hc))(const eval_param<R>& ep, const mass_param_coll& masses);
+-template complex<RHP>  (*A2q2G1y_Tree_Ptr_eval(long hc))(const eval_param<RHP>& ep, const mass_param_coll& masses);
+-template complex<RVHP>  (*A2q2G1y_Tree_Ptr_eval(long hc))(const eval_param<RVHP>& ep, const mass_param_coll& masses);
++template complex<R>  (*A2q2G1y_Tree_Ptr_eval(long long hc))(const eval_param<R>& ep, const mass_param_coll& masses);
++template complex<RHP>  (*A2q2G1y_Tree_Ptr_eval(long long hc))(const eval_param<RHP>& ep, const mass_param_coll& masses);
++template complex<RVHP>  (*A2q2G1y_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>& ep, const mass_param_coll& masses);
+ 
+ 
+ #if BH_USE_GMP
+-template complex<RGMP>  (*A2q2G1y_Tree_Ptr_eval(long hc))(const eval_param<RGMP>& ep, const mass_param_coll& masses);
++template complex<RGMP>  (*A2q2G1y_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>& ep, const mass_param_coll& masses);
+ #endif
+ }
+ 
+diff --git a/src/trees_eval/A0_2q2Q1g2l_eval.cpp b/src/trees_eval/A0_2q2Q1g2l_eval.cpp
+index c90420c..294e5f3 100644
+--- a/src/trees_eval/A0_2q2Q1g2l_eval.cpp
++++ b/src/trees_eval/A0_2q2Q1g2l_eval.cpp
+@@ -3721,7 +3721,7 @@ return(
+ 
+ 
+ 
+-template <class T> complex<T> (*A2q2Q1g2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q2Q1g2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+ 	switch (hc) {
+ 
+@@ -3796,14 +3796,14 @@ case 2052816:	 return &A2q2Q1g2l_qmqb2mq2pqbpplmlbp_eval<0,1,2,3,4,5,6>;//qm qb2
+ 	}
+ }
+ 
+-template complex<R> (*A2q2Q1g2l_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q2Q1g2l_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q2Q1g2l_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q2Q1g2l_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q2Q1g2l_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q2Q1g2l_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ 
+ #if BH_USE_GMP
+ 
+-template complex<RGMP> (*A2q2Q1g2l_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q2Q1g2l_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ 
+ #endif
+ }
+diff --git a/src/trees_eval/A0_2q2Q2g2l_eval.cpp b/src/trees_eval/A0_2q2Q2g2l_eval.cpp
+index f95ef76..8134f01 100644
+--- a/src/trees_eval/A0_2q2Q2g2l_eval.cpp
++++ b/src/trees_eval/A0_2q2Q2g2l_eval.cpp
+@@ -7301,7 +7301,7 @@ return(
+ 
+ 
+ 
+-template <class T> complex<T> (*A2q2Q2g2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q2Q2g2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+ 	switch (hc) {
+ 
+@@ -7408,10 +7408,10 @@ case 16308944:	 return &A2q2Q2g2l_qmqb2mq2pppqbplmlbp_eval<0,1,2,3,4,5,6,7>;//qm
+ 	}
+ }
+ 
+-template complex<R> (*A2q2Q2g2l_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q2Q2g2l_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q2Q2g2l_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q2Q2g2l_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q2Q2g2l_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q2Q2g2l_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ #if BH_USE_GMP
+-template complex<RGMP> (*A2q2Q2g2l_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q2Q2g2l_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ }
+diff --git a/src/trees_eval/A0_2q2Q2l_eval.cpp b/src/trees_eval/A0_2q2Q2l_eval.cpp
+index c7918ff..d8d1780 100644
+--- a/src/trees_eval/A0_2q2Q2l_eval.cpp
++++ b/src/trees_eval/A0_2q2Q2l_eval.cpp
+@@ -321,7 +321,7 @@ return(
+ 
+ 
+ 
+-template <class T> complex<T> (*A2q2Q2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q2Q2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+ 	switch (hc) {
+ 
+@@ -340,11 +340,11 @@ case 254672:	 return &A2q2Q2l_qmqb2mq2pqbplmlbp_eval<0,1,2,3,4,5>;//qm qb2m q2p
+ 	}
+ }
+ 
+-template complex<R> (*A2q2Q2l_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q2Q2l_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q2Q2l_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q2Q2l_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q2Q2l_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q2Q2l_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ #if BH_USE_GMP
+-template complex<RGMP> (*A2q2Q2l_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q2Q2l_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ }
+diff --git a/src/trees_eval/A0_2q2Q3g2l_eval.cpp b/src/trees_eval/A0_2q2Q3g2l_eval.cpp
+index d24f296..2950da9 100644
+--- a/src/trees_eval/A0_2q2Q3g2l_eval.cpp
++++ b/src/trees_eval/A0_2q2Q3g2l_eval.cpp
+@@ -15477,7 +15477,7 @@ return(
+ 
+ 
+ 
+-template <class T> complex<T> (*A2q2Q3g2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q2Q3g2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+ 	switch (hc) {
+ 
+@@ -15648,12 +15648,12 @@ case 130472656:	 return &A2q2Q3g2l_qmqb2mq2ppppqbplmlbp_eval<0,1,2,3,4,5,6,7,8>;
+ 	}
+ }
+ 
+-template complex<R> (*A2q2Q3g2l_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q2Q3g2l_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q2Q3g2l_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q2Q3g2l_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q2Q3g2l_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q2Q3g2l_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ #if BH_USE_GMP
+-template complex<RGMP> (*A2q2Q3g2l_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q2Q3g2l_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ }
+diff --git a/src/trees_eval/A0_2q2l2G_eval.cpp b/src/trees_eval/A0_2q2l2G_eval.cpp
+index 363e6f2..6fdace1 100644
+--- a/src/trees_eval/A0_2q2l2G_eval.cpp
++++ b/src/trees_eval/A0_2q2l2G_eval.cpp
+@@ -116,7 +116,7 @@ template <class T> complex<T> A2q2l2G_GqqbllbGB_mmpmpp_eval(const eval_param<T>&
+ 	;
+ }
+ 
+-template <class T> complex<T>  (*A2q2l2G_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T>  (*A2q2l2G_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 
+    switch (hc) {
+ 
+@@ -141,12 +141,12 @@ default: return 0;
+ }
+ 
+ 
+-template complex<R>  (*A2q2l2G_Tree_Ptr_eval(long hc))(const eval_param<R>& ep, const mass_param_coll& masses);
+-template complex<RHP>  (*A2q2l2G_Tree_Ptr_eval(long hc))(const eval_param<RHP>& ep, const mass_param_coll& masses);
+-template complex<RVHP>  (*A2q2l2G_Tree_Ptr_eval(long hc))(const eval_param<RVHP>& ep, const mass_param_coll& masses);
++template complex<R>  (*A2q2l2G_Tree_Ptr_eval(long long hc))(const eval_param<R>& ep, const mass_param_coll& masses);
++template complex<RHP>  (*A2q2l2G_Tree_Ptr_eval(long long hc))(const eval_param<RHP>& ep, const mass_param_coll& masses);
++template complex<RVHP>  (*A2q2l2G_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>& ep, const mass_param_coll& masses);
+ 
+ #if BH_USE_GMP
+-template complex<RGMP>  (*A2q2l2G_Tree_Ptr_eval(long hc))(const eval_param<RGMP>& ep, const mass_param_coll& masses);
++template complex<RGMP>  (*A2q2l2G_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>& ep, const mass_param_coll& masses);
+ #endif
+ 
+ }
+diff --git a/src/trees_eval/A0_G3_eval.cpp b/src/trees_eval/A0_G3_eval.cpp
+index 574f513..6061207 100644
+--- a/src/trees_eval/A0_G3_eval.cpp
++++ b/src/trees_eval/A0_G3_eval.cpp
+@@ -138,7 +138,7 @@ template < int i1, int i2, int i3, int i4, class T> complex<T>  A4g_pppp_G3_eval
+ }
+ 
+ 
+-template <class T> complex<T> (*A4g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A4g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+         switch (hc) {
+     case	0:	return &A4g_mmmm_G3_eval<0,1,2,3>;
+@@ -163,11 +163,11 @@ template <class T> complex<T> (*A4g_G3_Tree_Ptr_eval(long hc))(const eval_param<
+         }
+ }
+ 
+-template complex<R> (*A4g_G3_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A4g_G3_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A4g_G3_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A4g_G3_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A4g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A4g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ #if BH_USE_GMP
+-template complex<RGMP> (*A4g_G3_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A4g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ 
+@@ -237,7 +237,7 @@ template < int i1, int i2, int i3, int i4, class T> complex<T>  A2q2g_qpppqbm_G3
+ }
+ 
+ 
+-template <class T> complex<T> (*A2q2g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q2g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+         switch (hc) {
+     case	129:	return &A2q2g_qmmmqbp_G3_eval<0,1,2,3>;
+@@ -254,11 +254,11 @@ template <class T> complex<T> (*A2q2g_G3_Tree_Ptr_eval(long hc))(const eval_para
+         }
+ }
+ 
+-template complex<R> (*A2q2g_G3_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q2g_G3_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q2g_G3_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q2g_G3_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q2g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q2g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ #if BH_USE_GMP
+-template complex<RGMP> (*A2q2g_G3_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q2g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ /*
+@@ -299,7 +299,7 @@ template < int i1, int i2, int i3, int i4, class T> complex<T>  A2q2Q_q1pq2bpq2m
+ }
+ 
+ 
+-template <class T> complex<T> (*A2q2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+         switch (hc) {
+     case	637:	return &A2q2Q_q1mq2bmq2pq1bp_G3_eval<0,1,2,3>;
+@@ -312,12 +312,12 @@ template <class T> complex<T> (*A2q2Q_G3_Tree_Ptr_eval(long hc))(const eval_para
+         }
+ }
+ 
+-template complex<R> (*A2q2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+ #if BH_USE_GMP
+-template complex<RGMP> (*A2q2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ /*
+ *
+@@ -553,7 +553,7 @@ template < int i1, int i2, int i3, int i4, int i5, class T> complex<T>  A5g_pppp
+ }
+ 
+ 
+-template <class T> complex<T> (*A5g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A5g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+         switch (hc) {
+     case	0:	return &A5g_mmmmm_G3_eval<0,1,2,3,4>;
+@@ -594,11 +594,11 @@ template <class T> complex<T> (*A5g_G3_Tree_Ptr_eval(long hc))(const eval_param<
+         }
+ }
+ 
+-template complex<R> (*A5g_G3_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A5g_G3_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A5g_G3_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A5g_G3_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A5g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A5g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ #if BH_USE_GMP
+-template complex<RGMP> (*A5g_G3_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A5g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ /*
+@@ -723,7 +723,7 @@ template < int i1, int i2, int i3, int i4, int i5, class T> complex<T>  A2q3g_qp
+ }
+ 
+ 
+-template <class T> complex<T> (*A2q3g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q3g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+         switch (hc) {
+     case	513:	return &A2q3g_qmmmmqbp_G3_eval<0,1,2,3,4>;
+@@ -748,11 +748,11 @@ template <class T> complex<T> (*A2q3g_G3_Tree_Ptr_eval(long hc))(const eval_para
+         }
+ }
+ 
+-template complex<R> (*A2q3g_G3_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q3g_G3_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q3g_G3_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q3g_G3_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q3g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q3g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ #if BH_USE_GMP
+-template complex<RGMP> (*A2q3g_G3_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q3g_G3_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ /*
+@@ -989,7 +989,7 @@ template < int i1, int i2, int i3, int i4, int i5, class T> complex<T>  A2q1g2Q_
+ }
+ 
+ 
+-template <class T> complex<T> (*A2q1g2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A2q1g2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+         switch (hc) {
+     case	3817:	return &A2q1g2Q_q1mmq2bmq2pq1bp_G3_eval<0,1,2,3,4>;
+@@ -1030,11 +1030,11 @@ template <class T> complex<T> (*A2q1g2Q_G3_Tree_Ptr_eval(long hc))(const eval_pa
+         }
+ }
+ 
+-template complex<R> (*A2q1g2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2q1g2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2q1g2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2q1g2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2q1g2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2q1g2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ #if BH_USE_GMP
+-template complex<RGMP> (*A2q1g2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2q1g2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ }
+diff --git a/src/trees_eval/A0_sc_massless.cpp b/src/trees_eval/A0_sc_massless.cpp
+index 48eee06..dd0b3a1 100644
+--- a/src/trees_eval/A0_sc_massless.cpp
++++ b/src/trees_eval/A0_sc_massless.cpp
+@@ -118,7 +118,7 @@ template <int i0, int i1, int i2, class T> complex<T>  A2sc1g2_eval(const eval_p
+ 	return complex<T>(0,-1)*(ep.p(i1)->L()*ep.p(i0)->Sm()*ep.ref()->Lt())/(ep.p(i1)->Lt()*ep.ref()->Lt());
+ }
+ 
+-template <class T> complex<T> (*A2sc1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {
+ 		case 0x414://s(0)+s(0)
+ 			return &A2sc1g1_eval<0,1,2>;
+@@ -164,7 +164,7 @@ template <int i0, int i1, int i2, int i3, class T> complex<T>  A2sc2g4_eval(cons
+ }
+ 
+ 
+-template <class T> complex<T> (*A2sc2g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A2sc2g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	switch (hc) {			
+ 		case 0x4104://s(0)+-s(0)
+ 			return &A2sc2g3_eval<0,1,2,3>;
+@@ -222,7 +222,7 @@ template <int i0, int i1, int i2, int i3, class T> complex<T>  A1ph2scm1g3_eval(
+ }
+     
+ 
+-template <class T> complex<T> (*A1ph2scm1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2scm1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	//cout << hex << hc << dec << endl;
+ 	switch (hc) {
+ 			
+@@ -431,7 +431,7 @@ template <int i0, int i1, int i2, class T> complex<T>  A1ph2SM1_eval(const eval_
+     return complex<T>(0,1)*mass;
+ }
+ 
+-template <class T> complex<T> (*A1ph2SM_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2SM_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+     switch (hc) {
+         case 0x944://phss
+         case 0xA44://phdss
+@@ -548,7 +548,7 @@ template <class T> complex<T> (*A1ph2SM_Tree_Ptr_eval(long hc))(const eval_param
+ //                            );
+ //}
+ //
+-//template <class T> complex<T> (*A1ph2SM1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++//template <class T> complex<T> (*A1ph2SM1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ //    //		cout << hex << hc << dec << endl;
+ //    switch (hc) {
+ //            
+@@ -761,7 +761,7 @@ template <int i0, int i1, int i2, int i3, class T> complex<T>  A1ph2SM1g3_eval(c
+ }
+ 
+ 
+-template <class T> complex<T> (*A1ph2SM1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph2SM1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+ 	//	cout << hex << hc << dec << endl;
+ 	switch (hc) {
+ 			
+@@ -1086,7 +1086,7 @@ template <int i0, int i1, int i2, class T> complex<T>  A1ph1QM1SM1q8p_eval(const
+ }
+  
+  
+-template <class T, int SPOS, int QPOS, int QMPOS> complex<T> (*A1ph1QM1SM1q_phi_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T, int SPOS, int QPOS, int QMPOS> complex<T> (*A1ph1QM1SM1q_phi_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+      //	cout << hex << hc << dec << endl;
+      switch (hc) {
+          case 0x428: //258: //(s,q3-,Qb+)
+@@ -1233,7 +1233,7 @@ template <class T, int SPOS, int QPOS, int QMPOS> complex<T> (*A1ph1QM1SM1q_phi_
+      }
+ }
+  
+-template <class T> complex<T> (*A1ph1QM1SM1q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) {
++template <class T> complex<T> (*A1ph1QM1SM1q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) {
+      // We first extract the position of the higgs and then analyse the colour ordered particles in the next level down
+      long rem=hc;
+      long newhc=0;
+@@ -1421,7 +1421,7 @@ template <int i1, int i2, int i3, int i4, int i5, class T> complex<T>  A1ph2SM2q
+  
+ }
+ 
+-template <class T> complex<T> (*A1ph2SM2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&)
++template <class T> complex<T> (*A1ph2SM2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&)
+ {
+     switch (hc) {
+         case 0x94234: //2169: //(ph,s,qb-,q+,s)
+@@ -1960,48 +1960,48 @@ template <class T> complex<T> (*A1ph2SM2q_Tree_Ptr_eval(long hc))(const eval_par
+ 
+                              
+                              
+-template complex<R> (*A2sc1g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2sc1g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2sc1g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A2sc2g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A2sc2g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A2sc2g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A2sc2g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A2sc2g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A2sc2g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-  //template complex<R> (*A2sc3g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-  //template complex<RHP> (*A2sc3g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-  //template complex<RVHP> (*A2sc3g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++  //template complex<R> (*A2sc3g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++  //template complex<RHP> (*A2sc3g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++  //template complex<RVHP> (*A2sc3g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 	
+-template complex<R> (*A1ph2scm1g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2scm1g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2scm1g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2scm1g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2scm1g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2scm1g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A1ph2SM_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2SM_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2SM_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2SM_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2SM_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2SM_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+                              
+-template complex<R> (*A1ph2SM1g_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2SM1g_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2SM1g_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2SM1g_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2SM1g_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2SM1g_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+                              
+-template complex<R> (*A1ph1QM1SM1q_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph1QM1SM1q_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph1QM1SM1q_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph1QM1SM1q_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph1QM1SM1q_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph1QM1SM1q_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+-template complex<R> (*A1ph2SM2q_Tree_Ptr_eval(long hc))(const eval_param<R>&, const mass_param_coll&);
+-template complex<RHP> (*A1ph2SM2q_Tree_Ptr_eval(long hc))(const eval_param<RHP>&, const mass_param_coll&);
+-template complex<RVHP> (*A1ph2SM2q_Tree_Ptr_eval(long hc))(const eval_param<RVHP>&, const mass_param_coll&);
++template complex<R> (*A1ph2SM2q_Tree_Ptr_eval(long long hc))(const eval_param<R>&, const mass_param_coll&);
++template complex<RHP> (*A1ph2SM2q_Tree_Ptr_eval(long long hc))(const eval_param<RHP>&, const mass_param_coll&);
++template complex<RVHP> (*A1ph2SM2q_Tree_Ptr_eval(long long hc))(const eval_param<RVHP>&, const mass_param_coll&);
+ 
+                              
+ #if BH_USE_GMP
+     
+-template complex<RGMP> (*A2sc1g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A2sc2g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2scm1g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2SM_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2SM1g_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph1QM1SM1q_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+-template complex<RGMP> (*A1ph2SM2q_Tree_Ptr_eval(long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A2sc2g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2scm1g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2SM_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2SM1g_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph1QM1SM1q_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
++template complex<RGMP> (*A1ph2SM2q_Tree_Ptr_eval(long long hc))(const eval_param<RGMP>&, const mass_param_coll&);
+ #endif
+ 
+ }
+diff --git a/src/trees_eval/amplitudes_tree_eval.h b/src/trees_eval/amplitudes_tree_eval.h
+index 8794102..c5dbbd4 100644
+--- a/src/trees_eval/amplitudes_tree_eval.h
++++ b/src/trees_eval/amplitudes_tree_eval.h
+@@ -63,12 +63,12 @@ template <class T> std::complex<T> (*A2QM2q_Tree_Ptr_eval(int hc))(const eval_pa
+ template <class T> std::complex<T> (*A1QM1qs_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+ template <class T> std::complex<T> (*A1QM1q1gs_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+ 
+-template <class T> std::complex<T>  (*A2q2l2G_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) ;
++template <class T> std::complex<T>  (*A2q2l2G_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) ;
+ 
+-template <class T> std::complex<T>  (*A2q2Q2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) ;
+-template <class T> std::complex<T>  (*A2q2Q1g2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) ;
+-template <class T> std::complex<T>  (*A2q2Q2g2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) ;
+-template <class T> std::complex<T>  (*A2q2Q3g2l_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&) ;
++template <class T> std::complex<T>  (*A2q2Q2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) ;
++template <class T> std::complex<T>  (*A2q2Q1g2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) ;
++template <class T> std::complex<T>  (*A2q2Q2g2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) ;
++template <class T> std::complex<T>  (*A2q2Q3g2l_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&) ;
+ 
+ template <class T> std::complex<T>  (*A2q1g1y_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+ 
+@@ -81,7 +81,7 @@ template <class T> std::complex<T> (*A2QM1g2l_Tree_Ptr_eval(int hc))(const eval_
+ template <class T> std::complex<T>  (*A2q2g1y_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+ template <class T> std::complex<T>  (*A2q2Q1y_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+ 
+-template <class T> std::complex<T>  (*A2q2G1y_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A2q2G1y_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
+ 
+ template <class T> std::complex<T> (*A2LM1g_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+ template <class T> std::complex<T> (*A2LM2g_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+@@ -95,38 +95,38 @@ template <class T> std::complex<T> (*A2QM2q1y_Tree_Ptr_eval(int hc))(const eval_
+ 
+ template <class T> std::complex<T> (*A2s2G_Tree_Ptr_eval(int hc))(const eval_param<T>&, const mass_param_coll&);
+ 
+-template <class T> std::complex<T>  (*A1ph2g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph3g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph1g2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2g2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2q2Q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2q2QM_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2sc_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2sc1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2QM1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph1QM1sc1q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2sc2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-
+-template <class T> std::complex<T> (*A2sc1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A2sc2g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A2sc3g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2scm1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2SM_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T>  (*A1ph2SM1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A1ph1QM1SM1q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A1ph2SM2q_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph3g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph1g2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2g2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2q2Q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2q2QM_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2sc_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2QM1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph1QM1sc1q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2sc2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++
++template <class T> std::complex<T> (*A2sc1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A2sc2g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A2sc3g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2scm1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2SM_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2SM1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A1ph1QM1SM1q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A1ph2SM2q_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
+     
+-template <class T> std::complex<T>  (*A1ph2Gsc_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A2Gsc1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A1Gsc1gM1g_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T>  (*A1ph2Gsc_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A2Gsc1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A1Gsc1gM1g_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
+ 
+ /* special purpose trees */
+-template <class T> std::complex<T> (*A4g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A5g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A2q2g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A2q3g_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A2q2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
+-template <class T> std::complex<T> (*A2q1g2Q_G3_Tree_Ptr_eval(long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A4g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A5g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A2q2g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A2q3g_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A2q2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
++template <class T> std::complex<T> (*A2q1g2Q_G3_Tree_Ptr_eval(long long hc))(const eval_param<T>&, const mass_param_coll&);
+ 
+ 
+ 

--- a/blackhat.spec
+++ b/blackhat.spec
@@ -2,12 +2,14 @@
 Source: http://www.hepforge.org/archive/blackhat/blackhat-%{realversion}.tar.gz
 
 Patch0: blackhat-gcc48
+Patch1: blackhat-0.9.9-armv7hl
 
 Requires: qd python openssl
 %prep
 %setup -n blackhat-%{realversion}
 
 %patch0 -p1
+%patch1 -p1
 
 ./configure --prefix=%i --with-QDpath=$QD_ROOT CXXFLAGS="-Wno-deprecated -I$OPENSSL_ROOT/include" LDFLAGS="-L$OPENSSL_ROOT/lib"
 # The following hack insures that the bins with the library linked explicitly


### PR DESCRIPTION
On armv7hl target integers in switch(..) expressions overflow, .e.g,

```
case 0x0F02030908:
case 0x0E02030908:
```

generates:

```
warning: overflow in implicit constant conversion [-Woverflow]
```

and:

```
error: duplicate case value
error: previously used here
```

Change all 'long' to 'long long'. long is 4 bytes on armv7hl, but 8
bytes on x86_64. long long is 8 bytes on both platforms. Thus there
should be no changes on ABI level.

In addition package is using OpenSSL from the standard system location.
Force it to link to OpenSSL from CMSDIST.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
