### PR TITLE
p5-time-hires is required for taskworker

### DIFF
--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -11,6 +11,7 @@ Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=C
 
 #Patch0: crabtaskworker-setup
 
+Requires: p5-time-hires
 Requires: python  dbs-client dls-client dbs3-client py2-pycurl py2-httplib2 cherrypy condor
 BuildRequires: py2-sphinx
 


### PR DESCRIPTION
Requires to include this, on slc6 it fails to deploy because of missing it.
