### PR TITLE
updated config tag to V05-01-27: which find condformats_serialization_generate.py in CMSSW_FULL_BASE_RELEASE too

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-01-25
+%define configtag       V05-01-27
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
- find condformats_serialization_generate.py in full cmssw base release if not found locally
- always add -I<path>/poison if exists
