### PR TITLE
Eigen backport to 62x SLHC

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -119,6 +119,7 @@ Requires: sloccount-toolfile
 Requires: cvs2git-toolfile
 Requires: pacparser-toolfile
 Requires: git-toolfile
+Requires: eigen-toolfile
 
 %if "%isslc" == "true"
 Requires: openldap-toolfile

--- a/eigen-toolfile.spec
+++ b/eigen-toolfile.spec
@@ -1,0 +1,20 @@
+### RPM external eigen-toolfile 1.0
+Requires: eigen
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/eigen.xml
+<tool name="eigen" version="@TOOL_VERSION@">
+  <client>
+    <environment name="EIGEN_BASE"   default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$EIGEN_BASE/include"/>
+  </client>
+  <flags CPPDEFINES="EIGEN_DONT_PARALLELIZE"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/eigen.spec
+++ b/eigen.spec
@@ -1,0 +1,13 @@
+### RPM external eigen 3.2.2
+## NOCOMPILER
+Source: http://bitbucket.org/%{n}/%{n}/get/%{realversion}.tar.gz
+   
+%prep
+%setup -n %n-%n-1306d75b4a21
+
+%build
+mkdir -p %i/include
+
+%install
+cp -r Eigen %i/include
+


### PR DESCRIPTION
Is this the right branch for 62x_SLHC releases?

I was able to "build" it here (eigen is headers only) and test with CMSSW_6_2_0_SLHC19 against backported ecal multifit local reco in any case.
