### PR TITLE
fix the processing of debug symbols and the related subpackage functionality (stable)

### DIFF
--- a/cmssw-patch.spec
+++ b/cmssw-patch.spec
@@ -4,9 +4,17 @@ Requires: cmssw-patch-tool-conf
 %define runGlimpse      yes
 %define useCmsTC        yes
 %define saveDeps        yes
+# build with debug symbols, and package them in a separate rpm
+%define subpackageDebug yes
 
 #Set it to -cmsX added by cmsBuild (if any) to the base release
 %define baserel_postfix %{nil}
+
+%if "%(case %realversion in (*_DEBUG_X*) echo true ;; (*) echo false ;; esac)" == "true"
+%define branch          %(echo %realversion | sed -e 's|_DEBUG_X.*|_X|')
+%define gitcommit       %(echo %realversion | sed -e 's|_DEBUG||')
+%endif
+
 %if "%(case %realversion in (*_ICC_X*) echo true ;; (*) echo false ;; esac)" == "true"
 %define branch		%(echo %realversion | sed -e 's|_ICC_X.*|_X|')
 %define gitcommit       %(echo %realversion | sed -e 's|_ICC_X|_X|')
@@ -23,3 +31,4 @@ Requires: cmssw-patch-tool-conf
 
 ## IMPORT cmssw-patch-build
 ## IMPORT scram-project-build
+## SUBPACKAGE debug IF %subpackageDebug

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -131,6 +131,7 @@ Requires: sherpa-toolfile
 Requires: geant4-parfullcms-toolfile
 Requires: fasthadd
 Requires: eigen-toolfile
+Requires: file-toolfile
 
 # Only for Linux platform.
 %if %islinux

--- a/cmssw.spec
+++ b/cmssw.spec
@@ -1,12 +1,14 @@
-### RPM cms cmssw CMSSW_7_2_DEVEL_X_2014-07-08-0900
+### RPM cms cmssw CMSSW_7_2_X_2014-08-23-1400
 
 Requires: cmssw-tool-conf python cms-git-tools
 
 %define runGlimpse      yes
 %define useCmsTC        yes
 %define saveDeps        yes
-%define branch          CMSSW_7_0_X
+%define branch          CMSSW_7_2_X
 %define gitcommit       %{realversion}
+# build with debug symbols, and package them in a separate rpm
+%define subpackageDebug yes
 
 %if "%(case %realversion in (*_COVERAGE_X*) echo true ;; (*) echo false ;; esac)" == "true"
 %define branch		%(echo %realversion | sed -e 's|_COVERAGE_X.*|_X|')
@@ -52,3 +54,4 @@ Requires: cmssw-tool-conf python cms-git-tools
 %define source1         git://github.com/cms-sw/cmssw.git?protocol=https&obj=%{branch}/%{gitcommit}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
 
 ## IMPORT scram-project-build
+## SUBPACKAGE debug IF %subpackageDebug

--- a/coral.spec
+++ b/coral.spec
@@ -14,11 +14,12 @@ Patch6: coral-CORAL_2_3_21-forever-ttl
 %define cvssrc          %{n}
 %define cvsrepo         cvs://:pserver:anonymous@%{n}.cvs.cern.ch/cvs/%{n}?passwd=Ah<Z&force=1
 
+# Build with debug symbols, and package them in a separate rpm:
+%define subpackageDebug yes
+
 %if %isonline
 # Disable building tests, since they bring dependency on cppunit:
 %define patchsrc2       perl -p -i -e 's!(<classpath.*/tests\\+.*>)!!;' config/BuildFile.xml
-# Build with debug symbols, and package them in a separate rpm:
-%define subpackageDebug yes
 %endif
 
 # Disable building tests, since they bring dependency on cppunit:
@@ -40,6 +41,4 @@ Patch6: coral-CORAL_2_3_21-forever-ttl
 %endif
 
 ## IMPORT scram-project-build
