### PR TITLE
autotools: bump gettext to 0.19.2 and fix Darwin compilation

### DIFF
--- a/autotools.spec
+++ b/autotools.spec
@@ -4,12 +4,14 @@
 %define automake_version 1.14
 %define libtool_version 2.4.2
 %define m4_version 1.4.17
-%define gettext_version 0.18.3.2
+%define gettext_version 0.19.2
 Source0: http://ftpmirror.gnu.org/autoconf/autoconf-%{autoconf_version}.tar.gz
 Source1: http://ftpmirror.gnu.org/automake/automake-%{automake_version}.tar.gz
 Source2: http://ftpmirror.gnu.org/libtool/libtool-%{libtool_version}.tar.gz
 Source3: http://ftp.gnu.org/gnu/m4/m4-%{m4_version}.tar.bz2
 Source4: http://ftp.gnu.org/pub/gnu/gettext/gettext-%{gettext_version}.tar.gz
+
+Patch0: gettext-0.19.2-fix-darwin
 
 %prep
 %setup -D -T -b 0 -n autoconf-%{autoconf_version}
@@ -17,6 +19,7 @@ Source4: http://ftp.gnu.org/pub/gnu/gettext/gettext-%{gettext_version}.tar.gz
 %setup -D -T -b 2 -n libtool-%{libtool_version}
 %setup -D -T -b 3 -n m4-%{m4_version}
 %setup -D -T -b 4 -n gettext-%{gettext_version}
+%patch0 -p1
 
 %build
 export PATH=%i/bin:$PATH

--- a/gettext-0.19.2-fix-darwin.patch
+++ b/gettext-0.19.2-fix-darwin.patch
@@ -1,0 +1,14 @@
+diff --git a/build-aux/install-reloc b/build-aux/install-reloc
+index 2dfbf60..eedc855 100755
+--- a/build-aux/install-reloc
++++ b/build-aux/install-reloc
+@@ -232,6 +232,9 @@ func_create_wrapper ()
+                "$srcdir"/areadlink.c \
+                "$srcdir"/careadlinkat.c \
+                "$srcdir"/allocator.c \
++               "$srcdir"/strerror-override.c \
++               "$srcdir"/stat.c \
++               "$srcdir"/lstat.c \
+                "$srcdir"/readlink.c \
+                "$srcdir"/canonicalize-lgpl.c \
+                "$srcdir"/malloca.c \


### PR DESCRIPTION
Gettext does not compile on Darwin platform. The following updates
gettext to 0.19.2 (latest) version and fixes Darwin compilation
errors.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
