### PR TITLE
SCRAMV1: add BuildRequires on gmake

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,5 +1,8 @@
 ### RPM lcg SCRAMV1 V2_2_6_pre2
 ## NOCOMPILER
+
+BuildRequires: gmake
+
 Provides: perl(BuildSystem::Template::Plugins::PluginCore)
 Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)


### PR DESCRIPTION
`gmake` must be used from CMSDIST as it's not required or/and provided
on the target system.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
