### PR TITLE
updated config tag to V05-01-25

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-24
+%define configtag       V05-01-25
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
new tag has a fix for patch releases i.e override base release dependency information by the patch release dependency