-# For now disable SUBPACKAGE as it is causing problem calculating checksum
-# Looks like sub package support in V00-22/21 is not working
-# SUBPACKAGE debug IF %subpackageDebug
+## SUBPACKAGE debug IF %subpackageDebug

--- a/dwz.spec
+++ b/dwz.spec
@@ -1,0 +1,16 @@
+### RPM external dwz 0.11
+
+%define dwz_branch master
+%define dwz_commit dwz-0.11
+
+Source: git://sourceware.org/git/dwz.git?obj=%{dwz_branch}/%{dwz_commit}&export=dwz-%{dwz_commit}&output=/dwz-%{dwz_commit}.tgz
+
+%prep
+%setup -T -b 0 -n dwz-%{dwz_commit}
+
+%build
+make %{makeprocesses}
+
+%install
+mkdir -p %{i}/bin
+cp dwz %{i}/bin

--- a/file-toolfile.spec
+++ b/file-toolfile.spec
@@ -1,0 +1,19 @@
+### RPM external file-toolfile 1.0
+Requires: file
+
+%prep
+%build
+%install
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE > %{i}/etc/scram.d/file.xml
+  <tool name="file" version="@TOOL_VERSION@">
+    <lib name="magic"/>
+    <client>
+      <environment name="FILE_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$FILE_BASE/lib"/>
+      <environment name="INCLUDE" default="$FILE_BASE/include"/>
+    </client>
+    <runtime name="PATH" value="$FILE_BASE/bin" type="path"/>
+  </tool>
+EOF_TOOLFILE
+## IMPORT scram-tools-post

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -63,7 +63,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-cxxcompiler.xml
     <flags CXXFLAGS="-Werror=unused-variable -Werror=conversion-null"/>
     <flags CXXFLAGS="-Werror=return-local-addr"/>
     <flags CXXFLAGS="-Werror=switch -fdiagnostics-show-option"/>
-    <flags CXXFLAGS="-Wno-unused-local-typedefs -Wno-attributes"/>
+    <flags CXXFLAGS="-Wno-unused-local-typedefs -Wno-attributes -Wno-psabi"/>
     <flags LDFLAGS="@OS_LDFLAGS@ @ARCH_LDFLAGS@ @COMPILER_LDFLAGS@"/>
     <flags CXXSHAREDFLAGS="@OS_SHAREDFLAGS@ @ARCH_SHAREDFLAGS@ @COMPILER_SHAREDFLAGS@"/>
     <flags LD_UNIT="@OS_LD_UNIT@ @ARCH_LD_UNIT@ @COMPILER_LD_UNIT@"/>

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -199,6 +199,13 @@ case %cmsplatf in
   ;;
 esac
 
+# Compressed debug sections for linker
+case %cmsplatf in
+  *_gcc49*)
+    COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Wa,--compress-debug-sections"
+  ;;
+esac
+
 export COMPILER_CXXFLAGS
 
 # General substitutions

--- a/gcc.spec
+++ b/gcc.spec
@@ -17,31 +17,31 @@ Patch1: gcc-4.8.1-0001-pr-58065
 
 %define keep_archives true
 
-%define gmpVersion 5.1.0a
-%define mpfrVersion 3.1.1 
-%define mpcVersion 1.0.1
+%define gmpVersion 5.1.3
+%define mpfrVersion 3.1.2
+%define mpcVersion 1.0.2
 %define islVersion 0.11.1
-%define cloogVersion 0.18.0
+%define cloogVersion 0.18.1
+%define zlibVersion 1.2.8
 Source1: ftp://ftp.gnu.org/gnu/gmp/gmp-%{gmpVersion}.tar.bz2
 Source2: http://www.mpfr.org/mpfr-%{mpfrVersion}/mpfr-%{mpfrVersion}.tar.bz2
 Source3: http://www.multiprecision.org/mpc/download/mpc-%{mpcVersion}.tar.gz
 Source4: ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-%{islVersion}.tar.bz2
 Source5: https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/asan/scripts/asan_symbolize.py
