### PR TITLE
cx_Oracle updated from 5.1 to 5.1.3 version

### DIFF
--- a/py2-cx-oracle.spec
+++ b/py2-cx-oracle.spec
@@ -1,7 +1,8 @@
-### RPM external py2-cx-oracle 5.1
+### RPM external py2-cx-oracle 5.1.3
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 %define downloadn cx_Oracle
-Source: http://switch.dl.sourceforge.net/sourceforge/cx-oracle/%downloadn-%realversion.tar.gz
+
+Source: https://pypi.python.org/packages/source/c/cx_Oracle/cx_Oracle-%realversion.tar.gz
 Patch: py2-cx-oracle-pingbreak
 
 Requires: python oracle oracle-env


### PR DESCRIPTION
Updated cx_Oracle from 5.1 to 5.1.3 version.

It was tested only in SLC6 and pushed to comp_gcc481 branch.
It was tested also with SQLAlchemy 0.9.6 version [ https://github.com/cms-sw/cmsdist/pull/983 ]. Not with 0.5.2 version.

@amaltaro @juztas @hufnagel @geneguvo 
