### PR TITLE
fasthadd file permissions

### DIFF
--- a/fasthadd.spec
+++ b/fasthadd.spec
@@ -1,6 +1,8 @@
 ### RPM external fasthadd 1.1
 
-%define commit e193ee35083c2c1583e186130891087d6a4c7ac1 #commit mapped to CMSSW_7_1_6
+#Change the commit hash every time a new version is needed.
+#Commit mapped to CMSSW_7_1_6
+%define commit e193ee35083c2c1583e186130891087d6a4c7ac1
 Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Components/bin/fastHadd.cc
 Source1: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Core/src/ROOTFilePB.proto
 Requires: protobuf root

--- a/fasthadd.spec
+++ b/fasthadd.spec
@@ -1,8 +1,8 @@
 ### RPM external fasthadd 1.1
 
-%define tag e193ee35083c2c1583e186130891087d6a4c7ac1 #commit mapped to CMSSW_7_1_6
-Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%tag/DQMServices/Components/bin/fastHadd.cc
-Source1: https://raw.githubusercontent.com/cms-sw/cmssw/%tag/DQMServices/Core/src/ROOTFilePB.proto
+%define commit e193ee35083c2c1583e186130891087d6a4c7ac1 #commit mapped to CMSSW_7_1_6
+Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Components/bin/fastHadd.cc
+Source1: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Core/src/ROOTFilePB.proto
 Requires: protobuf root
 
 %prep

--- a/fasthadd.spec
+++ b/fasthadd.spec
@@ -1,6 +1,6 @@
-### RPM external fasthadd 1.0
+### RPM external fasthadd 1.1
 
-%define tag 743bde9939bbc4f34c2b4fd022cfb980314f912a
+%define tag e193ee35083c2c1583e186130891087d6a4c7ac1 #commit mapped to CMSSW_7_1_6
 Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%tag/DQMServices/Components/bin/fastHadd.cc
 Source1: https://raw.githubusercontent.com/cms-sw/cmssw/%tag/DQMServices/Core/src/ROOTFilePB.proto
 Requires: protobuf root


### PR DESCRIPTION
The new fastHadd external deals correctly with file permissions, by setting them to `0664`: this allows for testing/debugging purposes (files are accessible by all users), and for correctly handling files in `DAQ2` (while in the same step, files are handled by the same user, when moved in the data flow chain, files should be handled by users in the same group).
