### PR TITLE
boost-toolfile: add new toolfile, boost_test

### DIFF
--- a/boost-toolfile.spec
+++ b/boost-toolfile.spec
@@ -95,6 +95,14 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_serialization.xml
 </tool>
 EOF_TOOLFILE
 
+cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_test.xml
+<tool name="boost_test" version="@TOOL_VERSION@">
+  <info url="http://www.boost.org"/>
+  <lib name="boost_unit_test_framework"/>
+  <use name="boost"/>
+</tool>
+EOF_TOOLFILE
+
 cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_iostreams.xml
 <tool name="boost_iostreams" version="@TOOL_VERSION@">
   <info url="http://www.boost.org"/>


### PR DESCRIPTION
Fireworks are using Boost Test module, yet we do not provide the
toolfile for it. Patch resolves it by adding toolfile (boost_test).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
