### PR TITLE
gdb: move back to 7.7 until issues with 7.8 are understood

### DIFF
--- a/gdb.spec
+++ b/gdb.spec
@@ -1,4 +1,4 @@
-### RPM external gdb 7.8
+### RPM external gdb 7.7
 Source: http://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
 Patch0: gdb-7.6-fix-pythonhome
 Requires: python ncurses zlib xz expat


### PR DESCRIPTION
The following tests hangs in CMSSW "TestFWCoreServicesDriver"

Signed-off-by: David Abdurachmanov davidlt@cern.ch
