### PR TITLE
Request to add Photos++ 3.54, EvtGen 1.3.0 and move to Tauola++ 1.1.4 (currently 1.1.3)

### DIFF
--- a/evtgen-toolfile.spec
+++ b/evtgen-toolfile.spec
@@ -1,0 +1,27 @@
+### RPM external evtgen-toolfile 1.3.0
+Requires: evtgen
+
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/evtgen.xml
+<tool name="evtgen" version="@TOOL_VERSION@">
+  <lib name="EvtGen"/>
+  <lib name="EvtGenExternal"/>
+  <client>
+    <environment name="EVTGEN_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$EVTGEN_BASE/lib"/>
+    <environment name="INCLUDE" default="$EVTGEN_BASE/include"/>
+  </client>
+  <use name="hepmc"/>
+  <use name="pythia8"/>
+  <use name="tauolapp"/>
+  <use name="photospp"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -1,0 +1,51 @@
+### RPM external evtgen 1.3.0
+
+Requires: hepmc
+Requires: pythia8
+Requires: tauolapp
+Requires: photospp
+
+Source: http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/evtgen/evtgen-1.3.0-src.tgz
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx c++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -std=c++0x -g -O2
+%endif
+
+%define keep_archives true
+
+%prep
+%setup -q -n evtgen/%{realversion}
+
+case %cmsplatf in
+  osx*)
+  ;;
+esac
+
+export HEPMCLOCATION=${HEPMC_ROOT}
+export HEPMCVERSION=${HEPMC_VERSION}
+export PYTHIA8_LOCATION=${PYTHIA8_ROOT}
+export TAUOLAPP_LOCATION=${TAUOLAPP_ROOT}
+export PHOTOSPP_LOCATION=${PHOTOSPP_ROOT}
+
+
+./configure --prefix=%{i} --hepmcdir=$HEPMC_ROOT --pythiadir=$PYTHIA8_ROOT --tauoladir=$TAUOLAPP_ROOT --photosdir=$PHOTOSPP_ROOT CXXFLAGS="%cms_cxxflags" 
+# One more fix-up for OSX (in addition to the patch above)
+case %cmsplatf in
+  osx*)
+perl -p -i -e "s|-shared|-dynamiclib -undefined dynamic_lookup|" make.inc
+  ;;
+esac
+
+%build
+make
+
+%install
+make install
+find %i/lib/archive -name "*.a" -exec mv {} %i/lib \;
+rm -rf %i/lib/archive
+ls %{i}/lib/
+

--- a/photospp-354.patch
+++ b/photospp-354.patch
@@ -1,0 +1,12 @@
+diff -uprN 3.54/src/photosFortranInterfaces/PH_HEPEVT_Interface.cxx 3.54/src/photosFortranInterfaces/PH_HEPEVT_Interface.cxx
+--- 3.54/src/photosFortranInterfaces/PH_HEPEVT_Interface.cxx   2013-07-21 10:47:53.000000000 +0200
++++ 3.54/src/photosFortranInterfaces/PH_HEPEVT_Interface.cxx  2014-03-05 16:35:04.000000000 +0100
+@@ -57,7 +57,8 @@ void PH_HEPEVT_Interface::add_particle(i
+
+   //now set the element of PH_HEPEVT
+   hep.nevhep=0; //dummy
+-  hep.nhep=hep.nhep++;
++  hep.nhep = hep.nhep + 1; // 1.II.2014: fix for gcc 4.8.1. Previously it was:
++                           // hep.nhep = hep.nhep++; which technically is an undefined operation
+   hep.isthep[i]=particle->getStatus();
+   hep.idhep[i]=particle->getPdgID();

--- a/photospp-toolfile.spec
+++ b/photospp-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external photospp-toolfile 3.54
+Requires: photospp
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/photosapp.xml
+<tool name="photospp" version="@TOOL_VERSION@">
+  <lib name="PhotosFortran"/>
+  <lib name="PhotosCxxInterface"/>
+  <client>
+    <environment name="PHOTOSPP_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PHOTOSPP_BASE/lib"/>
+    <environment name="INCLUDE" default="$PHOTOSPP_BASE/include"/>
+  </client>
+  <use name="hepmc"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/photospp.spec
+++ b/photospp.spec
@@ -1,0 +1,45 @@
+### RPM external photos 3.54
+
+Requires: hepmc
+
+Source: http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/photos++/photos++-3.54-src.tgz
+
+Patch0: photospp-354
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx c++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -std=c++0x -g -O2
+%endif
+
+%define keep_archives true
+
+%prep
+%setup -q -n photos++/%{realversion}
+%patch0 -p1
+
+case %cmsplatf in
+  osx*)
+  ;;
+esac
+
+export HEPMCLOCATION=${HEPMC_ROOT}
+export HEPMCVERSION=${HEPMC_VERSION}
+
+./configure --prefix=%{i} --with-hepmc=$HEPMC_ROOT CXXFLAGS="%cms_cxxflags"
+# One more fix-up for OSX (in addition to the patch above)
+case %cmsplatf in
+  osx*)
+perl -p -i -e "s|-shared|-dynamiclib -undefined dynamic_lookup|" make.inc
+  ;;
+esac
+
+%build
+make
+
+%install
+make install
+ls %{i}/lib/
+

--- a/tauolapp-toolfile.spec
+++ b/tauolapp-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external tauolapp-toolfile 1.1.3
+### RPM external tauolapp-toolfile 1.1.4
 Requires: tauolapp
 %prep
 

--- a/tauolapp.spec
+++ b/tauolapp.spec
@@ -1,4 +1,4 @@
-### RPM external tauolapp 1.1.3
+### RPM external tauolapp 1.1.4
 Source: http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/tauola++/tauola++-%{realversion}-src.tgz
 Requires: hepmc
 Requires: pythia8
@@ -13,6 +13,7 @@ Requires: lhapdf
 %endif
 
 %define keep_archives true
+
 %if "%(case %cmsplatf in (osx*_*_gcc421) echo true ;; (*) echo false ;; esac)" == "true"
 Requires: gfortran-macosx
 %endif


### PR DESCRIPTION
This request is to add Photos++ 3.54 and EvtGen 1.3.0 to CMSSW and also switch Tauola++ versions from 1.1..3 to Tauola++ 1.1.4 which includes new features including new currents.These spec files have been tested on sl5 and sl6 and have had preliminary validation insides CMSSW with new interfaces in https://github.com/inugent/cmssw/tree/PhotosppEvtGen_v3.   Best regards,
Ian