-Source6: ftp://gcc.gnu.org/pub/gcc/infrastructure/cloog-%{cloogVersion}.tar.gz
+Source6: http://www.bastoul.net/cloog/pages/download/cloog-%{cloogVersion}.tar.gz
+Source12: http://zlib.net/zlib-%{zlibVersion}.tar.gz
 
 %if %islinux
-%define bisonVersion 2.7
-%define binutilsVersion 2.23.2
-%define elfutilsVersion 0.156
-%define m4Version 1.4.16
+%define bisonVersion 3.0.2
+%define binutilsVersion 2.24
+%define elfutilsVersion 0.158
+%define m4Version 1.4.17
 %define flexVersion 2.5.37
 Source7: http://ftp.gnu.org/gnu/bison/bison-%{bisonVersion}.tar.gz
 Source8: http://ftp.gnu.org/gnu/binutils/binutils-%{binutilsVersion}.tar.bz2
-Patch2: binutils-2.23.2-0000-PR-gas-14987-14887
 Source9: https://fedorahosted.org/releases/e/l/elfutils/%{elfutilsVersion}/elfutils-%{elfutilsVersion}.tar.bz2
 Patch3: https://fedorahosted.org/releases/e/l/elfutils/%{elfutilsVersion}/elfutils-portability.patch
 Source10: http://ftp.gnu.org/gnu/m4/m4-%m4Version.tar.gz
-Patch4: m4-1.4.16-fix-gets
 Source11: http://garr.dl.sourceforge.net/project/flex/flex-%{flexVersion}.tar.bz2
 %endif
 
@@ -97,20 +97,19 @@ cat << \EOF_CMS_H > gcc/config/general-cms.h
 EOF_CMS_H
 
 # GCC prerequisites
-%setup -D -T -b 1 -n gmp-5.1.0
+%setup -D -T -b 1 -n gmp-%{gmpVersion}
 %setup -D -T -b 2 -n mpfr-%{mpfrVersion}
 %setup -D -T -b 3 -n mpc-%{mpcVersion}
 %setup -D -T -b 4 -n isl-%{islVersion}
 %setup -D -T -b 6 -n cloog-%{cloogVersion}
+%setup -D -T -b 12 -n zlib-%{zlibVersion}
 
 %if %islinux
 %setup -D -T -b 7 -n bison-%{bisonVersion}
 %setup -D -T -b 8 -n binutils-%{binutilsVersion}
-%patch2 -p1
 %setup -D -T -b 9 -n elfutils-%{elfutilsVersion}
 %patch3 -p1
 %setup -D -T -b 10 -n m4-%{m4Version}
-%patch4 -p1
 %setup -D -T -b 11 -n flex-%{flexVersion}
 %endif
 
@@ -133,57 +132,79 @@ EOF_CMS_H
 CC="$CC -fPIC"
 CXX="$CXX -fPIC"
 
+mkdir -p %{i}/tmp/sw
+export PATH=%{i}/tmp/sw/bin:$PATH
+
+# Build zlib (required for compressed debug information)
+cd ../zlib-%{zlibVersion}
+case %{cmsplatf} in
+  *_amd64_*)
+    CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1 -msse3" \
+    ./configure --static --prefix=%{i}/tmp/sw
+    ;;
+  *_armv7hl_*|*_aarch64_*)
+    CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1" \
+    ./configure --static --prefix=%{i}/tmp/sw
+    ;;
+  *)
+    ./configure --static --prefix=%{i}/tmp/sw
+    ;;
+esac
+make %{makeprocesses}
+make install
+
 %if %islinux
   CONF_BINUTILS_OPTS="--enable-gold=yes --enable-ld=default --enable-lto --enable-plugins --enable-threads"
   CONF_GCC_WITH_LTO="--enable-gold=yes --enable-ld=default --enable-lto" # --with-build-config=bootstrap-lto
 
   # Build M4
   cd ../m4-%{m4Version}
