### PR TITLE
gcc-toolfile: select correct linker (ld) flags based on architecture

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -111,15 +111,17 @@ case %cmsplatf in
     export ARCH_CXXFLAGS="-arch x86_64"
     export ARCH_SHAREDFLAGS="-arch x86_64"
     export ARCH_LIB64DIR="lib"
+    export ARCH_LD_UNIT="-r"
   ;;
   slc*)
     # For some reason on mac, some of the header do not compile if this is
     # defined.  Ignore for now.
     export ARCH_LIB64DIR="lib64"
-    export ARCH_LD_UNIT="-r -m elf_x86_64"
+    export ARCH_LD_UNIT="-r -m elf_x86_64 -z muldefs"
   ;;
   *_armv7hl_*)
     export ARCH_LIB64DIR="lib"
+    export ARCH_LD_UNIT="-r -z muldefs"
   ;;
   *) 
     echo "Unsupported."


### PR DESCRIPTION
Darwin/OSX only needs '-r' for incremental linking. '-m' is deprecated.
'-z muldefs' only needs to be applied on GNU linkers, not for Darwin/OSX.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
