### PR TITLE
Pythia8.200pre2

### DIFF
--- a/evtgen.spec
+++ b/evtgen.spec
@@ -33,6 +33,9 @@ export PHOTOSPP_LOCATION=${PHOTOSPP_ROOT}
 
 
 ./configure --prefix=%{i} --hepmcdir=$HEPMC_ROOT --pythiadir=$PYTHIA8_ROOT --tauoladir=$TAUOLAPP_ROOT --photosdir=$PHOTOSPP_ROOT CXXFLAGS="%cms_cxxflags" 
+#remove obsolete pythia8 library
+sed -i 's/PYTHIALIBLIST = -lpythia8 -llhapdfdummy/PYTHIALIBLIST = -lpythia8/g' config.mk
+
 # One more fix-up for OSX (in addition to the patch above)
 case %cmsplatf in
   osx*)

--- a/pythia8-toolfile.spec
+++ b/pythia8-toolfile.spec
@@ -10,13 +10,12 @@ mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/pythia8.xml
 <tool name="pythia8" version="@TOOL_VERSION@">
   <lib name="pythia8"/>
-  <lib name="pythia8tohepmc"/>
   <client>
     <environment name="PYTHIA8_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PYTHIA8_BASE/lib"/>
     <environment name="INCLUDE" default="$PYTHIA8_BASE/include"/>
   </client>
-  <runtime name="PYTHIA8DATA" value="$PYTHIA8_BASE/xmldoc"/>
+  <runtime name="PYTHIA8DATA" value="$PYTHIA8_BASE/share/Pythia8/xmldoc"/>
   <use name="hepmc"/>
   <use name="lhapdf"/>
 </tool>

--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,4 +1,4 @@
-### RPM external pythia8 200pre1
+### RPM external pythia8 200pre2
 
 Requires: hepmc lhapdf
 

--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,8 +1,9 @@
-### RPM external pythia8 185
+### RPM external pythia8 200pre1
 
-Requires: hepmc
+Requires: hepmc lhapdf
 
-Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
+#Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
+Source: https://cms-project-generators.web.cern.ch/cms-project-generators/%{n}-%{realversion}-src.tgz
 
 %if "%{?cms_cxxflags:set}" != "set"
 %define cms_cxxflags -std=c++0x
@@ -12,9 +13,9 @@ Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-
 %setup -q -n %{n}/%{realversion}
 
 export USRCXXFLAGS="%cms_cxxflags"
-export HEPMCLOCATION=${HEPMC_ROOT} 
-export HEPMCVERSION=${HEPMC_VERSION} 
-./configure --prefix=%i --enable-shared --with-hepmc=${HEPMC_ROOT}
+export HEPMCLOCATION=${HEPMC_ROOT}  
+export HEPMCVERSION=${HEPMC_VERSION}
+./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-lhapdf5=${LHAPDF_ROOT}
 
 %build
 make %makeprocesses


### PR DESCRIPTION
@mkirsano

Add back pythia 8.200pre2 this time which solves some technical issues with headers and adds back a previously removed function needed by evtgen.

Because of the removal of the lhapdfdummy library from pythia8, the link options in the evtgen external are also modified.
