### PR TITLE
Changed the sherpa2.spec and toolfile to implement the newest sherpa ver...

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -154,7 +154,7 @@ Requires: igprof-toolfile
 %endif
 %endif
 
-%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler boost_serialization boost_iostreams cuda rivet2 opencl opencl-cpp sherpa2
+%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler boost_serialization boost_iostreams cuda rivet2 opencl opencl-cpp sherpa
 
 ## IMPORT scramv1-tool-conf
 

--- a/sherpa-2.1.0-lhapdf.patch
+++ b/sherpa-2.1.0-lhapdf.patch
@@ -1,0 +1,24 @@
+diff -Naur SHERPA-MC-2.1.0-orig/PDF/LHAPDF/Makefile.am SHERPA-MC-2.1.0/PDF/LHAPDF/Makefile.am
+--- SHERPA-MC-2.1.0-orig/PDF/LHAPDF/Makefile.am	2014-04-11 12:03:48.000000000 +0200
++++ SHERPA-MC-2.1.0/PDF/LHAPDF/Makefile.am	2014-04-11 12:08:02.000000000 +0200
+@@ -27,5 +27,6 @@
+ libLHAPDFSherpa_la_LIBADD = @CONDITIONAL_LHAPDFLIBS@
+ 
+ libLHAPDFSherpa_la_CPPFLAGS = $(AM_CPPFLAGS) @CONDITIONAL_LHAPDFINCS@
++libLHAPDFSherpa_la_LDFLAGS = -lz -L@CONDITIONAL_LHAPDFDIR@/lib -Bstatic -lLHAPDF
+ 
+ EXTRA_DIST    = $(LHAPDFEXTRADIST)
+diff -Naur SHERPA-MC-2.1.0-orig/SHERPA/Initialization/Initialization_Handler.C SHERPA-MC-2.1.0/SHERPA/Initialization/Initialization_Handler.C
+--- SHERPA-MC-2.1.0-orig/SHERPA/Initialization/Initialization_Handler.C	2014-04-11 12:04:33.000000000 +0200
++++ SHERPA-MC-2.1.0/SHERPA/Initialization/Initialization_Handler.C	2014-04-11 12:08:52.000000000 +0200
+@@ -527,8 +527,8 @@
+     if (*pdflib=="None") continue;
+     if (*pdflib=="LHAPDFSherpa") {
+ #ifdef USING__LHAPDF
+-      s_loader->AddPath(std::string(LHAPDF_PATH)+"/lib");
+-      s_loader->LoadLibrary("LHAPDF");
++    //  s_loader->AddPath(std::string(LHAPDF_PATH)+"/lib");
++    //  s_loader->LoadLibrary("LHAPDF");
+ #else
+       THROW(fatal_error, "Sherpa not compiled with LHAPDF support.");
+ #endif

--- a/sherpa2-toolfile.spec
+++ b/sherpa2-toolfile.spec
@@ -30,6 +30,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa2.xml
 <lib name="CSShowers"/>
 <lib name="CSTools"/>
 <lib name="CT10Sherpa"/>
+<lib name="CT12Sherpa"/>
 <lib name="CTEQ6Sherpa"/>
 <lib name="DipoleSubtraction"/>
 <lib name="ExtraXS1_2"/>
@@ -49,6 +50,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa2.xml
 <lib name="MCatNLOMain"/>
 <lib name="MCatNLOShowers"/>
 <lib name="MCatNLOTools"/>
+<lib name="MEProcess"/>
 <lib name="METoolsColors"/>
 <lib name="METoolsCurrents"/>
 <lib name="METoolsExplicit"/>
@@ -82,9 +84,11 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa2.xml
 <lib name="SherpaAnalysisTrigger"/>
 <lib name="SherpaBlackHat"/>
 <lib name="SherpaHepMCOutput"/>
+<lib name="SherpaHiggs"/>
 <lib name="SherpaInitialization"/>
 <lib name="SherpaMain"/>
 <lib name="SherpaObservables"/>
+<lib name="SherpaPythia"/>
 <lib name="SherpaPerturbativePhysics"/>
 <lib name="SherpaSingleEvents"/>
 <lib name="SherpaSoftPhysics"/>
@@ -113,6 +117,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa2.xml
 <use name="lhapdf"/>
 <use name="qd"/>
 <use name="blackhat"/>
+<use name="fastjet"/>
 </tool>
 EOF_TOOLFILE
 

--- a/sherpa2.spec
+++ b/sherpa2.spec
@@ -1,8 +1,7 @@
-### RPM external sherpa2 2.0.0
+### RPM external sherpa2 2.1.0
 Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-%{realversion}.tar.gz
-Requires: hepmc lhapdf blackhat openssl
-Patch0: sherpa-2.0.beta2-lhapdf
-Patch1: sherpa-1.4.2-fix-gcc47-cxx11
+Requires: hepmc lhapdf blackhat sqlite fastjet openssl
+Patch0: sherpa-2.1.0-lhapdf
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
@@ -14,15 +13,8 @@ Patch1: sherpa-1.4.2-fix-gcc47-cxx11
 
 %prep
 %setup -q -n SHERPA-MC-%{realversion}
-%patch0 -p0
-
-# Apply C++11 / gcc 4.7.x fixes only if using a 47x architecture.
-# See http://gcc.gnu.org/gcc-4.7/porting_to.html
-case %cmsplatf in
-  *gcc4[6789]*)
-%patch1 -p1
-  ;;
-esac
+#%patch0 -p0
+%patch0 -p1
 
 autoreconf -i --force
 
@@ -40,12 +32,13 @@ case %cmsplatf in
   ;;
 esac
 
-./configure --prefix=%i --enable-analysis --disable-silent-rules \
-            --enable-hepmc2=$HEPMC_ROOT --enable-lhapdf=$LHAPDF_ROOT --enable-blackhat=$BLACKHAT_ROOT \
+./configure --prefix=%i --enable-analysis --disable-silent-rules --enable-fastjet=$FASTJET_ROOT \
+            --enable-hepmc2=$HEPMC_ROOT --enable-lhapdf=$LHAPDF_ROOT --enable-blackhat=$BLACKHAT_ROOT --with-sqlite3=$SQLITE_ROOT \
             CXX="%cms_cxx" \
-            CPPFLAGS="-I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$OPENSSL_ROOT/include" \
-            CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF %cms_cxxflags" \
-            LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$LHAPDF_ROOT/lib -lLHAPDF -L$OPENSSL_ROOT/lib"
+            CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF %cms_cxxflags -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$OPENSSL_ROOT/include" \
+	          LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib" 
+#            CXX="%cms_cxx" CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF %cms_cxxflags -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include" LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$LHAPDF_ROOT/lib -lLHAPDF"
+#            CXX="%cms_cxx" CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF %cms_cxxflags -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include" LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib"
 %build
 # Fix up a configuration mistake coming from a test being confused
 # by the "skipping incompatible" linking messages when linking 32bit on 64bit


### PR DESCRIPTION
Update the Sherpa2 toolfile to the new version 2.1.0 of Sherpa
Added a new patchfile for the LHAPDF issue and added fastjet support in the configure step
Keep in mind, that either sherpa or sherpa2 has to be chosen, both do not work at the same time since the libraries & variables have the same name.