-  ./configure --prefix=%{i}/tmp/m4 \
+  ./configure --prefix=%{i}/tmp/sw \
               --build=%{_build} --host=%{_host} \
               CC="$CC"
   make %{makeprocesses}
   make install
-  export PATH=%{i}/tmp/m4/bin:$PATH
+  hash -r
 
   # Build Flex
   cd ../flex-%{flexVersion}
-  ./configure --disable-nls --prefix=%{i}/tmp/flex \
+  ./configure --disable-nls --prefix=%{i}/tmp/sw \
               --build=%{_build} --host=%{_host} \
               CC="$CC" CXX="$CXX"
   make %{makeprocesses}
   make install
-  export PATH=%{i}/tmp/flex/bin:$PATH
-
-  # Build elfutils
-  cd ../elfutils-%{elfutilsVersion}
-  ./configure --disable-static --without-zlib --without-bzlib --without-lzma \
-              --build=%{_build} --host=%{_host} \
-              --prefix=%{i} CC="$CC" CXX="$CXX -Wno-strict-aliasing" CPP="$CPP" CXXCPP="$CXXCPP"
-  make %{makeprocesses}
-  make install
+  hash -r
 
   # Build Bison
   cd ../bison-%{bisonVersion}
   ./configure --build=%{_build} --host=%{_host} \
-              --prefix=%{i}/tmp/bison CC="$CC"
+              --prefix=%{i}/tmp/sw CC="$CC"
   make %{makeprocesses}
   make install
-  export PATH=%{i}/tmp/bison/bin:$PATH
+  hash -r
+
+  # Build elfutils
+  cd ../elfutils-%{elfutilsVersion}
+  ./configure --disable-static --with-zlib --without-bzlib --without-lzma \
+              --build=%{_build} --host=%{_host} --program-prefix='eu-'\
+              --prefix=%{i} CC="$CC" CPP="$CPP" \
+              CFLAGS="-I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/tmp/sw/lib"
+  make %{makeprocesses}
+  make install
 
   # Build binutils
   cd ../binutils-%{binutilsVersion}
   ./configure --disable-static --prefix=%{i} ${CONF_BINUTILS_OPTS} --disable-werror \
-              --build=%{_build} --host=%{_host} --disable-nls --with-zlib=no --enable-targets=all \
-              CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" CFLAGS="-I%{i}/include" \
-              CXXFLAGS="-I%{i}/include" LDFLAGS="-L%{i}/lib"
+              --build=%{_build} --host=%{_host} --disable-nls --with-system-zlib --enable-targets=all \
+              CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" CFLAGS="-I%{i}/include -I%{i}/tmp/sw/include" \
+              CXXFLAGS="-I%{i}/include -I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/lib -L%{i}/tmp/sw/lib"
   make %{makeprocesses}
   find . -name Makefile -exec perl -p -i -e 's|LN = ln|LN = cp -p|;s|ln ([^-])|cp -p $1|g' {} \; 
   make install
 %endif
 
 # Build GMP
-cd ../gmp-5.1.0
+cd ../gmp-%{gmpVersion}
 ./configure --disable-static --prefix=%{i} --enable-shared --disable-static --enable-cxx \
             --build=%{_build} --host=%{_host} \
             CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
@@ -247,15 +268,20 @@ esac
 
 # Build GCC
 cd ../gcc-%{gccBranch}-%{gccRevision}
+rm gcc/DEV-PHASE
+touch gcc/DEV-PHASE
 mkdir -p obj
 cd obj
 export LD_LIBRARY_PATH=%{i}/lib64:%{i}/lib:$LD_LIBRARY_PATH
