### PR TITLE
updated config tag to V05-01-22

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-20
+%define configtag       V05-01-22
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
This is needed for CondFormats Serialization. If <package>/src/headers.h file exists then scram generate tmp/<arch>/src/<package>/src/<prod>/a/Serialization.cc file and compile and link it in to the shared library. 
It is safe to include it in any 53X/62X/70X/71X release. For 71X BOOSTIO release we need to include 
#3422 too
