### PR TITLE
updated config tag to V05-03-10

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -35,7 +35,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-09
+%define configtag       V05-03-10
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
- Basic support to check for dependents products of big plugin
- Add <project>/biglib/<arch> in to LD_LIBRARY_PATH
