### PR TITLE
updating to tauolapp 1.1.4

### DIFF
--- a/tauolapp-toolfile.spec
+++ b/tauolapp-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external tauolapp-toolfile 1.0
+### RPM external tauolapp-toolfile 1.1.4
 Requires: tauolapp
 %prep
 
@@ -16,14 +16,12 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/tauolapp.xml
     <environment name="TAUOLAPP_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$TAUOLAPP_BASE/lib"/>
     <environment name="INCLUDE" default="$TAUOLAPP_BASE/include"/>
-    <environment name="INCLUDE" default="$TAUOLAPP_BASE/include/TauSpinner"/>
-    <environment name="INCLUDE" default="$TAUOLAPP_BASE/include/Tauola"/>
   </client>
   <use name="hepmc"/>
   <use name="f77compiler"/>
+  <use name="pythia8"/>
+  <use name="lhapdf"/>
 </tool>
 EOF_TOOLFILE
 
 ## IMPORT scram-tools-post
-
-

--- a/tauolapp.spec
+++ b/tauolapp.spec
@@ -1,4 +1,4 @@
-### RPM external tauolapp 1.1.1a
+### RPM external tauolapp 1.1.4
 Source: http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/tauola++/tauola++-%{realversion}-src.tgz
 Requires: hepmc
 Requires: pythia8
@@ -13,6 +13,7 @@ Requires: lhapdf
 %endif
 
 %define keep_archives true
+
 %if "%(case %cmsplatf in (osx*_*_gcc421) echo true ;; (*) echo false ;; esac)" == "true"
 Requires: gfortran-macosx
 %endif
@@ -25,7 +26,7 @@ export HEPMCVERSION=${HEPMC_VERSION}
 export LHAPDF_LOCATION=${LHAPDF_ROOT}
 export PYTHIA8_LOCATION=${PYTHIA8_ROOT}
 
-case %cmsplatf in 
+case %cmsplatf in
   osx*)
 #%patch0 -p2
   ;;


### PR DESCRIPTION
This is a back port of Tauola 1.1.4 from 7_2_X to 5_3_X. Any CMSSW release built from a cmsdist version with this pull request requires the patch contained https://github.com/inugent/cmssw/tree/Tauola114_backportto53X  for TauSpinner to be used. I am not sure how to organize this. Best regards,
Ian 
