### PR TITLE
adding Photos++ 3.55

### DIFF
--- a/photospp-toolfile.spec
+++ b/photospp-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external photospp-toolfile 3.55
+Requires: photospp
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/photosapp.xml
+<tool name="photospp" version="@TOOL_VERSION@">
+  <lib name="PhotosFortran"/>
+  <lib name="PhotosCxxInterface"/>
+  <client>
+    <environment name="PHOTOSPP_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PHOTOSPP_BASE/lib"/>
+    <environment name="INCLUDE" default="$PHOTOSPP_BASE/include"/>
+  </client>
+  <use name="hepmc"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/photospp.spec
+++ b/photospp.spec
@@ -1,0 +1,42 @@
+### RPM external photos 3.55
+
+Requires: hepmc
+
+Source: http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/photos++/photos++-%{realversion}-src.tgz
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx c++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -std=c++0x -g -O2
+%endif
+
+%define keep_archives true
+
+%prep
+%setup -q -n photos++/%{realversion}
+
+case %cmsplatf in
+  osx*)
+  ;;
+esac
+
+export HEPMCLOCATION=${HEPMC_ROOT}
+export HEPMCVERSION=${HEPMC_VERSION}
+
+./configure --prefix=%{i} --with-hepmc=$HEPMC_ROOT CXXFLAGS="%cms_cxxflags"
+# One more fix-up for OSX (in addition to the patch above)
+case %cmsplatf in
+  osx*)
+perl -p -i -e "s|-shared|-dynamiclib -undefined dynamic_lookup|" make.inc
+  ;;
+esac
+
+%build
+make
+
+%install
+make install
+ls %{i}/lib/
+


### PR DESCRIPTION
This pull request replaces PR 568. It is going to CMSSW_7_2_X/stable to allow for testing of the new PhotosppInterface. We expect to replace this version once there is a stable version of Photos++.  The libraries were tested to compile with cmsdist CMSSW_7_2_X/stable.
