### PR TITLE
updated config tag to V05-03-16

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -58,7 +58,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-15
+%define configtag       V05-03-16
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
new config tag should avoid deleting the symlinks for data packages during unittest running
