### PR TITLE
New spec/patches for CouchDB 1.5

### DIFF
--- a/autotools.spec
+++ b/autotools.spec
@@ -1,6 +1,6 @@
 ### RPM external autotools 1.0
 # We keep all of them together to simplify the "requires" statements.
-%define autoconf_version 2.68
+%define autoconf_version 2.69
 %define automake_version 1.11.4
 %define libtool_version 2.4.2
 %define m4_version 1.4.16

--- a/couchdb15-cmsauth-Makefile.patch
+++ b/couchdb15-cmsauth-Makefile.patch
@@ -1,0 +1,18 @@
+--- src/couchdb/Makefile.am	2014-04-28 19:38:09.000000000 +0200
++++ src/couchdb/Makefile.am.new	2014-04-28 19:41:56.000000000 +0200
+@@ -32,6 +32,7 @@
+     couch_auth_cache.erl \
+     couch_btree.erl \
+     couch_changes.erl \
++    couch_cms_auth.erl \
+     couch_compaction_daemon.erl \
+     couch_compress.erl \
+     couch_config.erl \
+@@ -89,6 +90,7 @@
+     couch_auth_cache.beam \
+     couch_btree.beam \
+     couch_changes.beam \
++    couch_cms_auth.beam \
+     couch_compaction_daemon.beam \
+     couch_compress.beam \
+     couch_config.beam \

--- a/couchdb15-makefile-in.patch
+++ b/couchdb15-makefile-in.patch
@@ -1,0 +1,24 @@
+--- Makefile.in	2014-04-28 22:55:46.000000000 +0200
++++ Makefile.in.new	2014-04-28 22:59:26.000000000 +0200
+@@ -399,14 +399,14 @@
+ 	    cd $(top_builddir) && $(SHELL) ./config.status $@ $(am__depfiles_maybe);; \
+ 	esac;
+ 
+-$(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
+-	$(SHELL) ./config.status --recheck
++# $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
++#     $(SHELL) ./config.status --recheck
+ 
+-$(top_srcdir)/configure:  $(am__configure_deps)
+-	$(am__cd) $(srcdir) && $(AUTOCONF)
+-$(ACLOCAL_M4):  $(am__aclocal_m4_deps)
+-	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
+-$(am__aclocal_m4_deps):
++# $(top_srcdir)/configure:  $(am__configure_deps)
++#     $(am__cd) $(srcdir) && $(AUTOCONF)
++# $(ACLOCAL_M4):  $(am__aclocal_m4_deps)
++#     $(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
++# $(am__aclocal_m4_deps):
+ 
+ config.h: stamp-h1
+ 	@if test ! -f $@; then rm -f stamp-h1; else :; fi

--- a/couchdb15-ssl-client-cert.patch
+++ b/couchdb15-ssl-client-cert.patch
@@ -1,0 +1,13 @@
+--- src/couch_replicator/src/couch_replicator_utils.erl	2014-04-28 19:57:01.000000000 +0200
++++ src/couch_replicator/src/couch_replicator_utils.erl	2014-04-28 20:04:11.000000000 +0200
+@@ -321,8 +321,9 @@
+         VerifyCerts = couch_config:get("replicator", "verify_ssl_certificates"),
+         CertFile = couch_config:get("replicator", "cert_file", nil),
+         KeyFile = couch_config:get("replicator", "key_file", nil),
++        CaCertFile=couch_config:get("replicator", "cacert_file", nil),
+         Password = couch_config:get("replicator", "password", nil),
+-        SslOpts = [{depth, Depth} | ssl_verify_options(VerifyCerts =:= "true")],
++        SslOpts = [{certfile, CertFile}, {keyfile, KeyFile}, {cacertfile, CaCertFile}, {depth, Depth} | ssl_verify_options(VerifyCerts =:= "true")],
+         SslOpts1 = case CertFile /= nil andalso KeyFile /= nil of
+             true ->
+                 case Password of

--- a/couchdb15.spec
+++ b/couchdb15.spec
@@ -1,0 +1,65 @@
+### RPM external couchdb 1.5.1
+
+# Using the svn url instead of the default release on because we need the 
+# bootstrap script after patching the Makefile.am
+# Source0: svn://svn.apache.org/repos/asf/couchdb/tags/%realversion?scheme=https&module=couchdb&output=/apache-%n-%realversion.tgz
+Source0: http://www.interior-dsgn.com/apache/couchdb/source/%realversion/apache-couchdb-%realversion.tar.gz
+Source1: couch_cms_auth.erl
+Patch0: couchdb15-cmsauth-Makefile
+Patch1: couchdb15-ssl-client-cert
+Patch2: couchdb15-makefile-in
+
+# Although there is no technical software dependency,
+# couchapp was included because all CMS applications will need it.
+Requires: curl spidermonkey openssl icu4c erlang couchapp
+BuildRequires: autotools
+
+%prep
+%setup -n apache-couchdb-%realversion
+%patch0 -p0
+%patch1 -p0
+%patch2 -p0
+cp %_sourcedir/couch_cms_auth.erl %_builddir/apache-couchdb-%realversion/src/couchdb
+perl -p -i -e 's{\s*-L/(opt|usr)/local/lib}{}g; s{-I/(opt|usr)/local/include}{-I/no-no-no/include}g' configure.ac
+perl -p -i -e 's{-licuuc -licudt -licuin}{-licui18n -licuuc -licudata}g;' configure
+perl -p -i -e 's{-licuuc -licudt -licuin}{-licui18n -licuuc -licudata}g;' configure.ac
+
+%build
+# apache 1.5.1 does not have option to specify --with-icu4c, instead
+# they used --with-win32-icu-binaries which mostly the same
+export CURL_ROOT SPIDERMONKEY_ROOT OPENSSL_ROOT ICU4C_ROOT ERLANG_ROOT AUTOTOOLS_ROOT
+export PATH=$ERLANG_ROOT/bin:$AUTOTOOLS_ROOT/bin:$PATH
+export ACLOCAL=$AUTOTOOLS_ROOT/bin/aclocal
+export AUTOCONF=$AUTOTOOLS_ROOT/bin/autoconf
+export AUTOMAKE=$AUTOTOOLS_ROOT/bin/automake
+export AUTOHEADER=$AUTOTOOLS_ROOT/bin/autoheader
+./configure --prefix=%i --with-js-lib=$SPIDERMONKEY_ROOT/lib --with-js-include=$SPIDERMONKEY_ROOT/include --with-erlang=$ERLANG_ROOT/lib/erlang/usr/include --with-win32-icu-binaries=$ICU4C_ROOT
+make %makeprocesses
+
+%install
+make %makeprocesses install
+# install creates symlink which will point to build area, we'll resolve this
+rm %i/bin/couchjs
+cp %i/lib/couchdb/bin/couchjs %i/bin/
+%define drop_files %i/{man,share/doc}
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$$root != X || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh
+%{relocateConfig}etc/{rc.d,logrotate.d}/couchdb
+%{relocateConfig}etc/couchdb/default.ini
+%{relocateConfig}bin/couch*
+%{relocateConfig}lib/couchdb/erlang/lib/couch-%realversion/ebin/couch.app
+%{relocateConfig}lib/couchdb/erlang/lib/couch-%realversion/priv/lib/couch_icu_driver.la
+


### PR DESCRIPTION
Please take separate patches and spec file for couchdb 1.5 which we can use independently from default couchdb. This will allow to test CDB1.5 within wmagent environment.
