### PR TITLE
Push crabserver 3.3.7.rc6

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,4 +1,4 @@
-### RPM cms crabserver 3.3.7.rc5
+### RPM cms crabserver 3.3.7.rc6
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
We have been asked to change how we validate the outlfn parameter and do not check that users write in they space (e.g.: we were enforcing `/store/user/mmascher` but sites like LPC have group space under `/store/user`).

The discussion might not be over (https://github.com/dmwm/CRABServer/issues/4344), but I guess for CSA14 we need to loose this up.
