### PR TITLE
cmsswdata: broken by auto-merge, add missing data packages

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -23,6 +23,9 @@ Requires: data-Configuration-Generator
 Requires: data-DQM-PhysicsHWW
 Requires: data-CondFormats-JetMETObjects
 Requires: data-RecoLocalCalo-EcalDeadChannelRecoveryAlgos
+Requires: data-RecoHI-HiJetAlgos
+Requires: data-GeneratorInterface-EvtGenInterface
+Requires: data-MagneticField-Interpolation
 Requires: data-FWCore-Framework
 
 %if %isnotonline


### PR DESCRIPTION
Broken by auto-merge, add back missing data packages.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
