### PR TITLE
update debug subpackage functionality

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -202,32 +202,6 @@ pushd %{i}/tmp/%{cmsplatf}/cache/log/src
   tar czf ${LOG_WEB_DIR}/logs/src/src-logs.tgz ./
 popd
 
-# split the debug symbols out of tha main binaries, into separate files
-%if "%{?subpackageDebug:set}" == "set"
-rm -f %_builddir/files.debug %_builddir/files
-touch %_builddir/files.debug %_builddir/files
-echo "%exclude %{installroot}/%{pkgrel}/debug.tar.gz" >> %_builddir/files
-BINDIR=$(%scramcmd tool info Self | grep "^PATH\|LD_LIBRARY_PATH=" | cut -d= -f2 | tr ":" "\n" | grep -v external)
-for DIR in $BINDIR; do
-  mkdir -p $DIR/.debug
-  # FIXME - work around the 2GB limit in RPM 4.4.2
-  #echo "%dir $DIR/.debug"     >> %_builddir/files.debug
-  DIR=`echo $DIR | sed 's|^%i/||'`
-  echo "%exclude %{installroot}/%{pkgrel}/$DIR/.debug" >> %_builddir/files
-  echo "$DIR/.debug" >> %_builddir/files.debug
-done
-for FILE in $(find $BINDIR -type f | xargs file | grep "ELF" | cut -d: -f1); do
-  NAME=$(basename $FILE)
-  DIR=$(dirname $FILE)
-  DEBUG="$DIR/.debug/$NAME.debug"
-  eu-strip "$FILE" -f "$DEBUG"
-  # FIXME - work around the 2GB limit in RPM 4.4.2
-  #echo "$DEBUG"          >> %_builddir/files.debug
-  #echo "%exclude $DEBUG" >> %_builddir/files
-  echo "$DEBUG" | sed 's#%{pkginstroot}/##' >> %_builddir/files.debug
-done
-%endif
-
 %if "%{?saveDeps:set}" == "set"
 mkdir -p %i/etc/dependencies
 perl %{_sourcedir}/findDependencies.pl -rel %i -arch %cmsplatf -scramroot $SCRAMV1_ROOT
@@ -263,11 +237,6 @@ cd %i
 
 tar czf %{srctree}.tar.gz %{srctree}
 rm -fR %{srctree} tmp
-
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-tar czf debug.tar.gz --files-from %_builddir/files.debug --no-recursion --remove-files
-%endif
 
 # Begin debug
 
@@ -315,6 +284,17 @@ if [ -d "$BASE_TEST_PATH" ]; then
   fi
   popd
 fi
+
+# split the debug symbols out of the main binaries, into separate files
+%if "%{?subpackageDebug:set}" == "set"
+rm -f %_builddir/files.debug %_builddir/files
+touch %_builddir/files.debug %_builddir/files
+for DIR in $BASE_LIB_PATH $BASE_BIN_PATH $BASE_TEST_PATH; do
+  DIR=`echo $DIR | sed 's|^%i/|%{installroot}/%{pkgrel}/|'`
+  echo "%exclude $DIR/.debug"   >> %_builddir/files
+  echo "$DIR/.debug"            >> %_builddir/files.debug
+done
+%endif
 
 # End debug
 

--- a/subpackage-debug.file
+++ b/subpackage-debug.file
@@ -13,26 +13,10 @@ Separate debug symbol files for %{pkgcategory}+%{pkgname}+%{pkgversion}.
 %post -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion}
 # nothing to do
 
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-if [ -e $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz ] ; then
-  tar xzf $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz -C $RPM_INSTALL_PREFIX/%pkgrel/
-  rm -fR  $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz
-fi
-%endif
-
 %preun -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion}
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-if [ -e $RPM_INSTALL_PREFIX/%pkgrel ] ; then
-  rm -fR $(find $RPM_INSTALL_PREFIX/%pkgrel/ -type d -name .debug)
-fi
-%endif
+# nothing to do
 
 %if "%{?subpackageDebug:set}" == "set"
-%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} 
-# FIXME - work around the 2GB limit in RPM 4.4.2
-#%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} -f %_builddir/files.debug
-%{pkginstroot}/debug.tar.gz
+%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} -f %_builddir/files.debug
 %defattr(-, root, root)
 %endif


### PR DESCRIPTION
scram-project-build.file:
- remove old RPM workaround
- update code to build the list of .debug directories

subpackage-debug.file
- remove old RPM workaround
