### PR TITLE
(re)introduce the subpackage functionality for debug symbols

### DIFF
--- a/cmssw.spec
+++ b/cmssw.spec
@@ -16,6 +16,7 @@ Requires: cmssw-tool-conf python cms-git-tools
 %if "%(case %realversion in (*_DEBUG_X*) echo true ;; (*) echo false ;; esac)" == "true"
 %define branch		%(echo %realversion | sed -e 's|_DEBUG_X.*|_X|')
 %define gitcommit       %(echo %realversion | sed -e 's|_DEBUG||')
+%define subpackageDebug yes
 %endif
 
 %if "%(case %realversion in (*_EXPERIMENTAL_X*) echo true ;; (*) echo false ;; esac)" == "true"
@@ -48,3 +49,4 @@ Requires: cmssw-tool-conf python cms-git-tools
 %define source1         git://github.com/cms-sw/cmssw.git?protocol=https&obj=%{branch}/%{gitcommit}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
 
 ## IMPORT scram-project-build
+## SUBPACKAGE debug IF %subpackageDebug

--- a/coral.spec
+++ b/coral.spec
@@ -14,11 +14,12 @@ Patch6: coral-CORAL_2_3_21-forever-ttl
 %define cvssrc          %{n}
 %define cvsrepo         cvs://:pserver:anonymous@%{n}.cvs.cern.ch/cvs/%{n}?passwd=Ah<Z&force=1
 
+# Build with debug symbols, and package them in a separate rpm:
+%define subpackageDebug yes
+
 %if %isonline
 # Disable building tests, since they bring dependency on cppunit:
 %define patchsrc2       perl -p -i -e 's!(<classpath.*/tests\\+.*>)!!;' config/BuildFile.xml
-# Build with debug symbols, and package them in a separate rpm:
-%define subpackageDebug yes
 %endif
 
 # Disable building tests, since they bring dependency on cppunit:
@@ -40,6 +41,4 @@ Patch6: coral-CORAL_2_3_21-forever-ttl
 %endif
 
 ## IMPORT scram-project-build
-# For now disable SUBPACKAGE as it is causing problem calculating checksum
-# Looks like sub package support in V00-22/21 is not working
-# SUBPACKAGE debug IF %subpackageDebug
+## SUBPACKAGE debug IF %subpackageDebug

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -238,52 +238,29 @@ cd %i
 tar czf %{srctree}.tar.gz %{srctree}
 rm -fR %{srctree} tmp
 
-# Begin debug
-
-if [ "%{n}" == "cmssw" ]; then
+# handle debug symbols
+if [ "%{n}" == "coral" ]; then
+  BASE_LIB_PATH=%i/%cmsplatf/lib
+  BASE_BIN_PATH=
+  BASE_TEST_PATH=%i/%cmsplatf/tests/bin
+else
   BASE_LIB_PATH=%i/lib/%cmsplatf
   BASE_BIN_PATH=%i/bin/%cmsplatf
   BASE_TEST_PATH=%i/test/%cmsplatf
-elif [ "%{n}" == "coral" ]; then
-  BASE_LIB_PATH=%i/%cmsplatf/lib
-  BASE_TEST_PATH=%i/%cmsplatf/tests/bin
 fi
 
-if [ -d "$BASE_LIB_PATH" ]; then
-  pushd $BASE_LIB_PATH
+# optimise the debug symbols, compress them, and split them into separate file
+for DIR in $BASE_LIB_PATH $BASE_BIN_PATH $BASE_TEST_PATH; do
+  pushd $DIR
   mkdir -p .debug
   # ELF binaries
-  ELF_BINS=$(ls | xargs -I% file % | grep ELF | cut -d':' -f1)
+  ELF_BINS=$(file * | grep ELF | cut -d':' -f1)
   if [ ! -z "$ELF_BINS" ]; then
-    dwz -m .debug/lib-common.so.debug -M lib-common.so.debug $ELF_BINS
-    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
+    dwz -m .debug/common-symbols.debug -M common-symbols.debug $ELF_BINS
+    echo "$ELF_BINS" | xargs -t -n1 -P%{compiling_processes} -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
   popd
-fi
-
-if [ -d "BASE_BIN_PATH" ]; then
-  pushd $BASE_BIN_PATH
-  mkdir -p .debug
-  # ELF binaries
-  ELF_BINS=$(ls | xargs -I% file % | grep ELF | cut -d':' -f1)
-  if [ ! -z "$ELF_BINS" ]; then
-    dwz -m .debug/bin-common.debug -M bin-common.debug $ELF_BINS
-    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
-  fi
-  popd
-fi
-
-if [ -d "$BASE_TEST_PATH" ]; then
-  pushd $BASE_TEST_PATH
-  mkdir -p .debug
-  # ELF binaries
-  ELF_BINS=$(ls | xargs -I% file % | grep ELF | cut -d':' -f1)
-  if [ ! -z "$ELF_BINS" ]; then
-    dwz -m .debug/tests-common.debug -M tests-common.debug $ELF_BINS
-    echo "$ELF_BINS" | xargs -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
-  fi
-  popd
-fi
+done
 
 # split the debug symbols out of the main binaries, into separate files
 %if "%{?subpackageDebug:set}" == "set"
@@ -295,8 +272,6 @@ for DIR in $BASE_LIB_PATH $BASE_BIN_PATH $BASE_TEST_PATH; do
   echo "$DIR/.debug"            >> %_builddir/files.debug
 done
 %endif
-
-# End debug
 
 ######################################################
 #Do the symlink relocation as a last step in install


### PR DESCRIPTION
cmssw.spec:
- introduce debug subpackage in the DEBUG builds

coral.spec:
- introduce debug subpackage
