### PR TITLE
Ib/cmssw 6 2 x/stable

### DIFF
--- a/sherpa-2.1.1-lhapdf.patch
+++ b/sherpa-2.1.1-lhapdf.patch
@@ -1,6 +1,6 @@
-diff -Naur SHERPA-MC-2.1.0-orig/PDF/LHAPDF/Makefile.am SHERPA-MC-2.1.0/PDF/LHAPDF/Makefile.am
---- SHERPA-MC-2.1.0-orig/PDF/LHAPDF/Makefile.am	2014-04-11 12:03:48.000000000 +0200
-+++ SHERPA-MC-2.1.0/PDF/LHAPDF/Makefile.am	2014-04-11 12:08:02.000000000 +0200
+diff -Naur SHERPA-MC-2.1.1-orig/PDF/LHAPDF/Makefile.am SHERPA-MC-2.1.1/PDF/LHAPDF/Makefile.am
+--- SHERPA-MC-2.1.1-orig/PDF/LHAPDF/Makefile.am	2014-04-11 12:03:48.000000000 +0200
++++ SHERPA-MC-2.1.1/PDF/LHAPDF/Makefile.am	2014-04-11 12:08:02.000000000 +0200
 @@ -27,5 +27,6 @@
  libLHAPDFSherpa_la_LIBADD = @CONDITIONAL_LHAPDFLIBS@
  
@@ -8,9 +8,9 @@ diff -Naur SHERPA-MC-2.1.0-orig/PDF/LHAPDF/Makefile.am SHERPA-MC-2.1.0/PDF/LHAPD
 +libLHAPDFSherpa_la_LDFLAGS = -lz -L@CONDITIONAL_LHAPDFDIR@/lib -Bstatic -lLHAPDF
  
  EXTRA_DIST    = $(LHAPDFEXTRADIST)
