### PR TITLE
cmssw-ib: fetch int-build sources from GitHub

### DIFF
--- a/cmssw-ib.spec
+++ b/cmssw-ib.spec
@@ -1,11 +1,7 @@
 ### RPM cms cmssw-ib 1.0.0
 BuildRequires: cmssw SCRAMV1 local-cern-siteconf python
 %define initenv	        %initenv_direct
-#%define name1 1937
-#%define moduleName LogParser
-#%define url HTMLFiles/
-#Source: svn://svn.cern.ch/reps/CMSIntBld/tags/LogParser/parser?scheme=svn+ssh&revision=%{name1}&module=%{moduleName}&output=/%{moduleName}.tar.gz
-Source: svn://svn.cern.ch/reps/CMSIntBld/trunk/IntBuild?scheme=svn+ssh&revision=2829&module=IntBuild&output=/IntBuild.tar.gz
+Source: git://github.com/cms-sw/int-build.git?date=%(date +%%Y%%m%%d%%H%%M)&obj=master/HEAD&export=IntBuild&output=/int-build-%{realversion}.tgz
 %define scram $SCRAMV1_ROOT/bin/scram --arch %cmsplatf
 
 %prep


### PR DESCRIPTION
There is an inconsistency. cmssw-validation.spec is fetching the sources
from GitHub, but cmssw-ib.spec still used SVN. Correct the situation and
fetch sources from GitHub.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