-../configure --prefix=%{i} --disable-multilib --disable-nls --with-zlib=no \
+../configure --prefix=%{i} --disable-multilib --disable-nls --with-system-zlib --disable-dssi \
              --enable-languages=c,c++,fortran$ADDITIONAL_LANGUAGES \
+             --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object \
+             --enable-plugin --with-linker-hash-style=gnu --enable-linker-build-id \
              $CONF_GCC_OS_SPEC $CONF_GCC_WITH_LTO --with-gmp=%{i} --with-mpfr=%{i} \
              --with-mpc=%{i} --with-isl=%{i} --with-cloog=%{i} --enable-checking=release \
              --build=%{_build} --host=%{_host} --enable-libstdcxx-time=rt $CONF_GCC_ARCH_SPEC \
-             --enable-shared CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
+             --enable-shared CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" \
+             CFLAGS="-I%{i}/tmp/sw/include" CXXFLAGS="-I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/tmp/sw/lib"
 
 %if %isamd64
 make %{makeprocesses} profiledbootstrap

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -273,17 +273,13 @@ rm -fR %{srctree} tmp
 
 # handle debug symbols
 if [ "%{n}" == "coral" ]; then
-  BASE_LIB_PATH=%i/%cmsplatf/lib
-  BASE_BIN_PATH=
-  BASE_TEST_PATH=%i/%cmsplatf/tests/bin
+  ELF_DIRS="%i/%cmsplatf/lib %i/%cmsplatf/tests/bin"
 else
-  BASE_LIB_PATH=%i/lib/%cmsplatf
-  BASE_BIN_PATH=%i/bin/%cmsplatf
-  BASE_TEST_PATH=%i/test/%cmsplatf
+  ELF_DIRS="%i/lib/%cmsplatf %i/biglib/%cmsplatf %i/bin/%cmsplatf %i/test/%cmsplatf"
 fi
 
 # optimise the debug symbols, compress them, and split them into separate file
-for DIR in $BASE_LIB_PATH $BASE_BIN_PATH $BASE_TEST_PATH; do
+for DIR in $ELF_DIRS; do
   pushd $DIR
   mkdir -p .debug
   # ELF binaries
@@ -301,7 +297,7 @@ done
 %if "%{?subpackageDebug:set}" == "set"
 rm -f %_builddir/files.debug %_builddir/files
 touch %_builddir/files.debug %_builddir/files
-for DIR in $BASE_LIB_PATH $BASE_BIN_PATH $BASE_TEST_PATH; do
+for DIR in $ELF_DIRS; do
   DIR=`echo $DIR | sed 's|^%i/|%{installroot}/%{pkgrel}/|'`
   echo "%exclude $DIR/.debug"   >> %_builddir/files
   echo "$DIR/.debug"            >> %_builddir/files.debug

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -1,13 +1,13 @@
 ### FILE scram-project-build
 # FIXME: support building all platforms together like scram does?
 # FIXME: automatic sub-packages for "doc" etc?
-## NOCOMPILER
 %define mic %(case %cmsplatf in (*_mic_*) echo true;; (*) echo false;; esac)
 %define cmssw_libs biglib/%{cmsplatf} lib/%{cmsplatf}
 %define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
 %define islinux %(case %{cmsos} in (slc*|fc*) echo 1 ;; (*) echo 0 ;; esac)
 
 Requires: SCRAMV1
+BuildRequires: dwz gcc file
 
 %if %islinux
 %if %isamd64
@@ -301,6 +301,52 @@ rm -fR %{srctree} tmp
 %if "%{?subpackageDebug:set}" == "set"
 tar czf debug.tar.gz --files-from %_builddir/files.debug --no-recursion --remove-files
 %endif