-diff -Naur SHERPA-MC-2.1.0-orig/SHERPA/Initialization/Initialization_Handler.C SHERPA-MC-2.1.0/SHERPA/Initialization/Initialization_Handler.C
---- SHERPA-MC-2.1.0-orig/SHERPA/Initialization/Initialization_Handler.C	2014-04-11 12:04:33.000000000 +0200
-+++ SHERPA-MC-2.1.0/SHERPA/Initialization/Initialization_Handler.C	2014-04-11 12:08:52.000000000 +0200
+diff -Naur SHERPA-MC-2.1.1-orig/SHERPA/Initialization/Initialization_Handler.C SHERPA-MC-2.1.1/SHERPA/Initialization/Initialization_Handler.C
+--- SHERPA-MC-2.1.1-orig/SHERPA/Initialization/Initialization_Handler.C	2014-04-11 12:04:33.000000000 +0200
++++ SHERPA-MC-2.1.1/SHERPA/Initialization/Initialization_Handler.C	2014-04-11 12:08:52.000000000 +0200
 @@ -527,8 +527,8 @@
      if (*pdflib=="None") continue;
      if (*pdflib=="LHAPDFSherpa") {

--- a/sherpa-toolfile.spec
+++ b/sherpa-toolfile.spec
@@ -9,101 +9,9 @@ Requires: sherpa
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa.xml
 <tool name="sherpa" version="@TOOL_VERSION@">
-<lib name="AhadicDecays"/>
-<lib name="AhadicFormation"/>
-<lib name="AhadicMain"/>
-<lib name="AhadicTools"/>
-<lib name="AmegicCluster"/>
-<lib name="AmegicPSGen"/>
-<lib name="Amegic"/>
-<lib name="AmisicModel"/>
-<lib name="Amisic"/>
-<lib name="AmisicTools"/>
-<lib name="Amplitude"/>
-<lib name="Beam"/>
-<lib name="ComixAmplitude"/>
-<lib name="ComixCluster"/>
-<lib name="ComixPhasespace"/>
-<lib name="Comix"/>
-<lib name="CSCalculators"/>
-<lib name="CSMain"/>
-<lib name="CSShowers"/>
-<lib name="CSTools"/>
-<lib name="CT10Sherpa"/>
-<lib name="CT12Sherpa"/>
-<lib name="CTEQ6Sherpa"/>
-<lib name="DipoleSubtraction"/>
-<lib name="ExtraXS1_2"/>
-<lib name="ExtraXS1_3"/>
-<lib name="ExtraXS2_2"/>
-<lib name="ExtraXSCluster"/>
-<lib name="ExtraXSNLO"/>
-<lib name="ExtraXS"/>
-<lib name="GRVSherpa"/>
-<lib name="HadronsCurrents"/>
-<lib name="HadronsMain"/>
-<lib name="HadronsMEs"/>
-<lib name="HadronsPSs"/>
-<lib name="LHAPDFSherpa"/>
-<lib name="LundTools"/>
-<lib name="MCatNLOCalculators"/>
-<lib name="MCatNLOMain"/>
-<lib name="MCatNLOShowers"/>
-<lib name="MCatNLOTools"/>
-<lib name="MEProcess"/>
-<lib name="METoolsColors"/>
-<lib name="METoolsCurrents"/>
-<lib name="METoolsExplicit"/>
-<lib name="METoolsLoops"/>
-<lib name="METoolsMain"/>
-<lib name="METoolsSpinCorrelations"/>
-<lib name="METoolsVertices"/>
-<lib name="ModelInteractions"/>
-<lib name="ModelMain"/>
-<lib name="MRST01LOSherpa"/>
-<lib name="MRST04QEDSherpa"/>
-<lib name="MRST99Sherpa"/>
-<lib name="MSTW08Sherpa"/>
-<lib name="PDFESherpa"/>
-<lib name="PDF"/>
-<lib name="PhasicChannels"/>
-<lib name="PhasicDecays"/>
-<lib name="PhasicEnhance"/>
-<lib name="PhasicMain"/>
-<lib name="PhasicProcess"/>
-<lib name="PhasicScales"/>
-<lib name="PhasicSelectors"/>
-<lib name="PhotonsMain"/>
-<lib name="PhotonsMEs"/>
-<lib name="PhotonsPhaseSpace"/>
-<lib name="PhotonsTools"/>
-<lib name="Remnant"/>
-<lib name="SherpaAnalyses"/>
-<lib name="SherpaAnalysis"/>
-<lib name="SherpaAnalysisTools"/>
-<lib name="SherpaAnalysisTrigger"/>
-<lib name="SherpaBlackHat"/>
-<lib name="SherpaHepMCOutput"/>
-<lib name="SherpaHiggs"/>
-<lib name="SherpaInitialization"/>
 <lib name="SherpaMain"/>
-<lib name="SherpaObservables"/>
-<lib name="SherpaPythia"/>
-<lib name="SherpaPerturbativePhysics"/>
-<lib name="SherpaSingleEvents"/>
-<lib name="SherpaSoftPhysics"/>
-<lib name="SherpaTools"/>
-<lib name="ShrimpsBeamRemnants"/>
-<lib name="ShrimpsEikonals"/>
-<lib name="ShrimpsEvents"/>
-<lib name="ShrimpsMain"/>
-<lib name="ShrimpsTools"/>
-<lib name="ShrimpsXsecs"/>
-<lib name="String"/>
 <lib name="ToolsMath"/>
 <lib name="ToolsOrg"/>
-<lib name="ToolsPhys"/>
-<lib name="Zfunctions"/>
 <client>
 <environment name="SHERPA_BASE" default="@TOOL_ROOT@"/>
 <environment name="BINDIR" default="$SHERPA_BASE/bin"/>
@@ -113,11 +21,13 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa.xml
 <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$SHERPA_BASE/include" type="path"/>
 <runtime name="SHERPA_SHARE_PATH" value="$SHERPA_BASE/share/SHERPA-MC" type="path"/>
 <runtime name="SHERPA_INCLUDE_PATH" value="$SHERPA_BASE/include/SHERPA-MC" type="path"/>
+<runtime name="SHERPA_LIBRARY_PATH" value="$SHERPA_BASE/lib/SHERPA-MC" type="path"/>
 <use name="HepMC"/>
 <use name="lhapdf"/>
 <use name="qd"/>
 <use name="blackhat"/>
 <use name="fastjet"/>
+<use name="sqlite"/>
 </tool>
 EOF_TOOLFILE
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -3,7 +3,7 @@
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
-Requires: hepmc lhapdf blackhat sqlite fastjet openssl
+Requires: autotools hepmc lhapdf blackhat sqlite fastjet openssl
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,8 +1,9 @@
-### RPM external sherpa 2.1.0
-Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-%{realversion}.tar.gz
+### RPM external sherpa 2.1.1
+%define tag ddb788ce152c8626876466d471eb7593ffd7ed9b
+%define branch cms/v%realversion
+%define github_user cms-externals
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl
-Patch0: sherpa-2.1.0-lhapdf
-Patch1: sherpa-2.1.0-disable-examples-manual
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
@@ -13,16 +14,13 @@ Patch1: sherpa-2.1.0-disable-examples-manual
 %endif
 
 %prep
-%setup -q -n SHERPA-MC-%{realversion}
-%patch0 -p1
-%patch1 -p1
+%setup -q -n %{n}-%{realversion}
 
 autoreconf -i --force
 
 # Force architecture based on %%cmsplatf
 case %cmsplatf in
   *_amd64_gcc*) ARCH_CMSPLATF="-m64" ;;
-  *_ia32_gcc*) ARCH_CMSPLATF="-m32" ;;
 esac
 
 case %cmsplatf in
@@ -33,15 +31,12 @@ case %cmsplatf in
   ;;
 esac
 
-./configure --prefix=%i --enable-analysis --disable-silent-rules --enable-fastjet=$FASTJET_ROOT \
+%build
+./configure --prefix=%i --disable-silent-rules --enable-fastjet=$FASTJET_ROOT \
             --enable-hepmc2=$HEPMC_ROOT --enable-lhapdf=$LHAPDF_ROOT --enable-blackhat=$BLACKHAT_ROOT --with-sqlite3=$SQLITE_ROOT \
             CXX="%cms_cxx" \
             CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF %cms_cxxflags -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$OPENSSL_ROOT/include" \
             LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib"
-%build
-# Fix up a configuration mistake coming from a test being confused
-# by the "skipping incompatible" linking messages when linking 32bit on 64bit
-find . -name Makefile -exec perl -p -i -e 's|/usr/lib64/libm.a||g;s|/usr/lib64/libc.a||g;' {} \;
 
 make %{makeprocesses}
 


### PR DESCRIPTION
Fix to make sherpa compile in CMSSW_6_2_X
(removed --enable-analysis from configure options of sherpa)
Also added autotools to sherpa requirements
