### PR TITLE
llvm-gcc-toolfile: remove -frounding-math for Clang

### DIFF
--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -50,6 +50,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags REM_CXXFLAGS="-Wno-unused-local-typedefs"/>
     <flags REM_CXXFLAGS="-Werror=return-local-addr"/>
     <flags REM_CXXFLAGS="-fipa-pta"/>
+    <flags REM_CXXFLAGS="-frounding-math"/>
     <flags REM_CXXFLAGS="-mrecip"/>
     <flags CXXFLAGS="-Wno-c99-extensions"/>
     <flags CXXFLAGS="-Wno-c++11-narrowing"/>


### PR DESCRIPTION
`-frounding-math` is not supported in Clang, thus remove it.
Tested with LLVM/Clang 3.5.0

```
clang: warning: optimization flag '-frounding-math' is not supported
[-Winvalid-command-line-argument]
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
