### PR TITLE
adding runtime var to mctester-toolfile

### DIFF
--- a/mctester-toolfile.spec
+++ b/mctester-toolfile.spec
@@ -17,6 +17,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/mctester.xml
     <environment name="LIBDIR" default="$MCTESTER_BASE/lib"/>
     <environment name="INCLUDE" default="$MCTESTER_BASE/include"/>
   </client>
+  <runtime name="MCTESTERLOCATION" value="$MCTESTER_BASE/lib/"/>
   <use name="root"/>
   <use name="HepMC"/>
 </tool>


### PR DESCRIPTION
This modification adds a runtime variable that enables the mctester analysis stage to be run in the default CMSSW environment. 
