### PR TITLE
First release candidate of CRABServer 3.3.8 series

### DIFF
--- a/crabcache.spec
+++ b/crabcache.spec
@@ -1,11 +1,11 @@
-### RPM cms crabcache 3.3.7.rc4
+### RPM cms crabcache 3.3.8.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.95b
+%define wmcver 0.9.96
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz

--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,11 +1,11 @@
-### RPM cms crabclient 3.3.7.patch2
+### RPM cms crabclient 3.3.8.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-%define wmcver 0.9.95e
+%define wmcver 0.9.96
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define crabserver 3.3.7.rc4
+%define crabserver 3.3.8.rc1
 
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,11 +1,11 @@
-### RPM cms crabserver 3.3.7.rc6
+### RPM cms crabserver 3.3.8.rc4
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.95b
+%define wmcver 0.9.96
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
@@ -13,12 +13,12 @@ Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=C
 Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle
 Requires: py2-pyopenssl condor mysql py2-mysqldb dbs3-pycurl-client dbs-client dbs3-client
 BuildRequires: py2-sphinx
-Patch0: crabserver3-setup
+#Patch0: crabserver3-setup
 
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
 %setup -T -b 0 -n WMCore-%{wmcver}
-%patch0 -p1
+#%patch0 -p1
 
 %build
 touch $PWD/condor_config

--- a/crabtaskworker-setup.patch
+++ b/crabtaskworker-setup.patch
@@ -1,0 +1,24 @@
+commit cc4b906203c6144e30c7f50bdaf6f2d76d6fbe9b
+Author: Marco Mascheroni <marco.mascheroni@cern.ch>
+Date:   Fri Jul 11 01:10:03 2014 +0200
+
+    Allow the possibility to set the runtimeDir for scram pre scripts in the CMSSW executor. Related to https://github.com/dmwm/CRABClient/issues/4177
+
+diff --git a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+index 26f8b32..6147377 100644
+--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
++++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+@@ -209,11 +209,12 @@ class CMSSW(Executor):
+         logging.info("RUNNING SCRAM SCRIPTS")
+         for script in self.step.runtime.scramPreScripts:
+             #invoke scripts with scram()
++            runtimeDir = getattr(self.step.runtime, 'scramPreDir', None)
+             invokeCommand = self.step.runtime.invokeCommand if hasattr(self.step.runtime, 'invokeCommand') else\
+                                 "%s -m WMCore.WMRuntime.ScriptInvoke %s" % (sys.executable, stepModule)
+             invokeCommand += " %s \n" % script
+             logging.info("    Invoking command: %s" % invokeCommand)
+-            retCode = scram(invokeCommand)
++            retCode = scram(invokeCommand, runtimeDir=runtimeDir)
+             if retCode > 0:
+                 msg = "Error running command\n%s\n" % invokeCommand
+                 msg += "%s\n " % retCode

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,15 +1,15 @@
-### RPM cms crabtaskworker 3.3.7.rc5
+### RPM cms crabtaskworker 3.3.8.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.95b
+%define wmcver 0.9.96
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-#Patch0: crabserver3-setup
+Patch0: crabtaskworker-setup
 
 Requires: python  dbs-client dls-client dbs3-client py2-pycurl py2-httplib2 cherrypy condor
 BuildRequires: py2-sphinx
@@ -17,7 +17,7 @@ BuildRequires: py2-sphinx
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
 %setup -T -b 0 -n WMCore-%{wmcver}
-#%patch0 -p0
+%patch0 -p1
 
 %build
 touch $PWD/condor_config


### PR DESCRIPTION
As usual listing only the REST changes here:

-added a first prototype of the monitor for operator (needed to modify the RPM packaging)
-added RESTTask API used by the monitor
-add a per-user throttle as a mechanism to manage excess load
-use always update_after in couch queries
-detect if collector is down and print a proper message
-fix handling of default values of ignorelocality and savelogs flags
