### PR TITLE
py2-dxr: misc fixes for Darwin support

### DIFF
--- a/py2-dxr-fix-clang-linker-flags.patch
+++ b/py2-dxr-fix-clang-linker-flags.patch
@@ -1,0 +1,20 @@
+diff --git a/dxr/plugins/clang/makefile b/dxr/plugins/clang/makefile
+index e75a5ad..b504c04 100644
+--- a/dxr/plugins/clang/makefile
++++ b/dxr/plugins/clang/makefile
+@@ -1,8 +1,13 @@
++CLANG_LIBS := -lclangFrontendTool -lclangFrontend -lclangDriver \
++              -lclangSerialization -lclangCodeGen -lclangParse \
++              -lclangSema -lclangRewriteFrontend -lclangRewrite \
++              -lclangAnalysis -lclangEdit -lclangAST -lclangLex \
++              -lclangBasic
+ LLVM_CONFIG ?= llvm-config
+-LLVM_LDFLAGS := $(shell ${LLVM_CONFIG} --ldflags)
++LLVM_LDFLAGS := $(shell ${LLVM_CONFIG} --ldflags --libs --system-libs) $(CLANG_LIBS)
+ CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -Wall -Wno-strict-aliasing \
+ 	$(if $(DEBUG),-O0 -g)
+-LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared
++LDFLAGS := $(LDFLAGS) -fPIC -g $(LLVM_LDFLAGS) -shared
+ 
+ build: libclang-index-plugin.so
+ 

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -1,7 +1,7 @@
 ### RPM external py2-dxr 1.0
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
 BuildRequires: llvm sqlite
-Requires: python py2-setuptools py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious
+Requires: python zlib py2-setuptools py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious
 
 %define dxrCommit 6ea764102a
 %define triliteCommit e64a2a1 
@@ -13,22 +13,35 @@ Source1: git+https://github.com/jonasfj/trilite.git?obj=%{branch}/%{triliteCommi
 Source2: https://re2.googlecode.com/files/re2-%re2Version.tgz
 Patch0: py2-dxr
 Patch1: trilite
+Patch2: py2-dxr-fix-clang-linker-flags
 %define keep_archives true
 
 %prep
 %setup -T -b0 -n dxr-%dxrCommit
 %setup -T -D -a1 -c -n dxr-%dxrCommit
 %setup -T -D -a2 -n dxr-%dxrCommit/trilite-%triliteCommit
-%patch -P 1 -p0
+%patch1 -p0
 cd ..
-%patch -P 0 -p1
+%patch0 -p1
+%patch2 -p1
 mv trilite-%triliteCommit/* trilite
 %setup -T -D -n dxr-%dxrCommit
 
+# We are not using LLVM/Clang + libc++ on Darwin, but
+# GCC + libstdc++. The ABIs are different, thus correct
+# it accordingly.
+# https://code.google.com/p/re2/issues/detail?id=99
+sed -ibak 's;__ZlsRNSt3__113basic_ostreamIcNS_11char_traitsIcEEEERKN3re211StringPieceE;__ZlsRSoRKN3re211StringPieceE;' ./trilite/re2/libre2.symbols.darwin
 
 %build
-export SQLITE_ROOT; make build-plugin-clang build-plugin-pygmentize;cd  trilite; make release; cd re2; make ; cd ../../; python setup.py build
-
+export SQLITE_ROOT
+LDFLAGS="-L${ZLIB_ROOT}/lib" make build-plugin-clang build-plugin-pygmentize
+cd trilite
+make release
+cd re2
+make
+cd ../../
+python setup.py build
 
 %install
 mkdir %i/lib


### PR DESCRIPTION
re2 on Darwin/OSX only supports Clang + libc++. libstdc++ and libc++
are not ABI compatible, causing build issues.

```
libc++    : operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, re2::StringPiece const&)
libstdc++ : operator<<(std::ostream&, re2::StringPiece const&)
```

Modify re2 `libre2.symbols.darwin` symbols file to be compatible with
libstdc++.

`libclang-index-plugin.so` Makefile seems to be out-of-date. Removed
unsupported and not needed linker flags. To resolve all undefined
symbols we need to link to LLVM, Clang and zlib.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
