### PR TITLE
cms-common: add support for fc19_aarch64_gcc490

### DIFF
--- a/bootstrap.file
+++ b/bootstrap.file
@@ -635,7 +635,7 @@ echo "Done."
 
 # Initialise the rpmdb using the new rpm.
 echo_n "Initializing local rpm database..."
-rpm --define "_rpmlock_path $rpmlock" -r $rootdir --dbpath $rootdir/$rpmdb --initdb || cleanup_and_exit 1 "Unable to initialize $rootdir/$rpmdb. Exiting."
+rpmdb --define "_rpmlock_path $rpmlock" -r $rootdir --dbpath $rootdir/$rpmdb --initdb || cleanup_and_exit 1 "Unable to initialize $rootdir/$rpmdb. Exiting."
 
 # Build the seed spec and install it, in order to seed the newly generated db.
 rpmOptions="-r $rootdir --dbpath $rootdir/$rpmdb --rcfile $DOWNLOAD_DIR/inst/$cmsplatf/external/rpm/$rpm_version/lib/rpm/rpmrc --nodeps --prefix $rootdir --ignoreos --ignorearch"

--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,5 +1,5 @@
 ### RPM cms cms-common 1.0
-## REVISION 1117
+## REVISION 1118
 ## NOCOMPILER
 
 %define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
@@ -42,17 +42,18 @@ then
     osarch=`%instroot/common/cmsos`
     compilerv=gcc462
     case $osarch in
-        osx104_ia32) compilerv=gcc401;;
-        osx104_ppc32) compilerv=gcc400;;
-        osx105_*) compilerv=gcc401;;
-        osx106_*) compilerv=gcc421;;
-        osx107_*) compilerv=gcc462;;
-        osx108_*) compilerv=gcc472;;
-        slc6_*) compilerv=gcc481; osarch=slc6_amd64;;
-        slc5_*) compilerv=gcc462; osarch=slc5_amd64;;
-        fc18_*) compilerv=gcc481; osarch=fc18_armv7hl;;
-        fc19_*) compilerv=gcc481; osarch=fc19_armv7hl;;
-        *) compilerv=gcc481; osarch=slc6_amd64;;
+        osx104_ia32) compilerv=gcc401 ;;
+        osx104_ppc32) compilerv=gcc400 ;;
+        osx105_*) compilerv=gcc401 ;;
+        osx106_*) compilerv=gcc421 ;;
+        osx107_*) compilerv=gcc462 ;;
+        osx108_*) compilerv=gcc472 ;;
+        slc6_*) compilerv=gcc472; osarch=slc6_amd64 ;;
+        slc5_*) compilerv=gcc462; osarch=slc5_amd64 ;;
+        fc18_*) compilerv=gcc481; osarch=fc18_armv7hl ;;
+        fc19_armv7hl_*) compilerv=gcc481; osarch=fc19_armv7hl ;;
+        fc19_aarch64_*) compilerv=gcc490; osarch=fc19_aarch64 ;;
+        *) compilerv=gcc481; osarch=slc6_amd64 ;;
     esac
     echo ${osarch}_${compilerv}
 else

--- a/cmsos.file
+++ b/cmsos.file
@@ -4,10 +4,11 @@ cmsos()
 {
   # Determine the cpu architecture string.
   case `uname -p` in
-    i*86) cpuarch=ia32;;
-    x86_64) cpuarch=amd64;;
-    *EMT*) cpuarch=amd64;;
-    armv7l) cpuarch=armv7hl;; # The kernel is armv7l, but we assume system as armv7hl (hard floats)
+    i*86) cpuarch=ia32 ;;
+    x86_64) cpuarch=amd64 ;;
+    *EMT*) cpuarch=amd64 ;;
+    armv7l) cpuarch=armv7hl ;; # The kernel is armv7l, but we assume system as armv7hl (hard floats)
+    aarch64) cpuarch=aarch64 ;;
     *) cpuarch=`uname -p`;;
   esac
  


### PR DESCRIPTION
Add changes to cms-common to support `fc19_aarch64_gcc490` architecture.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
