### PR TITLE
cmssw-tool-conf fixed to avoid cyrus-sasl/nss/nspr dependency

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 27.0
+### RPM cms cmssw-tool-conf 27.1
 ## NOCOMPILER
 # with cmsBuild, change the above version only when a new
 # tool is added
@@ -68,7 +68,6 @@ Requires: py2-cx-oracle-toolfile
 Requires: qt-toolfile
 Requires: roofit-toolfile
 Requires: root-toolfile
-Requires: sherpa-toolfile
 Requires: sigcpp-toolfile
 Requires: sqlite-toolfile
 Requires: systemtools
@@ -119,6 +118,12 @@ Requires: sloccount-toolfile
 Requires: cvs2git-toolfile
 Requires: pacparser-toolfile
 Requires: git-toolfile
+Requires: cuda-toolfile
+Requires: opencl-toolfile
+Requires: opencl-cpp-toolfile
+Requires: qd-toolfile
+Requires: blackhat-toolfile
+Requires: sherpa-toolfile
 Requires: eigen-toolfile
 
 %if "%isslc" == "true"
@@ -129,13 +134,7 @@ Requires: google-perftools-toolfile
 Requires: igprof-toolfile
 %endif
 
-%if "%isslc6" == "true"
-Requires: nspr-toolfile
-Requires: nss-toolfile
-Requires: cyrus-sasl-toolfile
-%endif
-
-%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler
+%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler cuda opencl opencl-cpp
 
 ## IMPORT scramv1-tool-conf
 


### PR DESCRIPTION
remove accidently added cyrus-sasl/nss/nspr dependency and added back the cuda/blackhat/sherpa deps
