### PR TITLE
Setup dxr as an external python package and all of its python dependencies

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -90,6 +90,12 @@ Requires: py2-pycurl-toolfile
 Requires: py2-sqlalchemy-toolfile
 Requires: py2-pygithub-toolfile
 Requires: py2-networkx-toolfile
+Requires: py2-dxr-toolfile
+Requires: py2-futures-toolfile
+Requires: py2-jinja-toolfile
+Requires: py2-markupsafe-toolfile
+Requires: py2-ordereddict-toolfile
+Requires: py2-parsimonious-toolfile
 Requires: rivet-toolfile
 Requires: cascade-toolfile
 Requires: cython-toolfile

--- a/py2-dxr-toolfile.spec
+++ b/py2-dxr-toolfile.spec
@@ -1,0 +1,31 @@
+### RPM external py2-dxr-toolfile 1.0
+Requires: py2-dxr py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-dxr.xml
+<tool name="py2-dxr" version="@TOOL_VERSION@">
+  <info url="https://dxr.readthedocs.org/"/>
+  <client>
+    <environment name="PY2_DXR" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PY2_DXR/lib"/>
+  </client>
+    <runtime name="PYTHONPATH" value="$PY2_DXR/lib/python@PYTHONV@/site-packages" type="path"/>
+    <runtime name="PATH" value="$PY2_DXR/bin" type="path"/>
+    <use name="python"/>
+    <use name="sqlite"/>
+    <use name="py2-futures"/>
+    <use name="py2-jinja"/>
+    <use name="py2-markupsafe"/>
+    <use name="py2-ordereddict"/>
+    <use name="py2-parsimonious"/>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -1,0 +1,28 @@
+### RPM external py2-dxr master
+## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
+BuildRequires: llvm sqlite
+Requires: python py2-setuptools py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious
+
+%define dxrCommit 6ea764102a
+%define triliteCommit e64a2a1 
+%define branch master
+%define github_user mozilla
+
+Source0: git+https://github.com/%github_user/dxr.git?obj=%{branch}/%{dxrCommit}&export=dxr-%{realversion}-%{dxrCommit}&module=dxr-%realversion-%dxrCommit&output=/dxr-%{realversion}-%{dxrCommit}.tgz
+Source1: git+https://github.com/jonasfj/trilite.git?obj=%{branch}/%{triliteCommit}&export=trilite-%{realversion}-%{triliteCommit}&module=trilite-%realversion-%triliteCommit&output=/trilite-%{realversion}-%{triliteCommit}.tgz
+
+%define keep_archives true
+
+%prep
+%setup -T -b0 -n dxr-%realversion-%dxrCommit
+%setup -T -D -a1 -c -n dxr-%realversion-%dxrCommit
+mv trilite-%realversion-%triliteCommit/* trilite
+%setup -T -D -n dxr-%realversion-%dxrCommit
+
+%build
+make build-plugin-clang build-plugin-pygmentize trilite ; python setup.py build
+
+%install
+mkdir %i/lib
+cp -p trilite/libtrilite.so %i/lib
+python setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null

--- a/py2-futures-toolfile.spec
+++ b/py2-futures-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external py2-futures-toolfile 1.0
+Requires: py2-futures
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-futures.xml
+<tool name="py2-futures" version="@TOOL_VERSION@">
+  <info url="https://pypi.python.org/pypi/MarkupSafe"/>
+  <client>
+    <environment name="PY2_FUTURES" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PY2_FUTURES/lib"/>
+    <runtime name="PYTHONPATH" value="$PY2_FUTURES/lib/python@PYTHONV@/site-packages" type="path"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/py2-futures.spec
+++ b/py2-futures.spec
@@ -1,0 +1,13 @@
+### RPM external py2-futures 2.2.0
+## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
+Source: https://pypi.python.org/packages/source/f/futures/futures-%realversion.tar.gz
+Requires: python py2-setuptools
+
+%prep
+%setup -n futures-%realversion
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null

--- a/py2-jinja-toolfile.spec
+++ b/py2-jinja-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external py2-jinja-toolfile 1.0
+Requires: py2-jinja
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-jinja.xml
+<tool name="py2-jinja" version="@TOOL_VERSION@">
+  <info url="https://pypi.python.org/pypi/jinja"/>
+  <client>
+    <environment name="PY2_JINJA" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PY2_JINJA/lib"/>
+    <runtime name="PYTHONPATH" value="$PY2_JINJA/lib/python@PYTHONV@/site-packages" type="path"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/py2-markupsafe-toolfile.spec
+++ b/py2-markupsafe-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external py2-markupsafe-toolfile 1.0
+Requires: py2-markupsafe
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-markupsafe.xml
+<tool name="py2-markupsafe" version="@TOOL_VERSION@">
+  <info url="https://pypi.python.org/pypi/MarkupSafe"/>
+  <client>
+    <environment name="PY2_MARKUPSAFE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PY2_MARKUPSAFE/lib"/>
+    <runtime name="PYTHONPATH" value="$PY2_MARKUPSAFE/lib/python@PYTHONV@/site-packages" type="path"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/py2-markupsafe.spec
+++ b/py2-markupsafe.spec
@@ -1,0 +1,13 @@
+### RPM external py2-markupsafe 0.23
+## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
+Source: https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-%realversion.tar.gz
+Requires: python py2-setuptools
+
+%prep
+%setup -n MarkupSafe-%realversion
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null

--- a/py2-ordereddict-toolfile.spec
+++ b/py2-ordereddict-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external py2-ordereddict-toolfile 1.0
+Requires: py2-ordereddict
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-ordereddict.xml
+<tool name="py2-ordereddict" version="@TOOL_VERSION@">
+  <info url="https://pypi.python.org/pypi/MarkupSafe"/>
+  <client>
+    <environment name="PY2_ORDEREDDICT" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PY2_ORDEREDDICT/lib"/>
+    <runtime name="PYTHONPATH" value="$PY2_ORDEREDDICT/lib/python@PYTHONV@/site-packages" type="path"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/py2-ordereddict.spec
+++ b/py2-ordereddict.spec
@@ -1,0 +1,13 @@
+### RPM external py2-ordereddict 1.1
+## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
+Source: https://pypi.python.org/packages/source/o/ordereddict/ordereddict-%realversion.tar.gz
+Requires: python py2-setuptools
+
+%prep
+%setup -n ordereddict-%realversion
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%i 

--- a/py2-parsimonious-toolfile.spec
+++ b/py2-parsimonious-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external py2-parsimonious-toolfile 1.0
+Requires: py2-parsimonious
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-parsimonious.xml
+<tool name="py2-parsimonious" version="@TOOL_VERSION@">
+  <info url="https://pypi.python.org/pypi/MarkupSafe"/>
+  <client>
+    <environment name="PY2_PARSIMONIOUS" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$PY2_PARSIMONIOUS/lib"/>
+    <runtime name="PYTHONPATH" value="$PY2_PARSIMONIOUS/lib/python@PYTHONV@/site-packages" type="path"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/py2-parsimonious.spec
+++ b/py2-parsimonious.spec
@@ -1,11 +1,10 @@
-### RPM external py2-jinja 2.7.2
+### RPM external py2-parsimonious 0.6.1
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
-
-Source: http://pypi.python.org/packages/source/J/Jinja2/Jinja2-%realversion.tar.gz
+Source: https://pypi.python.org/packages/source/p/parsimonious/parsimonious-%realversion.tar.gz
 Requires: python py2-setuptools
 
 %prep
-%setup -n Jinja2-%realversion
+%setup -n parsimonious-%realversion
 
 %build
 python setup.py build


### PR DESCRIPTION
This allows dxr-build.py to be run in the CMSSW environment. This script sets environment variables that can be used to override the default CC and CXX. 
