### PR TITLE
Rename LHAPDF6 libraries and python modules.

### DIFF
--- a/lhapdf6-toolfile.spec
+++ b/lhapdf6-toolfile.spec
@@ -9,7 +9,7 @@ Requires: lhapdf6
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/lhapdf6.xml
 <tool name="lhapdf6" version="@TOOL_VERSION@">
-  <lib name="LHAPDF"/>
+  <lib name="LHAPDF6"/>
   <client>
     <environment name="LHAPDF6_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$LHAPDF6_BASE/lib"/>

--- a/lhapdf6.spec
+++ b/lhapdf6.spec
@@ -47,6 +47,8 @@ rm -f MSTW2008nlo68cl.tar.gz
 chmod a+x %{_sourcedir}/lhapdf6_makeLinks
 %{_sourcedir}/lhapdf6_makeLinks
 cd -
+mv %i/lib/libLHAPDF.a %i/lib/libLHAPDF6.a
+mv %i/lib/python2.7/site-packages/lhapdf.so %i/lib/python2.7/site-packages/lhapdf6.so
 
 %post
 %{relocateConfig}bin/lhapdf-config


### PR DESCRIPTION
This is needed to have lhapdf5 and lhapdf6 coexisting in one given scram environment.
