### PR TITLE
cython: drop egg-info; fix python shebang

### DIFF
--- a/cython.spec
+++ b/cython.spec
@@ -1,4 +1,5 @@
 ### RPM external cython 0.19.1
+## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
 
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
 
@@ -11,4 +12,13 @@ Requires: python
 ${PYTHON_ROOT}/bin/python setup.py build
 
 %install
-${PYTHON_ROOT}/bin/python setup.py install --prefix %i
+${PYTHON_ROOT}/bin/python setup.py install --prefix %{i}
+
+sed -ideleteme 's|#!.*/bin/python|#!/usr/bin/env python|' \
+  %{i}/bin/cython \
+  %{i}/bin/cygdb \
+  %{i}/${PYTHON_LIB_SITE_PACKAGES}/Cython/Debugger/libpython.py
+
+find %{i} -name '*deleteme' -delete
+
+find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -f


### PR DESCRIPTION
- Drop egg-info, not needed
- Use python via `/usr/bin/env`, otherwise it hardcodes not-relocated
  full path to Python. This generates unwanted RPM dependencies, e.g.,

```
  rpm -qp --requires external+cython+0.19.1-1-1.fc19_aarch64_gcc490.rpm
  [snip]
  /home/david.abdurachmanov/real-arch/allext/a/fc19_aarch64_gcc490/external/python/2.7.6/bin/python
  [snip]
```

```
[davidlt@lxplus0191]/afs/cern.ch/cms/slc6_amd64_gcc481/external/cython/0.19.1-cms% grep -n -R 'bin/python' *
bin/cygdb:1:#!/build/degano/CMSSW_7_2_0_pre1-build/slc6_amd64_gcc481/external/python/2.7.6/bin/python
bin/cython:1:#!/build/degano/CMSSW_7_2_0_pre1-build/slc6_amd64_gcc481/external/python/2.7.6/bin/python
lib/python2.7/site-packages/Cython/Debugger/libpython.py:1:#!/usr/bin/python
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
