### PR TITLE
CRAB 3.3.8.rc5 series

### DIFF
--- a/crabcache.spec
+++ b/crabcache.spec
@@ -1,4 +1,4 @@
-### RPM cms crabcache 3.3.8.rc1
+### RPM cms crabcache 3.3.8.rc5
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}

--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,4 +1,4 @@
-### RPM cms crabclient 3.3.8.rc1
+### RPM cms crabclient 3.3.8.rc4
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,4 +1,4 @@
-### RPM cms crabserver 3.3.8.rc4
+### RPM cms crabserver 3.3.8.rc5
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,4 +1,4 @@
-### RPM cms crabtaskworker 3.3.8.rc1
+### RPM cms crabtaskworker 3.3.8.rc5
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
As usual only listing changes for the CRAB3 REST interface:
- Catch error when contacting schedd during the status
- reverse saveoutput and ignorelocality boolean conditions
- Cooloff states are no longer possible for nodes in STATUS_ERROR
- New version of the monitor: add quicksearch and list users for tasks
