### PR TITLE
upgrade t0_reqmon to 1.0.1.pre1

### DIFF
--- a/t0_reqmon.spec
+++ b/t0_reqmon.spec
@@ -1,4 +1,4 @@
-### RPM cms t0_reqmon 0.9.39
+### RPM cms t0_reqmon 1.0.1.pre1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
 Source0: git://github.com/dmwm/WMCore?obj=master/%realversion&export=%n&output=/%n.tar.gz


### PR DESCRIPTION
Hi Diego, please review, Not completely sure what following patch does. But it seems reqmon is updated with that.
Patch0: reqmon-erl-views
Also I was wondering this can be updated as soon as possible on testbed. Global run starts 27th and this need to be validated before that. It doesn't have to be in the production on that day though. Could you also delete all the data in tier0_wmstats in the testbed and production right before Global run starts?
@hufnagel, Dirk, please confirm that decision (deleting all the data from tier0_wmstats)

Thanks, 
Seangchan
