### PR TITLE
adding new version of SQLAlchemy

### DIFF
--- a/py2-sqlalchemy.spec
+++ b/py2-sqlalchemy.spec
@@ -1,11 +1,8 @@
-### RPM external py2-sqlalchemy 0.5.2
+### RPM external py2-sqlalchemy 0.9.6
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source: http://downloads.sourceforge.net/sqlalchemy/SQLAlchemy-%realversion.tar.gz
-Requires: python 
-# Apply patch to make ORACLE works correctly while specifying owner, see
-# http://groups.google.com/group/sqlalchemy/browse_thread/thread/902d39df9bc8cf21
-#Patch: py2-sqlalchemy_patch_0.4.4_0.4.5
+Source: https://pypi.python.org/packages/source/S/SQLAlchemy/SQLAlchemy-%realversion.tar.gz
+Requires: python
 
 %prep
 %setup -n SQLAlchemy-%realversion


### PR DESCRIPTION
Updated sqlalchemy from 0.5.2 to 0.9.6 version.

Before using this change, the patch to WMCore must be installed: https://github.com/dmwm/WMCore/pull/5286

It was tested only in SLC6 and pushed to comp_gcc481 branch.

@amaltaro @juztas @hufnagel 
