### PR TITLE
root: disable Cocoa on Darwin, use X11 front-end

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -107,7 +107,9 @@ TARGET_PLATF=
 %if %isdarwin
   TARGET_PLATF=macosx64
   EXTRA_OPTS="${EXTRA_OPTS} --disable-rfio
-                            --disable-builtin_afterimage"
+                            --disable-builtin_afterimage
+                            --disable-cocoa
+                            --enable-x11"
 %endif
 
 %if %isarmv7


### PR DESCRIPTION
ROOT expect to be compiled with LLVM/Clang on Darwin for Cocoa front-end
and uses -ObjC++ flag. The flag is not supported by GCC and produces an
error.

Signed-off-by: David Abdurachmanov davidlt@macms07.cern.ch
