### PR TITLE
cms-common: fix cmsarch for fc19_aarch64 cmsos

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,5 +1,5 @@
 ### RPM cms cms-common 1.0
-## REVISION 1118
+## REVISION 1119
 ## NOCOMPILER
 
 %define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
@@ -51,8 +51,8 @@ then
         slc6_*) compilerv=gcc472; osarch=slc6_amd64 ;;
         slc5_*) compilerv=gcc462; osarch=slc5_amd64 ;;
         fc18_*) compilerv=gcc481; osarch=fc18_armv7hl ;;
-        fc19_armv7hl_*) compilerv=gcc481; osarch=fc19_armv7hl ;;
-        fc19_aarch64_*) compilerv=gcc490; osarch=fc19_aarch64 ;;
+        fc19_armv7hl) compilerv=gcc481; osarch=fc19_armv7hl ;;
+        fc19_aarch64) compilerv=gcc490; osarch=fc19_aarch64 ;;
         *) compilerv=gcc481; osarch=slc6_amd64 ;;
     esac
     echo ${osarch}_${compilerv}


### PR DESCRIPTION
_cmsos_ script returns `fc19_aarch64` or `fc19_armv7hl`, yet _cmsarch_
script expected an additional underscore after _cmsos_. Resolve it
by checking exact match to _cmsos_.

```
[david.abdurachmanov@dagr delme]$ cmsarch
slc6_amd64_gcc481
[david.abdurachmanov@dagr delme]$ ./cmsarch
fc19_aarch64_gcc490
[david.abdurachmanov@dagr delme]$ cmsos
fc19_aarch64
[david.abdurachmanov@dagr delme]$ diff -u $(which cmsarch) ./cmsarch
--- /cvmfs/cms.cern.ch/common/cmsarch   2014-07-18 09:53:11.000000000 -0400
+++ ./cmsarch   2014-08-13 04:03:09.125553706 -0400
@@ -15,8 +15,8 @@
         slc6_*) compilerv=gcc472; osarch=slc6_amd64 ;;
         slc5_*) compilerv=gcc462; osarch=slc5_amd64 ;;
         fc18_*) compilerv=gcc481; osarch=fc18_armv7hl ;;
-        fc19_armv7hl_*) compilerv=gcc481; osarch=fc19_armv7hl ;;
-        fc19_aarch64_*) compilerv=gcc490; osarch=fc19_aarch64 ;;
+        fc19_armv7hl) compilerv=gcc481; osarch=fc19_armv7hl ;;
+        fc19_aarch64) compilerv=gcc490; osarch=fc19_aarch64 ;;
         *) compilerv=gcc481; osarch=slc6_amd64 ;;
     esac
     echo ${osarch}_${compilerv}
```

This the following two line change CMSSW from CVMFS on Fedora 19 AArch64 should work out-of-the-box.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
