### PR TITLE
scram-project-build: disable biglibs for ASAN builds

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -197,6 +197,10 @@ export SCRAM_NOLOADCHECK=true
 export SCRAM_NOSYMCHECK=true
 %endif
 
+# For any builds, which adds '-g' flag LTO needs to be disabled, i.e.,
+# BigLibs needs to be disabled.
+%scramcmd b disable-biglib
+
 %{?preBuildCommand:%preBuildCommand}
 
 %scramcmd b -r echo_CXX </dev/null


### PR DESCRIPTION
LTO breaks down if we add '-g' flags into CXXFLAGS. There are no
BigLib users currently, thus we can safely disable it for ASAN
builds.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
