### PR TITLE
scram-project-build.file: fix processing of debug symbols

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -270,44 +270,50 @@ tar czf debug.tar.gz --files-from %_builddir/files.debug --no-recursion --remove
 
 # Begin debug
 
-BASE_LIB_PATH=%i/lib/%cmsplatf
-BASE_BIN_PATH=%i/bin/%cmsplatf
-BASE_TEST_PATH=%i/test/%cmsplatf
-if [ "%{n}" == "coral" ]; then
+if [ "%{n}" == "cmssw" ]; then
+  BASE_LIB_PATH=%i/lib/%cmsplatf
+  BASE_BIN_PATH=%i/bin/%cmsplatf
+  BASE_TEST_PATH=%i/test/%cmsplatf
+elif [ "%{n}" == "coral" ]; then
   BASE_LIB_PATH=%i/%cmsplatf/lib
-  BASE_BIN_PATH=%i/%cmsplatf/bin
   BASE_TEST_PATH=%i/%cmsplatf/tests/bin
 fi
 
-pushd $BASE_LIB_PATH
+if [ -d "$BASE_LIB_PATH" ]; then
+  pushd $BASE_LIB_PATH
   mkdir -p .debug
   # ELF binaries
   ELF_BINS=$(ls | xargs -I% file % | grep ELF | cut -d':' -f1)
   if [ ! -z "$ELF_BINS" ]; then
     dwz -m .debug/lib-common.so.debug -r *.so
-    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug %; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug % %'
+    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
-popd
+  popd
+fi
 
-pushd $BASE_BIN_PATH
+if [ -d "BASE_BIN_PATH" ]; then
+  pushd $BASE_BIN_PATH
   mkdir -p .debug
   # ELF binaries
   ELF_BINS=$(ls | xargs -I% file % | grep ELF | cut -d':' -f1)
   if [ ! -z "$ELF_BINS" ]; then
     dwz -m .debug/bin-common.debug -r $ELF_BINS
-    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug %; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug % %'
+    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
-popd
+  popd
+fi
 
-pushd $BASE_TEST_PATH
+if [ -d "$BASE_TEST_PATH" ]; then
+  pushd $BASE_TEST_PATH
   mkdir -p .debug
   # ELF binaries
   ELF_BINS=$(ls | xargs -I% file % | grep ELF | cut -d':' -f1)
   if [ ! -z "$ELF_BINS" ]; then
     dwz -m .debug/tests-common.debug -r $ELF_BINS
-    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug %; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug % %'
+    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
-popd
+  popd
+fi
 
 # End debug
 


### PR DESCRIPTION
- fix objcopy syntax for debug symbols
- check that a directory exists before processing it for debug symbols
