### PR TITLE
Backport of DNS resolution patch for Xrootd client.

### DIFF
--- a/xrootd-3.2.4-dns-resolve.patch
+++ b/xrootd-3.2.4-dns-resolve.patch
@@ -1,0 +1,160 @@
+--- /build/bbockelm/w/BUILD/slc6_amd64_gcc481/external/xrootd/3.2.4-cms3/xrootd-3.2.4/src/XrdClient/XrdClient.cc	2014-09-09 22:03:40.555125936 +0200
++++ xrootd/src/XrdClient/XrdClient.cc	2014-09-09 21:57:29.855184893 +0200
+@@ -198,10 +198,40 @@
+     //cout << "Mytest " << time(0) << " File: " << fUrl.File << " - Open finished." << endl;
+ }
+ 
++#define OpenErr(a,b) fConnModule->LastServerError.errnum=a;\
++                     strcpy(fConnModule->LastServerError.errmsg,b);\
++                     Error("Open", b)
++
+ //_____________________________________________________________________________
+ bool XrdClient::Open(kXR_unt16 mode, kXR_unt16 options, bool doitparallel) {
+-    short locallogid;
+-  
++    class urlHelper
++         {public:
++          void              Erase(XrdClientUrlInfo *url){urlSet->EraseUrl(url);}
++
++          XrdClientUrlInfo *Get() {return urlSet->GetARandomUrl(seed);}
++
++          int               Init(XrdOucString urls)
++                                {if (urlSet) delete urlSet;
++                                 urlSet = new XrdClientUrlSet(urls);
++                                 iSize = (urlSet->IsValid() ? urlSet->Size():0);
++                                 return iSize;
++                                }
++
++          int               Size() {return iSize;}
++
++                            urlHelper() : urlSet(0), iSize(0)
++                                        {seed = static_cast<unsigned int>
++                                                (getpid() ^ getppid());
++                                        }
++                           ~urlHelper() {if (urlSet) delete urlSet;}
++          private:
++          XrdClientUrlSet *urlSet;
++          int iSize;
++          unsigned int seed;
++         };
++    urlHelper urlList;
++
++
+     // But we initialize the internal params...
+     fOpenPars.opened = FALSE;  
+     fOpenPars.options = options;
+@@ -217,25 +247,22 @@
+     fConnModule->SetOpTimeLimit(EnvGetLong(NAME_TRANSACTIONTIMEOUT));
+ 
+     //
+-    // Now start the connection phase, picking randomly from UrlArray
++    // Now start the connection phase, picking randomly from UrlList
+     //
+-    unsigned int seed = static_cast<unsigned int>(getpid() ^ getppid()); // Once!
+-    locallogid = -1;
+     int urlstried = 0;
++    fConnModule->LastServerError.errnum = kXR_noErrorYet;
+     for (int connectTry = 0;
+ 	 (connectTry < connectMaxTry) && (!fConnModule->IsConnected()); 
+ 	 connectTry++) {
+ 
+-        XrdClientUrlSet urlArray(fInitialUrl);
+-        if (!urlArray.IsValid()) {
+-           Error("Open", "The URL provided is incorrect.");
++        int urlCount;
++        if ((urlCount = urlList.Init(fInitialUrl)) < 1) {
++           OpenErr(kXR_ArgInvalid, "The URL provided is incorrect.");
+            return FALSE;
+         }
+-        int urlCount = urlArray.Size();
+-        urlArray.Rewind();
+ 
+ 	XrdClientUrlInfo *thisUrl = 0;
+-	urlstried = (urlstried == urlArray.Size()) ? 0 : urlstried;
++	urlstried = (urlstried == urlCount) ? 0 : urlstried;
+ 
+         if ( fConnModule->IsOpTimeLimitElapsed(time(0)) ) {
+            // We have been so unlucky and wasted too much time in connecting and being redirected
+@@ -248,7 +275,7 @@
+ 	while (urlCount--) {
+ 
+ 	    // Get an url from the available set
+-	    if ((thisUrl = urlArray.GetARandomUrl(seed))) {
++	    if ((thisUrl = urlList.Get())) {
+ 
+ 		if (fConnModule->CheckHostDomain(thisUrl->Host)) {
+ 		    nogoodurl = FALSE;
+@@ -256,20 +283,20 @@
+ 		    Info(XrdClientDebug::kHIDEBUG, "Open", "Trying to connect to " <<
+ 			 thisUrl->Host << ":" << thisUrl->Port << ". Connect try " <<
+ 			 connectTry+1);
+-		    locallogid = fConnModule->Connect(*thisUrl, this);
++		    fConnModule->Connect(*thisUrl, this);
+ 		    // To find out if we have tried the whole URLs set
+ 		    urlstried++;
+                     if (!(fConnModule->IsConnected())) continue;
+ 		    break;
+ 		} else {
+ 		    // Invalid domain: drop the url and move to next, if any
+-		    urlArray.EraseUrl(thisUrl);
++		    urlList.Erase(thisUrl);
+ 		    continue;
+ 		}
+ 	    }
+ 	}
+ 	if (nogoodurl) {
+-	    Error("Open", "Access denied to all URL domains requested");
++	    OpenErr(kXR_NotAuthorized, "Access denied to all URL domains requested");
+ 	    break;
+ 	}
+ 
+@@ -295,12 +322,12 @@
+                   // We have been so unlucky.
+                   // The max number of redirections was exceeded while logging in
+                   fConnModule->Disconnect(TRUE);
+-                  Error("Open", "Access to server failed: Max redirections exceeded. This means typically 'too many errors'.");
++                  OpenErr(kXR_ServerError, "Unable to connect; too many redirections.");
+                   break;
+                }
+ 
+ 		if (fConnModule->LastServerError.errnum == kXR_NotAuthorized) {
+-		    if (urlstried == urlArray.Size()) {
++		    if (urlstried == urlList.Size()) {
+ 			// Authentication error: we tried all the indicated URLs:
+ 			// does not make much sense to retry
+ 			fConnModule->Disconnect(TRUE);
+@@ -346,6 +373,8 @@
+     } //for connect try
+ 
+     if (!fConnModule->IsConnected()) {
++       if (fConnModule->LastServerError.errnum == kXR_noErrorYet)
++          {OpenErr(kXR_noserver, "Server is unreachable.");}
+ 	return FALSE;
+     }
+ 
+@@ -369,6 +398,7 @@
+ 
+             if (fXrdCcb && !doitparallel) 
+                fXrdCcb->OpenComplete(this, fXrdCcbArg, false);
++     OpenErr(kXR_Cancelled, "Open failed for unknown reason.");
+ 
+ 	    return FALSE;
+ 
+@@ -388,14 +418,17 @@
+     } else {
+ 	// the server is an old rootd
+ 	if (fConnModule->GetServerType() == kSTRootd) {
++    OpenErr(kXR_ArgInvalid, "Server is not an xrootd server.");
+ 	    return FALSE;
+ 	}
+ 	if (fConnModule->GetServerType() == kSTNone) {
++    OpenErr(kXR_ArgInvalid, "Server is not an xrootd server.");
+ 	    return FALSE;
+ 	}
+     }
+ 
+ 
++    fConnModule->LastServerError.errnum = kXR_noErrorYet;
+     return TRUE;
+ 
+ }

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -12,6 +12,7 @@ Patch6: xrootd-3.1.0-add-GetHandle-XrdClientAbs-header
 Patch7: xrootd-3.1.0-narrowing-conversion
 Patch8: xrootd-3.2.3-rename-macos-to-apple
 Patch9: xrootd-3.2.4-xrdclient
+Patch10: xrootd-3.2.4-dns-resolve
 
 BuildRequires: cmake
 %if "%online" != "true"
@@ -36,6 +37,7 @@ Requires: gcc openssl
 %patch7 -p1
 %patch8 -p1
 %patch9 -p1
+%patch10 -p1
 
 # need to fix these from xrootd git
 perl -p -i -e 's|^#!.*perl(.*)|#!/usr/bin/env perl$1|' src/XrdMon/cleanup.pl


### PR DESCRIPTION
Previously, we tried to update to 3.3.3 to get this patch, then to 4.0.3, then hit
a ROOT issue.  Meanwhile, Ops didn't get the fix they were waiting
for.  So, while we wait on ROOT 5.34.20, here's the originally-requested
backport.

Original patch here:
https://github.com/xrootd/xrootd/commit/6184cd0f24145ebae66bc782d929444d19700fdc

I think this is the correct branch to pull to - if not, let me know.  Tested the build on cmsdev6.cern.ch.  
