### PR TITLE
CRAB3 release candidate version for July deployment: 3.3.7.rc4

### DIFF
--- a/crabcache.spec
+++ b/crabcache.spec
@@ -1,11 +1,11 @@
-### RPM cms crabcache 3.3.6.rc9
+### RPM cms crabcache 3.3.7.rc4
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.95a
+%define wmcver 0.9.95b
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz

--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,11 +1,11 @@
-### RPM cms crabclient 3.3.6.patch1
+### RPM cms crabclient 3.3.7
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-%define wmcver 0.9.95a
+%define wmcver 0.9.95e
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define crabserver 3.3.6.rc9
+%define crabserver 3.3.7.rc4
 
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
@@ -13,13 +13,13 @@ Source1: git://github.com/dmwm/CRABClient.git?obj=master/%{realversion}&export=C
 Source2: git://github.com/dmwm/CRABServer.git?obj=master/%{crabserver}&export=CRABServer-%{crabserver}&output=/CRABServer-%{crabserver}.tar.gz
 
 Requires: python py2-httplib2 py2-sphinx py2-pycurl
-Patch0: crabclient-setup
+#Patch0: crabclient-setup
 
 %prep
 %setup -D -T -b 1 -n CRABClient-%{realversion}
 %setup -T -b 2 -n CRABServer-%{crabserver}
 %setup -T -b 0 -n WMCore-%{wmcver}
-%patch0 -p1
+#%patch0 -p1
 
 %build
 pushd ../WMCore-%{wmcver}

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,16 +1,17 @@
-### RPM cms crabserver 3.3.6.rc9
+### RPM cms crabserver 3.3.7.rc4
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.95a
+%define wmcver 0.9.95b
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle py2-pyopenssl condor mysql py2-mysqldb
+Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle
+Requires: py2-pyopenssl condor mysql py2-mysqldb dbs3-pycurl-client dbs-client dbs3-client
 BuildRequires: py2-sphinx
 #Patch0: crabserver3-setup
 

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,10 +1,10 @@
-### RPM cms crabtaskworker 3.3.6.rc9
+### RPM cms crabtaskworker 3.3.7.rc4
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.95a
+%define wmcver 0.9.95b
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz


### PR DESCRIPTION
Contains needed changes for CSA14. Most notably support for /store/group
