### PR TITLE
fastjet: new commit hash which should hide C++11 features from header files

### DIFF
--- a/fastjet.spec
+++ b/fastjet.spec
@@ -1,5 +1,5 @@
 ### RPM external fastjet 3.0.3
-%define tag 87f4ff1f4a606ed82ca4f07d02bc0bce190ceeaf
+%define tag 3885d1f1b914749bd0d94a3a81c594038e37c05e
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/fastjet.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
back ported from 72X
