### PR TITLE
Drop -fipa-pta option.

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -183,7 +183,7 @@ esac
 # See: https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/2955.html
 case %cmsplatf in
   *_gcc4[789]*)
-    COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta"
+    COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50"
   ;;
 esac
 


### PR DESCRIPTION
Not supported by clang. This should be gcc specific but for some reason is not.
