### PR TITLE
scram-project-build: Check if debug logs exist before compressing them

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -213,9 +213,11 @@ export SCRAM_NOSYMCHECK=true
 LOG_WEB_DIR=%cmsroot/WEB/build-logs/%{cmsplatf}/%{v}
 rm -rf ${LOG_WEB_DIR}
 mkdir -p ${LOG_WEB_DIR}/logs/src
-pushd %{i}/tmp/%{cmsplatf}/cache/log/src
-  tar czf ${LOG_WEB_DIR}/logs/src/src-logs.tgz ./
-popd
+if [ -d %{i}/tmp/%{cmsplatf}/cache/log/src ]; then
+  pushd %{i}/tmp/%{cmsplatf}/cache/log/src
+    tar czf ${LOG_WEB_DIR}/logs/src/src-logs.tgz ./
+  popd
+fi
 
 # split the debug symbols out of tha main binaries, into separate files
 %if "%{?subpackageDebug:set}" == "set"


### PR DESCRIPTION
When I tried to build fwlite on osx108_amd64_gcc481 I had the following error: 

<pre>
+ pushd /Volumes/build1/dmendezl/CMSSW_7_1_6-build/tmp/BUILDROOT/a36aed06553e54d6eb76ebc2a5f45550/opt/cmssw/osx108_amd64_gcc481/cms/fwlite/CMSSW_7_1_6_FWLITE/tmp/osx108_amd64_gcc481/cache/log/src
/Volumes/build1/dmendezl/CMSSW_7_1_6-build/tmp/rpm-tmp.kliX35: line 66: pushd: /Volumes/build1/dmendezl/CMSSW_7_1_6-build/tmp/BUILDROOT/a36aed06553e54d6eb76ebc2a5f45550/opt/cmssw/osx108_amd64_gcc481/cms/fwlite/CMSSW_7_1_6_FWLITE/tmp/osx108_amd64_gcc481/cache/log/src: No such file or directory
error: Bad exit status from /Volumes/build1/dmendezl/CMSSW_7_1_6-build/tmp/rpm-tmp.kliX35 (%build)
</pre>


I used this workaround to make it work. 
