### PR TITLE
cgal,cgal-toolfile: add dependency on gmp-static and mpfr-static

### DIFF
--- a/cgal-toolfile.spec
+++ b/cgal-toolfile.spec
@@ -21,6 +21,8 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cgal.xml
   </client>
   <use name="zlib"/>
   <use name="boost_system"/>
+  <use name="gmp"/>
+  <use name="mpfr"/>
 </tool>
 EOF_TOOLFILE
 

--- a/cgal.spec
+++ b/cgal.spec
@@ -2,7 +2,8 @@
 
 Source: https://gforge.inria.fr/frs/download.php/32360/%{n}-%{realversion}.tar.bz2
 
-BuildRequires: cmake gmp-static mpfr-static
+BuildRequires: cmake
+Requires: gmp-static mpfr-static
 
 Requires: boost zlib
 


### PR DESCRIPTION
Failures in Clang builds shows that CGAL actually needs to find GMP and
MPFR headers. Originally I compiled GMP and MPFR statically, then had
them as build time only dependency. The patch resolves Clang and ICC
build errors correctly.

There is already a partial fix on ICC:

```
250dbe3a8d1df22f26eb625351c62d99ec629b02
```

Makes GMP and MPFR as 'Requires:' in CGAL. Then adds those dependencies
in CGAL toolfile.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
