### PR TITLE
CRAB3 3.3.9 release candidate 1

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,11 +1,11 @@
-### RPM cms crabclient 3.3.8
+### RPM cms crabclient 3.3.9.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-%define wmcver 0.9.96
+%define wmcver 0.9.97.pre7_crab.patch1
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define crabserver 3.3.8.rc1
+%define crabserver 3.3.9.rc1
 
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,11 +1,11 @@
-### RPM cms crabserver 3.3.8.rc10
+### RPM cms crabserver 3.3.9.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.96
+%define wmcver 0.9.97.pre7_crab.patch1
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,15 +1,15 @@
-### RPM cms crabtaskworker 3.3.8.rc10
+### RPM cms crabtaskworker 3.3.9.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 0.9.96
+%define wmcver 0.9.97.pre7_crab.patch1
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Patch0: crabtaskworker-setup
+#Patch0: crabtaskworker-setup
 
 Requires: python  dbs-client dls-client dbs3-client py2-pycurl py2-httplib2 cherrypy condor
 BuildRequires: py2-sphinx
@@ -17,7 +17,7 @@ BuildRequires: py2-sphinx
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
 %setup -T -b 0 -n WMCore-%{wmcver}
-%patch0 -p1
+#%patch0 -p1
 
 %build
 touch $PWD/condor_config


### PR DESCRIPTION
News are a new version of the monitor plus three minor fixes:

Use lfnPartsfrom lexicon for the outfile reg exp
Report an error if usedbs is used in the report and no outputdataset is found
