### PR TITLE
root,roofit: bump version

### DIFF
--- a/roofit.spec
+++ b/roofit.spec
@@ -1,8 +1,8 @@
 ### RPM lcg roofit 6.02.00
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 81b6d7e819ce91b9b628c3ba06529205f9f53406
-%define branch cms/d1f704f
+%define tag e4e2becd954f7a3f3667c8ae2a01ae51ec0c8df4
+%define branch cms/72d681a
 %define github_user cms-sw
 Source: git+https://github.com/%github_user/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 

--- a/root.spec
+++ b/root.spec
@@ -1,8 +1,8 @@
 ### RPM lcg root 6.02.00
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 81b6d7e819ce91b9b628c3ba06529205f9f53406
-%define branch cms/d1f704f
+%define tag e4e2becd954f7a3f3667c8ae2a01ae51ec0c8df4
+%define branch cms/72d681a
 %define github_user cms-sw
 Source: git+https://github.com/%github_user/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 


### PR DESCRIPTION
Update ROOT6 to solve issues in RelVals.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
