### PR TITLE
git: fix to use runtime prefix instead of buildtime prefix

### DIFF
--- a/git-1.8.3.1-runtime.patch
+++ b/git-1.8.3.1-runtime.patch
@@ -1,0 +1,104 @@
+diff --git a/exec_cmd.c b/exec_cmd.c
+index 125fa6f..4bb5787 100644
+--- a/exec_cmd.c
++++ b/exec_cmd.c
+@@ -4,12 +4,12 @@
+ #define MAX_ARGS	32
+ 
+ static const char *argv_exec_path;
+-static const char *argv0_path;
++static const char *argv0_path = NULL;
+ 
+ const char *system_path(const char *path)
+ {
+ #ifdef RUNTIME_PREFIX
+-	static const char *prefix;
++	static const char *prefix = NULL;
+ #else
+ 	static const char *prefix = PREFIX;
+ #endif
+@@ -19,13 +19,12 @@ const char *system_path(const char *path)
+ 		return path;
+ 
+ #ifdef RUNTIME_PREFIX
+-	assert(argv0_path);
+-	assert(is_absolute_path(argv0_path));
+-
+-	if (!prefix &&
+-	    !(prefix = strip_path_suffix(argv0_path, GIT_EXEC_PATH)) &&
+-	    !(prefix = strip_path_suffix(argv0_path, BINDIR)) &&
+-	    !(prefix = strip_path_suffix(argv0_path, "git"))) {
++	if (!argv0_path ||
++	    !is_absolute_path(argv0_path) ||
++	    (!prefix &&
++	     !(prefix = strip_path_suffix(argv0_path, GIT_EXEC_PATH)) &&
++	     !(prefix = strip_path_suffix(argv0_path, BINDIR)) &&
++	     !(prefix = strip_path_suffix(argv0_path, "git")))) {
+ 		prefix = PREFIX;
+ 		trace_printf("RUNTIME_PREFIX requested, "
+ 				"but prefix computation failed.  "
+@@ -41,20 +40,63 @@ const char *system_path(const char *path)
+ const char *git_extract_argv0_path(const char *argv0)
+ {
+ 	const char *slash;
++	char *abs_argv0 = NULL;
+ 
+ 	if (!argv0 || !*argv0)
+ 		return NULL;
+ 	slash = argv0 + strlen(argv0);
+ 
++	/* walk to the first slash from the end */ 
+ 	while (argv0 <= slash && !is_dir_sep(*slash))
+ 		slash--;
+ 
++	/* if there was a slash ... */ 
+ 	if (slash >= argv0) {
++	    /* ... it's either an absolute path */
++	    if (is_absolute_path(argv0)) {
++		/* FIXME: memory leak here */
+ 		argv0_path = xstrndup(argv0, slash - argv0);
+ 		return slash + 1;
++	    }
++	    /* ... or a relative path, in which case we have to make it
++	     * absolute first and do the whole thing again */
++	    abs_argv0 = xstrdup(real_path(argv0));
++	} else {
++	    /* argv0 is no path at all, just a name. Resolve it into a
++	     * path. Unfortunately, this gets system specific. */
++#if defined(__linux__)
++	    struct stat st;
++	    if (!stat("/proc/self/exe", &st)) {
++		abs_argv0 = xstrdup(real_path("/proc/self/exe"));
++	    }
++#elif defined(__APPLE__)
++	    /* Mac OS X has realpath, which incidentally allocates its own
++	     * memory, which in turn is why we do all the xstrdup's in the
++	     * other cases. */
++	     abs_argv0 = realpath(argv0, NULL);
++#endif
++
++	    /* if abs_argv0 is still NULL here, something failed above or
++	     * we are on an unsupported system. system_path() will warn
++	     * and fall back to the static prefix */
++	    if (!abs_argv0) {
++		argv0_path = NULL;
++		return argv0;
++ 	    }
+ 	}
+ 
+-	return argv0;
++	/* abs_argv0 is an absolute path now for which memory was allocated
++	* with malloc */
++
++	slash = abs_argv0 + strlen(abs_argv0);
++	while (abs_argv0 <= slash && !is_dir_sep(*slash))
++	    slash--;
++
++	/* FIXME: memory leaks here */
++	argv0_path = xstrndup(abs_argv0, slash - abs_argv0);
++	slash = xstrdup(slash + 1);
++	free(abs_argv0);
++	return slash; 
+ }
+ 
+ void git_set_argv_exec_path(const char *exec_path)

--- a/git.spec
+++ b/git.spec
@@ -9,6 +9,7 @@
 
 Source0: https://github.com/git/git/archive/v%{realversion}.tar.gz
 Patch1: git-1.8.3.1-no-symlink
+Patch2: git-1.8.3.1-runtime
 
 %define curl_tag curl-7_31_0
 Source1: https://raw.github.com/bagder/curl/%{curl_tag}/lib/mk-ca-bundle.pl
@@ -34,6 +35,7 @@ Provides: perl(Time::HiRes)
 %prep
 %setup -b 0 -n %{n}-%{realversion}
 %patch1 -p1
+%patch2 -p1
 
 %build
 make prefix=%{i} \
@@ -50,6 +52,7 @@ make prefix=%{i} \
      NO_R_TO_GCC_LINKER=1 \
      LIBPCREDIR="${PCRE_ROOT}" \
      NO_PYTHON=1 \
+     RUNTIME_PREFIX=1 \
      V=1 \
      %{makeprocesses} \
      all
@@ -77,6 +80,7 @@ make prefix=%{i} \
      NO_R_TO_GCC_LINKER=1 \
      LIBPCREDIR="${PCRE_ROOT}" \
      NO_PYTHON=1 \
+     RUNTIME_PREFIX=1 \
      V=1 \
      %{makeprocesses} \
      install
@@ -86,6 +90,22 @@ mkdir -p %{i}/share/ssl/certs
 cp ./ca-bundle/ca-bundle.crt %{i}/share/ssl/certs/ca-bundle.crt
 
 %post
+%{relocateConfig}bin/git-cvsserver
 %{relocateConfig}libexec/git-core/git-sh-i18n
 %{relocateConfig}libexec/git-core/git-citool
 %{relocateConfig}libexec/git-core/git-gui
+%{relocateConfig}libexec/git-core/git-add--interactive
+%{relocateConfig}libexec/git-core/git-archimport
+%{relocateConfig}libexec/git-core/git-cvsexportcommit
+%{relocateConfig}libexec/git-core/git-cvsimport
+%{relocateConfig}libexec/git-core/git-cvsserver
+%{relocateConfig}libexec/git-core/git-difftool
+%{relocateConfig}libexec/git-core/git-instaweb
+%{relocateConfig}libexec/git-core/git-relink
+%{relocateConfig}libexec/git-core/git-send-email
+%{relocateConfig}libexec/git-core/git-svn
+%{relocateCmsFiles} `find $RPM_INSTALL_PREFIX/%{pkgrel}/share -name "*" -type f`
+%{relocateCmsFiles} `find $RPM_INSTALL_PREFIX/%{pkgrel}/lib64/perl5 -name "*" -type f`
+if [ -d $RPM_INSTALL_PREFIX/%{pkgrel}/lib/perl5 ]; then 
+  %{relocateCmsFiles} `find $RPM_INSTALL_PREFIX/%{pkgrel}/lib/perl5 -name "*" -type f`
+fi


### PR DESCRIPTION
build with RUNTIME_PREFIX enabled; http://git.661346.n2.nabble.com/PATCH-Extend-runtime-prefix-computation-td7572082.html patched applied to find the absolute argv0 path; few more files in libexec, share and lib are relocated
