### PR TITLE
updating to Tauola 1.1.4

### DIFF
--- a/tauolapp-toolfile.spec
+++ b/tauolapp-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external tauolapp-toolfile 1.1.3
+### RPM external tauolapp-toolfile 1.1.4
 Requires: tauolapp
 %prep
 

--- a/tauolapp.spec
+++ b/tauolapp.spec
@@ -1,4 +1,4 @@
-### RPM external tauolapp 1.1.3
+### RPM external tauolapp 1.1.4
 Source: http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/tauola++/tauola++-%{realversion}-src.tgz
 Requires: hepmc
 Requires: pythia8
@@ -13,6 +13,7 @@ Requires: lhapdf
 %endif
 
 %define keep_archives true
+
 %if "%(case %cmsplatf in (osx*_*_gcc421) echo true ;; (*) echo false ;; esac)" == "true"
 Requires: gfortran-macosx
 %endif


### PR DESCRIPTION
Switching Tauola++ 1.1.3 to 1.1.4 to include RCHL models in Tauola++ and TauSpinner and Higgs transverse spin effects for TauSpinner.