+
+# Begin debug
+
+mkdir -p %i/%cmsplatf/lib/.debug %i/%cmsplatf/bin/.debug %i/%cmsplatf/tests/bin/.debug
+
+BASE_LIB_PATH=%i/lib/%cmsplatf
+BASE_BIN_PATH=%i/bin/%cmsplatf
+BASE_TEST_PATH=%i/test/%cmsplatf
+if [ "%{n}" == "coral" ]; then
+  BASE_LIB_PATH=%i/%cmsplatf/lib
+  BASE_BIN_PATH=%i/%cmsplatf/bin
+  BASE_TEST_PATH=%i/%cmsplatf/tests/bin
+fi
+
+pushd $BASE_LIB_PATH
+  dwz -m lib-common.so.debug -r *.so
+  find . -type f -name '*.so' -exec objcopy --compress-debug-sections {} \;
+  find . -type f -name '*.so' -print0 | xargs -0 -I% -n1 sh -c 'eu-strip -f %.debug %'
+  find . -type f -name '*.so.debug' -exec mv {} %i/%cmsplatf/lib/.debug \;
+popd
+
+pushd $BASE_BIN_PATH
+  # ELF binaries
+  ELF_BINS=$(find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1)
+  if [ ! -z "$ELF_BINS" ]; then
+    dwz -m bin-common.debug -r $ELF_BINS
+    find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | xargs -I% -n1 sh -c 'objcopy --compress-debug-sections %'
+    find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | xargs -I% -n1 sh -c 'eu-strip -f %.debug %'
+    find . -type f -name '*.debug' -exec mv {} %i/%cmsplatf/bin/.debug \;
+  fi
+popd
+
+pushd $BASE_TEST_PATH
+  # ELF binaries
+  ELF_BINS=$(find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1)
+  if [ ! -z "$ELF_BINS" ]; then
+    dwz -m tests-common.debug -r $ELF_BINS
+    # find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | grep -v tests-common.debug | xargs -I% -n1 sh -c 'objcopy --compress-debug-sections %'
+    echo "$ELF_BINS" | xargs -I% -n1 sh -c 'echo %; objcopy --compress-debug-sections %'
+    # find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | grep -v tests-common.debug | xargs -I% -n1 sh -c 'eu-strip -f %.debug %'
+    echo "$ELF_BINS" | xargs -I% -n1 sh -c 'eu-strip -f %.debug %'
+    find . -type f -name '*.debug' -exec mv {} %i/%cmsplatf/tests/bin/.debug \;
+  fi
+popd
+
+# End debug
 
 ######################################################
 #Do the symlink relocation as a last step in install

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -44,17 +44,17 @@ Requires: file
 %endif
 %endif
 
-%if "%{?usercxxflags:set}" == "set"
-%define extraOptions USER_CXXFLAGS='"%{usercxxflags}"'
-%else
-%define extraOptions %{nil}
-%endif
 %define bootstrapfile   config/bootsrc.xml
 
 %if "%{?subpackageDebug:set}" == "set"
 # note: do not change the order of the -fdebug-prefix-map options, they seem to be use in reverse order
-# note: the single quotes are needed to protect the double quotes, otherwise scram will pass separate arguments to make
-%define extraOptions USER_CXXFLAGS='"-fdebug-prefix-map=%{cmsroot}=%{installroot} -fdebug-prefix-map=%{instroot}=%{installroot} -g"'
+%define extraOptions USER_CXXFLAGS='-fdebug-prefix-map=%{cmsroot}=%{installroot} -fdebug-prefix-map=%{instroot}=%{installroot} -g %{?usercxxflags}'
+%else
+%if "%{?usercxxflags:set}" == "set"
+%define extraOptions USER_CXXFLAGS='%{usercxxflags}'
+%else
+%define extraOptions %{nil}
+%endif
 %endif
 
 %if "%{?configtag:set}" != "set"
@@ -231,32 +231,6 @@ if [ -d %{i}/tmp/%{cmsplatf}/cache/log/src ]; then
   popd
 fi
 
