### PR TITLE
removed a patch which doesn't apply anymore

### DIFF
--- a/sherpa2.spec
+++ b/sherpa2.spec
@@ -3,7 +3,6 @@ Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-%{realversion}.tar.gz
 Requires: hepmc lhapdf blackhat 
 Patch0: sherpa-2.0.beta2-lhapdf
 Patch1: sherpa-1.4.2-fix-gcc47-cxx11
-Patch2: sherpa-1.4.0-add-support-osx108
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
@@ -25,11 +24,6 @@ case %cmsplatf in
   ;;
 esac
 
-
-
-if [[ %cmsplatf == osx108_* ]]; then
-%patch2 -p1
-fi
 
 autoreconf -i --force
 


### PR DESCRIPTION
I noticed it when trying to build 710pre4 for osx.
I tested it building sherpa2 on osx108_amd64_gcc481. And now I am building  pre4 on osx.
