### PR TITLE
CRAB3 3.3.7.rc4/rc5 versions for HG1407

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,4 +1,4 @@
-### RPM cms crabclient 3.3.7
+### RPM cms crabclient 3.3.7.rc4
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,4 +1,4 @@
-### RPM cms crabserver 3.3.7.rc4
+### RPM cms crabserver 3.3.7.rc5
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
@@ -13,12 +13,12 @@ Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=C
 Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle
 Requires: py2-pyopenssl condor mysql py2-mysqldb dbs3-pycurl-client dbs-client dbs3-client
 BuildRequires: py2-sphinx
-#Patch0: crabserver3-setup
+Patch0: crabserver3-setup
 
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
 %setup -T -b 0 -n WMCore-%{wmcver}
-#%patch0 -p0
+%patch0 -p1
 
 %build
 touch $PWD/condor_config

--- a/crabserver3-setup.patch
+++ b/crabserver3-setup.patch
@@ -1,0 +1,32 @@
+commit 37f8befeb74b398db42a7da2ced516015841aa8c
+Author: Marco Mascheroni <marco.mascheroni@cern.ch>
+Date:   Wed Jul 2 03:17:08 2014 +0200
+
+    setup_dependencies.py: add LumiList dependency for CRABServer and CRABClient
+
+diff --git a/setup_dependencies.py b/setup_dependencies.py
+index 8c40f12..14b2efa 100644
+--- a/setup_dependencies.py
++++ b/setup_dependencies.py
+@@ -122,17 +122,18 @@ dependencies = {'wmc-rest':{
+                 'crabserver':{
+                         'packages': ['WMCore.Credential', 'WMCore.Services+', 'WMCore.RequestManager+',
+                                      'WMCore.WMSpec+', 'WMCore.HTTPFrontEnd+', 'WMCore.ACDC'],
+-                        'systems': ['wmc-rest', 'wmc-database'],
++                        'modules' : ['WMCore.DataStructs.LumiList'],
++                        'systems' : ['wmc-rest', 'wmc-database'],
+                         },
+                 'crabclient':{
+                         'packages': ['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks', 'WMCore.Services.UserFileCache+', 'WMCore.Services.SiteDB+', 'WMCore.Services.PhEDEx+'],
+                         'systems': ['wmc-base'],
+-                        'modules': ['WMCore.FwkJobReport.FileInfo', 'WMCore.Services.Requests',
++                        'modules': ['WMCore.FwkJobReport.FileInfo', 'WMCore.Services.Requests', 'WMCore.DataStructs.LumiList',
+                                     'WMCore.Services.Service', 'WMCore.Services.pycurl_manager', 'WMCore.Services.EmulatorSwitch'],
+                         },
+                 'crabtaskworker':{
+                         'packages':['WMCore.WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
+-                                    'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+', 
++                                    'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+',
+                                     'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+'],
+                         'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
+                         'systems': ['wmc-database', 'wmc-runtime'],

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,4 +1,4 @@
-### RPM cms crabtaskworker 3.3.7.rc4
+### RPM cms crabtaskworker 3.3.7.rc5
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
Includes the following fixes (just mentioning crabserver and ignoring crabclient and crabtaskworker):
- Fix the regexp for the publishname parameter.
- Fix getoutput and getlog which were always failing
- Raise a proper error when the task is not found in the database (status API)
- Fix dbs report for usage with multiple output datasets

And a new feature recently requested for CSA14:
- Add the possibility to blacklist site in case ignoreLocality is set