-# split the debug symbols out of tha main binaries, into separate files
-%if "%{?subpackageDebug:set}" == "set"
-rm -f %_builddir/files.debug %_builddir/files
-touch %_builddir/files.debug %_builddir/files
-echo "%exclude %{installroot}/%{pkgrel}/debug.tar.gz" >> %_builddir/files
-BINDIR=$(%scramcmd tool info Self | grep "^PATH\|LD_LIBRARY_PATH=" | cut -d= -f2 | tr ":" "\n" | grep -v external)
-for DIR in $BINDIR; do
-  mkdir -p $DIR/.debug
-  # FIXME - work around the 2GB limit in RPM 4.4.2
-  #echo "%dir $DIR/.debug"     >> %_builddir/files.debug
-  DIR=`echo $DIR | sed 's|^%i/||'`
-  echo "%exclude %{installroot}/%{pkgrel}/$DIR/.debug" >> %_builddir/files
-  echo "$DIR/.debug" >> %_builddir/files.debug
-done
-for FILE in $(find $BINDIR -type f | xargs file | grep "ELF" | cut -d: -f1); do
-  NAME=$(basename $FILE)
-  DIR=$(dirname $FILE)
-  DEBUG="$DIR/.debug/$NAME.debug"
-  eu-strip "$FILE" -f "$DEBUG"
-  # FIXME - work around the 2GB limit in RPM 4.4.2
-  #echo "$DEBUG"          >> %_builddir/files.debug
-  #echo "%exclude $DEBUG" >> %_builddir/files
-  echo "$DEBUG" | sed 's#%{pkginstroot}/##' >> %_builddir/files.debug
-done
-%endif
-
 %if "%{?saveDeps:set}" == "set"
 mkdir -p %i/etc/dependencies
 perl %{_sourcedir}/findDependencies.pl -rel %i -arch %cmsplatf -scramroot $SCRAMV1_ROOT
@@ -297,56 +271,42 @@ cd %i
 tar czf %{srctree}.tar.gz %{srctree}
 rm -fR %{srctree} tmp
 
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-tar czf debug.tar.gz --files-from %_builddir/files.debug --no-recursion --remove-files
-%endif
-
-# Begin debug
-
-mkdir -p %i/%cmsplatf/lib/.debug %i/%cmsplatf/bin/.debug %i/%cmsplatf/tests/bin/.debug
-
-BASE_LIB_PATH=%i/lib/%cmsplatf
-BASE_BIN_PATH=%i/bin/%cmsplatf
-BASE_TEST_PATH=%i/test/%cmsplatf
+# handle debug symbols
 if [ "%{n}" == "coral" ]; then
   BASE_LIB_PATH=%i/%cmsplatf/lib
-  BASE_BIN_PATH=%i/%cmsplatf/bin
+  BASE_BIN_PATH=
   BASE_TEST_PATH=%i/%cmsplatf/tests/bin
+else
+  BASE_LIB_PATH=%i/lib/%cmsplatf
+  BASE_BIN_PATH=%i/bin/%cmsplatf
+  BASE_TEST_PATH=%i/test/%cmsplatf
 fi
 
-pushd $BASE_LIB_PATH
-  dwz -m lib-common.so.debug -r *.so
-  find . -type f -name '*.so' -exec objcopy --compress-debug-sections {} \;
-  find . -type f -name '*.so' -print0 | xargs -0 -I% -n1 sh -c 'eu-strip -f %.debug %'
-  find . -type f -name '*.so.debug' -exec mv {} %i/%cmsplatf/lib/.debug \;
-popd
-
-pushd $BASE_BIN_PATH
+# optimise the debug symbols, compress them, and split them into separate file
+for DIR in $BASE_LIB_PATH $BASE_BIN_PATH $BASE_TEST_PATH; do
+  pushd $DIR
+  mkdir -p .debug
   # ELF binaries
