### PR TITLE
cmssw-tool-conf: remove mpfr and gmp from skipreqtools

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -170,7 +170,7 @@ Requires: glibc-toolfile
 %endif
 %endif
 
-%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler gmp mpfr cuda rivet2 opencl opencl-cpp lhapdf6
+%define skipreqtools jcompiler lhapdfwrapfull lhapdffull icc-cxxcompiler icc-ccompiler icc-f77compiler cuda rivet2 opencl opencl-cpp lhapdf6
 
 ## IMPORT scramv1-tool-conf
 


### PR DESCRIPTION
We need MPFR and GMP available for normal builds, otherwise CLANG and
ICC builds file. CGAL headers include headers from those two packages.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
