### PR TITLE
Fix a numer of issues with glibc post-install step

### DIFF
--- a/glibc-toolfile.spec
+++ b/glibc-toolfile.spec
@@ -11,7 +11,6 @@ cat << \EOF_TOOLFILE > %{i}/etc/scram.d/glibc.xml
     <client>
       <environment name="GLIBC_BASE" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="GLIBC_ROOT" value="$GLIBC_BASE" type="path"/>
   </tool>
 EOF_TOOLFILE
 ## IMPORT scram-tools-post

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -10,7 +10,7 @@ Requires: SCRAMV1
 
 %if %islinux
 %if %isamd64
-%if "%{?n}" == "cmssw"
+%if "%{?n}" != "coral"
 Requires: patchelf
 Requires: glibc
 Requires: file
@@ -329,7 +329,7 @@ done
 %{?PartialReleaseFilesRelocate:%PartialReleaseFilesRelocate}
 [ -f $RPM_INSTALL_PREFIX/etc/scramrc/%{pkgname}.map ] || (mkdir -p $RPM_INSTALL_PREFIX/etc/scramrc && echo '%{ucprojtype}=$SCRAM_ARCH/%{pkgcategory}/%{pkgname}/%{ucprojtype}_*' > $RPM_INSTALL_PREFIX/etc/scramrc/%{pkgname}.map)
 
-%if "%{?n}" == "cmssw"
+%if "%{?n}" != "coral"
 case %cmsplatf in
   slc6_amd64_*)
     FILE_PKG=$(echo "%{directpkgreqs}" | tr ' ' '\n' | grep 'external/file/')

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -10,9 +10,11 @@ Requires: SCRAMV1
 
 %if %islinux
 %if %isamd64
+%if "%{?n}" == "cmssw"
 Requires: patchelf
 Requires: glibc
 Requires: file
+%endif # cmssw
 %endif # isamd64
 %endif # islinux
 
@@ -327,20 +329,20 @@ done
 %{?PartialReleaseFilesRelocate:%PartialReleaseFilesRelocate}
 [ -f $RPM_INSTALL_PREFIX/etc/scramrc/%{pkgname}.map ] || (mkdir -p $RPM_INSTALL_PREFIX/etc/scramrc && echo '%{ucprojtype}=$SCRAM_ARCH/%{pkgcategory}/%{pkgname}/%{ucprojtype}_*' > $RPM_INSTALL_PREFIX/etc/scramrc/%{pkgname}.map)
 
+%if "%{?n}" == "cmssw"
 case %cmsplatf in
   slc6_amd64_*)
     FILE_PKG=$(echo "%{directpkgreqs}" | tr ' ' '\n' | grep 'external/file/')
     FILE_PATH=$RPM_INSTALL_PREFIX/%cmsplatf/$FILE_PKG
     PATCHELF_PKG=$(echo "%{directpkgreqs}" | tr ' ' '\n' | grep 'external/patchelf/')
     PATCHELF_PATH=$RPM_INSTALL_PREFIX/%cmsplatf/$PATCHELF_PKG
-    . $PATCHELF_PATH/etc/profile.d/init.sh
-    . $FILE_PATH/etc/profile.d/init.sh
     CMSSW_BIN_PATH="$RPM_INSTALL_PREFIX/%pkgrel/bin/%cmsplatf $RPM_INSTALL_PREFIX/%pkgrel/test/%cmsplatf"
-    CMSSW_ELF_BIN=$(find $CMSSW_BIN_PATH -type f -exec file {} \; | grep ELF | cut -d':' -f1)
+    CMSSW_ELF_BIN=$(find $CMSSW_BIN_PATH -type f -exec $FILE_PATH/bin/file {} \; | grep ELF | cut -d':' -f1)
     GLIBC_PKG=$(echo "%{directpkgreqs}" | tr ' ' '\n' | grep 'external/glibc/')
     GLIBC_PATH=$CMS_INSTALL_PREFIX/%cmsplatf/$GLIBC_PKG
-    echo "$CMSSW_ELF_BIN" | xargs -t -n 1 -I% -P $(getconf _NPROCESSORS_ONLN) sh -c "strings % 2>&1 | grep '%{cmsplatf}/external/glibc' 2>&1 >/dev/null && patchelf --set-interpreter $GLIBC_PATH/lib64/ld.so %"
-  esac
+    echo "$CMSSW_ELF_BIN" | xargs -t -n 1 -I% -P $(getconf _NPROCESSORS_ONLN) sh -c "strings % 2>&1 | grep '%{cmsplatf}/external/glibc' 2>&1 >/dev/null && $PATCHELF_PATH/bin/patchelf --set-interpreter $GLIBC_PATH/lib64/ld.so % || true"
+esac
+%endif
 
 %postun
 rm -fR $RPM_INSTALL_PREFIX/%pkgrel

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -10,7 +10,7 @@ Requires: SCRAMV1
 
 %if %islinux
 %if %isamd64
-%if "%{?n}" != "coral"
+%if "%{?pkgname}" != "coral"
 Requires: patchelf
 Requires: glibc
 Requires: file
@@ -329,7 +329,7 @@ done
 %{?PartialReleaseFilesRelocate:%PartialReleaseFilesRelocate}
 [ -f $RPM_INSTALL_PREFIX/etc/scramrc/%{pkgname}.map ] || (mkdir -p $RPM_INSTALL_PREFIX/etc/scramrc && echo '%{ucprojtype}=$SCRAM_ARCH/%{pkgcategory}/%{pkgname}/%{ucprojtype}_*' > $RPM_INSTALL_PREFIX/etc/scramrc/%{pkgname}.map)
 
-%if "%{?n}" != "coral"
+%if "%{?pkgname}" != "coral"
 case %cmsplatf in
   slc6_amd64_*)
     FILE_PKG=$(echo "%{directpkgreqs}" | tr ' ' '\n' | grep 'external/file/')

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -14,7 +14,7 @@ Requires: SCRAMV1
 Requires: patchelf
 Requires: glibc
 Requires: file
-%endif # cmssw
+%endif # coral
 %endif # isamd64
 %endif # islinux
 
@@ -342,7 +342,7 @@ case %cmsplatf in
     GLIBC_PATH=$CMS_INSTALL_PREFIX/%cmsplatf/$GLIBC_PKG
     echo "$CMSSW_ELF_BIN" | xargs -t -n 1 -I% -P $(getconf _NPROCESSORS_ONLN) sh -c "strings % 2>&1 | grep '%{cmsplatf}/external/glibc' 2>&1 >/dev/null && $PATCHELF_PATH/bin/patchelf --set-interpreter $GLIBC_PATH/lib64/ld.so % || true"
 esac
-%endif
+%endif # coral
 
 %postun
 rm -fR $RPM_INSTALL_PREFIX/%pkgrel


### PR DESCRIPTION
- Only add dependencies on file, glibc and patchelf if we are building
  CMSSW;
- Only execute post-install relocation for CMSSW. There are no binaries
  in CORAL;
- Remove GLIBC_ROOT environment variable. It was used for bash wrappers
  around cmsRun*. Not needed anymore;
- Do not source init.sh for file and patchelf as we install in
  /afs/.cern.ch (write/read) and then relocate to /afs/cern.ch
  (read-only). The paths in init.sh script are relocated, but files are
  not yet present on /afs/cern.ch. Use binaries directly by full path.
- If grep fails (does not find) the post-install scriplet fails. Ignore
  if grep finds nothing.

**Not tested**

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
