### PR TITLE
Version 7.4.5, improve support for SLC6

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 7.4.3
+### RPM cms dqmgui 7.4.5
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
@@ -13,12 +13,11 @@ Source0: git+https://github.com/rovere/dqmgui.git?obj=master/6.6.1&export=Monito
 #Source0: git+:///build1/rovere/GUIDevelopment/GHM?obj=RovereDevelopment&export=Monitoring&output=/Monitoring.tar.gz
 #Source0: %{svn}?scheme=svn+ssh&strategy=export&module=Monitoring&output=/src.tar.gz
 # For documentation, please refer to http://cms-sw.github.io/pkgtools/fetching-sources.html
-Source1: git+https://github.com/cms-sw/cmssw.git?obj=CMSSW_7_0_X/CMSSW_7_0_0_pre6&export=./&output=/DQMCore.tar.gz
+Source1: git+https://github.com/cms-sw/cmssw.git?obj=CMSSW_7_0_X/CMSSW_7_0_0_pre6&export=./&filter=*DQMServices*&output=/DQMCore.tar.gz
 #Source1: %{cvs}&strategy=export&module=CMSSW/DQMServices/Core&export=DQMServices/Core&tag=-rV03-15-19&output=/DQMCore.tar.gz
 Source2: svn://rotoglup-scratchpad.googlecode.com/svn/trunk/rtgu/image?module=image&revision=10&scheme=http&output=/rtgu.tar.gz
 Source3: http://opensource.adobe.com/wiki/download/attachments/3866769/numeric.tar.gz
-Source4: git+https://github.com/rovere/dqmgui.git?obj=index128/7.4.3&export=Monitoring&output=/Monitoring128.tar.gz
-#Source4: git+:///build1/rovere/GUIDevelopment/GHM?obj=Develop128&export=Monitoring&output=/Monitoring128.tar.gz
+Source4: git+https://github.com/rovere/dqmgui.git?obj=index128/7.4.5&export=Monitoring&output=/Monitoring128.tar.gz
 Patch0: dqmgui-rtgu
 
 Requires: cherrypy py2-cheetah yui extjs gmake pcre boost root libpng libjpg classlib rotatelogs py2-pycurl py2-cjson libuuid d3 protobuf


### PR DESCRIPTION
Ciao,
this should guarantee to have a fully working DQMGUI on top of SLC6, plus some further developments, unrelated to SLC6. 
As mentioned in a thread over HN, this is meant to be deployed on testbed only instances, not on production machines.

Ciao,
M.