-  ELF_BINS=$(find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1)
+  ELF_BINS=$(file * | grep ELF | cut -d':' -f1)
   if [ ! -z "$ELF_BINS" ]; then
-    dwz -m bin-common.debug -r $ELF_BINS
-    find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | xargs -I% -n1 sh -c 'objcopy --compress-debug-sections %'
-    find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | xargs -I% -n1 sh -c 'eu-strip -f %.debug %'
-    find . -type f -name '*.debug' -exec mv {} %i/%cmsplatf/bin/.debug \;
+    %if "%{?isPatch:set}" != "set"
+    dwz -m .debug/common-symbols.debug -M common-symbols.debug $ELF_BINS
+    %endif
+    echo "$ELF_BINS" | xargs -t -n1 -P%{compiling_processes} -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
-popd
+  popd
+done
 
-pushd $BASE_TEST_PATH
-  # ELF binaries
-  ELF_BINS=$(find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1)
-  if [ ! -z "$ELF_BINS" ]; then
-    dwz -m tests-common.debug -r $ELF_BINS
-    # find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | grep -v tests-common.debug | xargs -I% -n1 sh -c 'objcopy --compress-debug-sections %'
-    echo "$ELF_BINS" | xargs -I% -n1 sh -c 'echo %; objcopy --compress-debug-sections %'
-    # find . -type f -exec file {} \; | grep -i elf | cut -d':' -f1 | grep -v tests-common.debug | xargs -I% -n1 sh -c 'eu-strip -f %.debug %'
-    echo "$ELF_BINS" | xargs -I% -n1 sh -c 'eu-strip -f %.debug %'
-    find . -type f -name '*.debug' -exec mv {} %i/%cmsplatf/tests/bin/.debug \;
-  fi
-popd
-
-# End debug
+# split the debug symbols out of the main binaries, into separate files
+%if "%{?subpackageDebug:set}" == "set"
+rm -f %_builddir/files.debug %_builddir/files
+touch %_builddir/files.debug %_builddir/files
+for DIR in $BASE_LIB_PATH $BASE_BIN_PATH $BASE_TEST_PATH; do
+  DIR=`echo $DIR | sed 's|^%i/|%{installroot}/%{pkgrel}/|'`
+  echo "%exclude $DIR/.debug"   >> %_builddir/files
+  echo "$DIR/.debug"            >> %_builddir/files.debug
+done
+%endif
 
 ######################################################
 #Do the symlink relocation as a last step in install

--- a/subpackage-debug.file
+++ b/subpackage-debug.file
@@ -13,26 +13,10 @@ Separate debug symbol files for %{pkgcategory}+%{pkgname}+%{pkgversion}.
 %post -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion}
 # nothing to do
 
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-if [ -e $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz ] ; then
-  tar xzf $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz -C $RPM_INSTALL_PREFIX/%pkgrel/
-  rm -fR  $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz
-fi
-%endif
-
 %preun -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion}
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-if [ -e $RPM_INSTALL_PREFIX/%pkgrel ] ; then
-  rm -fR $(find $RPM_INSTALL_PREFIX/%pkgrel/ -type d -name .debug)
-fi
-%endif
+# nothing to do
 
 %if "%{?subpackageDebug:set}" == "set"
-%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} 
-# FIXME - work around the 2GB limit in RPM 4.4.2
-#%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} -f %_builddir/files.debug
-%{pkginstroot}/debug.tar.gz
+%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} -f %_builddir/files.debug
 %defattr(-, root, root)
 %endif


### PR DESCRIPTION
Backport from the IB/CMSSW_7_2_X/gcc491 branch:
- update binutils and other packages for better support of debug symbols 

Backport #946 (support for debug symbols in scram projects):
- generate debug information
- relocate the source file information to a default directory (that GB can later remap)
- split and compress the debugging symbols
- package the debugging symbols in a separate sub-package

Needs https://github.com/cms-sw/pkgtools/pull/63 to be integrated before it can work.
