### PR TITLE
new config tag and cmssw-toolfile fixed

### DIFF
--- a/cmssw-toolfile.spec
+++ b/cmssw-toolfile.spec
@@ -15,6 +15,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cmssw.xml
     <environment name="CMSSW_BINDIR" default="$CMSSW_BASE/bin/$SCRAM_ARCH"/>
     <environment name="INCLUDE" default="$CMSSW_BASE/src"/>
   </client>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/biglib/$SCRAM_ARCH" type="path"/>
   <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHONPATH" value="$CMSSW_BINDIR" type="path"/>

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -47,7 +47,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-10
+%define configtag       V05-03-12
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
New config tag V05-03-12:
- Avoid using deprecated URNIVERSAL::isa()
- No need to add biglib/<arch> in to LIBDIR list as it only contains plugins

cmssw-toolfile:
  fix for patch releases to pick up big plugins from full release.
