### PR TITLE
Autotools fix perl path

### DIFF
--- a/autotools.spec
+++ b/autotools.spec
@@ -34,6 +34,12 @@ pushd %_builddir/libtool-%{libtool_version}
   make %makeprocesses && make install
 popd
 
+# Fix perl location, required on /usr/bin/perl
+grep -l -R '/bin/perl' %{i} | xargs -n1 sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/env perl;'
+find %{i} -name '*deleteme' -delete
+grep -l -R '/bin/perl' %{i} | xargs -n1 sed -ideleteme -e 's;exec [^ ]*/perl;exec /usr/bin/perl;g'
+find %{i} -name '*deleteme' -delete
+
 %install
 echo "Foo"
 %post


### PR DESCRIPTION
LSF-GLIBC package at CERN installs Perl symlink (/bin/perl) pointing
to /usr/bin/perl. All machines by default have Perl on /usr/bin/perl
(incl. Darwin). /bin/perl ends up the first in PATH, thus packages
assume Perl is installed under /bin/perl causing breakage on machines
without LSF-GLIBC.

Always set perl to /usr/bin/perl to avoid issues.
