### PR TITLE
updated config tag to V05-03-13

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -47,7 +47,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-12
+%define configtag       V05-03-13
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
New config contains fixes for:
- Do not link biglink until all its dependencies are built
- make sure the logs of biglib are also available in IB
