### PR TITLE
scram-project-build: update config to V05-03-25

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -58,7 +58,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-24
+%define configtag       V05-03-25
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
New config does not pass --exclude-libs option to cctools linker on
Darwin/OSX. It is not supported.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
