### PR TITLE
updated config tag to V05-03-14

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -49,7 +49,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-13
+%define configtag       V05-03-14
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
- Make sure scram picks up changes in plugins/BuildFile.xml
- new build rule check_dependents_<biglib> to check the packages which are not part of <biglib> but depend on small libs of <biglib>
