### PR TITLE
lhapdf: disable $(srcdir) in TESTS

### DIFF
--- a/lhapdf-5.9.1-tests-no-srcdir.patch
+++ b/lhapdf-5.9.1-tests-no-srcdir.patch
@@ -1,0 +1,10 @@
+diff --git a/5.8.5/octave/Makefile.am b/5.8.5/octave/Makefile.am
+index 7ef2eac..079c5d5 100644
+--- a/5.8.5/octave/Makefile.am
++++ b/5.8.5/octave/Makefile.am
+@@ -6,4 +6,4 @@ lhapdf.oct: wrapoctave.cc
+ 	$(MKOCTFILE) -I$(top_srcdir)/include -v -g -o lhapdf.oct wrapoctave.cc -L$(top_builddir)/lib -L$(top_builddir)/lib/.libs -lLHAPDF
+ 
+ TESTS_ENVIRONMENT = LHAPATH=$(top_srcdir)/PDFsets $(OCTAVE)
+-TESTS = $(srcdir)/lhapdf-octave-example1.m
++TESTS = lhapdf-octave-example1.m

--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -2,7 +2,8 @@
 
 %define realversion %(echo %{v} | cut -d- -f1)
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
-Patch3: lhapdf-5.9.0-disable-examples-and-tests
+Patch0: lhapdf-5.9.0-disable-examples-and-tests
+Patch1: lhapdf-5.9.1-tests-no-srcdir
 
 Source1: lhapdf_makeLinks
 
@@ -24,7 +25,8 @@ Requires: gfortran-macosx
 
 %prep
 %setup -q -n %{n}/%{realversion}
-%patch3 -p2
+%patch0 -p2
+%patch1 -p2
 
 # Remove wrapper generated w/ SWIG 1.3* version. Makefile will
 # regenerate it w/ our SWIG version.
@@ -33,11 +35,7 @@ rm ./pyext/lhapdf_wrap.cc
 %build
 # We do everything in install because we need to do it twice.
 %install
-libtoolize --force --copy
-autoupdate
-aclocal -I m4
-autoconf
-automake --add-missing
+autoreconf -fiv
 
 FC="`which gfortran` -fPIC"
 CXX="`which %{cms_cxx}` -fPIC"


### PR DESCRIPTION
This is not supported by autotools. Only affects LHAPDF version 5.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
