### PR TITLE
New SCRAM and config tag

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_5_pre8
+### RPM lcg SCRAMV1 V2_2_5_pre9
 ## NOCOMPILER
 Provides: perl(BuildSystem::Template::Plugins::PluginCore)
 Provides: perl(BuildSystem::TemplateStash)

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -49,7 +49,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-14
+%define configtag       V05-03-15
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
SCRAM:
- Fix cmsenv errors by sending verbose::errors to stderr.
- --force|-f Command-line option for "scram project" to avoid reading releases.map file from web.
- New <release|compiler> tag for BuildFiles.
- Get IBs production arch from releases.map file.

config tag:
- Disable biglib for llvm
