### PR TITLE
scram-project-build: use $CMS_INSTALL_PREFIX for glibc path

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -323,7 +323,7 @@ case %cmsplatf in
     CMSSW_BIN_PATH=$RPM_INSTALL_PREFIX/%pkgrel/{bin,test}/%cmsplatf
     CMSSW_ELF_BIN=$(find $CMSSW_BIN_PATH -type f -exec file {} \; | grep ELF | cut -d':' -f1)
     GLIBC_PKG=$(echo "%{directpkgreqs}" | tr ' ' '\n' | grep 'external/glibc/')
-    GLIBC_PATH=$RPM_INSTALL_PREFIX/%cmsplatf/$GLIBC_PKG
+    GLIBC_PATH=$CMS_INSTALL_PREFIX/%cmsplatf/$GLIBC_PKG
     echo "$CMSSW_ELF_BIN" | xargs -t -n 1 -I% -P $(getconf _NPROCESSORS_ONLN) sh -c "patchelf --set-interpreter $GLIBC_PATH/lib64/ld.so %"
   esac
 %endif


### PR DESCRIPTION
`$RPM_INSTALL_PREFIX` is not the final destination for CMSSW, we
might install _CMSSW_ locally and then move to AFS. `$CMS_INSTALL_PREFIX`
holds the final destination for software.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
