### PR TITLE
Revert unwanted changes in gcc brought by automatic merges

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -52,7 +52,18 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-cxxcompiler.xml
     <flags CXXFLAGS="-O2 -pthread -pipe -Werror=main -Werror=pointer-arith"/>
     <flags CXXFLAGS="-Werror=overlength-strings -Wno-vla @OS_CXXFLAGS@ @ARCH_CXXFLAGS@ @COMPILER_CXXFLAGS@"/>
     <flags CXXFLAGS="-felide-constructors -fmessage-length=0 -ftemplate-depth-300"/>
-    <flags CXXFLAGS="-Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi"/>
+    <flags CXXFLAGS="-Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type "/>
+    <flags CXXFLAGS="-Wunused -Wparentheses -Wno-deprecated -Werror=return-type"/>
+    <flags CXXFLAGS="-Werror=missing-braces -Werror=unused-value "/>
+    <flags CXXFLAGS="-Werror=address -Werror=format -Werror=sign-compare"/>
+    <flags CXXFLAGS="-Werror=write-strings -Werror=delete-non-virtual-dtor"/>
+    <flags CXXFLAGS="-Werror=maybe-uninitialized -Werror=strict-aliasing"/>
+    <flags CXXFLAGS="-Werror=narrowing -Werror=uninitialized "/>
+    <flags CXXFLAGS="-Werror=unused-but-set-variable -Werror=reorder"/>
+    <flags CXXFLAGS="-Werror=unused-variable -Werror=conversion-null"/>
+    <flags CXXFLAGS="-Werror=return-local-addr"/>
+    <flags CXXFLAGS="-Werror=switch -fdiagnostics-show-option"/>
+    <flags CXXFLAGS="-Wno-unused-local-typedefs -Wno-attributes"/>
     <flags LDFLAGS="@OS_LDFLAGS@ @ARCH_LDFLAGS@ @COMPILER_LDFLAGS@"/>
     <flags CXXSHAREDFLAGS="@OS_SHAREDFLAGS@ @ARCH_SHAREDFLAGS@ @COMPILER_SHAREDFLAGS@"/>
     <flags LD_UNIT="@OS_LD_UNIT@ @ARCH_LD_UNIT@ @COMPILER_LD_UNIT@"/>

--- a/gccxml-0.9.0_20100308-gcc45-iomanip.patch
+++ b/gccxml-0.9.0_20100308-gcc45-iomanip.patch
@@ -1,0 +1,353 @@
+diff -Naur orig.gccxml/GCC_XML/Support/GCC/4.5/iomanip gccxml/GCC_XML/Support/GCC/4.5/iomanip
+--- orig.gccxml/GCC_XML/Support/GCC/4.5/iomanip	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.5/iomanip	2010-04-12 11:56:31.000000000 +0200
+@@ -0,0 +1,349 @@
++// Standard stream manipulators -*- C++ -*-
++
++// Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005
++// 2006, 2007, 2008, 2009, 2010
++// Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file iomanip
++ *  This is a Standard C++ Library header.
++ */
++
++//
++// ISO C++ 14882: 27.6.3  Standard manipulators
++//
++
++#ifndef _GLIBCXX_IOMANIP
++#define _GLIBCXX_IOMANIP 1
++
++#pragma GCC system_header
++
++#include <bits/c++config.h>
++#include <iosfwd>
++#include <bits/ios_base.h>
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++#include <locale>
++#endif
++
++_GLIBCXX_BEGIN_NAMESPACE(std)
++
++  // [27.6.3] standard manipulators
++  // Also see DR 183.
++
++  struct _Resetiosflags { ios_base::fmtflags _M_mask; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  mask  A format flags mask.
++   *
++   *  Sent to a stream object, this manipulator resets the specified flags,
++   *  via @e stream.setf(0,mask).
++  */
++  inline _Resetiosflags 
++  resetiosflags(ios_base::fmtflags __mask)
++    { _Resetiosflags r = { __mask }; return r; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Resetiosflags __f)
++    { 
++      __is.setf(ios_base::fmtflags(0), __f._M_mask); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Resetiosflags __f)
++    { 
++      __os.setf(ios_base::fmtflags(0), __f._M_mask); 
++      return __os; 
++    }
++
++
++  struct _Setiosflags { ios_base::fmtflags _M_mask; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  mask  A format flags mask.
++   *
++   *  Sent to a stream object, this manipulator sets the format flags
++   *  to @a mask.
++  */
++  inline _Setiosflags 
++  setiosflags(ios_base::fmtflags __mask)
++    { _Setiosflags s = { __mask }; return s; } 
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setiosflags __f)
++    { 
++      __is.setf(__f._M_mask); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setiosflags __f)
++    { 
++      __os.setf(__f._M_mask); 
++      return __os; 
++    }
++
++
++  struct _Setbase { int _M_base; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  base  A numeric base.
++   *
++   *  Sent to a stream object, this manipulator changes the
++   *  @c ios_base::basefield flags to @c oct, @c dec, or @c hex when @a base
++   *  is 8, 10, or 16, accordingly, and to 0 if @a base is any other value.
++  */
++  inline _Setbase 
++  setbase(int __base)
++    { _Setbase s = { __base }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setbase __f)
++    {
++      __is.setf(__f._M_base ==  8 ? ios_base::oct : 
++		__f._M_base == 10 ? ios_base::dec : 
++		__f._M_base == 16 ? ios_base::hex : 
++		ios_base::fmtflags(0), ios_base::basefield);
++      return __is; 
++    }
++  
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setbase __f)
++    {
++      __os.setf(__f._M_base ==  8 ? ios_base::oct : 
++		__f._M_base == 10 ? ios_base::dec : 
++		__f._M_base == 16 ? ios_base::hex : 
++		ios_base::fmtflags(0), ios_base::basefield);
++      return __os; 
++    }
++  
++
++  template<typename _CharT>
++    struct _Setfill { _CharT _M_c; };
++
++  /**
++   *  @brief  Manipulator for @c fill.
++   *  @param  c  The new fill character.
++   *
++   *  Sent to a stream object, this manipulator calls @c fill(c) for that
++   *  object.
++  */
++  template<typename _CharT>
++    inline _Setfill<_CharT>
++    setfill(_CharT __c)
++    { _Setfill<_CharT> s = { __c }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setfill<_CharT> __f)
++    { 
++      __is.fill(__f._M_c); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setfill<_CharT> __f)
++    { 
++      __os.fill(__f._M_c); 
++      return __os; 
++    }
++
++
++  struct _Setprecision { int _M_n; };
++
++  /**
++   *  @brief  Manipulator for @c precision.
++   *  @param  n  The new precision.
++   *
++   *  Sent to a stream object, this manipulator calls @c precision(n) for
++   *  that object.
++  */
++  inline _Setprecision 
++  setprecision(int __n)
++    { _Setprecision s = { __n }; return s;} 
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setprecision __f)
++    { 
++      __is.precision(__f._M_n); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setprecision __f)
++    { 
++      __os.precision(__f._M_n); 
++      return __os; 
++    }
++
++
++  struct _Setw { int _M_n; };
++
++  /**
++   *  @brief  Manipulator for @c width.
++   *  @param  n  The new width.
++   *
++   *  Sent to a stream object, this manipulator calls @c width(n) for
++   *  that object.
++  */
++  inline _Setw 
++  setw(int __n)
++    { _Setw s = {__n} ; return s; } 
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setw __f)
++    {
++      __is.width(__f._M_n);
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setw __f)
++    {
++      __os.width(__f._M_n);
++      return __os; 
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  
++  template<typename _MoneyT>
++    struct _Get_money { _MoneyT& _M_mon; bool _M_intl; };
++
++  /**
++   *  @brief  Extended manipulator for extracting money.
++   *  @param  mon  Either long double or a specialization of @c basic_string.
++   *  @param  intl A bool indicating whether international format 
++   *               is to be used.
++   *
++   *  Sent to a stream object, this manipulator extracts @a mon.
++  */
++  template<typename _MoneyT>
++    inline _Get_money<_MoneyT>
++    get_money(_MoneyT& __mon, bool __intl = false)
++    { return { __mon, __intl }; }
++
++  template<typename _CharT, typename _Traits, typename _MoneyT>
++    basic_istream<_CharT, _Traits>&
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Get_money<_MoneyT> __f)
++    {
++      typedef istreambuf_iterator<_CharT, _Traits> _Iter;
++      typedef money_get<_CharT, _Iter> _MoneyGet;
++      
++      ios_base::iostate __err = ios_base::goodbit;
++      const _MoneyGet& __mg = use_facet<_MoneyGet>(__is.getloc());
++
++      __mg.get(_Iter(__is.rdbuf()), _Iter(), __f._M_intl,
++	       __is, __err, __f._M_mon);
++
++      if (ios_base::goodbit != __err)
++	__is.setstate(__err);
++
++      return __is; 
++    }
++
++
++  template<typename _MoneyT>
++    struct _Put_money { const _MoneyT& _M_mon; bool _M_intl; };
++
++  /**
++   *  @brief  Extended manipulator for inserting money.
++   *  @param  mon  Either long double or a specialization of @c basic_string.
++   *  @param  intl A bool indicating whether international format 
++   *               is to be used.
++   *
++   *  Sent to a stream object, this manipulator inserts @a mon.
++  */
++  template<typename _MoneyT>
++    inline _Put_money<_MoneyT>
++    put_money(const _MoneyT& __mon, bool __intl = false)
++    { return { __mon, __intl }; }
++
++  template<typename _CharT, typename _Traits, typename _MoneyT>
++    basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Put_money<_MoneyT> __f)
++    {
++      typedef ostreambuf_iterator<_CharT, _Traits> _Iter;
++      typedef money_put<_CharT, _Iter> _MoneyPut;
++      
++      const _MoneyPut& __mp = use_facet<_MoneyPut>(__os.getloc());
++      const _Iter __end = __mp.put(_Iter(__os.rdbuf()), __f._M_intl,
++				   __os, __os.fill(), __f._M_mon);
++
++      if (__end.failed())
++	__os.setstate(ios_base::badbit);
++
++      return __os; 
++    }
++
++#endif
++
++  // Inhibit implicit instantiations for required instantiations,
++  // which are defined via explicit instantiations elsewhere.  
++  // NB:  This syntax is a GNU extension.
++#if _GLIBCXX_EXTERN_TEMPLATE
++  extern template ostream& operator<<(ostream&, _Setfill<char>);
++  extern template ostream& operator<<(ostream&, _Setiosflags);
++  extern template ostream& operator<<(ostream&, _Resetiosflags);
++  extern template ostream& operator<<(ostream&, _Setbase);
++  extern template ostream& operator<<(ostream&, _Setprecision);
++  extern template ostream& operator<<(ostream&, _Setw);
++  extern template istream& operator>>(istream&, _Setfill<char>);
++  extern template istream& operator>>(istream&, _Setiosflags);
++  extern template istream& operator>>(istream&, _Resetiosflags);
++  extern template istream& operator>>(istream&, _Setbase);
++  extern template istream& operator>>(istream&, _Setprecision);
++  extern template istream& operator>>(istream&, _Setw);
++
++#ifdef _GLIBCXX_USE_WCHAR_T
++  extern template wostream& operator<<(wostream&, _Setfill<wchar_t>);
++  extern template wostream& operator<<(wostream&, _Setiosflags);
++  extern template wostream& operator<<(wostream&, _Resetiosflags);
++  extern template wostream& operator<<(wostream&, _Setbase);
++  extern template wostream& operator<<(wostream&, _Setprecision);
++  extern template wostream& operator<<(wostream&, _Setw);
++  extern template wistream& operator>>(wistream&, _Setfill<wchar_t>);
++  extern template wistream& operator>>(wistream&, _Setiosflags);
++  extern template wistream& operator>>(wistream&, _Resetiosflags);
++  extern template wistream& operator>>(wistream&, _Setbase);
++  extern template wistream& operator>>(wistream&, _Setprecision);
++  extern template wistream& operator>>(wistream&, _Setw);
++#endif
++#endif
++
++_GLIBCXX_END_NAMESPACE
++
++#endif /* _GLIBCXX_IOMANIP */

--- a/gccxml-20110825-add-support-for-gcc-4.7.patch
+++ b/gccxml-20110825-add-support-for-gcc-4.7.patch
@@ -1,0 +1,13737 @@
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/bits/stl_algo.h gccxml/GCC_XML/Support/GCC/4.7/bits/stl_algo.h
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/bits/stl_algo.h	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/bits/stl_algo.h	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,6305 @@
++// Algorithm implementation -*- C++ -*-
++
++// Copyright (C) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009,
++// 2010, 2011
++// Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/*
++ *
++ * Copyright (c) 1994
++ * Hewlett-Packard Company
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Hewlett-Packard Company makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ *
++ *
++ * Copyright (c) 1996
++ * Silicon Graphics Computer Systems, Inc.
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Silicon Graphics makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ */
++
++/** @file bits/stl_algo.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{algorithm}
++ */
++
++#ifndef _STL_ALGO_H
++#define _STL_ALGO_H 1
++
++#include <cstdlib>             // for rand
++#include <bits/algorithmfwd.h>
++#include <bits/stl_heap.h>
++#include <bits/stl_tempbuf.h>  // for _Temporary_buffer
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++#include <random>     // for std::uniform_int_distribution
++#include <functional> // for std::bind
++#endif
++
++// See concept_check.h for the __glibcxx_*_requires macros.
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  /// Swaps the median value of *__a, *__b and *__c to *__a
++  template<typename _Iterator>
++    void
++    __move_median_first(_Iterator __a, _Iterator __b, _Iterator __c)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_Iterator>::value_type>)
++
++      if (*__a < *__b)
++	{
++	  if (*__b < *__c)
++	    std::iter_swap(__a, __b);
++	  else if (*__a < *__c)
++	    std::iter_swap(__a, __c);
++	}
++      else if (*__a < *__c)
++	return;
++      else if (*__b < *__c)
++	std::iter_swap(__a, __c);
++      else
++	std::iter_swap(__a, __b);
++    }
++
++  /// Swaps the median value of *__a, *__b and *__c under __comp to *__a
++  template<typename _Iterator, typename _Compare>
++    void
++    __move_median_first(_Iterator __a, _Iterator __b, _Iterator __c,
++			_Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BinaryFunctionConcept<_Compare, bool,
++	    typename iterator_traits<_Iterator>::value_type,
++	    typename iterator_traits<_Iterator>::value_type>)
++
++      if (__comp(*__a, *__b))
++	{
++	  if (__comp(*__b, *__c))
++	    std::iter_swap(__a, __b);
++	  else if (__comp(*__a, *__c))
++	    std::iter_swap(__a, __c);
++	}
++      else if (__comp(*__a, *__c))
++	return;
++      else if (__comp(*__b, *__c))
++	std::iter_swap(__a, __c);
++      else
++	std::iter_swap(__a, __b);
++    }
++
++  // for_each
++
++  /// This is an overload used by find() for the Input Iterator case.
++  template<typename _InputIterator, typename _Tp>
++    inline _InputIterator
++    __find(_InputIterator __first, _InputIterator __last,
++	   const _Tp& __val, input_iterator_tag)
++    {
++      while (__first != __last && !(*__first == __val))
++	++__first;
++      return __first;
++    }
++
++  /// This is an overload used by find_if() for the Input Iterator case.
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    __find_if(_InputIterator __first, _InputIterator __last,
++	      _Predicate __pred, input_iterator_tag)
++    {
++      while (__first != __last && !bool(__pred(*__first)))
++	++__first;
++      return __first;
++    }
++
++  /// This is an overload used by find() for the RAI case.
++  template<typename _RandomAccessIterator, typename _Tp>
++    _RandomAccessIterator
++    __find(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	   const _Tp& __val, random_access_iterator_tag)
++    {
++      typename iterator_traits<_RandomAccessIterator>::difference_type
++	__trip_count = (__last - __first) >> 2;
++
++      for (; __trip_count > 0; --__trip_count)
++	{
++	  if (*__first == __val)
++	    return __first;
++	  ++__first;
++
++	  if (*__first == __val)
++	    return __first;
++	  ++__first;
++
++	  if (*__first == __val)
++	    return __first;
++	  ++__first;
++
++	  if (*__first == __val)
++	    return __first;
++	  ++__first;
++	}
++
++      switch (__last - __first)
++	{
++	case 3:
++	  if (*__first == __val)
++	    return __first;
++	  ++__first;
++	case 2:
++	  if (*__first == __val)
++	    return __first;
++	  ++__first;
++	case 1:
++	  if (*__first == __val)
++	    return __first;
++	  ++__first;
++	case 0:
++	default:
++	  return __last;
++	}
++    }
++
++  /// This is an overload used by find_if() for the RAI case.
++  template<typename _RandomAccessIterator, typename _Predicate>
++    _RandomAccessIterator
++    __find_if(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	      _Predicate __pred, random_access_iterator_tag)
++    {
++      typename iterator_traits<_RandomAccessIterator>::difference_type
++	__trip_count = (__last - __first) >> 2;
++
++      for (; __trip_count > 0; --__trip_count)
++	{
++	  if (__pred(*__first))
++	    return __first;
++	  ++__first;
++
++	  if (__pred(*__first))
++	    return __first;
++	  ++__first;
++
++	  if (__pred(*__first))
++	    return __first;
++	  ++__first;
++
++	  if (__pred(*__first))
++	    return __first;
++	  ++__first;
++	}
++
++      switch (__last - __first)
++	{
++	case 3:
++	  if (__pred(*__first))
++	    return __first;
++	  ++__first;
++	case 2:
++	  if (__pred(*__first))
++	    return __first;
++	  ++__first;
++	case 1:
++	  if (__pred(*__first))
++	    return __first;
++	  ++__first;
++	case 0:
++	default:
++	  return __last;
++	}
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  /// This is an overload used by find_if_not() for the Input Iterator case.
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    __find_if_not(_InputIterator __first, _InputIterator __last,
++		  _Predicate __pred, input_iterator_tag)
++    {
++      while (__first != __last && bool(__pred(*__first)))
++	++__first;
++      return __first;
++    }
++
++  /// This is an overload used by find_if_not() for the RAI case.
++  template<typename _RandomAccessIterator, typename _Predicate>
++    _RandomAccessIterator
++    __find_if_not(_RandomAccessIterator __first, _RandomAccessIterator __last,
++		  _Predicate __pred, random_access_iterator_tag)
++    {
++      typename iterator_traits<_RandomAccessIterator>::difference_type
++	__trip_count = (__last - __first) >> 2;
++
++      for (; __trip_count > 0; --__trip_count)
++	{
++	  if (!bool(__pred(*__first)))
++	    return __first;
++	  ++__first;
++
++	  if (!bool(__pred(*__first)))
++	    return __first;
++	  ++__first;
++
++	  if (!bool(__pred(*__first)))
++	    return __first;
++	  ++__first;
++
++	  if (!bool(__pred(*__first)))
++	    return __first;
++	  ++__first;
++	}
++
++      switch (__last - __first)
++	{
++	case 3:
++	  if (!bool(__pred(*__first)))
++	    return __first;
++	  ++__first;
++	case 2:
++	  if (!bool(__pred(*__first)))
++	    return __first;
++	  ++__first;
++	case 1:
++	  if (!bool(__pred(*__first)))
++	    return __first;
++	  ++__first;
++	case 0:
++	default:
++	  return __last;
++	}
++    }
++#endif
++
++  // set_difference
++  // set_intersection
++  // set_symmetric_difference
++  // set_union
++  // for_each
++  // find
++  // find_if
++  // find_first_of
++  // adjacent_find
++  // count
++  // count_if
++  // search
++
++  /**
++   *  This is an uglified
++   *  search_n(_ForwardIterator, _ForwardIterator, _Integer, const _Tp&)
++   *  overloaded for forward iterators.
++  */
++  template<typename _ForwardIterator, typename _Integer, typename _Tp>
++    _ForwardIterator
++    __search_n(_ForwardIterator __first, _ForwardIterator __last,
++	       _Integer __count, const _Tp& __val,
++	       std::forward_iterator_tag)
++    {
++      __first = _GLIBCXX_STD_A::find(__first, __last, __val);
++      while (__first != __last)
++	{
++	  typename iterator_traits<_ForwardIterator>::difference_type
++	    __n = __count;
++	  _ForwardIterator __i = __first;
++	  ++__i;
++	  while (__i != __last && __n != 1 && *__i == __val)
++	    {
++	      ++__i;
++	      --__n;
++	    }
++	  if (__n == 1)
++	    return __first;
++	  if (__i == __last)
++	    return __last;
++	  __first = _GLIBCXX_STD_A::find(++__i, __last, __val);
++	}
++      return __last;
++    }
++
++  /**
++   *  This is an uglified
++   *  search_n(_ForwardIterator, _ForwardIterator, _Integer, const _Tp&)
++   *  overloaded for random access iterators.
++  */
++  template<typename _RandomAccessIter, typename _Integer, typename _Tp>
++    _RandomAccessIter
++    __search_n(_RandomAccessIter __first, _RandomAccessIter __last,
++	       _Integer __count, const _Tp& __val, 
++	       std::random_access_iterator_tag)
++    {
++      
++      typedef typename std::iterator_traits<_RandomAccessIter>::difference_type
++	_DistanceType;
++
++      _DistanceType __tailSize = __last - __first;
++      const _DistanceType __pattSize = __count;
++
++      if (__tailSize < __pattSize)
++        return __last;
++
++      const _DistanceType __skipOffset = __pattSize - 1;
++      _RandomAccessIter __lookAhead = __first + __skipOffset;
++      __tailSize -= __pattSize;
++
++      while (1) // the main loop...
++	{
++	  // __lookAhead here is always pointing to the last element of next 
++	  // possible match.
++	  while (!(*__lookAhead == __val)) // the skip loop...
++	    {
++	      if (__tailSize < __pattSize)
++		return __last;  // Failure
++	      __lookAhead += __pattSize;
++	      __tailSize -= __pattSize;
++	    }
++	  _DistanceType __remainder = __skipOffset;
++	  for (_RandomAccessIter __backTrack = __lookAhead - 1; 
++	       *__backTrack == __val; --__backTrack)
++	    {
++	      if (--__remainder == 0)
++		return (__lookAhead - __skipOffset); // Success
++	    }
++	  if (__remainder > __tailSize)
++	    return __last; // Failure
++	  __lookAhead += __remainder;
++	  __tailSize -= __remainder;
++	}
++    }
++
++  // search_n
++
++  /**
++   *  This is an uglified
++   *  search_n(_ForwardIterator, _ForwardIterator, _Integer, const _Tp&,
++   *	       _BinaryPredicate)
++   *  overloaded for forward iterators.
++  */
++  template<typename _ForwardIterator, typename _Integer, typename _Tp,
++           typename _BinaryPredicate>
++    _ForwardIterator
++    __search_n(_ForwardIterator __first, _ForwardIterator __last,
++	       _Integer __count, const _Tp& __val,
++	       _BinaryPredicate __binary_pred, std::forward_iterator_tag)
++    {
++      while (__first != __last && !bool(__binary_pred(*__first, __val)))
++        ++__first;
++
++      while (__first != __last)
++	{
++	  typename iterator_traits<_ForwardIterator>::difference_type
++	    __n = __count;
++	  _ForwardIterator __i = __first;
++	  ++__i;
++	  while (__i != __last && __n != 1 && bool(__binary_pred(*__i, __val)))
++	    {
++	      ++__i;
++	      --__n;
++	    }
++	  if (__n == 1)
++	    return __first;
++	  if (__i == __last)
++	    return __last;
++	  __first = ++__i;
++	  while (__first != __last
++		 && !bool(__binary_pred(*__first, __val)))
++	    ++__first;
++	}
++      return __last;
++    }
++
++  /**
++   *  This is an uglified
++   *  search_n(_ForwardIterator, _ForwardIterator, _Integer, const _Tp&,
++   *	       _BinaryPredicate)
++   *  overloaded for random access iterators.
++  */
++  template<typename _RandomAccessIter, typename _Integer, typename _Tp,
++	   typename _BinaryPredicate>
++    _RandomAccessIter
++    __search_n(_RandomAccessIter __first, _RandomAccessIter __last,
++	       _Integer __count, const _Tp& __val,
++	       _BinaryPredicate __binary_pred, std::random_access_iterator_tag)
++    {
++      
++      typedef typename std::iterator_traits<_RandomAccessIter>::difference_type
++	_DistanceType;
++
++      _DistanceType __tailSize = __last - __first;
++      const _DistanceType __pattSize = __count;
++
++      if (__tailSize < __pattSize)
++        return __last;
++
++      const _DistanceType __skipOffset = __pattSize - 1;
++      _RandomAccessIter __lookAhead = __first + __skipOffset;
++      __tailSize -= __pattSize;
++
++      while (1) // the main loop...
++	{
++	  // __lookAhead here is always pointing to the last element of next 
++	  // possible match.
++	  while (!bool(__binary_pred(*__lookAhead, __val))) // the skip loop...
++	    {
++	      if (__tailSize < __pattSize)
++		return __last;  // Failure
++	      __lookAhead += __pattSize;
++	      __tailSize -= __pattSize;
++	    }
++	  _DistanceType __remainder = __skipOffset;
++	  for (_RandomAccessIter __backTrack = __lookAhead - 1; 
++	       __binary_pred(*__backTrack, __val); --__backTrack)
++	    {
++	      if (--__remainder == 0)
++		return (__lookAhead - __skipOffset); // Success
++	    }
++	  if (__remainder > __tailSize)
++	    return __last; // Failure
++	  __lookAhead += __remainder;
++	  __tailSize -= __remainder;
++	}
++    }
++
++  // find_end for forward iterators.
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    _ForwardIterator1
++    __find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	       _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	       forward_iterator_tag, forward_iterator_tag)
++    {
++      if (__first2 == __last2)
++	return __last1;
++      else
++	{
++	  _ForwardIterator1 __result = __last1;
++	  while (1)
++	    {
++	      _ForwardIterator1 __new_result
++		= _GLIBCXX_STD_A::search(__first1, __last1, __first2, __last2);
++	      if (__new_result == __last1)
++		return __result;
++	      else
++		{
++		  __result = __new_result;
++		  __first1 = __new_result;
++		  ++__first1;
++		}
++	    }
++	}
++    }
++
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    _ForwardIterator1
++    __find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	       _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	       forward_iterator_tag, forward_iterator_tag,
++	       _BinaryPredicate __comp)
++    {
++      if (__first2 == __last2)
++	return __last1;
++      else
++	{
++	  _ForwardIterator1 __result = __last1;
++	  while (1)
++	    {
++	      _ForwardIterator1 __new_result
++		= _GLIBCXX_STD_A::search(__first1, __last1, __first2,
++					 __last2, __comp);
++	      if (__new_result == __last1)
++		return __result;
++	      else
++		{
++		  __result = __new_result;
++		  __first1 = __new_result;
++		  ++__first1;
++		}
++	    }
++	}
++    }
++
++  // find_end for bidirectional iterators (much faster).
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2>
++    _BidirectionalIterator1
++    __find_end(_BidirectionalIterator1 __first1,
++	       _BidirectionalIterator1 __last1,
++	       _BidirectionalIterator2 __first2,
++	       _BidirectionalIterator2 __last2,
++	       bidirectional_iterator_tag, bidirectional_iterator_tag)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator1>)
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator2>)
++
++      typedef reverse_iterator<_BidirectionalIterator1> _RevIterator1;
++      typedef reverse_iterator<_BidirectionalIterator2> _RevIterator2;
++
++      _RevIterator1 __rlast1(__first1);
++      _RevIterator2 __rlast2(__first2);
++      _RevIterator1 __rresult = _GLIBCXX_STD_A::search(_RevIterator1(__last1),
++						       __rlast1,
++						       _RevIterator2(__last2),
++						       __rlast2);
++
++      if (__rresult == __rlast1)
++	return __last1;
++      else
++	{
++	  _BidirectionalIterator1 __result = __rresult.base();
++	  std::advance(__result, -std::distance(__first2, __last2));
++	  return __result;
++	}
++    }
++
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2,
++	   typename _BinaryPredicate>
++    _BidirectionalIterator1
++    __find_end(_BidirectionalIterator1 __first1,
++	       _BidirectionalIterator1 __last1,
++	       _BidirectionalIterator2 __first2,
++	       _BidirectionalIterator2 __last2,
++	       bidirectional_iterator_tag, bidirectional_iterator_tag,
++	       _BinaryPredicate __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator1>)
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator2>)
++
++      typedef reverse_iterator<_BidirectionalIterator1> _RevIterator1;
++      typedef reverse_iterator<_BidirectionalIterator2> _RevIterator2;
++
++      _RevIterator1 __rlast1(__first1);
++      _RevIterator2 __rlast2(__first2);
++      _RevIterator1 __rresult = std::search(_RevIterator1(__last1), __rlast1,
++					    _RevIterator2(__last2), __rlast2,
++					    __comp);
++
++      if (__rresult == __rlast1)
++	return __last1;
++      else
++	{
++	  _BidirectionalIterator1 __result = __rresult.base();
++	  std::advance(__result, -std::distance(__first2, __last2));
++	  return __result;
++	}
++    }
++
++  /**
++   *  @brief  Find last matching subsequence in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of sequence to match.
++   *  @param  __last2   End of sequence to match.
++   *  @return   The last iterator @c i in the range
++   *  @p [__first1,__last1-(__last2-__first2)) such that @c *(i+N) ==
++   *  @p *(__first2+N) for each @c N in the range @p
++   *  [0,__last2-__first2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2) and returns an iterator to the __first
++   *  element of the sub-sequence, or @p __last1 if the sub-sequence
++   *  is not found.  The sub-sequence will be the last such
++   *  subsequence contained in [__first,__last1).
++   *
++   *  Because the sub-sequence must lie completely within the range @p
++   *  [__first1,__last1) it must start at a position less than @p
++   *  __last1-(__last2-__first2) where @p __last2-__first2 is the
++   *  length of the sub-sequence.  This means that the returned
++   *  iterator @c i will be in the range @p
++   *  [__first1,__last1-(__last2-__first2))
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    inline _ForwardIterator1
++    find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	     _ForwardIterator2 __first2, _ForwardIterator2 __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__find_end(__first1, __last1, __first2, __last2,
++			     std::__iterator_category(__first1),
++			     std::__iterator_category(__first2));
++    }
++
++  /**
++   *  @brief  Find last matching subsequence in a sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of sequence to match.
++   *  @param  __last2   End of sequence to match.
++   *  @param  __comp    The predicate to use.
++   *  @return The last iterator @c i in the range @p
++   *  [__first1,__last1-(__last2-__first2)) such that @c
++   *  predicate(*(i+N), @p (__first2+N)) is true for each @c N in the
++   *  range @p [0,__last2-__first2), or @p __last1 if no such iterator
++   *  exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2) using comp as a predicate and returns an
++   *  iterator to the first element of the sub-sequence, or @p __last1
++   *  if the sub-sequence is not found.  The sub-sequence will be the
++   *  last such subsequence contained in [__first,__last1).
++   *
++   *  Because the sub-sequence must lie completely within the range @p
++   *  [__first1,__last1) it must start at a position less than @p
++   *  __last1-(__last2-__first2) where @p __last2-__first2 is the
++   *  length of the sub-sequence.  This means that the returned
++   *  iterator @c i will be in the range @p
++   *  [__first1,__last1-(__last2-__first2))
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    inline _ForwardIterator1
++    find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	     _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	     _BinaryPredicate __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__find_end(__first1, __last1, __first2, __last2,
++			     std::__iterator_category(__first1),
++			     std::__iterator_category(__first2),
++			     __comp);
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  /**
++   *  @brief  Checks that a predicate is true for all the elements
++   *          of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __pred    A predicate.
++   *  @return  True if the check is true, false otherwise.
++   *
++   *  Returns true if @p __pred is true for each element in the range
++   *  @p [__first,__last), and false otherwise.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    all_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    { return __last == std::find_if_not(__first, __last, __pred); }
++
++  /**
++   *  @brief  Checks that a predicate is false for all the elements
++   *          of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __pred    A predicate.
++   *  @return  True if the check is true, false otherwise.
++   *
++   *  Returns true if @p __pred is false for each element in the range
++   *  @p [__first,__last), and false otherwise.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    none_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    { return __last == _GLIBCXX_STD_A::find_if(__first, __last, __pred); }
++
++  /**
++   *  @brief  Checks that a predicate is false for at least an element
++   *          of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __pred    A predicate.
++   *  @return  True if the check is true, false otherwise.
++   *
++   *  Returns true if an element exists in the range @p
++   *  [__first,__last) such that @p __pred is true, and false
++   *  otherwise.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    any_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    { return !std::none_of(__first, __last, __pred); }
++
++  /**
++   *  @brief  Find the first element in a sequence for which a
++   *          predicate is false.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return   The first iterator @c i in the range @p [__first,__last)
++   *  such that @p __pred(*i) is false, or @p __last if no such iterator exists.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    find_if_not(_InputIterator __first, _InputIterator __last,
++		_Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	      typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      return std::__find_if_not(__first, __last, __pred,
++				std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief  Checks whether the sequence is partitioned.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return  True if the range @p [__first,__last) is partioned by @p __pred,
++   *  i.e. if all elements that satisfy @p __pred appear before those that
++   *  do not.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    is_partitioned(_InputIterator __first, _InputIterator __last,
++		   _Predicate __pred)
++    {
++      __first = std::find_if_not(__first, __last, __pred);
++      return std::none_of(__first, __last, __pred);
++    }
++
++  /**
++   *  @brief  Find the partition point of a partitioned range.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __pred    A predicate.
++   *  @return  An iterator @p mid such that @p all_of(__first, mid, __pred)
++   *           and @p none_of(mid, __last, __pred) are both true.
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    partition_point(_ForwardIterator __first, _ForwardIterator __last,
++		    _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	      typename iterator_traits<_ForwardIterator>::value_type>)
++
++      // A specific debug-mode test will be necessary...
++      __glibcxx_requires_valid_range(__first, __last);
++
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      _DistanceType __len = std::distance(__first, __last);
++      _DistanceType __half;
++      _ForwardIterator __middle;
++
++      while (__len > 0)
++	{
++	  __half = __len >> 1;
++	  __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__pred(*__middle))
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else
++	    __len = __half;
++	}
++      return __first;
++    }
++#endif
++
++
++  /**
++   *  @brief Copy a sequence, removing elements of a given value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @param  __value   The value to be removed.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) not equal
++   *  to @p __value to the range beginning at @p __result.
++   *  remove_copy() is stable, so the relative order of elements that
++   *  are copied is unchanged.
++  */
++  template<typename _InputIterator, typename _OutputIterator, typename _Tp>
++    _OutputIterator
++    remove_copy(_InputIterator __first, _InputIterator __last,
++		_OutputIterator __result, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (!(*__first == __value))
++	  {
++	    *__result = *__first;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++  /**
++   *  @brief Copy a sequence, removing elements for which a predicate is true.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @param  __pred    A predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) for which
++   *  @p __pred returns false to the range beginning at @p __result.
++   *
++   *  remove_copy_if() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate>
++    _OutputIterator
++    remove_copy_if(_InputIterator __first, _InputIterator __last,
++		   _OutputIterator __result, _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (!bool(__pred(*__first)))
++	  {
++	    *__result = *__first;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  /**
++   *  @brief Copy the elements of a sequence for which a predicate is true.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @param  __pred    A predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) for which
++   *  @p __pred returns true to the range beginning at @p __result.
++   *
++   *  copy_if() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate>
++    _OutputIterator
++    copy_if(_InputIterator __first, _InputIterator __last,
++	    _OutputIterator __result, _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (__pred(*__first))
++	  {
++	    *__result = *__first;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++
++  template<typename _InputIterator, typename _Size, typename _OutputIterator>
++    _OutputIterator
++    __copy_n(_InputIterator __first, _Size __n,
++	     _OutputIterator __result, input_iterator_tag)
++    {
++      if (__n > 0)
++	{
++	  while (true)
++	    {
++	      *__result = *__first;
++	      ++__result;
++	      if (--__n > 0)
++		++__first;
++	      else
++		break;
++	    }
++	}
++      return __result;
++    }
++
++  template<typename _RandomAccessIterator, typename _Size,
++	   typename _OutputIterator>
++    inline _OutputIterator
++    __copy_n(_RandomAccessIterator __first, _Size __n,
++	     _OutputIterator __result, random_access_iterator_tag)
++    { return std::copy(__first, __first + __n, __result); }
++
++  /**
++   *  @brief Copies the range [first,first+n) into [result,result+n).
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __n      The number of elements to copy.
++   *  @param  __result An output iterator.
++   *  @return  result+n.
++   *
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).
++  */
++  template<typename _InputIterator, typename _Size, typename _OutputIterator>
++    inline _OutputIterator
++    copy_n(_InputIterator __first, _Size __n, _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++
++      return std::__copy_n(__first, __n, __result,
++			   std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief Copy the elements of a sequence to separate output sequences
++   *         depending on the truth value of a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __out_true   An output iterator.
++   *  @param  __out_false  An output iterator.
++   *  @param  __pred    A predicate.
++   *  @return   A pair designating the ends of the resulting sequences.
++   *
++   *  Copies each element in the range @p [__first,__last) for which
++   *  @p __pred returns true to the range beginning at @p out_true
++   *  and each element for which @p __pred returns false to @p __out_false.
++  */
++  template<typename _InputIterator, typename _OutputIterator1,
++	   typename _OutputIterator2, typename _Predicate>
++    pair<_OutputIterator1, _OutputIterator2>
++    partition_copy(_InputIterator __first, _InputIterator __last,
++		   _OutputIterator1 __out_true, _OutputIterator2 __out_false,
++		   _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator1,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator2,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      
++      for (; __first != __last; ++__first)
++	if (__pred(*__first))
++	  {
++	    *__out_true = *__first;
++	    ++__out_true;
++	  }
++	else
++	  {
++	    *__out_false = *__first;
++	    ++__out_false;
++	  }
++
++      return pair<_OutputIterator1, _OutputIterator2>(__out_true, __out_false);
++    }
++#endif
++
++  /**
++   *  @brief Remove elements from a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __value  The value to be removed.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  All elements equal to @p __value are removed from the range
++   *  @p [__first,__last).
++   *
++   *  remove() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    _ForwardIterator
++    remove(_ForwardIterator __first, _ForwardIterator __last,
++	   const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      __first = _GLIBCXX_STD_A::find(__first, __last, __value);
++      if(__first == __last)
++        return __first;
++      _ForwardIterator __result = __first;
++      ++__first;
++      for(; __first != __last; ++__first)
++        if(!(*__first == __value))
++          {
++            *__result = _GLIBCXX_MOVE(*__first);
++            ++__result;
++          }
++      return __result;
++    }
++
++  /**
++   *  @brief Remove elements from a sequence using a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __pred   A predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  All elements for which @p __pred returns true are removed from the range
++   *  @p [__first,__last).
++   *
++   *  remove_if() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    remove_if(_ForwardIterator __first, _ForwardIterator __last,
++	      _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      __first = _GLIBCXX_STD_A::find_if(__first, __last, __pred);
++      if(__first == __last)
++        return __first;
++      _ForwardIterator __result = __first;
++      ++__first;
++      for(; __first != __last; ++__first)
++        if(!bool(__pred(*__first)))
++          {
++            *__result = _GLIBCXX_MOVE(*__first);
++            ++__result;
++          }
++      return __result;
++    }
++
++  /**
++   *  @brief Remove consecutive duplicate values from a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @return  An iterator designating the end of the resulting sequence.
++   *
++   *  Removes all but the first element from each group of consecutive
++   *  values that compare equal.
++   *  unique() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator>
++    _ForwardIterator
++    unique(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_EqualityComparableConcept<
++		     typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      // Skip the beginning, if already unique.
++      __first = _GLIBCXX_STD_A::adjacent_find(__first, __last);
++      if (__first == __last)
++	return __last;
++
++      // Do the real copy work.
++      _ForwardIterator __dest = __first;
++      ++__first;
++      while (++__first != __last)
++	if (!(*__dest == *__first))
++	  *++__dest = _GLIBCXX_MOVE(*__first);
++      return ++__dest;
++    }
++
++  /**
++   *  @brief Remove consecutive values from a sequence using a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first        A forward iterator.
++   *  @param  __last         A forward iterator.
++   *  @param  __binary_pred  A binary predicate.
++   *  @return  An iterator designating the end of the resulting sequence.
++   *
++   *  Removes all but the first element from each group of consecutive
++   *  values for which @p __binary_pred returns true.
++   *  unique() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator, typename _BinaryPredicate>
++    _ForwardIterator
++    unique(_ForwardIterator __first, _ForwardIterator __last,
++           _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++		typename iterator_traits<_ForwardIterator>::value_type,
++		typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      // Skip the beginning, if already unique.
++      __first = _GLIBCXX_STD_A::adjacent_find(__first, __last, __binary_pred);
++      if (__first == __last)
++	return __last;
++
++      // Do the real copy work.
++      _ForwardIterator __dest = __first;
++      ++__first;
++      while (++__first != __last)
++	if (!bool(__binary_pred(*__dest, *__first)))
++	  *++__dest = _GLIBCXX_MOVE(*__first);
++      return ++__dest;
++    }
++
++  /**
++   *  This is an uglified unique_copy(_InputIterator, _InputIterator,
++   *                                  _OutputIterator)
++   *  overloaded for forward iterators and output iterator as result.
++  */
++  template<typename _ForwardIterator, typename _OutputIterator>
++    _OutputIterator
++    __unique_copy(_ForwardIterator __first, _ForwardIterator __last,
++		  _OutputIterator __result,
++		  forward_iterator_tag, output_iterator_tag)
++    {
++      // concept requirements -- taken care of in dispatching function
++      _ForwardIterator __next = __first;
++      *__result = *__first;
++      while (++__next != __last)
++	if (!(*__first == *__next))
++	  {
++	    __first = __next;
++	    *++__result = *__first;
++	  }
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified unique_copy(_InputIterator, _InputIterator,
++   *                                  _OutputIterator)
++   *  overloaded for input iterators and output iterator as result.
++  */
++  template<typename _InputIterator, typename _OutputIterator>
++    _OutputIterator
++    __unique_copy(_InputIterator __first, _InputIterator __last,
++		  _OutputIterator __result,
++		  input_iterator_tag, output_iterator_tag)
++    {
++      // concept requirements -- taken care of in dispatching function
++      typename iterator_traits<_InputIterator>::value_type __value = *__first;
++      *__result = __value;
++      while (++__first != __last)
++	if (!(__value == *__first))
++	  {
++	    __value = *__first;
++	    *++__result = __value;
++	  }
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified unique_copy(_InputIterator, _InputIterator,
++   *                                  _OutputIterator)
++   *  overloaded for input iterators and forward iterator as result.
++  */
++  template<typename _InputIterator, typename _ForwardIterator>
++    _ForwardIterator
++    __unique_copy(_InputIterator __first, _InputIterator __last,
++		  _ForwardIterator __result,
++		  input_iterator_tag, forward_iterator_tag)
++    {
++      // concept requirements -- taken care of in dispatching function
++      *__result = *__first;
++      while (++__first != __last)
++	if (!(*__result == *__first))
++	  *++__result = *__first;
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified
++   *  unique_copy(_InputIterator, _InputIterator, _OutputIterator,
++   *              _BinaryPredicate)
++   *  overloaded for forward iterators and output iterator as result.
++  */
++  template<typename _ForwardIterator, typename _OutputIterator,
++	   typename _BinaryPredicate>
++    _OutputIterator
++    __unique_copy(_ForwardIterator __first, _ForwardIterator __last,
++		  _OutputIterator __result, _BinaryPredicate __binary_pred,
++		  forward_iterator_tag, output_iterator_tag)
++    {
++      // concept requirements -- iterators already checked
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	  typename iterator_traits<_ForwardIterator>::value_type,
++	  typename iterator_traits<_ForwardIterator>::value_type>)
++
++      _ForwardIterator __next = __first;
++      *__result = *__first;
++      while (++__next != __last)
++	if (!bool(__binary_pred(*__first, *__next)))
++	  {
++	    __first = __next;
++	    *++__result = *__first;
++	  }
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified
++   *  unique_copy(_InputIterator, _InputIterator, _OutputIterator,
++   *              _BinaryPredicate)
++   *  overloaded for input iterators and output iterator as result.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _BinaryPredicate>
++    _OutputIterator
++    __unique_copy(_InputIterator __first, _InputIterator __last,
++		  _OutputIterator __result, _BinaryPredicate __binary_pred,
++		  input_iterator_tag, output_iterator_tag)
++    {
++      // concept requirements -- iterators already checked
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	  typename iterator_traits<_InputIterator>::value_type,
++	  typename iterator_traits<_InputIterator>::value_type>)
++
++      typename iterator_traits<_InputIterator>::value_type __value = *__first;
++      *__result = __value;
++      while (++__first != __last)
++	if (!bool(__binary_pred(__value, *__first)))
++	  {
++	    __value = *__first;
++	    *++__result = __value;
++	  }
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified
++   *  unique_copy(_InputIterator, _InputIterator, _OutputIterator,
++   *              _BinaryPredicate)
++   *  overloaded for input iterators and forward iterator as result.
++  */
++  template<typename _InputIterator, typename _ForwardIterator,
++	   typename _BinaryPredicate>
++    _ForwardIterator
++    __unique_copy(_InputIterator __first, _InputIterator __last,
++		  _ForwardIterator __result, _BinaryPredicate __binary_pred,
++		  input_iterator_tag, forward_iterator_tag)
++    {
++      // concept requirements -- iterators already checked
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	  typename iterator_traits<_ForwardIterator>::value_type,
++	  typename iterator_traits<_InputIterator>::value_type>)
++
++      *__result = *__first;
++      while (++__first != __last)
++	if (!bool(__binary_pred(*__result, *__first)))
++	  *++__result = *__first;
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified reverse(_BidirectionalIterator,
++   *                              _BidirectionalIterator)
++   *  overloaded for bidirectional iterators.
++  */
++  template<typename _BidirectionalIterator>
++    void
++    __reverse(_BidirectionalIterator __first, _BidirectionalIterator __last,
++	      bidirectional_iterator_tag)
++    {
++      while (true)
++	if (__first == __last || __first == --__last)
++	  return;
++	else
++	  {
++	    std::iter_swap(__first, __last);
++	    ++__first;
++	  }
++    }
++
++  /**
++   *  This is an uglified reverse(_BidirectionalIterator,
++   *                              _BidirectionalIterator)
++   *  overloaded for random access iterators.
++  */
++  template<typename _RandomAccessIterator>
++    void
++    __reverse(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	      random_access_iterator_tag)
++    {
++      if (__first == __last)
++	return;
++      --__last;
++      while (__first < __last)
++	{
++	  std::iter_swap(__first, __last);
++	  ++__first;
++	  --__last;
++	}
++    }
++
++  /**
++   *  @brief Reverse a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A bidirectional iterator.
++   *  @param  __last   A bidirectional iterator.
++   *  @return   reverse() returns no value.
++   *
++   *  Reverses the order of the elements in the range @p [__first,__last),
++   *  so that the first element becomes the last etc.
++   *  For every @c i such that @p 0<=i<=(__last-__first)/2), @p reverse()
++   *  swaps @p *(__first+i) and @p *(__last-(i+1))
++  */
++  template<typename _BidirectionalIterator>
++    inline void
++    reverse(_BidirectionalIterator __first, _BidirectionalIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++      std::__reverse(__first, __last, std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief Copy a sequence, reversing its elements.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A bidirectional iterator.
++   *  @param  __last    A bidirectional iterator.
++   *  @param  __result  An output iterator.
++   *  @return  An iterator designating the end of the resulting sequence.
++   *
++   *  Copies the elements in the range @p [__first,__last) to the
++   *  range @p [__result,__result+(__last-__first)) such that the
++   *  order of the elements is reversed.  For every @c i such that @p
++   *  0<=i<=(__last-__first), @p reverse_copy() performs the
++   *  assignment @p *(__result+(__last-__first)-i) = *(__first+i).
++   *  The ranges @p [__first,__last) and @p
++   *  [__result,__result+(__last-__first)) must not overlap.
++  */
++  template<typename _BidirectionalIterator, typename _OutputIterator>
++    _OutputIterator
++    reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last,
++		 _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++		typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      while (__first != __last)
++	{
++	  --__last;
++	  *__result = *__last;
++	  ++__result;
++	}
++      return __result;
++    }
++
++  /**
++   *  This is a helper function for the rotate algorithm specialized on RAIs.
++   *  It returns the greatest common divisor of two integer values.
++  */
++  template<typename _EuclideanRingElement>
++    _EuclideanRingElement
++    __gcd(_EuclideanRingElement __m, _EuclideanRingElement __n)
++    {
++      while (__n != 0)
++	{
++	  _EuclideanRingElement __t = __m % __n;
++	  __m = __n;
++	  __n = __t;
++	}
++      return __m;
++    }
++
++  /// This is a helper function for the rotate algorithm.
++  template<typename _ForwardIterator>
++    void
++    __rotate(_ForwardIterator __first,
++	     _ForwardIterator __middle,
++	     _ForwardIterator __last,
++	     forward_iterator_tag)
++    {
++      if (__first == __middle || __last  == __middle)
++	return;
++
++      _ForwardIterator __first2 = __middle;
++      do
++	{
++	  std::iter_swap(__first, __first2);
++	  ++__first;
++	  ++__first2;
++	  if (__first == __middle)
++	    __middle = __first2;
++	}
++      while (__first2 != __last);
++
++      __first2 = __middle;
++
++      while (__first2 != __last)
++	{
++	  std::iter_swap(__first, __first2);
++	  ++__first;
++	  ++__first2;
++	  if (__first == __middle)
++	    __middle = __first2;
++	  else if (__first2 == __last)
++	    __first2 = __middle;
++	}
++    }
++
++   /// This is a helper function for the rotate algorithm.
++  template<typename _BidirectionalIterator>
++    void
++    __rotate(_BidirectionalIterator __first,
++	     _BidirectionalIterator __middle,
++	     _BidirectionalIterator __last,
++	      bidirectional_iterator_tag)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++
++      if (__first == __middle || __last  == __middle)
++	return;
++
++      std::__reverse(__first,  __middle, bidirectional_iterator_tag());
++      std::__reverse(__middle, __last,   bidirectional_iterator_tag());
++
++      while (__first != __middle && __middle != __last)
++	{
++	  std::iter_swap(__first, --__last);
++	  ++__first;
++	}
++
++      if (__first == __middle)
++	std::__reverse(__middle, __last,   bidirectional_iterator_tag());
++      else
++	std::__reverse(__first,  __middle, bidirectional_iterator_tag());
++    }
++
++  /// This is a helper function for the rotate algorithm.
++  template<typename _RandomAccessIterator>
++    void
++    __rotate(_RandomAccessIterator __first,
++	     _RandomAccessIterator __middle,
++	     _RandomAccessIterator __last,
++	     random_access_iterator_tag)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++
++      if (__first == __middle || __last  == __middle)
++	return;
++
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_Distance;
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      _Distance __n = __last   - __first;
++      _Distance __k = __middle - __first;
++
++      if (__k == __n - __k)
++	{
++	  std::swap_ranges(__first, __middle, __middle);
++	  return;
++	}
++
++      _RandomAccessIterator __p = __first;
++
++      for (;;)
++	{
++	  if (__k < __n - __k)
++	    {
++	      if (__is_pod(_ValueType) && __k == 1)
++		{
++		  _ValueType __t = _GLIBCXX_MOVE(*__p);
++		  _GLIBCXX_MOVE3(__p + 1, __p + __n, __p);
++		  *(__p + __n - 1) = _GLIBCXX_MOVE(__t);
++		  return;
++		}
++	      _RandomAccessIterator __q = __p + __k;
++	      for (_Distance __i = 0; __i < __n - __k; ++ __i)
++		{
++		  std::iter_swap(__p, __q);
++		  ++__p;
++		  ++__q;
++		}
++	      __n %= __k;
++	      if (__n == 0)
++		return;
++	      std::swap(__n, __k);
++	      __k = __n - __k;
++	    }
++	  else
++	    {
++	      __k = __n - __k;
++	      if (__is_pod(_ValueType) && __k == 1)
++		{
++		  _ValueType __t = _GLIBCXX_MOVE(*(__p + __n - 1));
++		  _GLIBCXX_MOVE_BACKWARD3(__p, __p + __n - 1, __p + __n);
++		  *__p = _GLIBCXX_MOVE(__t);
++		  return;
++		}
++	      _RandomAccessIterator __q = __p + __n;
++	      __p = __q - __k;
++	      for (_Distance __i = 0; __i < __n - __k; ++ __i)
++		{
++		  --__p;
++		  --__q;
++		  std::iter_swap(__p, __q);
++		}
++	      __n %= __k;
++	      if (__n == 0)
++		return;
++	      std::swap(__n, __k);
++	    }
++	}
++    }
++
++  /**
++   *  @brief Rotate the elements of a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __middle  A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @return  Nothing.
++   *
++   *  Rotates the elements of the range @p [__first,__last) by 
++   *  @p (__middle - __first) positions so that the element at @p __middle
++   *  is moved to @p __first, the element at @p __middle+1 is moved to
++   *  @p __first+1 and so on for each element in the range
++   *  @p [__first,__last).
++   *
++   *  This effectively swaps the ranges @p [__first,__middle) and
++   *  @p [__middle,__last).
++   *
++   *  Performs
++   *   @p *(__first+(n+(__last-__middle))%(__last-__first))=*(__first+n)
++   *  for each @p n in the range @p [0,__last-__first).
++  */
++  template<typename _ForwardIterator>
++    inline void
++    rotate(_ForwardIterator __first, _ForwardIterator __middle,
++	   _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      typedef typename iterator_traits<_ForwardIterator>::iterator_category
++	_IterType;
++      std::__rotate(__first, __middle, __last, _IterType());
++    }
++
++  /**
++   *  @brief Copy a sequence, rotating its elements.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __middle  A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __result  An output iterator.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies the elements of the range @p [__first,__last) to the
++   *  range beginning at @result, rotating the copied elements by 
++   *  @p (__middle-__first) positions so that the element at @p __middle
++   *  is moved to @p __result, the element at @p __middle+1 is moved
++   *  to @p __result+1 and so on for each element in the range @p
++   *  [__first,__last).
++   *
++   *  Performs 
++   *  @p *(__result+(n+(__last-__middle))%(__last-__first))=*(__first+n)
++   *  for each @p n in the range @p [0,__last-__first).
++  */
++  template<typename _ForwardIterator, typename _OutputIterator>
++    _OutputIterator
++    rotate_copy(_ForwardIterator __first, _ForwardIterator __middle,
++                _ForwardIterator __last, _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++		typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      return std::copy(__first, __middle,
++                       std::copy(__middle, __last, __result));
++    }
++
++  /// This is a helper function...
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    __partition(_ForwardIterator __first, _ForwardIterator __last,
++		_Predicate __pred, forward_iterator_tag)
++    {
++      if (__first == __last)
++	return __first;
++
++      while (__pred(*__first))
++	if (++__first == __last)
++	  return __first;
++
++      _ForwardIterator __next = __first;
++
++      while (++__next != __last)
++	if (__pred(*__next))
++	  {
++	    std::iter_swap(__first, __next);
++	    ++__first;
++	  }
++
++      return __first;
++    }
++
++  /// This is a helper function...
++  template<typename _BidirectionalIterator, typename _Predicate>
++    _BidirectionalIterator
++    __partition(_BidirectionalIterator __first, _BidirectionalIterator __last,
++		_Predicate __pred, bidirectional_iterator_tag)
++    {
++      while (true)
++	{
++	  while (true)
++	    if (__first == __last)
++	      return __first;
++	    else if (__pred(*__first))
++	      ++__first;
++	    else
++	      break;
++	  --__last;
++	  while (true)
++	    if (__first == __last)
++	      return __first;
++	    else if (!bool(__pred(*__last)))
++	      --__last;
++	    else
++	      break;
++	  std::iter_swap(__first, __last);
++	  ++__first;
++	}
++    }
++
++  // partition
++
++  /// This is a helper function...
++  template<typename _ForwardIterator, typename _Predicate, typename _Distance>
++    _ForwardIterator
++    __inplace_stable_partition(_ForwardIterator __first,
++			       _ForwardIterator __last,
++			       _Predicate __pred, _Distance __len)
++    {
++      if (__len == 1)
++	return __pred(*__first) ? __last : __first;
++      _ForwardIterator __middle = __first;
++      std::advance(__middle, __len / 2);
++      _ForwardIterator __begin = std::__inplace_stable_partition(__first,
++								 __middle,
++								 __pred,
++								 __len / 2);
++      _ForwardIterator __end = std::__inplace_stable_partition(__middle, __last,
++							       __pred,
++							       __len
++							       - __len / 2);
++      std::rotate(__begin, __middle, __end);
++      std::advance(__begin, std::distance(__middle, __end));
++      return __begin;
++    }
++
++  /// This is a helper function...
++  template<typename _ForwardIterator, typename _Pointer, typename _Predicate,
++	   typename _Distance>
++    _ForwardIterator
++    __stable_partition_adaptive(_ForwardIterator __first,
++				_ForwardIterator __last,
++				_Predicate __pred, _Distance __len,
++				_Pointer __buffer,
++				_Distance __buffer_size)
++    {
++      if (__len <= __buffer_size)
++	{
++	  _ForwardIterator __result1 = __first;
++	  _Pointer __result2 = __buffer;
++	  for (; __first != __last; ++__first)
++	    if (__pred(*__first))
++	      {
++		*__result1 = _GLIBCXX_MOVE(*__first);
++		++__result1;
++	      }
++	    else
++	      {
++		*__result2 = _GLIBCXX_MOVE(*__first);
++		++__result2;
++	      }
++	  _GLIBCXX_MOVE3(__buffer, __result2, __result1);
++	  return __result1;
++	}
++      else
++	{
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __len / 2);
++	  _ForwardIterator __begin =
++	    std::__stable_partition_adaptive(__first, __middle, __pred,
++					     __len / 2, __buffer,
++					     __buffer_size);
++	  _ForwardIterator __end =
++	    std::__stable_partition_adaptive(__middle, __last, __pred,
++					     __len - __len / 2,
++					     __buffer, __buffer_size);
++	  std::rotate(__begin, __middle, __end);
++	  std::advance(__begin, std::distance(__middle, __end));
++	  return __begin;
++	}
++    }
++
++  /**
++   *  @brief Move elements for which a predicate is true to the beginning
++   *         of a sequence, preserving relative ordering.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __pred    A predicate functor.
++   *  @return  An iterator @p middle such that @p __pred(i) is true for each
++   *  iterator @p i in the range @p [first,middle) and false for each @p i
++   *  in the range @p [middle,last).
++   *
++   *  Performs the same function as @p partition() with the additional
++   *  guarantee that the relative ordering of elements in each group is
++   *  preserved, so any two elements @p x and @p y in the range
++   *  @p [__first,__last) such that @p __pred(x)==__pred(y) will have the same
++   *  relative ordering after calling @p stable_partition().
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    stable_partition(_ForwardIterator __first, _ForwardIterator __last,
++		     _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __first;
++      else
++	{
++	  typedef typename iterator_traits<_ForwardIterator>::value_type
++	    _ValueType;
++	  typedef typename iterator_traits<_ForwardIterator>::difference_type
++	    _DistanceType;
++
++	  _Temporary_buffer<_ForwardIterator, _ValueType> __buf(__first,
++								__last);
++	if (__buf.size() > 0)
++	  return
++	    std::__stable_partition_adaptive(__first, __last, __pred,
++					  _DistanceType(__buf.requested_size()),
++					  __buf.begin(),
++					  _DistanceType(__buf.size()));
++	else
++	  return
++	    std::__inplace_stable_partition(__first, __last, __pred,
++					 _DistanceType(__buf.requested_size()));
++	}
++    }
++
++  /// This is a helper function for the sort routines.
++  template<typename _RandomAccessIterator>
++    void
++    __heap_select(_RandomAccessIterator __first,
++		  _RandomAccessIterator __middle,
++		  _RandomAccessIterator __last)
++    {
++      std::make_heap(__first, __middle);
++      for (_RandomAccessIterator __i = __middle; __i < __last; ++__i)
++	if (*__i < *__first)
++	  std::__pop_heap(__first, __middle, __i);
++    }
++
++  /// This is a helper function for the sort routines.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __heap_select(_RandomAccessIterator __first,
++		  _RandomAccessIterator __middle,
++		  _RandomAccessIterator __last, _Compare __comp)
++    {
++      std::make_heap(__first, __middle, __comp);
++      for (_RandomAccessIterator __i = __middle; __i < __last; ++__i)
++	if (__comp(*__i, *__first))
++	  std::__pop_heap(__first, __middle, __i, __comp);
++    }
++
++  // partial_sort
++
++  /**
++   *  @brief Copy the smallest elements of a sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __result_first   A random-access iterator.
++   *  @param  __result_last    Another random-access iterator.
++   *  @return   An iterator indicating the end of the resulting sequence.
++   *
++   *  Copies and sorts the smallest N values from the range @p [__first,__last)
++   *  to the range beginning at @p __result_first, where the number of
++   *  elements to be copied, @p N, is the smaller of @p (__last-__first) and
++   *  @p (__result_last-__result_first).
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__result_first,__result_first+N) such that i precedes j then
++   *  *j<*i is false.
++   *  The value returned is @p __result_first+N.
++  */
++  template<typename _InputIterator, typename _RandomAccessIterator>
++    _RandomAccessIterator
++    partial_sort_copy(_InputIterator __first, _InputIterator __last,
++		      _RandomAccessIterator __result_first,
++		      _RandomAccessIterator __result_last)
++    {
++      typedef typename iterator_traits<_InputIterator>::value_type
++	_InputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_OutputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_ConvertibleConcept<_InputValueType,
++				  _OutputValueType>)
++      __glibcxx_function_requires(_LessThanOpConcept<_InputValueType,
++				                     _OutputValueType>)
++      __glibcxx_function_requires(_LessThanComparableConcept<_OutputValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++      __glibcxx_requires_valid_range(__result_first, __result_last);
++
++      if (__result_first == __result_last)
++	return __result_last;
++      _RandomAccessIterator __result_real_last = __result_first;
++      while(__first != __last && __result_real_last != __result_last)
++	{
++	  *__result_real_last = *__first;
++	  ++__result_real_last;
++	  ++__first;
++	}
++      std::make_heap(__result_first, __result_real_last);
++      while (__first != __last)
++	{
++	  if (*__first < *__result_first)
++	    std::__adjust_heap(__result_first, _DistanceType(0),
++			       _DistanceType(__result_real_last
++					     - __result_first),
++			       _InputValueType(*__first));
++	  ++__first;
++	}
++      std::sort_heap(__result_first, __result_real_last);
++      return __result_real_last;
++    }
++
++  /**
++   *  @brief Copy the smallest elements of a sequence using a predicate for
++   *         comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    Another input iterator.
++   *  @param  __result_first   A random-access iterator.
++   *  @param  __result_last    Another random-access iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return   An iterator indicating the end of the resulting sequence.
++   *
++   *  Copies and sorts the smallest N values from the range @p [__first,__last)
++   *  to the range beginning at @p result_first, where the number of
++   *  elements to be copied, @p N, is the smaller of @p (__last-__first) and
++   *  @p (__result_last-__result_first).
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__result_first,__result_first+N) such that i precedes j then
++   *  @p __comp(*j,*i) is false.
++   *  The value returned is @p __result_first+N.
++  */
++  template<typename _InputIterator, typename _RandomAccessIterator, typename _Compare>
++    _RandomAccessIterator
++    partial_sort_copy(_InputIterator __first, _InputIterator __last,
++		      _RandomAccessIterator __result_first,
++		      _RandomAccessIterator __result_last,
++		      _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator>::value_type
++	_InputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_OutputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++      __glibcxx_function_requires(_ConvertibleConcept<_InputValueType,
++				  _OutputValueType>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _InputValueType, _OutputValueType>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _OutputValueType, _OutputValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++      __glibcxx_requires_valid_range(__result_first, __result_last);
++
++      if (__result_first == __result_last)
++	return __result_last;
++      _RandomAccessIterator __result_real_last = __result_first;
++      while(__first != __last && __result_real_last != __result_last)
++	{
++	  *__result_real_last = *__first;
++	  ++__result_real_last;
++	  ++__first;
++	}
++      std::make_heap(__result_first, __result_real_last, __comp);
++      while (__first != __last)
++	{
++	  if (__comp(*__first, *__result_first))
++	    std::__adjust_heap(__result_first, _DistanceType(0),
++			       _DistanceType(__result_real_last
++					     - __result_first),
++			       _InputValueType(*__first),
++			       __comp);
++	  ++__first;
++	}
++      std::sort_heap(__result_first, __result_real_last, __comp);
++      return __result_real_last;
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator>
++    void
++    __unguarded_linear_insert(_RandomAccessIterator __last)
++    {
++      typename iterator_traits<_RandomAccessIterator>::value_type
++	__val = _GLIBCXX_MOVE(*__last);
++      _RandomAccessIterator __next = __last;
++      --__next;
++      while (__val < *__next)
++	{
++	  *__last = _GLIBCXX_MOVE(*__next);
++	  __last = __next;
++	  --__next;
++	}
++      *__last = _GLIBCXX_MOVE(__val);
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __unguarded_linear_insert(_RandomAccessIterator __last,
++			      _Compare __comp)
++    {
++      typename iterator_traits<_RandomAccessIterator>::value_type
++	__val = _GLIBCXX_MOVE(*__last);
++      _RandomAccessIterator __next = __last;
++      --__next;
++      while (__comp(__val, *__next))
++	{
++	  *__last = _GLIBCXX_MOVE(*__next);
++	  __last = __next;
++	  --__next;
++	}
++      *__last = _GLIBCXX_MOVE(__val);
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator>
++    void
++    __insertion_sort(_RandomAccessIterator __first,
++		     _RandomAccessIterator __last)
++    {
++      if (__first == __last)
++	return;
++
++      for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	{
++	  if (*__i < *__first)
++	    {
++	      typename iterator_traits<_RandomAccessIterator>::value_type
++		__val = _GLIBCXX_MOVE(*__i);
++	      _GLIBCXX_MOVE_BACKWARD3(__first, __i, __i + 1);
++	      *__first = _GLIBCXX_MOVE(__val);
++	    }
++	  else
++	    std::__unguarded_linear_insert(__i);
++	}
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __insertion_sort(_RandomAccessIterator __first,
++		     _RandomAccessIterator __last, _Compare __comp)
++    {
++      if (__first == __last) return;
++
++      for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	{
++	  if (__comp(*__i, *__first))
++	    {
++	      typename iterator_traits<_RandomAccessIterator>::value_type
++		__val = _GLIBCXX_MOVE(*__i);
++	      _GLIBCXX_MOVE_BACKWARD3(__first, __i, __i + 1);
++	      *__first = _GLIBCXX_MOVE(__val);
++	    }
++	  else
++	    std::__unguarded_linear_insert(__i, __comp);
++	}
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator>
++    inline void
++    __unguarded_insertion_sort(_RandomAccessIterator __first,
++			       _RandomAccessIterator __last)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      for (_RandomAccessIterator __i = __first; __i != __last; ++__i)
++	std::__unguarded_linear_insert(__i);
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    __unguarded_insertion_sort(_RandomAccessIterator __first,
++			       _RandomAccessIterator __last, _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      for (_RandomAccessIterator __i = __first; __i != __last; ++__i)
++	std::__unguarded_linear_insert(__i, __comp);
++    }
++
++  /**
++   *  @doctodo
++   *  This controls some aspect of the sort routines.
++  */
++  enum { _S_threshold = 16 };
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator>
++    void
++    __final_insertion_sort(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last)
++    {
++      if (__last - __first > int(_S_threshold))
++	{
++	  std::__insertion_sort(__first, __first + int(_S_threshold));
++	  std::__unguarded_insertion_sort(__first + int(_S_threshold), __last);
++	}
++      else
++	std::__insertion_sort(__first, __last);
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __final_insertion_sort(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last, _Compare __comp)
++    {
++      if (__last - __first > int(_S_threshold))
++	{
++	  std::__insertion_sort(__first, __first + int(_S_threshold), __comp);
++	  std::__unguarded_insertion_sort(__first + int(_S_threshold), __last,
++					  __comp);
++	}
++      else
++	std::__insertion_sort(__first, __last, __comp);
++    }
++
++  /// This is a helper function...
++  template<typename _RandomAccessIterator, typename _Tp>
++    _RandomAccessIterator
++    __unguarded_partition(_RandomAccessIterator __first,
++			  _RandomAccessIterator __last, const _Tp& __pivot)
++    {
++      while (true)
++	{
++	  while (*__first < __pivot)
++	    ++__first;
++	  --__last;
++	  while (__pivot < *__last)
++	    --__last;
++	  if (!(__first < __last))
++	    return __first;
++	  std::iter_swap(__first, __last);
++	  ++__first;
++	}
++    }
++
++  /// This is a helper function...
++  template<typename _RandomAccessIterator, typename _Tp, typename _Compare>
++    _RandomAccessIterator
++    __unguarded_partition(_RandomAccessIterator __first,
++			  _RandomAccessIterator __last,
++			  const _Tp& __pivot, _Compare __comp)
++    {
++      while (true)
++	{
++	  while (__comp(*__first, __pivot))
++	    ++__first;
++	  --__last;
++	  while (__comp(__pivot, *__last))
++	    --__last;
++	  if (!(__first < __last))
++	    return __first;
++	  std::iter_swap(__first, __last);
++	  ++__first;
++	}
++    }
++
++  /// This is a helper function...
++  template<typename _RandomAccessIterator>
++    inline _RandomAccessIterator
++    __unguarded_partition_pivot(_RandomAccessIterator __first,
++				_RandomAccessIterator __last)
++    {
++      _RandomAccessIterator __mid = __first + (__last - __first) / 2;
++      std::__move_median_first(__first, __mid, (__last - 1));
++      return std::__unguarded_partition(__first + 1, __last, *__first);
++    }
++
++
++  /// This is a helper function...
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline _RandomAccessIterator
++    __unguarded_partition_pivot(_RandomAccessIterator __first,
++				_RandomAccessIterator __last, _Compare __comp)
++    {
++      _RandomAccessIterator __mid = __first + (__last - __first) / 2;
++      std::__move_median_first(__first, __mid, (__last - 1), __comp);
++      return std::__unguarded_partition(__first + 1, __last, *__first, __comp);
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Size>
++    void
++    __introsort_loop(_RandomAccessIterator __first,
++		     _RandomAccessIterator __last,
++		     _Size __depth_limit)
++    {
++      while (__last - __first > int(_S_threshold))
++	{
++	  if (__depth_limit == 0)
++	    {
++	      _GLIBCXX_STD_A::partial_sort(__first, __last, __last);
++	      return;
++	    }
++	  --__depth_limit;
++	  _RandomAccessIterator __cut =
++	    std::__unguarded_partition_pivot(__first, __last);
++	  std::__introsort_loop(__cut, __last, __depth_limit);
++	  __last = __cut;
++	}
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Size, typename _Compare>
++    void
++    __introsort_loop(_RandomAccessIterator __first,
++		     _RandomAccessIterator __last,
++		     _Size __depth_limit, _Compare __comp)
++    {
++      while (__last - __first > int(_S_threshold))
++	{
++	  if (__depth_limit == 0)
++	    {
++	      _GLIBCXX_STD_A::partial_sort(__first, __last, __last, __comp);
++	      return;
++	    }
++	  --__depth_limit;
++	  _RandomAccessIterator __cut =
++	    std::__unguarded_partition_pivot(__first, __last, __comp);
++	  std::__introsort_loop(__cut, __last, __depth_limit, __comp);
++	  __last = __cut;
++	}
++    }
++
++  // sort
++
++  template<typename _RandomAccessIterator, typename _Size>
++    void
++    __introselect(_RandomAccessIterator __first, _RandomAccessIterator __nth,
++		  _RandomAccessIterator __last, _Size __depth_limit)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      while (__last - __first > 3)
++	{
++	  if (__depth_limit == 0)
++	    {
++	      std::__heap_select(__first, __nth + 1, __last);
++
++	      // Place the nth largest element in its final position.
++	      std::iter_swap(__first, __nth);
++	      return;
++	    }
++	  --__depth_limit;
++	  _RandomAccessIterator __cut =
++	    std::__unguarded_partition_pivot(__first, __last);
++	  if (__cut <= __nth)
++	    __first = __cut;
++	  else
++	    __last = __cut;
++	}
++      std::__insertion_sort(__first, __last);
++    }
++
++  template<typename _RandomAccessIterator, typename _Size, typename _Compare>
++    void
++    __introselect(_RandomAccessIterator __first, _RandomAccessIterator __nth,
++		  _RandomAccessIterator __last, _Size __depth_limit,
++		  _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      while (__last - __first > 3)
++	{
++	  if (__depth_limit == 0)
++	    {
++	      std::__heap_select(__first, __nth + 1, __last, __comp);
++	      // Place the nth largest element in its final position.
++	      std::iter_swap(__first, __nth);
++	      return;
++	    }
++	  --__depth_limit;
++	  _RandomAccessIterator __cut =
++	    std::__unguarded_partition_pivot(__first, __last, __comp);
++	  if (__cut <= __nth)
++	    __first = __cut;
++	  else
++	    __last = __cut;
++	}
++      std::__insertion_sort(__first, __last, __comp);
++    }
++
++  // nth_element
++
++  // lower_bound moved to stl_algobase.h
++
++  /**
++   *  @brief Finds the first position in which @p __val could be inserted
++   *         without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return An iterator pointing to the first element <em>not less
++   *           than</em> @p __val, or end() if every element is less
++   *           than @p __val.
++   *  @ingroup binary_search_algorithms
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    _ForwardIterator
++    lower_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType, _Tp>)
++      __glibcxx_requires_partitioned_lower_pred(__first, __last,
++						__val, __comp);
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__comp(*__middle, __val))
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else
++	    __len = __half;
++	}
++      return __first;
++    }
++
++  /**
++   *  @brief Finds the last position in which @p __val could be inserted
++   *         without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return  An iterator pointing to the first element greater than @p __val,
++   *           or end() if no elements are greater than @p __val.
++   *  @ingroup binary_search_algorithms
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    _ForwardIterator
++    upper_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<_Tp, _ValueType>)
++      __glibcxx_requires_partitioned_upper(__first, __last, __val);
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__val < *__middle)
++	    __len = __half;
++	  else
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	}
++      return __first;
++    }
++
++  /**
++   *  @brief Finds the last position in which @p __val could be inserted
++   *         without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  An iterator pointing to the first element greater than @p __val,
++   *           or end() if no elements are greater than @p __val.
++   *  @ingroup binary_search_algorithms
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    _ForwardIterator
++    upper_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _Tp, _ValueType>)
++      __glibcxx_requires_partitioned_upper_pred(__first, __last,
++						__val, __comp);
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__comp(__val, *__middle))
++	    __len = __half;
++	  else
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	}
++      return __first;
++    }
++
++  /**
++   *  @brief Finds the largest subrange in which @p __val could be inserted
++   *         at any place in it without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return  An pair of iterators defining the subrange.
++   *  @ingroup binary_search_algorithms
++   *
++   *  This is equivalent to
++   *  @code
++   *    std::make_pair(lower_bound(__first, __last, __val),
++   *                   upper_bound(__first, __last, __val))
++   *  @endcode
++   *  but does not actually call those functions.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    pair<_ForwardIterator, _ForwardIterator>
++    equal_range(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType, _Tp>)
++      __glibcxx_function_requires(_LessThanOpConcept<_Tp, _ValueType>)	
++      __glibcxx_requires_partitioned_lower(__first, __last, __val);
++      __glibcxx_requires_partitioned_upper(__first, __last, __val);      
++
++      _DistanceType __len = std::distance(__first, __last);
++ 
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (*__middle < __val)
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else if (__val < *__middle)
++	    __len = __half;
++	  else
++	    {
++	      _ForwardIterator __left = std::lower_bound(__first, __middle,
++							 __val);
++	      std::advance(__first, __len);
++	      _ForwardIterator __right = std::upper_bound(++__middle, __first,
++							  __val);
++	      return pair<_ForwardIterator, _ForwardIterator>(__left, __right);
++	    }
++	}
++      return pair<_ForwardIterator, _ForwardIterator>(__first, __first);
++    }
++
++  /**
++   *  @brief Finds the largest subrange in which @p __val could be inserted
++   *         at any place in it without changing the ordering.
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  An pair of iterators defining the subrange.
++   *  @ingroup binary_search_algorithms
++   *
++   *  This is equivalent to
++   *  @code
++   *    std::make_pair(lower_bound(__first, __last, __val, __comp),
++   *                   upper_bound(__first, __last, __val, __comp))
++   *  @endcode
++   *  but does not actually call those functions.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    pair<_ForwardIterator, _ForwardIterator>
++    equal_range(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType, _Tp>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _Tp, _ValueType>)
++      __glibcxx_requires_partitioned_lower_pred(__first, __last,
++						__val, __comp);
++      __glibcxx_requires_partitioned_upper_pred(__first, __last,
++						__val, __comp);
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__comp(*__middle, __val))
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else if (__comp(__val, *__middle))
++	    __len = __half;
++	  else
++	    {
++	      _ForwardIterator __left = std::lower_bound(__first, __middle,
++							 __val, __comp);
++	      std::advance(__first, __len);
++	      _ForwardIterator __right = std::upper_bound(++__middle, __first,
++							  __val, __comp);
++	      return pair<_ForwardIterator, _ForwardIterator>(__left, __right);
++	    }
++	}
++      return pair<_ForwardIterator, _ForwardIterator>(__first, __first);
++    }
++
++  /**
++   *  @brief Determines whether an element exists in a range.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return True if @p __val (or its equivalent) is in [@p
++   *  __first,@p __last ].
++   *
++   *  Note that this does not actually return an iterator to @p __val.  For
++   *  that, use std::find or a container's specialized find member functions.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    bool
++    binary_search(_ForwardIterator __first, _ForwardIterator __last,
++                  const _Tp& __val)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<_Tp, _ValueType>)
++      __glibcxx_requires_partitioned_lower(__first, __last, __val);
++      __glibcxx_requires_partitioned_upper(__first, __last, __val);
++
++      _ForwardIterator __i = std::lower_bound(__first, __last, __val);
++      return __i != __last && !(__val < *__i);
++    }
++
++  /**
++   *  @brief Determines whether an element exists in a range.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  True if @p __val (or its equivalent) is in @p [__first,__last].
++   *
++   *  Note that this does not actually return an iterator to @p __val.  For
++   *  that, use std::find or a container's specialized find member functions.
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    bool
++    binary_search(_ForwardIterator __first, _ForwardIterator __last,
++                  const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _Tp, _ValueType>)
++      __glibcxx_requires_partitioned_lower_pred(__first, __last,
++						__val, __comp);
++      __glibcxx_requires_partitioned_upper_pred(__first, __last,
++						__val, __comp);
++
++      _ForwardIterator __i = std::lower_bound(__first, __last, __val, __comp);
++      return __i != __last && !bool(__comp(__val, *__i));
++    }
++
++  // merge
++
++  /// This is a helper function for the __merge_adaptive routines.
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    void
++    __move_merge_adaptive(_InputIterator1 __first1, _InputIterator1 __last1,
++			  _InputIterator2 __first2, _InputIterator2 __last2,
++			  _OutputIterator __result)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (*__first2 < *__first1)
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first2);
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first1);
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      if (__first1 != __last1)
++	_GLIBCXX_MOVE3(__first1, __last1, __result);
++    }
++
++  /// This is a helper function for the __merge_adaptive routines.
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    void
++    __move_merge_adaptive(_InputIterator1 __first1, _InputIterator1 __last1,
++			  _InputIterator2 __first2, _InputIterator2 __last2,
++			  _OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(*__first2, *__first1))
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first2);
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first1);
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      if (__first1 != __last1)
++	_GLIBCXX_MOVE3(__first1, __last1, __result);
++    }
++
++  /// This is a helper function for the __merge_adaptive routines.
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2,
++	   typename _BidirectionalIterator3>
++    void
++    __move_merge_adaptive_backward(_BidirectionalIterator1 __first1,
++				   _BidirectionalIterator1 __last1,
++				   _BidirectionalIterator2 __first2,
++				   _BidirectionalIterator2 __last2,
++				   _BidirectionalIterator3 __result)
++    {
++      if (__first1 == __last1)
++	{
++	  _GLIBCXX_MOVE_BACKWARD3(__first2, __last2, __result);
++	  return;
++	}
++      else if (__first2 == __last2)
++	return;
++
++      --__last1;
++      --__last2;
++      while (true)
++	{
++	  if (*__last2 < *__last1)
++	    {
++	      *--__result = _GLIBCXX_MOVE(*__last1);
++	      if (__first1 == __last1)
++		{
++		  _GLIBCXX_MOVE_BACKWARD3(__first2, ++__last2, __result);
++		  return;
++		}
++	      --__last1;
++	    }
++	  else
++	    {
++	      *--__result = _GLIBCXX_MOVE(*__last2);
++	      if (__first2 == __last2)
++		return;
++	      --__last2;
++	    }
++	}
++    }
++
++  /// This is a helper function for the __merge_adaptive routines.
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2,
++	   typename _BidirectionalIterator3, typename _Compare>
++    void
++    __move_merge_adaptive_backward(_BidirectionalIterator1 __first1,
++				   _BidirectionalIterator1 __last1,
++				   _BidirectionalIterator2 __first2,
++				   _BidirectionalIterator2 __last2,
++				   _BidirectionalIterator3 __result,
++				   _Compare __comp)
++    {
++      if (__first1 == __last1)
++	{
++	  _GLIBCXX_MOVE_BACKWARD3(__first2, __last2, __result);
++	  return;
++	}
++      else if (__first2 == __last2)
++	return;
++
++      --__last1;
++      --__last2;
++      while (true)
++	{
++	  if (__comp(*__last2, *__last1))
++	    {
++	      *--__result = _GLIBCXX_MOVE(*__last1);
++	      if (__first1 == __last1)
++		{
++		  _GLIBCXX_MOVE_BACKWARD3(__first2, ++__last2, __result);
++		  return;
++		}
++	      --__last1;
++	    }
++	  else
++	    {
++	      *--__result = _GLIBCXX_MOVE(*__last2);
++	      if (__first2 == __last2)
++		return;
++	      --__last2;
++	    }
++	}
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2,
++	   typename _Distance>
++    _BidirectionalIterator1
++    __rotate_adaptive(_BidirectionalIterator1 __first,
++		      _BidirectionalIterator1 __middle,
++		      _BidirectionalIterator1 __last,
++		      _Distance __len1, _Distance __len2,
++		      _BidirectionalIterator2 __buffer,
++		      _Distance __buffer_size)
++    {
++      _BidirectionalIterator2 __buffer_end;
++      if (__len1 > __len2 && __len2 <= __buffer_size)
++	{
++	  if (__len2)
++	    {
++	      __buffer_end = _GLIBCXX_MOVE3(__middle, __last, __buffer);
++	      _GLIBCXX_MOVE_BACKWARD3(__first, __middle, __last);
++	      return _GLIBCXX_MOVE3(__buffer, __buffer_end, __first);
++	    }
++	  else
++	    return __first;
++	}
++      else if (__len1 <= __buffer_size)
++	{
++	  if (__len1)
++	    {
++	      __buffer_end = _GLIBCXX_MOVE3(__first, __middle, __buffer);
++	      _GLIBCXX_MOVE3(__middle, __last, __first);
++	      return _GLIBCXX_MOVE_BACKWARD3(__buffer, __buffer_end, __last);
++	    }
++	  else
++	    return __last;
++	}
++      else
++	{
++	  std::rotate(__first, __middle, __last);
++	  std::advance(__first, std::distance(__middle, __last));
++	  return __first;
++	}
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator, typename _Distance,
++	   typename _Pointer>
++    void
++    __merge_adaptive(_BidirectionalIterator __first,
++                     _BidirectionalIterator __middle,
++		     _BidirectionalIterator __last,
++		     _Distance __len1, _Distance __len2,
++		     _Pointer __buffer, _Distance __buffer_size)
++    {
++      if (__len1 <= __len2 && __len1 <= __buffer_size)
++	{
++	  _Pointer __buffer_end = _GLIBCXX_MOVE3(__first, __middle, __buffer);
++	  std::__move_merge_adaptive(__buffer, __buffer_end, __middle, __last,
++				     __first);
++	}
++      else if (__len2 <= __buffer_size)
++	{
++	  _Pointer __buffer_end = _GLIBCXX_MOVE3(__middle, __last, __buffer);
++	  std::__move_merge_adaptive_backward(__first, __middle, __buffer,
++					      __buffer_end, __last);
++	}
++      else
++	{
++	  _BidirectionalIterator __first_cut = __first;
++	  _BidirectionalIterator __second_cut = __middle;
++	  _Distance __len11 = 0;
++	  _Distance __len22 = 0;
++	  if (__len1 > __len2)
++	    {
++	      __len11 = __len1 / 2;
++	      std::advance(__first_cut, __len11);
++	      __second_cut = std::lower_bound(__middle, __last,
++					      *__first_cut);
++	      __len22 = std::distance(__middle, __second_cut);
++	    }
++	  else
++	    {
++	      __len22 = __len2 / 2;
++	      std::advance(__second_cut, __len22);
++	      __first_cut = std::upper_bound(__first, __middle,
++					     *__second_cut);
++	      __len11 = std::distance(__first, __first_cut);
++	    }
++	  _BidirectionalIterator __new_middle =
++	    std::__rotate_adaptive(__first_cut, __middle, __second_cut,
++				   __len1 - __len11, __len22, __buffer,
++				   __buffer_size);
++	  std::__merge_adaptive(__first, __first_cut, __new_middle, __len11,
++				__len22, __buffer, __buffer_size);
++	  std::__merge_adaptive(__new_middle, __second_cut, __last,
++				__len1 - __len11,
++				__len2 - __len22, __buffer, __buffer_size);
++	}
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator, typename _Distance, 
++	   typename _Pointer, typename _Compare>
++    void
++    __merge_adaptive(_BidirectionalIterator __first,
++                     _BidirectionalIterator __middle,
++		     _BidirectionalIterator __last,
++		     _Distance __len1, _Distance __len2,
++		     _Pointer __buffer, _Distance __buffer_size,
++		     _Compare __comp)
++    {
++      if (__len1 <= __len2 && __len1 <= __buffer_size)
++	{
++	  _Pointer __buffer_end = _GLIBCXX_MOVE3(__first, __middle, __buffer);
++	  std::__move_merge_adaptive(__buffer, __buffer_end, __middle, __last,
++				     __first, __comp);
++	}
++      else if (__len2 <= __buffer_size)
++	{
++	  _Pointer __buffer_end = _GLIBCXX_MOVE3(__middle, __last, __buffer);
++	  std::__move_merge_adaptive_backward(__first, __middle, __buffer,
++					      __buffer_end, __last, __comp);
++	}
++      else
++	{
++	  _BidirectionalIterator __first_cut = __first;
++	  _BidirectionalIterator __second_cut = __middle;
++	  _Distance __len11 = 0;
++	  _Distance __len22 = 0;
++	  if (__len1 > __len2)
++	    {
++	      __len11 = __len1 / 2;
++	      std::advance(__first_cut, __len11);
++	      __second_cut = std::lower_bound(__middle, __last, *__first_cut,
++					      __comp);
++	      __len22 = std::distance(__middle, __second_cut);
++	    }
++	  else
++	    {
++	      __len22 = __len2 / 2;
++	      std::advance(__second_cut, __len22);
++	      __first_cut = std::upper_bound(__first, __middle, *__second_cut,
++					     __comp);
++	      __len11 = std::distance(__first, __first_cut);
++	    }
++	  _BidirectionalIterator __new_middle =
++	    std::__rotate_adaptive(__first_cut, __middle, __second_cut,
++				   __len1 - __len11, __len22, __buffer,
++				   __buffer_size);
++	  std::__merge_adaptive(__first, __first_cut, __new_middle, __len11,
++				__len22, __buffer, __buffer_size, __comp);
++	  std::__merge_adaptive(__new_middle, __second_cut, __last,
++				__len1 - __len11,
++				__len2 - __len22, __buffer,
++				__buffer_size, __comp);
++	}
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator, typename _Distance>
++    void
++    __merge_without_buffer(_BidirectionalIterator __first,
++			   _BidirectionalIterator __middle,
++			   _BidirectionalIterator __last,
++			   _Distance __len1, _Distance __len2)
++    {
++      if (__len1 == 0 || __len2 == 0)
++	return;
++      if (__len1 + __len2 == 2)
++	{
++	  if (*__middle < *__first)
++	    std::iter_swap(__first, __middle);
++	  return;
++	}
++      _BidirectionalIterator __first_cut = __first;
++      _BidirectionalIterator __second_cut = __middle;
++      _Distance __len11 = 0;
++      _Distance __len22 = 0;
++      if (__len1 > __len2)
++	{
++	  __len11 = __len1 / 2;
++	  std::advance(__first_cut, __len11);
++	  __second_cut = std::lower_bound(__middle, __last, *__first_cut);
++	  __len22 = std::distance(__middle, __second_cut);
++	}
++      else
++	{
++	  __len22 = __len2 / 2;
++	  std::advance(__second_cut, __len22);
++	  __first_cut = std::upper_bound(__first, __middle, *__second_cut);
++	  __len11 = std::distance(__first, __first_cut);
++	}
++      std::rotate(__first_cut, __middle, __second_cut);
++      _BidirectionalIterator __new_middle = __first_cut;
++      std::advance(__new_middle, std::distance(__middle, __second_cut));
++      std::__merge_without_buffer(__first, __first_cut, __new_middle,
++				  __len11, __len22);
++      std::__merge_without_buffer(__new_middle, __second_cut, __last,
++				  __len1 - __len11, __len2 - __len22);
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator, typename _Distance,
++	   typename _Compare>
++    void
++    __merge_without_buffer(_BidirectionalIterator __first,
++                           _BidirectionalIterator __middle,
++			   _BidirectionalIterator __last,
++			   _Distance __len1, _Distance __len2,
++			   _Compare __comp)
++    {
++      if (__len1 == 0 || __len2 == 0)
++	return;
++      if (__len1 + __len2 == 2)
++	{
++	  if (__comp(*__middle, *__first))
++	    std::iter_swap(__first, __middle);
++	  return;
++	}
++      _BidirectionalIterator __first_cut = __first;
++      _BidirectionalIterator __second_cut = __middle;
++      _Distance __len11 = 0;
++      _Distance __len22 = 0;
++      if (__len1 > __len2)
++	{
++	  __len11 = __len1 / 2;
++	  std::advance(__first_cut, __len11);
++	  __second_cut = std::lower_bound(__middle, __last, *__first_cut,
++					  __comp);
++	  __len22 = std::distance(__middle, __second_cut);
++	}
++      else
++	{
++	  __len22 = __len2 / 2;
++	  std::advance(__second_cut, __len22);
++	  __first_cut = std::upper_bound(__first, __middle, *__second_cut,
++					 __comp);
++	  __len11 = std::distance(__first, __first_cut);
++	}
++      std::rotate(__first_cut, __middle, __second_cut);
++      _BidirectionalIterator __new_middle = __first_cut;
++      std::advance(__new_middle, std::distance(__middle, __second_cut));
++      std::__merge_without_buffer(__first, __first_cut, __new_middle,
++				  __len11, __len22, __comp);
++      std::__merge_without_buffer(__new_middle, __second_cut, __last,
++				  __len1 - __len11, __len2 - __len22, __comp);
++    }
++
++  /**
++   *  @brief Merges two sorted ranges in place.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Merges two sorted and consecutive ranges, [__first,__middle) and
++   *  [__middle,__last), and puts the result in [__first,__last).  The
++   *  output will be sorted.  The sort is @e stable, that is, for
++   *  equivalent elements in the two ranges, elements from the first
++   *  range will always come before elements from the second.
++   *
++   *  If enough additional memory is available, this takes (__last-__first)-1
++   *  comparisons.  Otherwise an NlogN algorithm is used, where N is
++   *  distance(__first,__last).
++  */
++  template<typename _BidirectionalIterator>
++    void
++    inplace_merge(_BidirectionalIterator __first,
++		  _BidirectionalIterator __middle,
++		  _BidirectionalIterator __last)
++    {
++      typedef typename iterator_traits<_BidirectionalIterator>::value_type
++          _ValueType;
++      typedef typename iterator_traits<_BidirectionalIterator>::difference_type
++          _DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++	    _BidirectionalIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<_ValueType>)
++      __glibcxx_requires_sorted(__first, __middle);
++      __glibcxx_requires_sorted(__middle, __last);
++
++      if (__first == __middle || __middle == __last)
++	return;
++
++      _DistanceType __len1 = std::distance(__first, __middle);
++      _DistanceType __len2 = std::distance(__middle, __last);
++
++      _Temporary_buffer<_BidirectionalIterator, _ValueType> __buf(__first,
++								  __last);
++      if (__buf.begin() == 0)
++	std::__merge_without_buffer(__first, __middle, __last, __len1, __len2);
++      else
++	std::__merge_adaptive(__first, __middle, __last, __len1, __len2,
++			      __buf.begin(), _DistanceType(__buf.size()));
++    }
++
++  /**
++   *  @brief Merges two sorted ranges in place.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  Nothing.
++   *
++   *  Merges two sorted and consecutive ranges, [__first,__middle) and
++   *  [middle,last), and puts the result in [__first,__last).  The output will
++   *  be sorted.  The sort is @e stable, that is, for equivalent
++   *  elements in the two ranges, elements from the first range will always
++   *  come before elements from the second.
++   *
++   *  If enough additional memory is available, this takes (__last-__first)-1
++   *  comparisons.  Otherwise an NlogN algorithm is used, where N is
++   *  distance(__first,__last).
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _BidirectionalIterator, typename _Compare>
++    void
++    inplace_merge(_BidirectionalIterator __first,
++		  _BidirectionalIterator __middle,
++		  _BidirectionalIterator __last,
++		  _Compare __comp)
++    {
++      typedef typename iterator_traits<_BidirectionalIterator>::value_type
++          _ValueType;
++      typedef typename iterator_traits<_BidirectionalIterator>::difference_type
++          _DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++	    _BidirectionalIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    _ValueType, _ValueType>)
++      __glibcxx_requires_sorted_pred(__first, __middle, __comp);
++      __glibcxx_requires_sorted_pred(__middle, __last, __comp);
++
++      if (__first == __middle || __middle == __last)
++	return;
++
++      const _DistanceType __len1 = std::distance(__first, __middle);
++      const _DistanceType __len2 = std::distance(__middle, __last);
++
++      _Temporary_buffer<_BidirectionalIterator, _ValueType> __buf(__first,
++								  __last);
++      if (__buf.begin() == 0)
++	std::__merge_without_buffer(__first, __middle, __last, __len1,
++				    __len2, __comp);
++      else
++	std::__merge_adaptive(__first, __middle, __last, __len1, __len2,
++			      __buf.begin(), _DistanceType(__buf.size()),
++			      __comp);
++    }
++
++
++  /// This is a helper function for the __merge_sort_loop routines.
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    _OutputIterator
++    __move_merge(_InputIterator1 __first1, _InputIterator1 __last1,
++		 _InputIterator2 __first2, _InputIterator2 __last2,
++		 _OutputIterator __result)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (*__first2 < *__first1)
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first2);
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first1);
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      return _GLIBCXX_MOVE3(__first2, __last2,
++			    _GLIBCXX_MOVE3(__first1, __last1,
++					   __result));
++    }
++
++  /// This is a helper function for the __merge_sort_loop routines.
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    _OutputIterator
++    __move_merge(_InputIterator1 __first1, _InputIterator1 __last1,
++		 _InputIterator2 __first2, _InputIterator2 __last2,
++		 _OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(*__first2, *__first1))
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first2);
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first1);
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      return _GLIBCXX_MOVE3(__first2, __last2,
++			    _GLIBCXX_MOVE3(__first1, __last1,
++					   __result));
++    }
++
++  template<typename _RandomAccessIterator1, typename _RandomAccessIterator2,
++	   typename _Distance>
++    void
++    __merge_sort_loop(_RandomAccessIterator1 __first,
++		      _RandomAccessIterator1 __last,
++		      _RandomAccessIterator2 __result,
++		      _Distance __step_size)
++    {
++      const _Distance __two_step = 2 * __step_size;
++
++      while (__last - __first >= __two_step)
++	{
++	  __result = std::__move_merge(__first, __first + __step_size,
++				       __first + __step_size,
++				       __first + __two_step, __result);
++	  __first += __two_step;
++	}
++
++      __step_size = std::min(_Distance(__last - __first), __step_size);
++      std::__move_merge(__first, __first + __step_size,
++			__first + __step_size, __last, __result);
++    }
++
++  template<typename _RandomAccessIterator1, typename _RandomAccessIterator2,
++	   typename _Distance, typename _Compare>
++    void
++    __merge_sort_loop(_RandomAccessIterator1 __first,
++		      _RandomAccessIterator1 __last,
++		      _RandomAccessIterator2 __result, _Distance __step_size,
++		      _Compare __comp)
++    {
++      const _Distance __two_step = 2 * __step_size;
++
++      while (__last - __first >= __two_step)
++	{
++	  __result = std::__move_merge(__first, __first + __step_size,
++				       __first + __step_size,
++				       __first + __two_step,
++				       __result, __comp);
++	  __first += __two_step;
++	}
++      __step_size = std::min(_Distance(__last - __first), __step_size);
++
++      std::__move_merge(__first,__first + __step_size,
++			__first + __step_size, __last, __result, __comp);
++    }
++
++  template<typename _RandomAccessIterator, typename _Distance>
++    void
++    __chunk_insertion_sort(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last,
++			   _Distance __chunk_size)
++    {
++      while (__last - __first >= __chunk_size)
++	{
++	  std::__insertion_sort(__first, __first + __chunk_size);
++	  __first += __chunk_size;
++	}
++      std::__insertion_sort(__first, __last);
++    }
++
++  template<typename _RandomAccessIterator, typename _Distance,
++	   typename _Compare>
++    void
++    __chunk_insertion_sort(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last,
++			   _Distance __chunk_size, _Compare __comp)
++    {
++      while (__last - __first >= __chunk_size)
++	{
++	  std::__insertion_sort(__first, __first + __chunk_size, __comp);
++	  __first += __chunk_size;
++	}
++      std::__insertion_sort(__first, __last, __comp);
++    }
++
++  enum { _S_chunk_size = 7 };
++
++  template<typename _RandomAccessIterator, typename _Pointer>
++    void
++    __merge_sort_with_buffer(_RandomAccessIterator __first,
++			     _RandomAccessIterator __last,
++                             _Pointer __buffer)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_Distance;
++
++      const _Distance __len = __last - __first;
++      const _Pointer __buffer_last = __buffer + __len;
++
++      _Distance __step_size = _S_chunk_size;
++      std::__chunk_insertion_sort(__first, __last, __step_size);
++
++      while (__step_size < __len)
++	{
++	  std::__merge_sort_loop(__first, __last, __buffer, __step_size);
++	  __step_size *= 2;
++	  std::__merge_sort_loop(__buffer, __buffer_last, __first, __step_size);
++	  __step_size *= 2;
++	}
++    }
++
++  template<typename _RandomAccessIterator, typename _Pointer, typename _Compare>
++    void
++    __merge_sort_with_buffer(_RandomAccessIterator __first,
++			     _RandomAccessIterator __last,
++                             _Pointer __buffer, _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_Distance;
++
++      const _Distance __len = __last - __first;
++      const _Pointer __buffer_last = __buffer + __len;
++
++      _Distance __step_size = _S_chunk_size;
++      std::__chunk_insertion_sort(__first, __last, __step_size, __comp);
++
++      while (__step_size < __len)
++	{
++	  std::__merge_sort_loop(__first, __last, __buffer,
++				 __step_size, __comp);
++	  __step_size *= 2;
++	  std::__merge_sort_loop(__buffer, __buffer_last, __first,
++				 __step_size, __comp);
++	  __step_size *= 2;
++	}
++    }
++
++  template<typename _RandomAccessIterator, typename _Pointer,
++	   typename _Distance>
++    void
++    __stable_sort_adaptive(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last,
++                           _Pointer __buffer, _Distance __buffer_size)
++    {
++      const _Distance __len = (__last - __first + 1) / 2;
++      const _RandomAccessIterator __middle = __first + __len;
++      if (__len > __buffer_size)
++	{
++	  std::__stable_sort_adaptive(__first, __middle,
++				      __buffer, __buffer_size);
++	  std::__stable_sort_adaptive(__middle, __last,
++				      __buffer, __buffer_size);
++	}
++      else
++	{
++	  std::__merge_sort_with_buffer(__first, __middle, __buffer);
++	  std::__merge_sort_with_buffer(__middle, __last, __buffer);
++	}
++      std::__merge_adaptive(__first, __middle, __last,
++			    _Distance(__middle - __first),
++			    _Distance(__last - __middle),
++			    __buffer, __buffer_size);
++    }
++
++  template<typename _RandomAccessIterator, typename _Pointer,
++	   typename _Distance, typename _Compare>
++    void
++    __stable_sort_adaptive(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last,
++                           _Pointer __buffer, _Distance __buffer_size,
++                           _Compare __comp)
++    {
++      const _Distance __len = (__last - __first + 1) / 2;
++      const _RandomAccessIterator __middle = __first + __len;
++      if (__len > __buffer_size)
++	{
++	  std::__stable_sort_adaptive(__first, __middle, __buffer,
++				      __buffer_size, __comp);
++	  std::__stable_sort_adaptive(__middle, __last, __buffer,
++				      __buffer_size, __comp);
++	}
++      else
++	{
++	  std::__merge_sort_with_buffer(__first, __middle, __buffer, __comp);
++	  std::__merge_sort_with_buffer(__middle, __last, __buffer, __comp);
++	}
++      std::__merge_adaptive(__first, __middle, __last,
++			    _Distance(__middle - __first),
++			    _Distance(__last - __middle),
++			    __buffer, __buffer_size,
++			    __comp);
++    }
++
++  /// This is a helper function for the stable sorting routines.
++  template<typename _RandomAccessIterator>
++    void
++    __inplace_stable_sort(_RandomAccessIterator __first,
++			  _RandomAccessIterator __last)
++    {
++      if (__last - __first < 15)
++	{
++	  std::__insertion_sort(__first, __last);
++	  return;
++	}
++      _RandomAccessIterator __middle = __first + (__last - __first) / 2;
++      std::__inplace_stable_sort(__first, __middle);
++      std::__inplace_stable_sort(__middle, __last);
++      std::__merge_without_buffer(__first, __middle, __last,
++				  __middle - __first,
++				  __last - __middle);
++    }
++
++  /// This is a helper function for the stable sorting routines.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __inplace_stable_sort(_RandomAccessIterator __first,
++			  _RandomAccessIterator __last, _Compare __comp)
++    {
++      if (__last - __first < 15)
++	{
++	  std::__insertion_sort(__first, __last, __comp);
++	  return;
++	}
++      _RandomAccessIterator __middle = __first + (__last - __first) / 2;
++      std::__inplace_stable_sort(__first, __middle, __comp);
++      std::__inplace_stable_sort(__middle, __last, __comp);
++      std::__merge_without_buffer(__first, __middle, __last,
++				  __middle - __first,
++				  __last - __middle,
++				  __comp);
++    }
++
++  // stable_sort
++
++  // Set algorithms: includes, set_union, set_intersection, set_difference,
++  // set_symmetric_difference.  All of these algorithms have the precondition
++  // that their input ranges are sorted and the postcondition that their output
++  // ranges are sorted.
++
++  /**
++   *  @brief Determines whether all elements of a sequence exists in a range.
++   *  @param  __first1  Start of search range.
++   *  @param  __last1   End of search range.
++   *  @param  __first2  Start of sequence
++   *  @param  __last2   End of sequence.
++   *  @return  True if each element in [__first2,__last2) is contained in order
++   *  within [__first1,__last1).  False otherwise.
++   *  @ingroup set_algorithms
++   *
++   *  This operation expects both [__first1,__last1) and
++   *  [__first2,__last2) to be sorted.  Searches for the presence of
++   *  each element in [__first2,__last2) within [__first1,__last1).
++   *  The iterators over each range only move forward, so this is a
++   *  linear algorithm.  If an element in [__first2,__last2) is not
++   *  found before the search iterator reaches @p __last2, false is
++   *  returned.
++  */
++  template<typename _InputIterator1, typename _InputIterator2>
++    bool
++    includes(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _InputIterator2 __last2)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (*__first2 < *__first1)
++	  return false;
++	else if(*__first1 < *__first2)
++	  ++__first1;
++	else
++	  ++__first1, ++__first2;
++
++      return __first2 == __last2;
++    }
++
++  /**
++   *  @brief Determines whether all elements of a sequence exists in a range
++   *  using comparison.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of search range.
++   *  @param  __last1   End of search range.
++   *  @param  __first2  Start of sequence
++   *  @param  __last2   End of sequence.
++   *  @param  __comp    Comparison function to use.
++   *  @return True if each element in [__first2,__last2) is contained
++   *  in order within [__first1,__last1) according to comp.  False
++   *  otherwise.  @ingroup set_algorithms
++   *
++   *  This operation expects both [__first1,__last1) and
++   *  [__first2,__last2) to be sorted.  Searches for the presence of
++   *  each element in [__first2,__last2) within [__first1,__last1),
++   *  using comp to decide.  The iterators over each range only move
++   *  forward, so this is a linear algorithm.  If an element in
++   *  [__first2,__last2) is not found before the search iterator
++   *  reaches @p __last2, false is returned.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _Compare>
++    bool
++    includes(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _InputIterator2 __last2,
++	     _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(*__first2, *__first1))
++	  return false;
++	else if(__comp(*__first1, *__first2))
++	  ++__first1;
++	else
++	  ++__first1, ++__first2;
++
++      return __first2 == __last2;
++    }
++
++  // nth_element
++  // merge
++  // set_difference
++  // set_intersection
++  // set_union
++  // stable_sort
++  // set_symmetric_difference
++  // min_element
++  // max_element
++
++  /**
++   *  @brief  Permute range into the next @e dictionary ordering.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  False if wrapped to first permutation, true otherwise.
++   *
++   *  Treats all permutations of the range as a set of @e dictionary sorted
++   *  sequences.  Permutes the current sequence into the next one of this set.
++   *  Returns true if there are more sequences to generate.  If the sequence
++   *  is the largest of the set, the smallest is generated and false returned.
++  */
++  template<typename _BidirectionalIterator>
++    bool
++    next_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return false;
++      _BidirectionalIterator __i = __first;
++      ++__i;
++      if (__i == __last)
++	return false;
++      __i = __last;
++      --__i;
++
++      for(;;)
++	{
++	  _BidirectionalIterator __ii = __i;
++	  --__i;
++	  if (*__i < *__ii)
++	    {
++	      _BidirectionalIterator __j = __last;
++	      while (!(*__i < *--__j))
++		{}
++	      std::iter_swap(__i, __j);
++	      std::reverse(__ii, __last);
++	      return true;
++	    }
++	  if (__i == __first)
++	    {
++	      std::reverse(__first, __last);
++	      return false;
++	    }
++	}
++    }
++
++  /**
++   *  @brief  Permute range into the next @e dictionary ordering using
++   *          comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   A comparison functor.
++   *  @return  False if wrapped to first permutation, true otherwise.
++   *
++   *  Treats all permutations of the range [__first,__last) as a set of
++   *  @e dictionary sorted sequences ordered by @p __comp.  Permutes the current
++   *  sequence into the next one of this set.  Returns true if there are more
++   *  sequences to generate.  If the sequence is the largest of the set, the
++   *  smallest is generated and false returned.
++  */
++  template<typename _BidirectionalIterator, typename _Compare>
++    bool
++    next_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_BidirectionalIterator>::value_type,
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return false;
++      _BidirectionalIterator __i = __first;
++      ++__i;
++      if (__i == __last)
++	return false;
++      __i = __last;
++      --__i;
++
++      for(;;)
++	{
++	  _BidirectionalIterator __ii = __i;
++	  --__i;
++	  if (__comp(*__i, *__ii))
++	    {
++	      _BidirectionalIterator __j = __last;
++	      while (!bool(__comp(*__i, *--__j)))
++		{}
++	      std::iter_swap(__i, __j);
++	      std::reverse(__ii, __last);
++	      return true;
++	    }
++	  if (__i == __first)
++	    {
++	      std::reverse(__first, __last);
++	      return false;
++	    }
++	}
++    }
++
++  /**
++   *  @brief  Permute range into the previous @e dictionary ordering.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  False if wrapped to last permutation, true otherwise.
++   *
++   *  Treats all permutations of the range as a set of @e dictionary sorted
++   *  sequences.  Permutes the current sequence into the previous one of this
++   *  set.  Returns true if there are more sequences to generate.  If the
++   *  sequence is the smallest of the set, the largest is generated and false
++   *  returned.
++  */
++  template<typename _BidirectionalIterator>
++    bool
++    prev_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return false;
++      _BidirectionalIterator __i = __first;
++      ++__i;
++      if (__i == __last)
++	return false;
++      __i = __last;
++      --__i;
++
++      for(;;)
++	{
++	  _BidirectionalIterator __ii = __i;
++	  --__i;
++	  if (*__ii < *__i)
++	    {
++	      _BidirectionalIterator __j = __last;
++	      while (!(*--__j < *__i))
++		{}
++	      std::iter_swap(__i, __j);
++	      std::reverse(__ii, __last);
++	      return true;
++	    }
++	  if (__i == __first)
++	    {
++	      std::reverse(__first, __last);
++	      return false;
++	    }
++	}
++    }
++
++  /**
++   *  @brief  Permute range into the previous @e dictionary ordering using
++   *          comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   A comparison functor.
++   *  @return  False if wrapped to last permutation, true otherwise.
++   *
++   *  Treats all permutations of the range [__first,__last) as a set of
++   *  @e dictionary sorted sequences ordered by @p __comp.  Permutes the current
++   *  sequence into the previous one of this set.  Returns true if there are
++   *  more sequences to generate.  If the sequence is the smallest of the set,
++   *  the largest is generated and false returned.
++  */
++  template<typename _BidirectionalIterator, typename _Compare>
++    bool
++    prev_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_BidirectionalIterator>::value_type,
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return false;
++      _BidirectionalIterator __i = __first;
++      ++__i;
++      if (__i == __last)
++	return false;
++      __i = __last;
++      --__i;
++
++      for(;;)
++	{
++	  _BidirectionalIterator __ii = __i;
++	  --__i;
++	  if (__comp(*__ii, *__i))
++	    {
++	      _BidirectionalIterator __j = __last;
++	      while (!bool(__comp(*--__j, *__i)))
++		{}
++	      std::iter_swap(__i, __j);
++	      std::reverse(__ii, __last);
++	      return true;
++	    }
++	  if (__i == __first)
++	    {
++	      std::reverse(__first, __last);
++	      return false;
++	    }
++	}
++    }
++
++  // replace
++  // replace_if
++
++  /**
++   *  @brief Copy a sequence, replacing each element of one value with another
++   *         value.
++   *  @param  __first      An input iterator.
++   *  @param  __last       An input iterator.
++   *  @param  __result     An output iterator.
++   *  @param  __old_value  The value to be replaced.
++   *  @param  __new_value  The replacement value.
++   *  @return   The end of the output sequence, @p result+(last-first).
++   *
++   *  Copies each element in the input range @p [__first,__last) to the
++   *  output range @p [__result,__result+(__last-__first)) replacing elements
++   *  equal to @p __old_value with @p __new_value.
++  */
++  template<typename _InputIterator, typename _OutputIterator, typename _Tp>
++    _OutputIterator
++    replace_copy(_InputIterator __first, _InputIterator __last,
++		 _OutputIterator __result,
++		 const _Tp& __old_value, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first, ++__result)
++	if (*__first == __old_value)
++	  *__result = __new_value;
++	else
++	  *__result = *__first;
++      return __result;
++    }
++
++  /**
++   *  @brief Copy a sequence, replacing each value for which a predicate
++   *         returns true with another value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first      An input iterator.
++   *  @param  __last       An input iterator.
++   *  @param  __result     An output iterator.
++   *  @param  __pred       A predicate.
++   *  @param  __new_value  The replacement value.
++   *  @return   The end of the output sequence, @p __result+(__last-__first).
++   *
++   *  Copies each element in the range @p [__first,__last) to the range
++   *  @p [__result,__result+(__last-__first)) replacing elements for which
++   *  @p __pred returns true with @p __new_value.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate, typename _Tp>
++    _OutputIterator
++    replace_copy_if(_InputIterator __first, _InputIterator __last,
++		    _OutputIterator __result,
++		    _Predicate __pred, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first, ++__result)
++	if (__pred(*__first))
++	  *__result = __new_value;
++	else
++	  *__result = *__first;
++      return __result;
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  /**
++   *  @brief  Determines whether the elements of a sequence are sorted.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  True if the elements are sorted, false otherwise.
++  */
++  template<typename _ForwardIterator>
++    inline bool
++    is_sorted(_ForwardIterator __first, _ForwardIterator __last)
++    { return std::is_sorted_until(__first, __last) == __last; }
++
++  /**
++   *  @brief  Determines whether the elements of a sequence are sorted
++   *          according to a comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  True if the elements are sorted, false otherwise.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    inline bool
++    is_sorted(_ForwardIterator __first, _ForwardIterator __last,
++	      _Compare __comp)
++    { return std::is_sorted_until(__first, __last, __comp) == __last; }
++
++  /**
++   *  @brief  Determines the end of a sorted sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  An iterator pointing to the last iterator i in [__first, __last)
++   *           for which the range [__first, i) is sorted.
++  */
++  template<typename _ForwardIterator>
++    _ForwardIterator
++    is_sorted_until(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __last;
++
++      _ForwardIterator __next = __first;
++      for (++__next; __next != __last; __first = __next, ++__next)
++	if (*__next < *__first)
++	  return __next;
++      return __next;
++    }
++
++  /**
++   *  @brief  Determines the end of a sorted sequence using comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  An iterator pointing to the last iterator i in [__first, __last)
++   *           for which the range [__first, i) is sorted.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    _ForwardIterator
++    is_sorted_until(_ForwardIterator __first, _ForwardIterator __last,
++		    _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __last;
++
++      _ForwardIterator __next = __first;
++      for (++__next; __next != __last; __first = __next, ++__next)
++	if (__comp(*__next, *__first))
++	  return __next;
++      return __next;
++    }
++
++  /**
++   *  @brief  Determines min and max at once as an ordered pair.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @return A pair(__b, __a) if __b is smaller than __a, pair(__a,
++   *  __b) otherwise.
++  */
++  template<typename _Tp>
++    inline pair<const _Tp&, const _Tp&>
++    minmax(const _Tp& __a, const _Tp& __b)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_LessThanComparableConcept<_Tp>)
++
++      return __b < __a ? pair<const _Tp&, const _Tp&>(__b, __a)
++	               : pair<const _Tp&, const _Tp&>(__a, __b);
++    }
++
++  /**
++   *  @brief  Determines min and max at once as an ordered pair.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @param  __comp  A @link comparison_functors comparison functor @endlink.
++   *  @return A pair(__b, __a) if __b is smaller than __a, pair(__a,
++   *  __b) otherwise.
++  */
++  template<typename _Tp, typename _Compare>
++    inline pair<const _Tp&, const _Tp&>
++    minmax(const _Tp& __a, const _Tp& __b, _Compare __comp)
++    {
++      return __comp(__b, __a) ? pair<const _Tp&, const _Tp&>(__b, __a)
++	                      : pair<const _Tp&, const _Tp&>(__a, __b);
++    }
++
++  /**
++   *  @brief  Return a pair of iterators pointing to the minimum and maximum
++   *          elements in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  make_pair(m, M), where m is the first iterator i in 
++   *           [__first, __last) such that no other element in the range is
++   *           smaller, and where M is the last iterator i in [__first, __last)
++   *           such that no other element in the range is larger.
++  */
++  template<typename _ForwardIterator>
++    pair<_ForwardIterator, _ForwardIterator>
++    minmax_element(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      _ForwardIterator __next = __first;
++      if (__first == __last
++	  || ++__next == __last)
++	return std::make_pair(__first, __first);
++
++      _ForwardIterator __min, __max;
++      if (*__next < *__first)
++	{
++	  __min = __next;
++	  __max = __first;
++	}
++      else
++	{
++	  __min = __first;
++	  __max = __next;
++	}
++
++      __first = __next;
++      ++__first;
++
++      while (__first != __last)
++	{
++	  __next = __first;
++	  if (++__next == __last)
++	    {
++	      if (*__first < *__min)
++		__min = __first;
++	      else if (!(*__first < *__max))
++		__max = __first;
++	      break;
++	    }
++
++	  if (*__next < *__first)
++	    {
++	      if (*__next < *__min)
++		__min = __next;
++	      if (!(*__first < *__max))
++		__max = __first;
++	    }
++	  else
++	    {
++	      if (*__first < *__min)
++		__min = __first;
++	      if (!(*__next < *__max))
++		__max = __next;
++	    }
++
++	  __first = __next;
++	  ++__first;
++	}
++
++      return std::make_pair(__min, __max);
++    }
++
++  /**
++   *  @brief  Return a pair of iterators pointing to the minimum and maximum
++   *          elements in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   Comparison functor.
++   *  @return  make_pair(m, M), where m is the first iterator i in 
++   *           [__first, __last) such that no other element in the range is
++   *           smaller, and where M is the last iterator i in [__first, __last)
++   *           such that no other element in the range is larger.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    pair<_ForwardIterator, _ForwardIterator>
++    minmax_element(_ForwardIterator __first, _ForwardIterator __last,
++		   _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      _ForwardIterator __next = __first;
++      if (__first == __last
++	  || ++__next == __last)
++	return std::make_pair(__first, __first);
++
++      _ForwardIterator __min, __max;
++      if (__comp(*__next, *__first))
++	{
++	  __min = __next;
++	  __max = __first;
++	}
++      else
++	{
++	  __min = __first;
++	  __max = __next;
++	}
++
++      __first = __next;
++      ++__first;
++
++      while (__first != __last)
++	{
++	  __next = __first;
++	  if (++__next == __last)
++	    {
++	      if (__comp(*__first, *__min))
++		__min = __first;
++	      else if (!__comp(*__first, *__max))
++		__max = __first;
++	      break;
++	    }
++
++	  if (__comp(*__next, *__first))
++	    {
++	      if (__comp(*__next, *__min))
++		__min = __next;
++	      if (!__comp(*__first, *__max))
++		__max = __first;
++	    }
++	  else
++	    {
++	      if (__comp(*__first, *__min))
++		__min = __first;
++	      if (!__comp(*__next, *__max))
++		__max = __next;
++	    }
++
++	  __first = __next;
++	  ++__first;
++	}
++
++      return std::make_pair(__min, __max);
++    }
++
++  // N2722 + DR 915.
++  template<typename _Tp>
++    inline _Tp
++    min(initializer_list<_Tp> __l)
++    { return *std::min_element(__l.begin(), __l.end()); }
++
++  template<typename _Tp, typename _Compare>
++    inline _Tp
++    min(initializer_list<_Tp> __l, _Compare __comp)
++    { return *std::min_element(__l.begin(), __l.end(), __comp); }
++
++  template<typename _Tp>
++    inline _Tp
++    max(initializer_list<_Tp> __l)
++    { return *std::max_element(__l.begin(), __l.end()); }
++
++  template<typename _Tp, typename _Compare>
++    inline _Tp
++    max(initializer_list<_Tp> __l, _Compare __comp)
++    { return *std::max_element(__l.begin(), __l.end(), __comp); }
++
++  template<typename _Tp>
++    inline pair<_Tp, _Tp>
++    minmax(initializer_list<_Tp> __l)
++    {
++      pair<const _Tp*, const _Tp*> __p =
++	std::minmax_element(__l.begin(), __l.end());
++      return std::make_pair(*__p.first, *__p.second);
++    }
++
++  template<typename _Tp, typename _Compare>
++    inline pair<_Tp, _Tp>
++    minmax(initializer_list<_Tp> __l, _Compare __comp)
++    {
++      pair<const _Tp*, const _Tp*> __p =
++	std::minmax_element(__l.begin(), __l.end(), __comp);
++      return std::make_pair(*__p.first, *__p.second);
++    }
++
++  /**
++   *  @brief  Checks whether a permutaion of the second sequence is equal
++   *          to the first sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @return true if there exists a permutation of the elements in the range
++   *          [__first2, __first2 + (__last1 - __first1)), beginning with 
++   *          ForwardIterator2 begin, such that equal(__first1, __last1, begin)
++   *          returns true; otherwise, returns false.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    bool
++    is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		   _ForwardIterator2 __first2)
++    {
++      // Efficiently compare identical prefixes:  O(N) if sequences
++      // have the same elements in the same order.
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	if (!(*__first1 == *__first2))
++	  break;
++
++      if (__first1 == __last1)
++	return true;
++
++      // Establish __last2 assuming equal ranges by iterating over the
++      // rest of the list.
++      _ForwardIterator2 __last2 = __first2;
++      std::advance(__last2, std::distance(__first1, __last1));
++      for (_ForwardIterator1 __scan = __first1; __scan != __last1; ++__scan)
++	{
++	  if (__scan != _GLIBCXX_STD_A::find(__first1, __scan, *__scan))
++	    continue; // We've seen this one before.
++
++	  auto __matches = std::count(__first2, __last2, *__scan);
++	  if (0 == __matches
++	      || std::count(__scan, __last1, *__scan) != __matches)
++	    return false;
++	}
++      return true;
++    }
++
++  /**
++   *  @brief  Checks whether a permutation of the second sequence is equal
++   *          to the first sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __pred    A binary predicate.
++   *  @return true if there exists a permutation of the elements in
++   *          the range [__first2, __first2 + (__last1 - __first1)),
++   *          beginning with ForwardIterator2 begin, such that
++   *          equal(__first1, __last1, __begin, __pred) returns true;
++   *          otherwise, returns false.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    bool
++    is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		   _ForwardIterator2 __first2, _BinaryPredicate __pred)
++    {
++      // Efficiently compare identical prefixes:  O(N) if sequences
++      // have the same elements in the same order.
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	if (!bool(__pred(*__first1, *__first2)))
++	  break;
++
++      if (__first1 == __last1)
++	return true;
++
++      // Establish __last2 assuming equal ranges by iterating over the
++      // rest of the list.
++      _ForwardIterator2 __last2 = __first2;
++      std::advance(__last2, std::distance(__first1, __last1));
++      for (_ForwardIterator1 __scan = __first1; __scan != __last1; ++__scan)
++	{
++	  using std::placeholders::_1;
++
++	  if (__scan != _GLIBCXX_STD_A::find_if(__first1, __scan,
++						std::bind(__pred, _1, *__scan)))
++	    continue; // We've seen this one before.
++	  
++	  auto __matches = std::count_if(__first2, __last2,
++					 std::bind(__pred, _1, *__scan));
++	  if (0 == __matches
++	      || std::count_if(__scan, __last1,
++			       std::bind(__pred, _1, *__scan)) != __matches)
++	    return false;
++	}
++      return true;
++    }
++
++#ifdef _GLIBCXX_USE_C99_STDINT_TR1
++  /**
++   *  @brief Shuffle the elements of a sequence using a uniform random
++   *         number generator.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __g       A UniformRandomNumberGenerator (26.5.1.3).
++   *  @return  Nothing.
++   *
++   *  Reorders the elements in the range @p [__first,__last) using @p __g to
++   *  provide random numbers.
++  */
++  template<typename _RandomAccessIterator,
++	   typename _UniformRandomNumberGenerator>
++    void
++    shuffle(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	    _UniformRandomNumberGenerator&& __g)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return;
++
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      typedef typename std::make_unsigned<_DistanceType>::type __ud_type;
++      typedef typename std::uniform_int_distribution<__ud_type> __distr_type;
++      typedef typename __distr_type::param_type __p_type;
++      __distr_type __d;
++
++      for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	std::iter_swap(__i, __first + __d(__g, __p_type(0, __i - __first)));
++    }
++#endif
++
++#endif // __GXX_EXPERIMENTAL_CXX0X__
++
++_GLIBCXX_END_NAMESPACE_VERSION
++
++_GLIBCXX_BEGIN_NAMESPACE_ALGO
++
++  /**
++   *  @brief Apply a function to every element of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __f      A unary function object.
++   *  @return   @p __f (std::move(@p __f) in C++0x).
++   *
++   *  Applies the function object @p __f to each element in the range
++   *  @p [first,last).  @p __f must not modify the order of the sequence.
++   *  If @p __f has a return value it is ignored.
++  */
++  template<typename _InputIterator, typename _Function>
++    _Function
++    for_each(_InputIterator __first, _InputIterator __last, _Function __f)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++      for (; __first != __last; ++__first)
++	__f(*__first);
++      return _GLIBCXX_MOVE(__f);
++    }
++
++  /**
++   *  @brief Find the first occurrence of a value in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __val    The value to find.
++   *  @return   The first iterator @c i in the range @p [__first,__last)
++   *  such that @c *i == @p __val, or @p __last if no such iterator exists.
++  */
++  template<typename _InputIterator, typename _Tp>
++    inline _InputIterator
++    find(_InputIterator __first, _InputIterator __last,
++	 const _Tp& __val)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++		typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++      return std::__find(__first, __last, __val,
++		         std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief Find the first element in a sequence for which a
++   *         predicate is true.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return   The first iterator @c i in the range @p [__first,__last)
++   *  such that @p __pred(*i) is true, or @p __last if no such iterator exists.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    find_if(_InputIterator __first, _InputIterator __last,
++	    _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	      typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      return std::__find_if(__first, __last, __pred,
++			    std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief  Find element from a set in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of match candidates.
++   *  @param  __last2   End of match candidates.
++   *  @return   The first iterator @c i in the range
++   *  @p [__first1,__last1) such that @c *i == @p *(i2) such that i2 is an
++   *  iterator in [__first2,__last2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for an element that is
++   *  equal to some element in the range [__first2,__last2).  If
++   *  found, returns an iterator in the range [__first1,__last1),
++   *  otherwise returns @p __last1.
++  */
++  template<typename _InputIterator, typename _ForwardIterator>
++    _InputIterator
++    find_first_of(_InputIterator __first1, _InputIterator __last1,
++		  _ForwardIterator __first2, _ForwardIterator __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      for (; __first1 != __last1; ++__first1)
++	for (_ForwardIterator __iter = __first2; __iter != __last2; ++__iter)
++	  if (*__first1 == *__iter)
++	    return __first1;
++      return __last1;
++    }
++
++  /**
++   *  @brief  Find element from a set in a sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of match candidates.
++   *  @param  __last2   End of match candidates.
++   *  @param  __comp    Predicate to use.
++   *  @return   The first iterator @c i in the range
++   *  @p [__first1,__last1) such that @c comp(*i, @p *(i2)) is true
++   *  and i2 is an iterator in [__first2,__last2), or @p __last1 if no
++   *  such iterator exists.
++   *
++
++   *  Searches the range @p [__first1,__last1) for an element that is
++   *  equal to some element in the range [__first2,__last2).  If
++   *  found, returns an iterator in the range [__first1,__last1),
++   *  otherwise returns @p __last1.
++  */
++  template<typename _InputIterator, typename _ForwardIterator,
++	   typename _BinaryPredicate>
++    _InputIterator
++    find_first_of(_InputIterator __first1, _InputIterator __last1,
++		  _ForwardIterator __first2, _ForwardIterator __last2,
++		  _BinaryPredicate __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_InputIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      for (; __first1 != __last1; ++__first1)
++	for (_ForwardIterator __iter = __first2; __iter != __last2; ++__iter)
++	  if (__comp(*__first1, *__iter))
++	    return __first1;
++      return __last1;
++    }
++
++  /**
++   *  @brief Find two adjacent values in a sequence that are equal.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @return   The first iterator @c i such that @c i and @c i+1 are both
++   *  valid iterators in @p [__first,__last) and such that @c *i == @c *(i+1),
++   *  or @p __last if no such iterator exists.
++  */
++  template<typename _ForwardIterator>
++    _ForwardIterator
++    adjacent_find(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_EqualityComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      if (__first == __last)
++	return __last;
++      _ForwardIterator __next = __first;
++      while(++__next != __last)
++	{
++	  if (*__first == *__next)
++	    return __first;
++	  __first = __next;
++	}
++      return __last;
++    }
++
++  /**
++   *  @brief Find two adjacent values in a sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first         A forward iterator.
++   *  @param  __last          A forward iterator.
++   *  @param  __binary_pred   A binary predicate.
++   *  @return   The first iterator @c i such that @c i and @c i+1 are both
++   *  valid iterators in @p [__first,__last) and such that
++   *  @p __binary_pred(*i,*(i+1)) is true, or @p __last if no such iterator
++   *  exists.
++  */
++  template<typename _ForwardIterator, typename _BinaryPredicate>
++    _ForwardIterator
++    adjacent_find(_ForwardIterator __first, _ForwardIterator __last,
++		  _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      if (__first == __last)
++	return __last;
++      _ForwardIterator __next = __first;
++      while(++__next != __last)
++	{
++	  if (__binary_pred(*__first, *__next))
++	    return __first;
++	  __first = __next;
++	}
++      return __last;
++    }
++
++  /**
++   *  @brief Count the number of copies of a value in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __value  The value to be counted.
++   *  @return   The number of iterators @c i in the range @p [__first,__last)
++   *  for which @c *i == @p __value
++  */
++  template<typename _InputIterator, typename _Tp>
++    typename iterator_traits<_InputIterator>::difference_type
++    count(_InputIterator __first, _InputIterator __last, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++      typename iterator_traits<_InputIterator>::difference_type __n = 0;
++      for (; __first != __last; ++__first)
++	if (*__first == __value)
++	  ++__n;
++      return __n;
++    }
++
++  /**
++   *  @brief Count the elements of a sequence for which a predicate is true.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return   The number of iterators @c i in the range @p [__first,__last)
++   *  for which @p __pred(*i) is true.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    typename iterator_traits<_InputIterator>::difference_type
++    count_if(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      typename iterator_traits<_InputIterator>::difference_type __n = 0;
++      for (; __first != __last; ++__first)
++	if (__pred(*__first))
++	  ++__n;
++      return __n;
++    }
++
++  /**
++   *  @brief Search a sequence for a matching sub-sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  A forward iterator.
++   *  @param  __last1   A forward iterator.
++   *  @param  __first2  A forward iterator.
++   *  @param  __last2   A forward iterator.
++   *  @return The first iterator @c i in the range @p
++   *  [__first1,__last1-(__last2-__first2)) such that @c *(i+N) == @p
++   *  *(__first2+N) for each @c N in the range @p
++   *  [0,__last2-__first2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2) and returns an iterator to the first element
++   *  of the sub-sequence, or @p __last1 if the sub-sequence is not
++   *  found.
++   *
++   *  Because the sub-sequence must lie completely within the range @p
++   *  [__first1,__last1) it must start at a position less than @p
++   *  __last1-(__last2-__first2) where @p __last2-__first2 is the
++   *  length of the sub-sequence.
++   *
++   *  This means that the returned iterator @c i will be in the range
++   *  @p [__first1,__last1-(__last2-__first2))
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    _ForwardIterator1
++    search(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	   _ForwardIterator2 __first2, _ForwardIterator2 __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      // Test for empty ranges
++      if (__first1 == __last1 || __first2 == __last2)
++	return __first1;
++
++      // Test for a pattern of length 1.
++      _ForwardIterator2 __p1(__first2);
++      if (++__p1 == __last2)
++	return _GLIBCXX_STD_A::find(__first1, __last1, *__first2);
++
++      // General case.
++      _ForwardIterator2 __p;
++      _ForwardIterator1 __current = __first1;
++
++      for (;;)
++	{
++	  __first1 = _GLIBCXX_STD_A::find(__first1, __last1, *__first2);
++	  if (__first1 == __last1)
++	    return __last1;
++
++	  __p = __p1;
++	  __current = __first1;
++	  if (++__current == __last1)
++	    return __last1;
++
++	  while (*__current == *__p)
++	    {
++	      if (++__p == __last2)
++		return __first1;
++	      if (++__current == __last1)
++		return __last1;
++	    }
++	  ++__first1;
++	}
++      return __first1;
++    }
++
++  /**
++   *  @brief Search a sequence for a matching sub-sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1     A forward iterator.
++   *  @param  __last1      A forward iterator.
++   *  @param  __first2     A forward iterator.
++   *  @param  __last2      A forward iterator.
++   *  @param  __predicate  A binary predicate.
++   *  @return   The first iterator @c i in the range
++   *  @p [__first1,__last1-(__last2-__first2)) such that
++   *  @p __predicate(*(i+N),*(__first2+N)) is true for each @c N in the range
++   *  @p [0,__last2-__first2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2), using @p __predicate to determine equality,
++   *  and returns an iterator to the first element of the
++   *  sub-sequence, or @p __last1 if no such iterator exists.
++   *
++   *  @see search(_ForwardIter1, _ForwardIter1, _ForwardIter2, _ForwardIter2)
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    _ForwardIterator1
++    search(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	   _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	   _BinaryPredicate  __predicate)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      // Test for empty ranges
++      if (__first1 == __last1 || __first2 == __last2)
++	return __first1;
++
++      // Test for a pattern of length 1.
++      _ForwardIterator2 __p1(__first2);
++      if (++__p1 == __last2)
++	{
++	  while (__first1 != __last1
++		 && !bool(__predicate(*__first1, *__first2)))
++	    ++__first1;
++	  return __first1;
++	}
++
++      // General case.
++      _ForwardIterator2 __p;
++      _ForwardIterator1 __current = __first1;
++
++      for (;;)
++	{
++	  while (__first1 != __last1
++		 && !bool(__predicate(*__first1, *__first2)))
++	    ++__first1;
++	  if (__first1 == __last1)
++	    return __last1;
++
++	  __p = __p1;
++	  __current = __first1;
++	  if (++__current == __last1)
++	    return __last1;
++
++	  while (__predicate(*__current, *__p))
++	    {
++	      if (++__p == __last2)
++		return __first1;
++	      if (++__current == __last1)
++		return __last1;
++	    }
++	  ++__first1;
++	}
++      return __first1;
++    }
++
++
++  /**
++   *  @brief Search a sequence for a number of consecutive values.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __count  The number of consecutive values.
++   *  @param  __val    The value to find.
++   *  @return The first iterator @c i in the range @p
++   *  [__first,__last-__count) such that @c *(i+N) == @p __val for
++   *  each @c N in the range @p [0,__count), or @p __last if no such
++   *  iterator exists.
++   *
++   *  Searches the range @p [__first,__last) for @p count consecutive elements
++   *  equal to @p __val.
++  */
++  template<typename _ForwardIterator, typename _Integer, typename _Tp>
++    _ForwardIterator
++    search_n(_ForwardIterator __first, _ForwardIterator __last,
++	     _Integer __count, const _Tp& __val)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__count <= 0)
++	return __first;
++      if (__count == 1)
++	return _GLIBCXX_STD_A::find(__first, __last, __val);
++      return std::__search_n(__first, __last, __count, __val,
++			     std::__iterator_category(__first));
++    }
++
++
++  /**
++   *  @brief Search a sequence for a number of consecutive values using a
++   *         predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first        A forward iterator.
++   *  @param  __last         A forward iterator.
++   *  @param  __count        The number of consecutive values.
++   *  @param  __val          The value to find.
++   *  @param  __binary_pred  A binary predicate.
++   *  @return The first iterator @c i in the range @p
++   *  [__first,__last-__count) such that @p
++   *  __binary_pred(*(i+N),__val) is true for each @c N in the range
++   *  @p [0,__count), or @p __last if no such iterator exists.
++   *
++   *  Searches the range @p [__first,__last) for @p __count
++   *  consecutive elements for which the predicate returns true.
++  */
++  template<typename _ForwardIterator, typename _Integer, typename _Tp,
++           typename _BinaryPredicate>
++    _ForwardIterator
++    search_n(_ForwardIterator __first, _ForwardIterator __last,
++	     _Integer __count, const _Tp& __val,
++	     _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__count <= 0)
++	return __first;
++      if (__count == 1)
++	{
++	  while (__first != __last && !bool(__binary_pred(*__first, __val)))
++	    ++__first;
++	  return __first;
++	}
++      return std::__search_n(__first, __last, __count, __val, __binary_pred,
++			     std::__iterator_category(__first));
++    }
++
++
++  /**
++   *  @brief Perform an operation on a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first     An input iterator.
++   *  @param  __last      An input iterator.
++   *  @param  __result    An output iterator.
++   *  @param  __unary_op  A unary operator.
++   *  @return   An output iterator equal to @p __result+(__last-__first).
++   *
++   *  Applies the operator to each element in the input range and assigns
++   *  the results to successive elements of the output sequence.
++   *  Evaluates @p *(__result+N)=unary_op(*(__first+N)) for each @c N in the
++   *  range @p [0,__last-__first).
++   *
++   *  @p unary_op must not alter its argument.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _UnaryOperation>
++    _OutputIterator
++    transform(_InputIterator __first, _InputIterator __last,
++	      _OutputIterator __result, _UnaryOperation __unary_op)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++            // "the type returned by a _UnaryOperation"
++            __typeof__(__unary_op(*__first))>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first, ++__result)
++	*__result = __unary_op(*__first);
++      return __result;
++    }
++
++  /**
++   *  @brief Perform an operation on corresponding elements of two sequences.
++   *  @ingroup mutating_algorithms
++   *  @param  __first1     An input iterator.
++   *  @param  __last1      An input iterator.
++   *  @param  __first2     An input iterator.
++   *  @param  __result     An output iterator.
++   *  @param  __binary_op  A binary operator.
++   *  @return   An output iterator equal to @p result+(last-first).
++   *
++   *  Applies the operator to the corresponding elements in the two
++   *  input ranges and assigns the results to successive elements of the
++   *  output sequence.
++   *  Evaluates @p
++   *  *(__result+N)=__binary_op(*(__first1+N),*(__first2+N)) for each
++   *  @c N in the range @p [0,__last1-__first1).
++   *
++   *  @p binary_op must not alter either of its arguments.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _BinaryOperation>
++    _OutputIterator
++    transform(_InputIterator1 __first1, _InputIterator1 __last1,
++	      _InputIterator2 __first2, _OutputIterator __result,
++	      _BinaryOperation __binary_op)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++            // "the type returned by a _BinaryOperation"
++            __typeof__(__binary_op(*__first1,*__first2))>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      for (; __first1 != __last1; ++__first1, ++__first2, ++__result)
++	*__result = __binary_op(*__first1, *__first2);
++      return __result;
++    }
++
++  /**
++   *  @brief Replace each occurrence of one value in a sequence with another
++   *         value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first      A forward iterator.
++   *  @param  __last       A forward iterator.
++   *  @param  __old_value  The value to be replaced.
++   *  @param  __new_value  The replacement value.
++   *  @return   replace() returns no value.
++   *
++   *  For each iterator @c i in the range @p [__first,__last) if @c *i ==
++   *  @p __old_value then the assignment @c *i = @p __new_value is performed.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    void
++    replace(_ForwardIterator __first, _ForwardIterator __last,
++	    const _Tp& __old_value, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_function_requires(_ConvertibleConcept<_Tp,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (*__first == __old_value)
++	  *__first = __new_value;
++    }
++
++  /**
++   *  @brief Replace each value in a sequence for which a predicate returns
++   *         true with another value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first      A forward iterator.
++   *  @param  __last       A forward iterator.
++   *  @param  __pred       A predicate.
++   *  @param  __new_value  The replacement value.
++   *  @return   replace_if() returns no value.
++   *
++   *  For each iterator @c i in the range @p [__first,__last) if @p __pred(*i)
++   *  is true then the assignment @c *i = @p __new_value is performed.
++  */
++  template<typename _ForwardIterator, typename _Predicate, typename _Tp>
++    void
++    replace_if(_ForwardIterator __first, _ForwardIterator __last,
++	       _Predicate __pred, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_ConvertibleConcept<_Tp,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (__pred(*__first))
++	  *__first = __new_value;
++    }
++
++  /**
++   *  @brief Assign the result of a function object to each value in a
++   *         sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __gen    A function object taking no arguments and returning
++   *                 std::iterator_traits<_ForwardIterator>::value_type
++   *  @return   generate() returns no value.
++   *
++   *  Performs the assignment @c *i = @p __gen() for each @c i in the range
++   *  @p [__first,__last).
++  */
++  template<typename _ForwardIterator, typename _Generator>
++    void
++    generate(_ForwardIterator __first, _ForwardIterator __last,
++	     _Generator __gen)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_GeneratorConcept<_Generator,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	*__first = __gen();
++    }
++
++  /**
++   *  @brief Assign the result of a function object to each value in a
++   *         sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __n      The length of the sequence.
++   *  @param  __gen    A function object taking no arguments and returning
++   *                 std::iterator_traits<_ForwardIterator>::value_type
++   *  @return   The end of the sequence, @p __first+__n
++   *
++   *  Performs the assignment @c *i = @p __gen() for each @c i in the range
++   *  @p [__first,__first+__n).
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 865. More algorithms that throw away information
++  */
++  template<typename _OutputIterator, typename _Size, typename _Generator>
++    _OutputIterator
++    generate_n(_OutputIterator __first, _Size __n, _Generator __gen)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++            // "the type returned by a _Generator"
++            __typeof__(__gen())>)
++
++      for (; __n > 0; --__n, ++__first)
++	*__first = __gen();
++      return __first;
++    }
++
++
++  /**
++   *  @brief Copy a sequence, removing consecutive duplicate values.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) to the range
++   *  beginning at @p __result, except that only the first element is copied
++   *  from groups of consecutive elements that compare equal.
++   *  unique_copy() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 241. Does unique_copy() require CopyConstructible and Assignable?
++   *  
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 538. 241 again: Does unique_copy() require CopyConstructible and 
++   *  Assignable?
++  */
++  template<typename _InputIterator, typename _OutputIterator>
++    inline _OutputIterator
++    unique_copy(_InputIterator __first, _InputIterator __last,
++		_OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_EqualityComparableConcept<
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __result;
++      return std::__unique_copy(__first, __last, __result,
++				std::__iterator_category(__first),
++				std::__iterator_category(__result));
++    }
++
++  /**
++   *  @brief Copy a sequence, removing consecutive values using a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first        An input iterator.
++   *  @param  __last         An input iterator.
++   *  @param  __result       An output iterator.
++   *  @param  __binary_pred  A binary predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) to the range
++   *  beginning at @p __result, except that only the first element is copied
++   *  from groups of consecutive elements for which @p __binary_pred returns
++   *  true.
++   *  unique_copy() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 241. Does unique_copy() require CopyConstructible and Assignable?
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _BinaryPredicate>
++    inline _OutputIterator
++    unique_copy(_InputIterator __first, _InputIterator __last,
++		_OutputIterator __result,
++		_BinaryPredicate __binary_pred)
++    {
++      // concept requirements -- predicates checked later
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __result;
++      return std::__unique_copy(__first, __last, __result, __binary_pred,
++				std::__iterator_category(__first),
++				std::__iterator_category(__result));
++    }
++
++
++  /**
++   *  @brief Randomly shuffle the elements of a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @return  Nothing.
++   *
++   *  Reorder the elements in the range @p [__first,__last) using a random
++   *  distribution, so that every possible ordering of the sequence is
++   *  equally likely.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    random_shuffle(_RandomAccessIterator __first, _RandomAccessIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first != __last)
++	for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	  std::iter_swap(__i, __first + (std::rand() % ((__i - __first) + 1)));
++    }
++
++  /**
++   *  @brief Shuffle the elements of a sequence using a random number
++   *         generator.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __rand    The RNG functor or function.
++   *  @return  Nothing.
++   *
++   *  Reorders the elements in the range @p [__first,__last) using @p __rand to
++   *  provide a random distribution. Calling @p __rand(N) for a positive
++   *  integer @p N should return a randomly chosen integer from the
++   *  range [0,N).
++  */
++  template<typename _RandomAccessIterator, typename _RandomNumberGenerator>
++    void
++    random_shuffle(_RandomAccessIterator __first, _RandomAccessIterator __last,
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++		   _RandomNumberGenerator&& __rand)
++#else
++		   _RandomNumberGenerator& __rand)
++#endif
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return;
++      for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	std::iter_swap(__i, __first + __rand((__i - __first) + 1));
++    }
++
++
++  /**
++   *  @brief Move elements for which a predicate is true to the beginning
++   *         of a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __pred    A predicate functor.
++   *  @return  An iterator @p middle such that @p __pred(i) is true for each
++   *  iterator @p i in the range @p [__first,middle) and false for each @p i
++   *  in the range @p [middle,__last).
++   *
++   *  @p __pred must not modify its operand. @p partition() does not preserve
++   *  the relative ordering of elements in each group, use
++   *  @p stable_partition() if this is needed.
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    inline _ForwardIterator
++    partition(_ForwardIterator __first, _ForwardIterator __last,
++	      _Predicate   __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__partition(__first, __last, __pred,
++			      std::__iterator_category(__first));
++    }
++
++
++
++  /**
++   *  @brief Sort the smallest elements of a sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Sorts the smallest @p (__middle-__first) elements in the range
++   *  @p [first,last) and moves them to the range @p [__first,__middle). The
++   *  order of the remaining elements in the range @p [__middle,__last) is
++   *  undefined.
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__first,__middle) such that i precedes j and @e k is an iterator in
++   *  the range @p [__middle,__last) then *j<*i and *k<*i are both false.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    partial_sort(_RandomAccessIterator __first,
++		 _RandomAccessIterator __middle,
++		 _RandomAccessIterator __last)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<_ValueType>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      std::__heap_select(__first, __middle, __last);
++      std::sort_heap(__first, __middle);
++    }
++
++  /**
++   *  @brief Sort the smallest elements of a sequence using a predicate
++   *         for comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Sorts the smallest @p (__middle-__first) elements in the range
++   *  @p [__first,__last) and moves them to the range @p [__first,__middle). The
++   *  order of the remaining elements in the range @p [__middle,__last) is
++   *  undefined.
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__first,__middle) such that i precedes j and @e k is an iterator in
++   *  the range @p [__middle,__last) then @p *__comp(j,*i) and @p __comp(*k,*i)
++   *  are both false.
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    partial_sort(_RandomAccessIterator __first,
++		 _RandomAccessIterator __middle,
++		 _RandomAccessIterator __last,
++		 _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType, _ValueType>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      std::__heap_select(__first, __middle, __last, __comp);
++      std::sort_heap(__first, __middle, __comp);
++    }
++
++  /**
++   *  @brief Sort a sequence just enough to find a particular position.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __nth     Another iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Rearranges the elements in the range @p [__first,__last) so that @p *__nth
++   *  is the same element that would have been in that position had the
++   *  whole sequence been sorted. The elements either side of @p *__nth are
++   *  not completely sorted, but for any iterator @e i in the range
++   *  @p [__first,__nth) and any iterator @e j in the range @p [__nth,__last) it
++   *  holds that *j < *i is false.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth,
++		_RandomAccessIterator __last)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<_ValueType>)
++      __glibcxx_requires_valid_range(__first, __nth);
++      __glibcxx_requires_valid_range(__nth, __last);
++
++      if (__first == __last || __nth == __last)
++	return;
++
++      std::__introselect(__first, __nth, __last,
++			 std::__lg(__last - __first) * 2);
++    }
++
++  /**
++   *  @brief Sort a sequence just enough to find a particular position
++   *         using a predicate for comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __nth     Another iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Rearranges the elements in the range @p [__first,__last) so that @p *__nth
++   *  is the same element that would have been in that position had the
++   *  whole sequence been sorted. The elements either side of @p *__nth are
++   *  not completely sorted, but for any iterator @e i in the range
++   *  @p [__first,__nth) and any iterator @e j in the range @p [__nth,__last) it
++   *  holds that @p __comp(*j,*i) is false.
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth,
++		_RandomAccessIterator __last, _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType, _ValueType>)
++      __glibcxx_requires_valid_range(__first, __nth);
++      __glibcxx_requires_valid_range(__nth, __last);
++
++      if (__first == __last || __nth == __last)
++	return;
++
++      std::__introselect(__first, __nth, __last,
++			 std::__lg(__last - __first) * 2, __comp);
++    }
++
++
++  /**
++   *  @brief Sort the elements of a sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that for each iterator @e i in the range @p [__first,__last-1),  
++   *  *(i+1)<*i is false.
++   *
++   *  The relative ordering of equivalent elements is not preserved, use
++   *  @p stable_sort() if this is needed.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    sort(_RandomAccessIterator __first, _RandomAccessIterator __last)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<_ValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first != __last)
++	{
++	  std::__introsort_loop(__first, __last,
++				std::__lg(__last - __first) * 2);
++	  std::__final_insertion_sort(__first, __last);
++	}
++    }
++
++  /**
++   *  @brief Sort the elements of a sequence using a predicate for comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that @p __comp(*(i+1),*i) is false for every iterator @e i in the
++   *  range @p [__first,__last-1).
++   *
++   *  The relative ordering of equivalent elements is not preserved, use
++   *  @p stable_sort() if this is needed.
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    sort(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	 _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare, _ValueType,
++				  _ValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first != __last)
++	{
++	  std::__introsort_loop(__first, __last,
++				std::__lg(__last - __first) * 2, __comp);
++	  std::__final_insertion_sort(__first, __last, __comp);
++	}
++    }
++
++  /**
++   *  @brief Merges two sorted ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An iterator.
++   *  @param  __first2  Another iterator.
++   *  @param  __last1   Another iterator.
++   *  @param  __last2   Another iterator.
++   *  @param  __result  An iterator pointing to the end of the merged range.
++   *  @return         An iterator pointing to the first element <em>not less
++   *                  than</em> @e val.
++   *
++   *  Merges the ranges @p [__first1,__last1) and @p [__first2,__last2) into
++   *  the sorted range @p [__result, __result + (__last1-__first1) +
++   *  (__last2-__first2)).  Both input ranges must be sorted, and the
++   *  output range must not overlap with either of the input ranges.
++   *  The sort is @e stable, that is, for equivalent elements in the
++   *  two ranges, elements from the first range will always come
++   *  before elements from the second.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    _OutputIterator
++    merge(_InputIterator1 __first1, _InputIterator1 __last1,
++	  _InputIterator2 __first2, _InputIterator2 __last2,
++	  _OutputIterator __result)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)	
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (*__first2 < *__first1)
++	    {
++	      *__result = *__first2;
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      return std::copy(__first2, __last2, std::copy(__first1, __last1,
++						    __result));
++    }
++
++  /**
++   *  @brief Merges two sorted ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An iterator.
++   *  @param  __first2  Another iterator.
++   *  @param  __last1   Another iterator.
++   *  @param  __last2   Another iterator.
++   *  @param  __result  An iterator pointing to the end of the merged range.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return         An iterator pointing to the first element "not less
++   *                  than" @e val.
++   *
++   *  Merges the ranges @p [__first1,__last1) and @p [__first2,__last2) into
++   *  the sorted range @p [__result, __result + (__last1-__first1) +
++   *  (__last2-__first2)).  Both input ranges must be sorted, and the
++   *  output range must not overlap with either of the input ranges.
++   *  The sort is @e stable, that is, for equivalent elements in the
++   *  two ranges, elements from the first range will always come
++   *  before elements from the second.
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    _OutputIterator
++    merge(_InputIterator1 __first1, _InputIterator1 __last1,
++	  _InputIterator2 __first2, _InputIterator2 __last2,
++	  _OutputIterator __result, _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(*__first2, *__first1))
++	    {
++	      *__result = *__first2;
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      return std::copy(__first2, __last2, std::copy(__first1, __last1,
++						    __result));
++    }
++
++
++  /**
++   *  @brief Sort the elements of a sequence, preserving the relative order
++   *         of equivalent elements.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that for each iterator @p i in the range @p [__first,__last-1),
++   *  @p *(i+1)<*i is false.
++   *
++   *  The relative ordering of equivalent elements is preserved, so any two
++   *  elements @p x and @p y in the range @p [__first,__last) such that
++   *  @p x<y is false and @p y<x is false will have the same relative
++   *  ordering after calling @p stable_sort().
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<_ValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      _Temporary_buffer<_RandomAccessIterator, _ValueType> __buf(__first,
++								 __last);
++      if (__buf.begin() == 0)
++	std::__inplace_stable_sort(__first, __last);
++      else
++	std::__stable_sort_adaptive(__first, __last, __buf.begin(),
++				    _DistanceType(__buf.size()));
++    }
++
++  /**
++   *  @brief Sort the elements of a sequence using a predicate for comparison,
++   *         preserving the relative order of equivalent elements.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that for each iterator @p i in the range @p [__first,__last-1),
++   *  @p __comp(*(i+1),*i) is false.
++   *
++   *  The relative ordering of equivalent elements is preserved, so any two
++   *  elements @p x and @p y in the range @p [__first,__last) such that
++   *  @p __comp(x,y) is false and @p __comp(y,x) is false will have the same
++   *  relative ordering after calling @p stable_sort().
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last,
++		_Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType,
++				  _ValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      _Temporary_buffer<_RandomAccessIterator, _ValueType> __buf(__first,
++								 __last);
++      if (__buf.begin() == 0)
++	std::__inplace_stable_sort(__first, __last, __comp);
++      else
++	std::__stable_sort_adaptive(__first, __last, __buf.begin(),
++				    _DistanceType(__buf.size()), __comp);
++    }
++
++
++  /**
++   *  @brief Return the union of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  each range in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other,
++   *  that element is copied and the iterator advanced.  If an element is
++   *  contained in both ranges, the element from the first range is copied and
++   *  both ranges advance.  The output range may not overlap either input
++   *  range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    _OutputIterator
++    set_union(_InputIterator1 __first1, _InputIterator1 __last1,
++	      _InputIterator2 __first2, _InputIterator2 __last2,
++	      _OutputIterator __result)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (*__first1 < *__first2)
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	    }
++	  else if (*__first2 < *__first1)
++	    {
++	      *__result = *__first2;
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	      ++__first2;
++	    }
++	  ++__result;
++	}
++      return std::copy(__first2, __last2, std::copy(__first1, __last1,
++						    __result));
++    }
++
++  /**
++   *  @brief Return the union of two sorted ranges using a comparison functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  each range in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other
++   *  according to @p __comp, that element is copied and the iterator advanced.
++   *  If an equivalent element according to @p __comp is contained in both
++   *  ranges, the element from the first range is copied and both ranges
++   *  advance.  The output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    _OutputIterator
++    set_union(_InputIterator1 __first1, _InputIterator1 __last1,
++	      _InputIterator2 __first2, _InputIterator2 __last2,
++	      _OutputIterator __result, _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(*__first1, *__first2))
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	    }
++	  else if (__comp(*__first2, *__first1))
++	    {
++	      *__result = *__first2;
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	      ++__first2;
++	    }
++	  ++__result;
++	}
++      return std::copy(__first2, __last2, std::copy(__first1, __last1,
++						    __result));
++    }
++
++  /**
++   *  @brief Return the intersection of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  both ranges in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other,
++   *  that iterator advances.  If an element is contained in both ranges, the
++   *  element from the first range is copied and both ranges advance.  The
++   *  output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    _OutputIterator
++    set_intersection(_InputIterator1 __first1, _InputIterator1 __last1,
++		     _InputIterator2 __first2, _InputIterator2 __last2,
++		     _OutputIterator __result)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (*__first1 < *__first2)
++	  ++__first1;
++	else if (*__first2 < *__first1)
++	  ++__first2;
++	else
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__first2;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++  /**
++   *  @brief Return the intersection of two sorted ranges using comparison
++   *  functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  both ranges in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other
++   *  according to @p __comp, that iterator advances.  If an element is
++   *  contained in both ranges according to @p __comp, the element from the
++   *  first range is copied and both ranges advance.  The output range may not
++   *  overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    _OutputIterator
++    set_intersection(_InputIterator1 __first1, _InputIterator1 __last1,
++		     _InputIterator2 __first2, _InputIterator2 __last2,
++		     _OutputIterator __result, _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(*__first1, *__first2))
++	  ++__first1;
++	else if (__comp(*__first2, *__first1))
++	  ++__first2;
++	else
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__first2;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++  /**
++   *  @brief Return the difference of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  the first range but not the second in order to the output range.
++   *  Iterators increment for each range.  When the current element of the
++   *  first range is less than the second, that element is copied and the
++   *  iterator advances.  If the current element of the second range is less,
++   *  the iterator advances, but no element is copied.  If an element is
++   *  contained in both ranges, no elements are copied and both ranges
++   *  advance.  The output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    _OutputIterator
++    set_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++		   _InputIterator2 __first2, _InputIterator2 __last2,
++		   _OutputIterator __result)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)	
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (*__first1 < *__first2)
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__result;
++	  }
++	else if (*__first2 < *__first1)
++	  ++__first2;
++	else
++	  {
++	    ++__first1;
++	    ++__first2;
++	  }
++      return std::copy(__first1, __last1, __result);
++    }
++
++  /**
++   *  @brief  Return the difference of two sorted ranges using comparison
++   *  functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  the first range but not the second in order to the output range.
++   *  Iterators increment for each range.  When the current element of the
++   *  first range is less than the second according to @p __comp, that element
++   *  is copied and the iterator advances.  If the current element of the
++   *  second range is less, no element is copied and the iterator advances.
++   *  If an element is contained in both ranges according to @p __comp, no
++   *  elements are copied and both ranges advance.  The output range may not
++   *  overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    _OutputIterator
++    set_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++		   _InputIterator2 __first2, _InputIterator2 __last2,
++		   _OutputIterator __result, _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(*__first1, *__first2))
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__result;
++	  }
++	else if (__comp(*__first2, *__first1))
++	  ++__first2;
++	else
++	  {
++	    ++__first1;
++	    ++__first2;
++	  }
++      return std::copy(__first1, __last1, __result);
++    }
++
++  /**
++   *  @brief  Return the symmetric difference of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  one range but not the other in order to the output range.  Iterators
++   *  increment for each range.  When the current element of one range is less
++   *  than the other, that element is copied and the iterator advances.  If an
++   *  element is contained in both ranges, no elements are copied and both
++   *  ranges advance.  The output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    _OutputIterator
++    set_symmetric_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++			     _InputIterator2 __first2, _InputIterator2 __last2,
++			     _OutputIterator __result)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)	
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (*__first1 < *__first2)
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__result;
++	  }
++	else if (*__first2 < *__first1)
++	  {
++	    *__result = *__first2;
++	    ++__first2;
++	    ++__result;
++	  }
++	else
++	  {
++	    ++__first1;
++	    ++__first2;
++	  }
++      return std::copy(__first2, __last2, std::copy(__first1,
++						    __last1, __result));
++    }
++
++  /**
++   *  @brief  Return the symmetric difference of two sorted ranges using
++   *  comparison functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  one range but not the other in order to the output range.  Iterators
++   *  increment for each range.  When the current element of one range is less
++   *  than the other according to @p comp, that element is copied and the
++   *  iterator advances.  If an element is contained in both ranges according
++   *  to @p __comp, no elements are copied and both ranges advance.  The output
++   *  range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    _OutputIterator
++    set_symmetric_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++			     _InputIterator2 __first2, _InputIterator2 __last2,
++			     _OutputIterator __result,
++			     _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_InputIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType1>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++				  _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType2, _ValueType1>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(*__first1, *__first2))
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__result;
++	  }
++	else if (__comp(*__first2, *__first1))
++	  {
++	    *__result = *__first2;
++	    ++__first2;
++	    ++__result;
++	  }
++	else
++	  {
++	    ++__first1;
++	    ++__first2;
++	  }
++      return std::copy(__first2, __last2, 
++		       std::copy(__first1, __last1, __result));
++    }
++
++
++  /**
++   *  @brief  Return the minimum element in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  Iterator referencing the first instance of the smallest value.
++  */
++  template<typename _ForwardIterator>
++    _ForwardIterator
++    min_element(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __first;
++      _ForwardIterator __result = __first;
++      while (++__first != __last)
++	if (*__first < *__result)
++	  __result = __first;
++      return __result;
++    }
++
++  /**
++   *  @brief  Return the minimum element in a range using comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   Comparison functor.
++   *  @return  Iterator referencing the first instance of the smallest value
++   *  according to __comp.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    _ForwardIterator
++    min_element(_ForwardIterator __first, _ForwardIterator __last,
++		_Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __first;
++      _ForwardIterator __result = __first;
++      while (++__first != __last)
++	if (__comp(*__first, *__result))
++	  __result = __first;
++      return __result;
++    }
++
++  /**
++   *  @brief  Return the maximum element in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  Iterator referencing the first instance of the largest value.
++  */
++  template<typename _ForwardIterator>
++    _ForwardIterator
++    max_element(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __first;
++      _ForwardIterator __result = __first;
++      while (++__first != __last)
++	if (*__result < *__first)
++	  __result = __first;
++      return __result;
++    }
++
++  /**
++   *  @brief  Return the maximum element in a range using comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   Comparison functor.
++   *  @return  Iterator referencing the first instance of the largest value
++   *  according to __comp.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    _ForwardIterator
++    max_element(_ForwardIterator __first, _ForwardIterator __last,
++		_Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last) return __first;
++      _ForwardIterator __result = __first;
++      while (++__first != __last)
++	if (__comp(*__result, *__first))
++	  __result = __first;
++      return __result;
++    }
++
++_GLIBCXX_END_NAMESPACE_ALGO
++} // namespace std
++
++#endif /* _STL_ALGO_H */
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/bits/stl_algobase.h gccxml/GCC_XML/Support/GCC/4.7/bits/stl_algobase.h
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/bits/stl_algobase.h	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/bits/stl_algobase.h	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,1210 @@
++// Core algorithmic facilities -*- C++ -*-
++
++// Copyright (C) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
++// 2011 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/*
++ *
++ * Copyright (c) 1994
++ * Hewlett-Packard Company
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Hewlett-Packard Company makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ *
++ *
++ * Copyright (c) 1996-1998
++ * Silicon Graphics Computer Systems, Inc.
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Silicon Graphics makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ */
++
++/** @file bits/stl_algobase.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{algorithm}
++ */
++
++#ifndef _STL_ALGOBASE_H
++#define _STL_ALGOBASE_H 1
++
++#include <bits/c++config.h>
++#include <bits/functexcept.h>
++#include <bits/cpp_type_traits.h>
++#include <ext/type_traits.h>
++#include <ext/numeric_traits.h>
++#include <bits/stl_pair.h>
++#include <bits/stl_iterator_base_types.h>
++#include <bits/stl_iterator_base_funcs.h>
++#include <bits/stl_iterator.h>
++#include <bits/concept_check.h>
++#include <debug/debug.h>
++#include <bits/move.h> // For std::swap and _GLIBCXX_MOVE
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // See http://gcc.gnu.org/ml/libstdc++/2004-08/msg00167.html: in a
++  // nutshell, we are partially implementing the resolution of DR 187,
++  // when it's safe, i.e., the value_types are equal.
++  template<bool _BoolType>
++    struct __iter_swap
++    {
++      template<typename _ForwardIterator1, typename _ForwardIterator2>
++        static void
++        iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
++        {
++          typedef typename iterator_traits<_ForwardIterator1>::value_type
++            _ValueType1;
++          _ValueType1 __tmp = _GLIBCXX_MOVE(*__a);
++          *__a = _GLIBCXX_MOVE(*__b);
++          *__b = _GLIBCXX_MOVE(__tmp);
++	}
++    };
++
++  template<>
++    struct __iter_swap<true>
++    {
++      template<typename _ForwardIterator1, typename _ForwardIterator2>
++        static void 
++        iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
++        {
++          swap(*__a, *__b);
++        }
++    };
++
++  /**
++   *  @brief Swaps the contents of two iterators.
++   *  @ingroup mutating_algorithms
++   *  @param  __a  An iterator.
++   *  @param  __b  Another iterator.
++   *  @return   Nothing.
++   *
++   *  This function swaps the values pointed to by two iterators, not the
++   *  iterators themselves.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    inline void
++    iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
++    {
++      typedef typename iterator_traits<_ForwardIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_ForwardIterator2>::value_type
++	_ValueType2;
++
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator1>)
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator2>)
++      __glibcxx_function_requires(_ConvertibleConcept<_ValueType1,
++				  _ValueType2>)
++      __glibcxx_function_requires(_ConvertibleConcept<_ValueType2,
++				  _ValueType1>)
++
++      typedef typename iterator_traits<_ForwardIterator1>::reference
++	_ReferenceType1;
++      typedef typename iterator_traits<_ForwardIterator2>::reference
++	_ReferenceType2;
++      std::__iter_swap<__are_same<_ValueType1, _ValueType2>::__value
++	&& __are_same<_ValueType1&, _ReferenceType1>::__value
++	&& __are_same<_ValueType2&, _ReferenceType2>::__value>::
++	iter_swap(__a, __b);
++    }
++
++  /**
++   *  @brief Swap the elements of two sequences.
++   *  @ingroup mutating_algorithms
++   *  @param  __first1  A forward iterator.
++   *  @param  __last1   A forward iterator.
++   *  @param  __first2  A forward iterator.
++   *  @return   An iterator equal to @p first2+(last1-first1).
++   *
++   *  Swaps each element in the range @p [first1,last1) with the
++   *  corresponding element in the range @p [first2,(last1-first1)).
++   *  The ranges must not overlap.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    _ForwardIterator2
++    swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		_ForwardIterator2 __first2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator1>)
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	std::iter_swap(__first1, __first2);
++      return __first2;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @return   The lesser of the parameters.
++   *
++   *  This is the simple classic generic implementation.  It will work on
++   *  temporary expressions, since they are only evaluated once, unlike a
++   *  preprocessor macro.
++  */
++  template<typename _Tp>
++    inline const _Tp&
++    min(const _Tp& __a, const _Tp& __b)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_LessThanComparableConcept<_Tp>)
++      //return __b < __a ? __b : __a;
++      if (__b < __a)
++	return __b;
++      return __a;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @return   The greater of the parameters.
++   *
++   *  This is the simple classic generic implementation.  It will work on
++   *  temporary expressions, since they are only evaluated once, unlike a
++   *  preprocessor macro.
++  */
++  template<typename _Tp>
++    inline const _Tp&
++    max(const _Tp& __a, const _Tp& __b)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_LessThanComparableConcept<_Tp>)
++      //return  __a < __b ? __b : __a;
++      if (__a < __b)
++	return __b;
++      return __a;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @param  __comp  A @link comparison_functors comparison functor@endlink.
++   *  @return   The lesser of the parameters.
++   *
++   *  This will work on temporary expressions, since they are only evaluated
++   *  once, unlike a preprocessor macro.
++  */
++  template<typename _Tp, typename _Compare>
++    inline const _Tp&
++    min(const _Tp& __a, const _Tp& __b, _Compare __comp)
++    {
++      //return __comp(__b, __a) ? __b : __a;
++      if (__comp(__b, __a))
++	return __b;
++      return __a;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @param  __comp  A @link comparison_functors comparison functor@endlink.
++   *  @return   The greater of the parameters.
++   *
++   *  This will work on temporary expressions, since they are only evaluated
++   *  once, unlike a preprocessor macro.
++  */
++  template<typename _Tp, typename _Compare>
++    inline const _Tp&
++    max(const _Tp& __a, const _Tp& __b, _Compare __comp)
++    {
++      //return __comp(__a, __b) ? __b : __a;
++      if (__comp(__a, __b))
++	return __b;
++      return __a;
++    }
++
++  // If _Iterator is a __normal_iterator return its base (a plain pointer,
++  // normally) otherwise return it untouched.  See copy, fill, ... 
++  template<typename _Iterator>
++    struct _Niter_base
++    : _Iter_base<_Iterator, __is_normal_iterator<_Iterator>::__value>
++    { };
++
++  template<typename _Iterator>
++    inline typename _Niter_base<_Iterator>::iterator_type
++    __niter_base(_Iterator __it)
++    { return std::_Niter_base<_Iterator>::_S_base(__it); }
++
++  // Likewise, for move_iterator.
++  template<typename _Iterator>
++    struct _Miter_base
++    : _Iter_base<_Iterator, __is_move_iterator<_Iterator>::__value>
++    { };
++
++  template<typename _Iterator>
++    inline typename _Miter_base<_Iterator>::iterator_type
++    __miter_base(_Iterator __it)
++    { return std::_Miter_base<_Iterator>::_S_base(__it); }
++
++  // All of these auxiliary structs serve two purposes.  (1) Replace
++  // calls to copy with memmove whenever possible.  (Memmove, not memcpy,
++  // because the input and output ranges are permitted to overlap.)
++  // (2) If we're using random access iterators, then write the loop as
++  // a for loop with an explicit count.
++
++  template<bool, bool, typename>
++    struct __copy_move
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        {
++	  for (; __first != __last; ++__result, ++__first)
++	    *__result = *__first;
++	  return __result;
++	}
++    };
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  template<typename _Category>
++    struct __copy_move<true, false, _Category>
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        {
++	  for (; __first != __last; ++__result, ++__first)
++	    *__result = std::move(*__first);
++	  return __result;
++	}
++    };
++#endif
++
++  template<>
++    struct __copy_move<false, false, random_access_iterator_tag>
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        { 
++	  typedef typename iterator_traits<_II>::difference_type _Distance;
++	  for(_Distance __n = __last - __first; __n > 0; --__n)
++	    {
++	      *__result = *__first;
++	      ++__first;
++	      ++__result;
++	    }
++	  return __result;
++	}
++    };
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  template<>
++    struct __copy_move<true, false, random_access_iterator_tag>
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        { 
++	  typedef typename iterator_traits<_II>::difference_type _Distance;
++	  for(_Distance __n = __last - __first; __n > 0; --__n)
++	    {
++	      *__result = std::move(*__first);
++	      ++__first;
++	      ++__result;
++	    }
++	  return __result;
++	}
++    };
++#endif
++
++  template<bool _IsMove>
++    struct __copy_move<_IsMove, true, random_access_iterator_tag>
++    {
++      template<typename _Tp>
++        static _Tp*
++        __copy_m(const _Tp* __first, const _Tp* __last, _Tp* __result)
++        {
++	  const ptrdiff_t _Num = __last - __first;
++	  if (_Num)
++	    __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
++	  return __result + _Num;
++	}
++    };
++
++  template<bool _IsMove, typename _II, typename _OI>
++    inline _OI
++    __copy_move_a(_II __first, _II __last, _OI __result)
++    {
++      typedef typename iterator_traits<_II>::value_type _ValueTypeI;
++      typedef typename iterator_traits<_OI>::value_type _ValueTypeO;
++      typedef typename iterator_traits<_II>::iterator_category _Category;
++      const bool __simple = (__is_trivial(_ValueTypeI)
++	                     && __is_pointer<_II>::__value
++	                     && __is_pointer<_OI>::__value
++			     && __are_same<_ValueTypeI, _ValueTypeO>::__value);
++
++      return std::__copy_move<_IsMove, __simple,
++	                      _Category>::__copy_m(__first, __last, __result);
++    }
++
++  // Helpers for streambuf iterators (either istream or ostream).
++  // NB: avoid including <iosfwd>, relatively large.
++  template<typename _CharT>
++    struct char_traits;
++
++  template<typename _CharT, typename _Traits>
++    class istreambuf_iterator;
++
++  template<typename _CharT, typename _Traits>
++    class ostreambuf_iterator;
++
++  template<bool _IsMove, typename _CharT>
++    typename __gnu_cxx::__enable_if<__is_char<_CharT>::__value, 
++	     ostreambuf_iterator<_CharT, char_traits<_CharT> > >::__type
++    __copy_move_a2(_CharT*, _CharT*,
++		   ostreambuf_iterator<_CharT, char_traits<_CharT> >);
++
++  template<bool _IsMove, typename _CharT>
++    typename __gnu_cxx::__enable_if<__is_char<_CharT>::__value, 
++	     ostreambuf_iterator<_CharT, char_traits<_CharT> > >::__type
++    __copy_move_a2(const _CharT*, const _CharT*,
++		   ostreambuf_iterator<_CharT, char_traits<_CharT> >);
++
++  template<bool _IsMove, typename _CharT>
++    typename __gnu_cxx::__enable_if<__is_char<_CharT>::__value,
++				    _CharT*>::__type
++    __copy_move_a2(istreambuf_iterator<_CharT, char_traits<_CharT> >,
++		   istreambuf_iterator<_CharT, char_traits<_CharT> >, _CharT*);
++
++  template<bool _IsMove, typename _II, typename _OI>
++    inline _OI
++    __copy_move_a2(_II __first, _II __last, _OI __result)
++    {
++      return _OI(std::__copy_move_a<_IsMove>(std::__niter_base(__first),
++					     std::__niter_base(__last),
++					     std::__niter_base(__result)));
++    }
++
++  /**
++   *  @brief Copies the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __result An output iterator.
++   *  @return   result + (first - last)
++   *
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).  Result may not be contained within
++   *  [first,last); the copy_backward function should be used instead.
++   *
++   *  Note that the end of the output range is permitted to be contained
++   *  within [first,last).
++  */
++  template<typename _II, typename _OI>
++    inline _OI
++    copy(_II __first, _II __last, _OI __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OI,
++	    typename iterator_traits<_II>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return (std::__copy_move_a2<__is_move_iterator<_II>::__value>
++	      (std::__miter_base(__first), std::__miter_base(__last),
++	       __result));
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  /**
++   *  @brief Moves the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __result An output iterator.
++   *  @return   result + (first - last)
++   *
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).  Result may not be contained within
++   *  [first,last); the move_backward function should be used instead.
++   *
++   *  Note that the end of the output range is permitted to be contained
++   *  within [first,last).
++  */
++  template<typename _II, typename _OI>
++    inline _OI
++    move(_II __first, _II __last, _OI __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OI,
++	    typename iterator_traits<_II>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__copy_move_a2<true>(std::__miter_base(__first),
++				       std::__miter_base(__last), __result);
++    }
++
++#define _GLIBCXX_MOVE3(_Tp, _Up, _Vp) std::move(_Tp, _Up, _Vp)
++#else
++#define _GLIBCXX_MOVE3(_Tp, _Up, _Vp) std::copy(_Tp, _Up, _Vp)
++#endif
++
++  template<bool, bool, typename>
++    struct __copy_move_backward
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  while (__first != __last)
++	    *--__result = *--__last;
++	  return __result;
++	}
++    };
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  template<typename _Category>
++    struct __copy_move_backward<true, false, _Category>
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  while (__first != __last)
++	    *--__result = std::move(*--__last);
++	  return __result;
++	}
++    };
++#endif
++
++  template<>
++    struct __copy_move_backward<false, false, random_access_iterator_tag>
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  typename iterator_traits<_BI1>::difference_type __n;
++	  for (__n = __last - __first; __n > 0; --__n)
++	    *--__result = *--__last;
++	  return __result;
++	}
++    };
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  template<>
++    struct __copy_move_backward<true, false, random_access_iterator_tag>
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  typename iterator_traits<_BI1>::difference_type __n;
++	  for (__n = __last - __first; __n > 0; --__n)
++	    *--__result = std::move(*--__last);
++	  return __result;
++	}
++    };
++#endif
++
++  template<bool _IsMove>
++    struct __copy_move_backward<_IsMove, true, random_access_iterator_tag>
++    {
++      template<typename _Tp>
++        static _Tp*
++        __copy_move_b(const _Tp* __first, const _Tp* __last, _Tp* __result)
++        {
++	  const ptrdiff_t _Num = __last - __first;
++	  if (_Num)
++	    __builtin_memmove(__result - _Num, __first, sizeof(_Tp) * _Num);
++	  return __result - _Num;
++	}
++    };
++
++  template<bool _IsMove, typename _BI1, typename _BI2>
++    inline _BI2
++    __copy_move_backward_a(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      typedef typename iterator_traits<_BI1>::value_type _ValueType1;
++      typedef typename iterator_traits<_BI2>::value_type _ValueType2;
++      typedef typename iterator_traits<_BI1>::iterator_category _Category;
++      const bool __simple = (__is_trivial(_ValueType1)
++	                     && __is_pointer<_BI1>::__value
++	                     && __is_pointer<_BI2>::__value
++			     && __are_same<_ValueType1, _ValueType2>::__value);
++
++      return std::__copy_move_backward<_IsMove, __simple,
++	                               _Category>::__copy_move_b(__first,
++								 __last,
++								 __result);
++    }
++
++  template<bool _IsMove, typename _BI1, typename _BI2>
++    inline _BI2
++    __copy_move_backward_a2(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      return _BI2(std::__copy_move_backward_a<_IsMove>
++		  (std::__niter_base(__first), std::__niter_base(__last),
++		   std::__niter_base(__result)));
++    }
++
++  /**
++   *  @brief Copies the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A bidirectional iterator.
++   *  @param  __last   A bidirectional iterator.
++   *  @param  __result A bidirectional iterator.
++   *  @return   result - (first - last)
++   *
++   *  The function has the same effect as copy, but starts at the end of the
++   *  range and works its way to the start, returning the start of the result.
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).
++   *
++   *  Result may not be in the range [first,last).  Use copy instead.  Note
++   *  that the start of the output range may overlap [first,last).
++  */
++  template<typename _BI1, typename _BI2>
++    inline _BI2
++    copy_backward(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<_BI1>)
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<_BI2>)
++      __glibcxx_function_requires(_ConvertibleConcept<
++	    typename iterator_traits<_BI1>::value_type,
++	    typename iterator_traits<_BI2>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return (std::__copy_move_backward_a2<__is_move_iterator<_BI1>::__value>
++	      (std::__miter_base(__first), std::__miter_base(__last),
++	       __result));
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  /**
++   *  @brief Moves the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A bidirectional iterator.
++   *  @param  __last   A bidirectional iterator.
++   *  @param  __result A bidirectional iterator.
++   *  @return   result - (first - last)
++   *
++   *  The function has the same effect as move, but starts at the end of the
++   *  range and works its way to the start, returning the start of the result.
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).
++   *
++   *  Result may not be in the range (first,last].  Use move instead.  Note
++   *  that the start of the output range may overlap [first,last).
++  */
++  template<typename _BI1, typename _BI2>
++    inline _BI2
++    move_backward(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<_BI1>)
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<_BI2>)
++      __glibcxx_function_requires(_ConvertibleConcept<
++	    typename iterator_traits<_BI1>::value_type,
++	    typename iterator_traits<_BI2>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__copy_move_backward_a2<true>(std::__miter_base(__first),
++						std::__miter_base(__last),
++						__result);
++    }
++
++#define _GLIBCXX_MOVE_BACKWARD3(_Tp, _Up, _Vp) std::move_backward(_Tp, _Up, _Vp)
++#else
++#define _GLIBCXX_MOVE_BACKWARD3(_Tp, _Up, _Vp) std::copy_backward(_Tp, _Up, _Vp)
++#endif
++
++  template<typename _ForwardIterator, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<!__is_scalar<_Tp>::__value, void>::__type
++    __fill_a(_ForwardIterator __first, _ForwardIterator __last,
++ 	     const _Tp& __value)
++    {
++      for (; __first != __last; ++__first)
++	*__first = __value;
++    }
++    
++  template<typename _ForwardIterator, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_scalar<_Tp>::__value, void>::__type
++    __fill_a(_ForwardIterator __first, _ForwardIterator __last,
++	     const _Tp& __value)
++    {
++      const _Tp __tmp = __value;
++      for (; __first != __last; ++__first)
++	*__first = __tmp;
++    }
++
++  // Specialization: for char types we can use memset.
++  template<typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_byte<_Tp>::__value, void>::__type
++    __fill_a(_Tp* __first, _Tp* __last, const _Tp& __c)
++    {
++      const _Tp __tmp = __c;
++      __builtin_memset(__first, static_cast<unsigned char>(__tmp),
++		       __last - __first);
++    }
++
++  /**
++   *  @brief Fills the range [first,last) with copies of value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __value  A reference-to-const of arbitrary type.
++   *  @return   Nothing.
++   *
++   *  This function fills a range with copies of the same value.  For char
++   *  types filling contiguous areas of memory, this becomes an inline call
++   *  to @c memset or @c wmemset.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    inline void
++    fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      std::__fill_a(std::__niter_base(__first), std::__niter_base(__last),
++		    __value);
++    }
++
++  template<typename _OutputIterator, typename _Size, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<!__is_scalar<_Tp>::__value, _OutputIterator>::__type
++    __fill_n_a(_OutputIterator __first, _Size __n, const _Tp& __value)
++    {
++      for (; __n > 0; --__n, ++__first)
++	*__first = __value;
++      return __first;
++    }
++
++  template<typename _OutputIterator, typename _Size, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_scalar<_Tp>::__value, _OutputIterator>::__type
++    __fill_n_a(_OutputIterator __first, _Size __n, const _Tp& __value)
++    {
++      const _Tp __tmp = __value;
++      for (; __n > 0; --__n, ++__first)
++	*__first = __tmp;
++      return __first;
++    }
++
++  template<typename _Size, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_byte<_Tp>::__value, _Tp*>::__type
++    __fill_n_a(_Tp* __first, _Size __n, const _Tp& __c)
++    {
++      std::__fill_a(__first, __first + __n, __c);
++      return __first + __n;
++    }
++
++  /**
++   *  @brief Fills the range [first,first+n) with copies of value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An output iterator.
++   *  @param  __n      The count of copies to perform.
++   *  @param  __value  A reference-to-const of arbitrary type.
++   *  @return   The iterator at first+n.
++   *
++   *  This function fills a range with copies of the same value.  For char
++   *  types filling contiguous areas of memory, this becomes an inline call
++   *  to @c memset or @ wmemset.
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 865. More algorithms that throw away information
++  */
++  template<typename _OI, typename _Size, typename _Tp>
++    inline _OI
++    fill_n(_OI __first, _Size __n, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_OutputIteratorConcept<_OI, _Tp>)
++
++      return _OI(std::__fill_n_a(std::__niter_base(__first), __n, __value));
++    }
++
++  template<bool _BoolType>
++    struct __equal
++    {
++      template<typename _II1, typename _II2>
++        static bool
++        equal(_II1 __first1, _II1 __last1, _II2 __first2)
++        {
++	  for (; __first1 != __last1; ++__first1, ++__first2)
++	    if (!(*__first1 == *__first2))
++	      return false;
++	  return true;
++	}
++    };
++
++  template<>
++    struct __equal<true>
++    {
++      template<typename _Tp>
++        static bool
++        equal(const _Tp* __first1, const _Tp* __last1, const _Tp* __first2)
++        {
++	  return !__builtin_memcmp(__first1, __first2, sizeof(_Tp)
++				   * (__last1 - __first1));
++	}
++    };
++
++  template<typename _II1, typename _II2>
++    inline bool
++    __equal_aux(_II1 __first1, _II1 __last1, _II2 __first2)
++    {
++      typedef typename iterator_traits<_II1>::value_type _ValueType1;
++      typedef typename iterator_traits<_II2>::value_type _ValueType2;
++      const bool __simple = ((__is_integer<_ValueType1>::__value
++			      || __is_pointer<_ValueType1>::__value)
++	                     && __is_pointer<_II1>::__value
++	                     && __is_pointer<_II2>::__value
++			     && __are_same<_ValueType1, _ValueType2>::__value);
++
++      return std::__equal<__simple>::equal(__first1, __last1, __first2);
++    }
++
++
++  template<typename, typename>
++    struct __lc_rai
++    {
++      template<typename _II1, typename _II2>
++        static _II1
++        __newlast1(_II1, _II1 __last1, _II2, _II2)
++        { return __last1; }
++
++      template<typename _II>
++        static bool
++        __cnd2(_II __first, _II __last)
++        { return __first != __last; }
++    };
++
++  template<>
++    struct __lc_rai<random_access_iterator_tag, random_access_iterator_tag>
++    {
++      template<typename _RAI1, typename _RAI2>
++        static _RAI1
++        __newlast1(_RAI1 __first1, _RAI1 __last1,
++		   _RAI2 __first2, _RAI2 __last2)
++        {
++	  const typename iterator_traits<_RAI1>::difference_type
++	    __diff1 = __last1 - __first1;
++	  const typename iterator_traits<_RAI2>::difference_type
++	    __diff2 = __last2 - __first2;
++	  return __diff2 < __diff1 ? __first1 + __diff2 : __last1;
++	}
++
++      template<typename _RAI>
++        static bool
++        __cnd2(_RAI, _RAI)
++        { return true; }
++    };
++
++  template<bool _BoolType>
++    struct __lexicographical_compare
++    {
++      template<typename _II1, typename _II2>
++        static bool __lc(_II1, _II1, _II2, _II2);
++    };
++
++  template<bool _BoolType>
++    template<typename _II1, typename _II2>
++      bool
++      __lexicographical_compare<_BoolType>::
++      __lc(_II1 __first1, _II1 __last1, _II2 __first2, _II2 __last2)
++      {
++	typedef typename iterator_traits<_II1>::iterator_category _Category1;
++	typedef typename iterator_traits<_II2>::iterator_category _Category2;
++	typedef std::__lc_rai<_Category1, _Category2> 	__rai_type;
++	
++	__last1 = __rai_type::__newlast1(__first1, __last1,
++					 __first2, __last2);
++	for (; __first1 != __last1 && __rai_type::__cnd2(__first2, __last2);
++	     ++__first1, ++__first2)
++	  {
++	    if (*__first1 < *__first2)
++	      return true;
++	    if (*__first2 < *__first1)
++	      return false;
++	  }
++	return __first1 == __last1 && __first2 != __last2;
++      }
++
++  template<>
++    struct __lexicographical_compare<true>
++    {
++      template<typename _Tp, typename _Up>
++        static bool
++        __lc(const _Tp* __first1, const _Tp* __last1,
++	     const _Up* __first2, const _Up* __last2)
++	{
++	  const size_t __len1 = __last1 - __first1;
++	  const size_t __len2 = __last2 - __first2;
++	  const int __result = __builtin_memcmp(__first1, __first2,
++						std::min(__len1, __len2));
++	  return __result != 0 ? __result < 0 : __len1 < __len2;
++	}
++    };
++
++  template<typename _II1, typename _II2>
++    inline bool
++    __lexicographical_compare_aux(_II1 __first1, _II1 __last1,
++				  _II2 __first2, _II2 __last2)
++    {
++      typedef typename iterator_traits<_II1>::value_type _ValueType1;
++      typedef typename iterator_traits<_II2>::value_type _ValueType2;
++      const bool __simple =
++	(__is_byte<_ValueType1>::__value && __is_byte<_ValueType2>::__value
++	 && !__gnu_cxx::__numeric_traits<_ValueType1>::__is_signed
++	 && !__gnu_cxx::__numeric_traits<_ValueType2>::__is_signed
++	 && __is_pointer<_II1>::__value
++	 && __is_pointer<_II2>::__value);
++
++      return std::__lexicographical_compare<__simple>::__lc(__first1, __last1,
++							    __first2, __last2);
++    }
++
++  /**
++   *  @brief Finds the first position in which @a val could be inserted
++   *         without changing the ordering.
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return         An iterator pointing to the first element <em>not less
++   *                  than</em> @a val, or end() if every element is less than 
++   *                  @a val.
++   *  @ingroup binary_search_algorithms
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    _ForwardIterator
++    lower_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType, _Tp>)
++      __glibcxx_requires_partitioned_lower(__first, __last, __val);
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (*__middle < __val)
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else
++	    __len = __half;
++	}
++      return __first;
++    }
++
++  /// This is a helper function for the sort routines and for random.tcc.
++  //  Precondition: __n > 0.
++  template<typename _Size>
++    inline _Size
++    __lg(_Size __n)
++    {
++      _Size __k;
++      for (__k = 0; __n != 0; __n >>= 1)
++	++__k;
++      return __k - 1;
++    }
++
++  inline int
++  __lg(int __n)
++  { return sizeof(int) * __CHAR_BIT__  - 1 - __builtin_clz(__n); }
++
++  inline long
++  __lg(long __n)
++  { return sizeof(long) * __CHAR_BIT__ - 1 - __builtin_clzl(__n); }
++
++  inline long long
++  __lg(long long __n)
++  { return sizeof(long long) * __CHAR_BIT__ - 1 - __builtin_clzll(__n); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++
++_GLIBCXX_BEGIN_NAMESPACE_ALGO
++
++  /**
++   *  @brief Tests a range for element-wise equality.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @return   A boolean true or false.
++   *
++   *  This compares the elements of two ranges using @c == and returns true or
++   *  false depending on whether all of the corresponding elements of the
++   *  ranges are equal.
++  */
++  template<typename _II1, typename _II2>
++    inline bool
++    equal(_II1 __first1, _II1 __last1, _II2 __first2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_II2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_II1>::value_type,
++	    typename iterator_traits<_II2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      return std::__equal_aux(std::__niter_base(__first1),
++			      std::__niter_base(__last1),
++			      std::__niter_base(__first2));
++    }
++
++  /**
++   *  @brief Tests a range for element-wise equality.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param __binary_pred A binary predicate @link functors
++   *                  functor@endlink.
++   *  @return         A boolean true or false.
++   *
++   *  This compares the elements of two ranges using the binary_pred
++   *  parameter, and returns true or
++   *  false depending on whether all of the corresponding elements of the
++   *  ranges are equal.
++  */
++  template<typename _IIter1, typename _IIter2, typename _BinaryPredicate>
++    inline bool
++    equal(_IIter1 __first1, _IIter1 __last1,
++	  _IIter2 __first2, _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_IIter1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_IIter2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	if (!bool(__binary_pred(*__first1, *__first2)))
++	  return false;
++      return true;
++    }
++
++  /**
++   *  @brief Performs @b dictionary comparison on ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @return   A boolean true or false.
++   *
++   *  <em>Returns true if the sequence of elements defined by the range
++   *  [first1,last1) is lexicographically less than the sequence of elements
++   *  defined by the range [first2,last2).  Returns false otherwise.</em>
++   *  (Quoted from [25.3.8]/1.)  If the iterators are all character pointers,
++   *  then this is an inline call to @c memcmp.
++  */
++  template<typename _II1, typename _II2>
++    inline bool
++    lexicographical_compare(_II1 __first1, _II1 __last1,
++			    _II2 __first2, _II2 __last2)
++    {
++      // concept requirements
++      typedef typename iterator_traits<_II1>::value_type _ValueType1;
++      typedef typename iterator_traits<_II2>::value_type _ValueType2;
++      __glibcxx_function_requires(_InputIteratorConcept<_II1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_II2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__lexicographical_compare_aux(std::__niter_base(__first1),
++						std::__niter_base(__last1),
++						std::__niter_base(__first2),
++						std::__niter_base(__last2));
++    }
++
++  /**
++   *  @brief Performs @b dictionary comparison on ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @param  __comp  A @link comparison_functors comparison functor@endlink.
++   *  @return   A boolean true or false.
++   *
++   *  The same as the four-parameter @c lexicographical_compare, but uses the
++   *  comp parameter instead of @c <.
++  */
++  template<typename _II1, typename _II2, typename _Compare>
++    bool
++    lexicographical_compare(_II1 __first1, _II1 __last1,
++			    _II2 __first2, _II2 __last2, _Compare __comp)
++    {
++      typedef typename iterator_traits<_II1>::iterator_category _Category1;
++      typedef typename iterator_traits<_II2>::iterator_category _Category2;
++      typedef std::__lc_rai<_Category1, _Category2> 	__rai_type;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_II2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      __last1 = __rai_type::__newlast1(__first1, __last1, __first2, __last2);
++      for (; __first1 != __last1 && __rai_type::__cnd2(__first2, __last2);
++	   ++__first1, ++__first2)
++	{
++	  if (__comp(*__first1, *__first2))
++	    return true;
++	  if (__comp(*__first2, *__first1))
++	    return false;
++	}
++      return __first1 == __last1 && __first2 != __last2;
++    }
++
++  /**
++   *  @brief Finds the places in ranges which don't match.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @return   A pair of iterators pointing to the first mismatch.
++   *
++   *  This compares the elements of two ranges using @c == and returns a pair
++   *  of iterators.  The first iterator points into the first range, the
++   *  second iterator points into the second range, and the elements pointed
++   *  to by the iterators are not equal.
++  */
++  template<typename _InputIterator1, typename _InputIterator2>
++    pair<_InputIterator1, _InputIterator2>
++    mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      while (__first1 != __last1 && *__first1 == *__first2)
++        {
++	  ++__first1;
++	  ++__first2;
++        }
++      return pair<_InputIterator1, _InputIterator2>(__first1, __first2);
++    }
++
++  /**
++   *  @brief Finds the places in ranges which don't match.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param __binary_pred A binary predicate @link functors
++   *         functor@endlink.
++   *  @return   A pair of iterators pointing to the first mismatch.
++   *
++   *  This compares the elements of two ranges using the binary_pred
++   *  parameter, and returns a pair
++   *  of iterators.  The first iterator points into the first range, the
++   *  second iterator points into the second range, and the elements pointed
++   *  to by the iterators are not equal.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _BinaryPredicate>
++    pair<_InputIterator1, _InputIterator2>
++    mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      while (__first1 != __last1 && bool(__binary_pred(*__first1, *__first2)))
++        {
++	  ++__first1;
++	  ++__first2;
++        }
++      return pair<_InputIterator1, _InputIterator2>(__first1, __first2);
++    }
++
++_GLIBCXX_END_NAMESPACE_ALGO
++} // namespace std
++
++// NB: This file is included within many other C++ includes, as a way
++// of getting the base algorithms. So, make sure that parallel bits
++// come in too if requested. 
++#ifdef _GLIBCXX_PARALLEL
++# include <parallel/algobase.h>
++#endif
++
++#endif
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/complex gccxml/GCC_XML/Support/GCC/4.7/complex
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/complex	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/complex	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,1912 @@
++// The template and inlines for the -*- C++ -*- complex number classes.
++
++// Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
++// 2006, 2007, 2008, 2009, 2010, 2011
++// Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file include/complex
++ *  This is a Standard C++ Library header.
++ */
++
++//
++// ISO C++ 14882: 26.2  Complex Numbers
++// Note: this is not a conforming implementation.
++// Initially implemented by Ulrich Drepper <drepper@cygnus.com>
++// Improved by Gabriel Dos Reis <dosreis@cmla.ens-cachan.fr>
++//
++
++#ifndef _GLIBCXX_COMPLEX
++#define _GLIBCXX_COMPLEX 1
++
++#pragma GCC system_header
++
++#include <bits/c++config.h>
++#include <bits/cpp_type_traits.h>
++#include <ext/type_traits.h>
++#include <cmath>
++#include <sstream>
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  /**
++   * @defgroup complex_numbers Complex Numbers
++   * @ingroup numerics
++   *
++   * Classes and functions for complex numbers.
++   * @{
++   */
++
++  // Forward declarations.
++  template<typename _Tp> class complex;
++  template<> class complex<float>;
++  template<> class complex<double>;
++  template<> class complex<long double>;
++
++  ///  Return magnitude of @a z.
++  template<typename _Tp> _Tp abs(const complex<_Tp>&);
++  ///  Return phase angle of @a z.
++  template<typename _Tp> _Tp arg(const complex<_Tp>&);
++  ///  Return @a z magnitude squared.
++  template<typename _Tp> _Tp norm(const complex<_Tp>&);
++
++  ///  Return complex conjugate of @a z.
++  template<typename _Tp> complex<_Tp> conj(const complex<_Tp>&);
++  ///  Return complex with magnitude @a rho and angle @a theta.
++  template<typename _Tp> complex<_Tp> polar(const _Tp&, const _Tp& = 0);
++
++  // Transcendentals:
++  /// Return complex cosine of @a z.
++  template<typename _Tp> complex<_Tp> cos(const complex<_Tp>&);
++  /// Return complex hyperbolic cosine of @a z.
++  template<typename _Tp> complex<_Tp> cosh(const complex<_Tp>&);
++  /// Return complex base e exponential of @a z.
++  template<typename _Tp> complex<_Tp> exp(const complex<_Tp>&);
++  /// Return complex natural logarithm of @a z.
++  template<typename _Tp> complex<_Tp> log(const complex<_Tp>&);
++  /// Return complex base 10 logarithm of @a z.
++  template<typename _Tp> complex<_Tp> log10(const complex<_Tp>&);
++#ifndef __GXX_EXPERIMENTAL_CXX0X__
++  // DR 844.
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const complex<_Tp>&, int);
++#endif
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const complex<_Tp>&, const _Tp&);
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const complex<_Tp>&, 
++                                          const complex<_Tp>&);
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const _Tp&, const complex<_Tp>&);
++  /// Return complex sine of @a z.
++  template<typename _Tp> complex<_Tp> sin(const complex<_Tp>&);
++  /// Return complex hyperbolic sine of @a z.
++  template<typename _Tp> complex<_Tp> sinh(const complex<_Tp>&);
++  /// Return complex square root of @a z.
++  template<typename _Tp> complex<_Tp> sqrt(const complex<_Tp>&);
++  /// Return complex tangent of @a z.
++  template<typename _Tp> complex<_Tp> tan(const complex<_Tp>&);
++  /// Return complex hyperbolic tangent of @a z.
++  template<typename _Tp> complex<_Tp> tanh(const complex<_Tp>&);
++    
++    
++  // 26.2.2  Primary template class complex
++  /**
++   *  Template to represent complex numbers.
++   *
++   *  Specializations for float, double, and long double are part of the
++   *  library.  Results with any other type are not guaranteed.
++   *
++   *  @param  Tp  Type of real and imaginary values.
++  */
++  template<typename _Tp>
++    struct complex
++    {
++      /// Value typedef.
++      typedef _Tp value_type;
++      
++      ///  Default constructor.  First parameter is x, second parameter is y.
++      ///  Unspecified parameters default to 0.
++      _GLIBCXX_CONSTEXPR complex(const _Tp& __r = _Tp(), const _Tp& __i = _Tp())
++      : _M_real(__r), _M_imag(__i) { }
++
++      // Lets the compiler synthesize the copy constructor   
++      // complex (const complex<_Tp>&);
++      ///  Copy constructor.
++      template<typename _Up>
++        _GLIBCXX_CONSTEXPR complex(const complex<_Up>& __z)
++	: _M_real(__z.real()), _M_imag(__z.imag()) { }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      constexpr _Tp 
++      real() { return _M_real; }
++
++      constexpr _Tp 
++      imag() { return _M_imag; }
++#else
++      ///  Return real part of complex number.
++      _Tp& 
++      real() { return _M_real; }
++
++      ///  Return real part of complex number.
++      const _Tp& 
++      real() const { return _M_real; }
++
++      ///  Return imaginary part of complex number.
++      _Tp& 
++      imag() { return _M_imag; }
++
++      ///  Return imaginary part of complex number.
++      const _Tp& 
++      imag() const { return _M_imag; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(_Tp __val) { _M_real = __val; }
++
++      void 
++      imag(_Tp __val) { _M_imag = __val; }
++
++      /// Assign this complex number to scalar @a t.
++      complex<_Tp>& operator=(const _Tp&);
++      
++      /// Add @a t to this complex number.
++      // 26.2.5/1
++      complex<_Tp>&
++      operator+=(const _Tp& __t)
++      {
++	_M_real += __t;
++	return *this;
++      }
++
++      /// Subtract @a t from this complex number.
++      // 26.2.5/3
++      complex<_Tp>&
++      operator-=(const _Tp& __t)
++      {
++	_M_real -= __t;
++	return *this;
++      }
++
++      /// Multiply this complex number by @a t.
++      complex<_Tp>& operator*=(const _Tp&);
++      /// Divide this complex number by @a t.
++      complex<_Tp>& operator/=(const _Tp&);
++
++      // Lets the compiler synthesize the
++      // copy and assignment operator
++      // complex<_Tp>& operator= (const complex<_Tp>&);
++      /// Assign this complex number to complex @a z.
++      template<typename _Up>
++        complex<_Tp>& operator=(const complex<_Up>&);
++      /// Add @a z to this complex number.
++      template<typename _Up>
++        complex<_Tp>& operator+=(const complex<_Up>&);
++      /// Subtract @a z from this complex number.
++      template<typename _Up>
++        complex<_Tp>& operator-=(const complex<_Up>&);
++      /// Multiply this complex number by @a z.
++      template<typename _Up>
++        complex<_Tp>& operator*=(const complex<_Up>&);
++      /// Divide this complex number by @a z.
++      template<typename _Up>
++        complex<_Tp>& operator/=(const complex<_Up>&);
++
++      _GLIBCXX_USE_CONSTEXPR complex __rep() const
++      { return *this; }
++
++    private:
++      _Tp _M_real;
++      _Tp _M_imag;
++    };
++
++  template<typename _Tp>
++    complex<_Tp>&
++    complex<_Tp>::operator=(const _Tp& __t)
++    {
++     _M_real = __t;
++     _M_imag = _Tp();
++     return *this;
++    } 
++
++  // 26.2.5/5
++  template<typename _Tp>
++    complex<_Tp>&
++    complex<_Tp>::operator*=(const _Tp& __t)
++    {
++      _M_real *= __t;
++      _M_imag *= __t;
++      return *this;
++    }
++
++  // 26.2.5/7
++  template<typename _Tp>
++    complex<_Tp>&
++    complex<_Tp>::operator/=(const _Tp& __t)
++    {
++      _M_real /= __t;
++      _M_imag /= __t;
++      return *this;
++    }
++
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator=(const complex<_Up>& __z)
++    {
++      _M_real = __z.real();
++      _M_imag = __z.imag();
++      return *this;
++    }
++
++  // 26.2.5/9
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator+=(const complex<_Up>& __z)
++    {
++      _M_real += __z.real();
++      _M_imag += __z.imag();
++      return *this;
++    }
++
++  // 26.2.5/11
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator-=(const complex<_Up>& __z)
++    {
++      _M_real -= __z.real();
++      _M_imag -= __z.imag();
++      return *this;
++    }
++
++  // 26.2.5/13
++  // XXX: This is a grammar school implementation.
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator*=(const complex<_Up>& __z)
++    {
++      const _Tp __r = _M_real * __z.real() - _M_imag * __z.imag();
++      _M_imag = _M_real * __z.imag() + _M_imag * __z.real();
++      _M_real = __r;
++      return *this;
++    }
++
++  // 26.2.5/15
++  // XXX: This is a grammar school implementation.
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator/=(const complex<_Up>& __z)
++    {
++      const _Tp __r =  _M_real * __z.real() + _M_imag * __z.imag();
++      const _Tp __n = std::norm(__z);
++      _M_imag = (_M_imag * __z.real() - _M_real * __z.imag()) / __n;
++      _M_real = __r / __n;
++      return *this;
++    }
++    
++  // Operators:
++  //@{
++  ///  Return new complex value @a x plus @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r += __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r += __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __y;
++      __r += __x;
++      return __r;
++    }
++  //@}
++
++  //@{
++  ///  Return new complex value @a x minus @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r -= __y;
++      return __r;
++    }
++    
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r -= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r(__x, -__y.imag());
++      __r -= __y.real();
++      return __r;
++    }
++  //@}
++
++  //@{
++  ///  Return new complex value @a x times @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator*(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r *= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator*(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r *= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator*(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __y;
++      __r *= __x;
++      return __r;
++    }
++  //@}
++
++  //@{
++  ///  Return new complex value @a x divided by @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator/(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r /= __y;
++      return __r;
++    }
++    
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator/(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r /= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator/(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r /= __y;
++      return __r;
++    }
++  //@}
++
++  ///  Return @a x.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const complex<_Tp>& __x)
++    { return __x; }
++
++  ///  Return complex negation of @a x.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const complex<_Tp>& __x)
++    {  return complex<_Tp>(-__x.real(), -__x.imag()); }
++
++  //@{
++  ///  Return true if @a x is equal to @a y.
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator==(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __x.real() == __y.real() && __x.imag() == __y.imag(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator==(const complex<_Tp>& __x, const _Tp& __y)
++    { return __x.real() == __y && __x.imag() == _Tp(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator==(const _Tp& __x, const complex<_Tp>& __y)
++    { return __x == __y.real() && _Tp() == __y.imag(); }
++  //@}
++
++  //@{
++  ///  Return false if @a x is equal to @a y.
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator!=(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __x.real() != __y.real() || __x.imag() != __y.imag(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator!=(const complex<_Tp>& __x, const _Tp& __y)
++    { return __x.real() != __y || __x.imag() != _Tp(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator!=(const _Tp& __x, const complex<_Tp>& __y)
++    { return __x != __y.real() || _Tp() != __y.imag(); }
++  //@}
++
++  ///  Extraction operator for complex values.
++  template<typename _Tp, typename _CharT, class _Traits>
++    basic_istream<_CharT, _Traits>&
++    operator>>(basic_istream<_CharT, _Traits>& __is, complex<_Tp>& __x)
++    {
++      _Tp __re_x, __im_x;
++      _CharT __ch;
++      __is >> __ch;
++      if (__ch == '(') 
++	{
++	  __is >> __re_x >> __ch;
++	  if (__ch == ',') 
++	    {
++	      __is >> __im_x >> __ch;
++	      if (__ch == ')') 
++		__x = complex<_Tp>(__re_x, __im_x);
++	      else
++		__is.setstate(ios_base::failbit);
++	    }
++	  else if (__ch == ')') 
++	    __x = __re_x;
++	  else
++	    __is.setstate(ios_base::failbit);
++	}
++      else 
++	{
++	  __is.putback(__ch);
++	  __is >> __re_x;
++	  __x = __re_x;
++	}
++      return __is;
++    }
++
++  ///  Insertion operator for complex values.
++  template<typename _Tp, typename _CharT, class _Traits>
++    basic_ostream<_CharT, _Traits>&
++    operator<<(basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x)
++    {
++      basic_ostringstream<_CharT, _Traits> __s;
++      __s.flags(__os.flags());
++      __s.imbue(__os.getloc());
++      __s.precision(__os.precision());
++      __s << '(' << __x.real() << ',' << __x.imag() << ')';
++      return __os << __s.str();
++    }
++
++  // Values
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  template<typename _Tp>
++    constexpr _Tp
++    real(const complex<_Tp>& __z)
++    { return __z.real(); }
++
++  template<typename _Tp>
++    constexpr _Tp
++    imag(const complex<_Tp>& __z)
++    { return __z.imag(); }
++#else
++  template<typename _Tp>
++    inline _Tp&
++    real(complex<_Tp>& __z)
++    { return __z.real(); }
++    
++  template<typename _Tp>
++    inline const _Tp&
++    real(const complex<_Tp>& __z)
++    { return __z.real(); }
++    
++  template<typename _Tp>
++    inline _Tp&
++    imag(complex<_Tp>& __z)
++    { return __z.imag(); }
++    
++  template<typename _Tp>
++    inline const _Tp&
++    imag(const complex<_Tp>& __z)
++    { return __z.imag(); }
++#endif
++
++  // 26.2.7/3 abs(__z):  Returns the magnitude of __z.
++  template<typename _Tp>
++    inline _Tp
++    __complex_abs(const complex<_Tp>& __z)
++    {
++      _Tp __x = __z.real();
++      _Tp __y = __z.imag();
++      const _Tp __s = std::max(abs(__x), abs(__y));
++      if (__s == _Tp())  // well ...
++        return __s;
++      __x /= __s; 
++      __y /= __s;
++      return __s * sqrt(__x * __x + __y * __y);
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline float
++  __complex_abs(__complex__ float __z) { return __builtin_cabsf(__z); }
++
++  inline double
++  __complex_abs(__complex__ double __z) { return __builtin_cabs(__z); }
++
++  inline long double
++  __complex_abs(const __complex__ long double& __z)
++  { return __builtin_cabsl(__z); }
++
++  template<typename _Tp>
++    inline _Tp
++    abs(const complex<_Tp>& __z) { return __complex_abs(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline _Tp
++    abs(const complex<_Tp>& __z) { return __complex_abs(__z); }
++#endif  
++
++
++  // 26.2.7/4: arg(__z): Returns the phase angle of __z.
++  template<typename _Tp>
++    inline _Tp
++    __complex_arg(const complex<_Tp>& __z)
++    { return  atan2(__z.imag(), __z.real()); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline float
++  __complex_arg(__complex__ float __z) { return __builtin_cargf(__z); }
++
++  inline double
++  __complex_arg(__complex__ double __z) { return __builtin_carg(__z); }
++
++  inline long double
++  __complex_arg(const __complex__ long double& __z)
++  { return __builtin_cargl(__z); }
++
++  template<typename _Tp>
++    inline _Tp
++    arg(const complex<_Tp>& __z) { return __complex_arg(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline _Tp
++    arg(const complex<_Tp>& __z) { return __complex_arg(__z); }
++#endif
++
++  // 26.2.7/5: norm(__z) returns the squared magnitude of __z.
++  //     As defined, norm() is -not- a norm is the common mathematical
++  //     sens used in numerics.  The helper class _Norm_helper<> tries to
++  //     distinguish between builtin floating point and the rest, so as
++  //     to deliver an answer as close as possible to the real value.
++  template<bool>
++    struct _Norm_helper
++    {
++      template<typename _Tp>
++        static inline _Tp _S_do_it(const complex<_Tp>& __z)
++        {
++          const _Tp __x = __z.real();
++          const _Tp __y = __z.imag();
++          return __x * __x + __y * __y;
++        }
++    };
++
++  template<>
++    struct _Norm_helper<true>
++    {
++      template<typename _Tp>
++        static inline _Tp _S_do_it(const complex<_Tp>& __z)
++        {
++          _Tp __res = std::abs(__z);
++          return __res * __res;
++        }
++    };
++  
++  template<typename _Tp>
++    inline _Tp
++    norm(const complex<_Tp>& __z)
++    {
++      return _Norm_helper<__is_floating<_Tp>::__value 
++	&& !_GLIBCXX_FAST_MATH>::_S_do_it(__z);
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    polar(const _Tp& __rho, const _Tp& __theta)
++    { return complex<_Tp>(__rho * cos(__theta), __rho * sin(__theta)); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    conj(const complex<_Tp>& __z)
++    { return complex<_Tp>(__z.real(), -__z.imag()); }
++  
++  // Transcendentals
++
++  // 26.2.8/1 cos(__z):  Returns the cosine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_cos(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp __y = __z.imag();
++      return complex<_Tp>(cos(__x) * cosh(__y), -sin(__x) * sinh(__y));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_cos(__complex__ float __z) { return __builtin_ccosf(__z); }
++
++  inline __complex__ double
++  __complex_cos(__complex__ double __z) { return __builtin_ccos(__z); }
++
++  inline __complex__ long double
++  __complex_cos(const __complex__ long double& __z)
++  { return __builtin_ccosl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    cos(const complex<_Tp>& __z) { return __complex_cos(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    cos(const complex<_Tp>& __z) { return __complex_cos(__z); }
++#endif
++
++  // 26.2.8/2 cosh(__z): Returns the hyperbolic cosine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_cosh(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp __y = __z.imag();
++      return complex<_Tp>(cosh(__x) * cos(__y), sinh(__x) * sin(__y));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_cosh(__complex__ float __z) { return __builtin_ccoshf(__z); }
++
++  inline __complex__ double
++  __complex_cosh(__complex__ double __z) { return __builtin_ccosh(__z); }
++
++  inline __complex__ long double
++  __complex_cosh(const __complex__ long double& __z)
++  { return __builtin_ccoshl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    cosh(const complex<_Tp>& __z) { return __complex_cosh(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    cosh(const complex<_Tp>& __z) { return __complex_cosh(__z); }
++#endif
++
++  // 26.2.8/3 exp(__z): Returns the complex base e exponential of x
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_exp(const complex<_Tp>& __z)
++    { return std::polar(exp(__z.real()), __z.imag()); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_exp(__complex__ float __z) { return __builtin_cexpf(__z); }
++
++  inline __complex__ double
++  __complex_exp(__complex__ double __z) { return __builtin_cexp(__z); }
++
++  inline __complex__ long double
++  __complex_exp(const __complex__ long double& __z)
++  { return __builtin_cexpl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    exp(const complex<_Tp>& __z) { return __complex_exp(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    exp(const complex<_Tp>& __z) { return __complex_exp(__z); }
++#endif
++
++  // 26.2.8/5 log(__z): Returns the natural complex logarithm of __z.
++  //                    The branch cut is along the negative axis.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_log(const complex<_Tp>& __z)
++    { return complex<_Tp>(log(std::abs(__z)), std::arg(__z)); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_log(__complex__ float __z) { return __builtin_clogf(__z); }
++
++  inline __complex__ double
++  __complex_log(__complex__ double __z) { return __builtin_clog(__z); }
++
++  inline __complex__ long double
++  __complex_log(const __complex__ long double& __z)
++  { return __builtin_clogl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    log(const complex<_Tp>& __z) { return __complex_log(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    log(const complex<_Tp>& __z) { return __complex_log(__z); }
++#endif
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    log10(const complex<_Tp>& __z)
++    { return std::log(__z) / log(_Tp(10.0)); }
++
++  // 26.2.8/10 sin(__z): Returns the sine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_sin(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp __y = __z.imag();
++      return complex<_Tp>(sin(__x) * cosh(__y), cos(__x) * sinh(__y)); 
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_sin(__complex__ float __z) { return __builtin_csinf(__z); }
++
++  inline __complex__ double
++  __complex_sin(__complex__ double __z) { return __builtin_csin(__z); }
++
++  inline __complex__ long double
++  __complex_sin(const __complex__ long double& __z)
++  { return __builtin_csinl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    sin(const complex<_Tp>& __z) { return __complex_sin(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    sin(const complex<_Tp>& __z) { return __complex_sin(__z); }
++#endif
++
++  // 26.2.8/11 sinh(__z): Returns the hyperbolic sine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_sinh(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp  __y = __z.imag();
++      return complex<_Tp>(sinh(__x) * cos(__y), cosh(__x) * sin(__y));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_sinh(__complex__ float __z) { return __builtin_csinhf(__z); }      
++
++  inline __complex__ double
++  __complex_sinh(__complex__ double __z) { return __builtin_csinh(__z); }      
++
++  inline __complex__ long double
++  __complex_sinh(const __complex__ long double& __z)
++  { return __builtin_csinhl(__z); }      
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    sinh(const complex<_Tp>& __z) { return __complex_sinh(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    sinh(const complex<_Tp>& __z) { return __complex_sinh(__z); }
++#endif
++
++  // 26.2.8/13 sqrt(__z): Returns the complex square root of __z.
++  //                     The branch cut is on the negative axis.
++  template<typename _Tp>
++    complex<_Tp>
++    __complex_sqrt(const complex<_Tp>& __z)
++    {
++      _Tp __x = __z.real();
++      _Tp __y = __z.imag();
++
++      if (__x == _Tp())
++        {
++          _Tp __t = sqrt(abs(__y) / 2);
++          return complex<_Tp>(__t, __y < _Tp() ? -__t : __t);
++        }
++      else
++        {
++          _Tp __t = sqrt(2 * (std::abs(__z) + abs(__x)));
++          _Tp __u = __t / 2;
++          return __x > _Tp()
++            ? complex<_Tp>(__u, __y / __t)
++            : complex<_Tp>(abs(__y) / __t, __y < _Tp() ? -__u : __u);
++        }
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_sqrt(__complex__ float __z) { return __builtin_csqrtf(__z); }
++
++  inline __complex__ double
++  __complex_sqrt(__complex__ double __z) { return __builtin_csqrt(__z); }
++
++  inline __complex__ long double
++  __complex_sqrt(const __complex__ long double& __z)
++  { return __builtin_csqrtl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    sqrt(const complex<_Tp>& __z) { return __complex_sqrt(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    sqrt(const complex<_Tp>& __z) { return __complex_sqrt(__z); }
++#endif
++
++  // 26.2.8/14 tan(__z):  Return the complex tangent of __z.
++  
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_tan(const complex<_Tp>& __z)
++    { return std::sin(__z) / std::cos(__z); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_tan(__complex__ float __z) { return __builtin_ctanf(__z); }
++
++  inline __complex__ double
++  __complex_tan(__complex__ double __z) { return __builtin_ctan(__z); }
++
++  inline __complex__ long double
++  __complex_tan(const __complex__ long double& __z)
++  { return __builtin_ctanl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    tan(const complex<_Tp>& __z) { return __complex_tan(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    tan(const complex<_Tp>& __z) { return __complex_tan(__z); }
++#endif
++
++
++  // 26.2.8/15 tanh(__z):  Returns the hyperbolic tangent of __z.
++  
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_tanh(const complex<_Tp>& __z)
++    { return std::sinh(__z) / std::cosh(__z); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_tanh(__complex__ float __z) { return __builtin_ctanhf(__z); }
++
++  inline __complex__ double
++  __complex_tanh(__complex__ double __z) { return __builtin_ctanh(__z); }
++
++  inline __complex__ long double
++  __complex_tanh(const __complex__ long double& __z)
++  { return __builtin_ctanhl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    tanh(const complex<_Tp>& __z) { return __complex_tanh(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    tanh(const complex<_Tp>& __z) { return __complex_tanh(__z); }
++#endif
++
++
++  // 26.2.8/9  pow(__x, __y): Returns the complex power base of __x
++  //                          raised to the __y-th power.  The branch
++  //                          cut is on the negative axis.
++#ifndef __GXX_EXPERIMENTAL_CXX0X__
++  template<typename _Tp>
++    complex<_Tp>
++    __complex_pow_unsigned(complex<_Tp> __x, unsigned __n)
++    {
++      complex<_Tp> __y = __n % 2 ? __x : complex<_Tp>(1);
++
++      while (__n >>= 1)
++        {
++          __x *= __x;
++          if (__n % 2)
++            __y *= __x;
++        }
++
++      return __y;
++    }
++
++  // _GLIBCXX_RESOLVE_LIB_DEFECTS
++  // DR 844. complex pow return type is ambiguous.
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const complex<_Tp>& __z, int __n)
++    {
++      return __n < 0
++        ? complex<_Tp>(1) / std::__complex_pow_unsigned(__z, -__n)
++        : std::__complex_pow_unsigned(__z, __n);
++    }
++#endif
++
++  template<typename _Tp>
++    complex<_Tp>
++    pow(const complex<_Tp>& __x, const _Tp& __y)
++    {
++#ifndef _GLIBCXX_USE_C99_COMPLEX
++      if (__x == _Tp())
++	return _Tp();
++#endif
++      if (__x.imag() == _Tp() && __x.real() > _Tp())
++        return pow(__x.real(), __y);
++
++      complex<_Tp> __t = std::log(__x);
++      return std::polar(exp(__y * __t.real()), __y * __t.imag());
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_pow(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __x == _Tp() ? _Tp() : std::exp(__y * std::log(__x)); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_pow(__complex__ float __x, __complex__ float __y)
++  { return __builtin_cpowf(__x, __y); }
++
++  inline __complex__ double
++  __complex_pow(__complex__ double __x, __complex__ double __y)
++  { return __builtin_cpow(__x, __y); }
++
++  inline __complex__ long double
++  __complex_pow(const __complex__ long double& __x,
++		const __complex__ long double& __y)
++  { return __builtin_cpowl(__x, __y); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __complex_pow(__x.__rep(), __y.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __complex_pow(__x, __y); }
++#endif
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      return __x > _Tp() ? std::polar(pow(__x, __y.real()),
++				      __y.imag() * log(__x))
++	                 : std::pow(complex<_Tp>(__x), __y);
++    }
++
++  /// 26.2.3  complex specializations
++  /// complex<float> specialization
++  template<>
++    struct complex<float>
++    {
++      typedef float value_type;
++      typedef __complex__ float _ComplexT;
++
++      _GLIBCXX_CONSTEXPR complex(_ComplexT __z) : _M_value(__z) { }
++
++      _GLIBCXX_CONSTEXPR complex(float __r = 0.0f, float __i = 0.0f)
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++      : _M_value{ __r, __i } { }
++#else
++      {
++	__real__ _M_value = __r;
++	__imag__ _M_value = __i;
++      }
++#endif
++
++      explicit _GLIBCXX_CONSTEXPR complex(const complex<double>&);
++      explicit _GLIBCXX_CONSTEXPR complex(const complex<long double>&);	
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      constexpr float 
++      real() { return __real__ _M_value; }
++
++      constexpr float 
++      imag() { return __imag__ _M_value; }
++#else
++      float& 
++      real() { return __real__ _M_value; }
++
++      const float& 
++      real() const { return __real__ _M_value; }      
++
++      float& 
++      imag() { return __imag__ _M_value; }
++
++      const float& 
++      imag() const { return __imag__ _M_value; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(float __val) { __real__ _M_value = __val; }
++
++      void 
++      imag(float __val) { __imag__ _M_value = __val; }
++
++      complex&
++      operator=(float __f);
++
++      complex&
++      operator+=(float __f)
++      {
++	_M_value += __f;
++	return *this;
++      }
++
++      complex&
++      operator-=(float __f)
++      {
++	_M_value -= __f;
++	return *this;
++      }
++
++      complex&
++      operator*=(float __f)
++      {
++	_M_value *= __f;
++	return *this;
++      }
++
++      complex&
++      operator/=(float __f)
++      {
++	_M_value /= __f;
++	return *this;
++      }
++
++      // Let the compiler synthesize the copy and assignment
++      // operator.  It always does a pretty good job.
++      // complex& operator=(const complex&);
++
++      template<typename _Tp>
++        complex&
++        operator=(const complex<_Tp>&  __z)
++	{
++	  __real__ _M_value = __z.real();
++	  __imag__ _M_value = __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator+=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value += __z.real();
++	  __imag__ _M_value += __z.imag();
++	  return *this;
++	}
++
++      template<class _Tp>
++        complex&
++        operator-=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value -= __z.real();
++	  __imag__ _M_value -= __z.imag();
++	  return *this;
++	}
++
++      template<class _Tp>
++        complex&
++        operator*=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value *= __t;
++	  return *this;
++	}
++
++      template<class _Tp>
++        complex&
++        operator/=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value /= __t;
++	  return *this;
++	}
++
++      _GLIBCXX_USE_CONSTEXPR _ComplexT __rep() const { return _M_value; }
++
++    private:
++      _ComplexT _M_value;
++    };
++
++  /// 26.2.3  complex specializations
++  /// complex<double> specialization
++  template<>
++    struct complex<double>
++    {
++      typedef double value_type;
++      typedef __complex__ double _ComplexT;
++
++      _GLIBCXX_CONSTEXPR complex(_ComplexT __z) : _M_value(__z) { }
++
++      _GLIBCXX_CONSTEXPR complex(double __r = 0.0, double __i = 0.0)
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++      : _M_value{ __r, __i } { }
++#else
++      {
++	__real__ _M_value = __r;
++	__imag__ _M_value = __i;
++      }
++#endif
++
++      _GLIBCXX_CONSTEXPR complex(const complex<float>& __z)
++      : _M_value(__z.__rep()) { }
++
++      explicit _GLIBCXX_CONSTEXPR complex(const complex<long double>&);	
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      constexpr double 
++      real() { return __real__ _M_value; }
++
++      constexpr double 
++      imag() { return __imag__ _M_value; }
++#else
++      double& 
++      real() { return __real__ _M_value; }
++
++      const double& 
++      real() const { return __real__ _M_value; }
++
++      double& 
++      imag() { return __imag__ _M_value; }
++
++      const double& 
++      imag() const { return __imag__ _M_value; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(double __val) { __real__ _M_value = __val; }
++
++      void 
++      imag(double __val) { __imag__ _M_value = __val; }
++
++      complex&
++      operator=(double __d);
++
++      complex&
++      operator+=(double __d)
++      {
++	_M_value += __d;
++	return *this;
++      }
++	
++      complex&
++      operator-=(double __d)
++      {
++	_M_value -= __d;
++	return *this;
++      }
++
++      complex&
++      operator*=(double __d)
++      {
++	_M_value *= __d;
++	return *this;
++      }
++
++      complex&
++      operator/=(double __d)
++      {
++	_M_value /= __d;
++	return *this;
++      }
++
++      // The compiler will synthesize this, efficiently.
++      // complex& operator=(const complex&);
++
++      template<typename _Tp>
++        complex&
++        operator=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value = __z.real();
++	  __imag__ _M_value = __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator+=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value += __z.real();
++	  __imag__ _M_value += __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator-=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value -= __z.real();
++	  __imag__ _M_value -= __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator*=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value *= __t;
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator/=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value /= __t;
++	  return *this;
++	}
++
++      _GLIBCXX_USE_CONSTEXPR _ComplexT __rep() const { return _M_value; }
++
++    private:
++      _ComplexT _M_value;
++    };
++
++  /// 26.2.3  complex specializations
++  /// complex<long double> specialization
++  template<>
++    struct complex<long double>
++    {
++      typedef long double value_type;
++      typedef __complex__ long double _ComplexT;
++
++      _GLIBCXX_CONSTEXPR complex(_ComplexT __z) : _M_value(__z) { }
++
++      _GLIBCXX_CONSTEXPR complex(long double __r = 0.0L, 
++				 long double __i = 0.0L)
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++      : _M_value{ __r, __i } { }
++#else
++      {
++	__real__ _M_value = __r;
++	__imag__ _M_value = __i;
++      }
++#endif
++
++      _GLIBCXX_CONSTEXPR complex(const complex<float>& __z)
++      : _M_value(__z.__rep()) { }
++
++      _GLIBCXX_CONSTEXPR complex(const complex<double>& __z)
++      : _M_value(__z.__rep()) { }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      constexpr long double 
++      real() { return __real__ _M_value; }
++
++      constexpr long double 
++      imag() { return __imag__ _M_value; }
++#else
++      long double& 
++      real() { return __real__ _M_value; }
++
++      const long double& 
++      real() const { return __real__ _M_value; }
++
++      long double& 
++      imag() { return __imag__ _M_value; }
++
++      const long double& 
++      imag() const { return __imag__ _M_value; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(long double __val) { __real__ _M_value = __val; }
++
++      void 
++      imag(long double __val) { __imag__ _M_value = __val; }
++
++      complex&
++      operator=(long double __r);
++
++      complex&
++      operator+=(long double __r)
++      {
++	_M_value += __r;
++	return *this;
++      }
++
++      complex&
++      operator-=(long double __r)
++      {
++	_M_value -= __r;
++	return *this;
++      }
++
++      complex&
++      operator*=(long double __r)
++      {
++	_M_value *= __r;
++	return *this;
++      }
++
++      complex&
++      operator/=(long double __r)
++      {
++	_M_value /= __r;
++	return *this;
++      }
++
++      // The compiler knows how to do this efficiently
++      // complex& operator=(const complex&);
++
++      template<typename _Tp>
++        complex&
++        operator=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value = __z.real();
++	  __imag__ _M_value = __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator+=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value += __z.real();
++	  __imag__ _M_value += __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator-=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value -= __z.real();
++	  __imag__ _M_value -= __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator*=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value *= __t;
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator/=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value /= __t;
++	  return *this;
++	}
++
++      _GLIBCXX_USE_CONSTEXPR _ComplexT __rep() const { return _M_value; }
++
++    private:
++      _ComplexT _M_value;
++    };
++
++  // These bits have to be at the end of this file, so that the
++  // specializations have all been defined.
++  inline _GLIBCXX_CONSTEXPR
++  complex<float>::complex(const complex<double>& __z)
++  : _M_value(__z.__rep()) { }
++
++  inline _GLIBCXX_CONSTEXPR
++  complex<float>::complex(const complex<long double>& __z)
++  : _M_value(__z.__rep()) { }
++
++  inline _GLIBCXX_CONSTEXPR
++  complex<double>::complex(const complex<long double>& __z)
++  : _M_value(__z.__rep()) { }
++
++  // Inhibit implicit instantiations for required instantiations,
++  // which are defined via explicit instantiations elsewhere.
++  // NB:  This syntax is a GNU extension.
++#if _GLIBCXX_EXTERN_TEMPLATE
++  extern template istream& operator>>(istream&, complex<float>&);
++  extern template ostream& operator<<(ostream&, const complex<float>&);
++  extern template istream& operator>>(istream&, complex<double>&);
++  extern template ostream& operator<<(ostream&, const complex<double>&);
++  extern template istream& operator>>(istream&, complex<long double>&);
++  extern template ostream& operator<<(ostream&, const complex<long double>&);
++
++#ifdef _GLIBCXX_USE_WCHAR_T
++  extern template wistream& operator>>(wistream&, complex<float>&);
++  extern template wostream& operator<<(wostream&, const complex<float>&);
++  extern template wistream& operator>>(wistream&, complex<double>&);
++  extern template wostream& operator<<(wostream&, const complex<double>&);
++  extern template wistream& operator>>(wistream&, complex<long double>&);
++  extern template wostream& operator<<(wostream&, const complex<long double>&);
++#endif
++#endif
++
++  // @} group complex_numbers
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // See ext/type_traits.h for the primary template.
++  template<typename _Tp, typename _Up>
++    struct __promote_2<std::complex<_Tp>, _Up>
++    {
++    public:
++      typedef std::complex<typename __promote_2<_Tp, _Up>::__type> __type;
++    };
++
++  template<typename _Tp, typename _Up>
++    struct __promote_2<_Tp, std::complex<_Up> >
++    {
++    public:
++      typedef std::complex<typename __promote_2<_Tp, _Up>::__type> __type;
++    };
++  
++  template<typename _Tp, typename _Up>
++    struct __promote_2<std::complex<_Tp>, std::complex<_Up> >
++    {
++    public:
++      typedef std::complex<typename __promote_2<_Tp, _Up>::__type> __type;
++    };
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // Forward declarations.
++  template<typename _Tp> std::complex<_Tp> acos(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> asin(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> atan(const std::complex<_Tp>&);
++
++  template<typename _Tp> std::complex<_Tp> acosh(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> asinh(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> atanh(const std::complex<_Tp>&);
++  // DR 595.
++  template<typename _Tp> _Tp               fabs(const std::complex<_Tp>&);
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    __complex_acos(const std::complex<_Tp>& __z)
++    {
++      const std::complex<_Tp> __t = std::asin(__z);
++      const _Tp __pi_2 = 1.5707963267948966192313216916397514L;
++      return std::complex<_Tp>(__pi_2 - __t.real(), -__t.imag());
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_acos(__complex__ float __z)
++  { return __builtin_cacosf(__z); }
++
++  inline __complex__ double
++  __complex_acos(__complex__ double __z)
++  { return __builtin_cacos(__z); }
++
++  inline __complex__ long double
++  __complex_acos(const __complex__ long double& __z)
++  { return __builtin_cacosl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acos(const std::complex<_Tp>& __z)
++    { return __complex_acos(__z.__rep()); }
++#else
++  /// acos(__z) [8.1.2].
++  //  Effects:  Behaves the same as C99 function cacos, defined
++  //            in subclause 7.3.5.1.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acos(const std::complex<_Tp>& __z)
++    { return __complex_acos(__z); }
++#endif
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    __complex_asin(const std::complex<_Tp>& __z)
++    {
++      std::complex<_Tp> __t(-__z.imag(), __z.real());
++      __t = std::asinh(__t);
++      return std::complex<_Tp>(__t.imag(), -__t.real());
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_asin(__complex__ float __z)
++  { return __builtin_casinf(__z); }
++
++  inline __complex__ double
++  __complex_asin(__complex__ double __z)
++  { return __builtin_casin(__z); }
++
++  inline __complex__ long double
++  __complex_asin(const __complex__ long double& __z)
++  { return __builtin_casinl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asin(const std::complex<_Tp>& __z)
++    { return __complex_asin(__z.__rep()); }
++#else
++  /// asin(__z) [8.1.3].
++  //  Effects:  Behaves the same as C99 function casin, defined
++  //            in subclause 7.3.5.2.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asin(const std::complex<_Tp>& __z)
++    { return __complex_asin(__z); }
++#endif
++  
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_atan(const std::complex<_Tp>& __z)
++    {
++      const _Tp __r2 = __z.real() * __z.real();
++      const _Tp __x = _Tp(1.0) - __r2 - __z.imag() * __z.imag();
++
++      _Tp __num = __z.imag() + _Tp(1.0);
++      _Tp __den = __z.imag() - _Tp(1.0);
++
++      __num = __r2 + __num * __num;
++      __den = __r2 + __den * __den;
++
++      return std::complex<_Tp>(_Tp(0.5) * atan2(_Tp(2.0) * __z.real(), __x),
++			       _Tp(0.25) * log(__num / __den));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_atan(__complex__ float __z)
++  { return __builtin_catanf(__z); }
++
++  inline __complex__ double
++  __complex_atan(__complex__ double __z)
++  { return __builtin_catan(__z); }
++
++  inline __complex__ long double
++  __complex_atan(const __complex__ long double& __z)
++  { return __builtin_catanl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atan(const std::complex<_Tp>& __z)
++    { return __complex_atan(__z.__rep()); }
++#else
++  /// atan(__z) [8.1.4].
++  //  Effects:  Behaves the same as C99 function catan, defined
++  //            in subclause 7.3.5.3.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atan(const std::complex<_Tp>& __z)
++    { return __complex_atan(__z); }
++#endif
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_acosh(const std::complex<_Tp>& __z)
++    {
++      // Kahan's formula.
++      return _Tp(2.0) * std::log(std::sqrt(_Tp(0.5) * (__z + _Tp(1.0)))
++				 + std::sqrt(_Tp(0.5) * (__z - _Tp(1.0))));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_acosh(__complex__ float __z)
++  { return __builtin_cacoshf(__z); }
++
++  inline __complex__ double
++  __complex_acosh(__complex__ double __z)
++  { return __builtin_cacosh(__z); }
++
++  inline __complex__ long double
++  __complex_acosh(const __complex__ long double& __z)
++  { return __builtin_cacoshl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acosh(const std::complex<_Tp>& __z)
++    { return __complex_acosh(__z.__rep()); }
++#else
++  /// acosh(__z) [8.1.5].
++  //  Effects:  Behaves the same as C99 function cacosh, defined
++  //            in subclause 7.3.6.1.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acosh(const std::complex<_Tp>& __z)
++    { return __complex_acosh(__z); }
++#endif
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_asinh(const std::complex<_Tp>& __z)
++    {
++      std::complex<_Tp> __t((__z.real() - __z.imag())
++			    * (__z.real() + __z.imag()) + _Tp(1.0),
++			    _Tp(2.0) * __z.real() * __z.imag());
++      __t = std::sqrt(__t);
++
++      return std::log(__t + __z);
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_asinh(__complex__ float __z)
++  { return __builtin_casinhf(__z); }
++
++  inline __complex__ double
++  __complex_asinh(__complex__ double __z)
++  { return __builtin_casinh(__z); }
++
++  inline __complex__ long double
++  __complex_asinh(const __complex__ long double& __z)
++  { return __builtin_casinhl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asinh(const std::complex<_Tp>& __z)
++    { return __complex_asinh(__z.__rep()); }
++#else
++  /// asinh(__z) [8.1.6].
++  //  Effects:  Behaves the same as C99 function casin, defined
++  //            in subclause 7.3.6.2.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asinh(const std::complex<_Tp>& __z)
++    { return __complex_asinh(__z); }
++#endif
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_atanh(const std::complex<_Tp>& __z)
++    {
++      const _Tp __i2 = __z.imag() * __z.imag();
++      const _Tp __x = _Tp(1.0) - __i2 - __z.real() * __z.real();
++
++      _Tp __num = _Tp(1.0) + __z.real();
++      _Tp __den = _Tp(1.0) - __z.real();
++
++      __num = __i2 + __num * __num;
++      __den = __i2 + __den * __den;
++
++      return std::complex<_Tp>(_Tp(0.25) * (log(__num) - log(__den)),
++			       _Tp(0.5) * atan2(_Tp(2.0) * __z.imag(), __x));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_atanh(__complex__ float __z)
++  { return __builtin_catanhf(__z); }
++
++  inline __complex__ double
++  __complex_atanh(__complex__ double __z)
++  { return __builtin_catanh(__z); }
++
++  inline __complex__ long double
++  __complex_atanh(const __complex__ long double& __z)
++  { return __builtin_catanhl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atanh(const std::complex<_Tp>& __z)
++    { return __complex_atanh(__z.__rep()); }
++#else
++  /// atanh(__z) [8.1.7].
++  //  Effects:  Behaves the same as C99 function catanh, defined
++  //            in subclause 7.3.6.3.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atanh(const std::complex<_Tp>& __z)
++    { return __complex_atanh(__z); }
++#endif
++
++  template<typename _Tp>
++    inline _Tp
++    /// fabs(__z) [8.1.8].
++    //  Effects:  Behaves the same as C99 function cabs, defined
++    //            in subclause 7.3.8.1.
++    fabs(const std::complex<_Tp>& __z)
++    { return std::abs(__z); }
++
++  /// Additional overloads [8.1.9].
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    arg(_Tp __x)
++    {
++      typedef typename __gnu_cxx::__promote<_Tp>::__type __type;
++#if (_GLIBCXX_USE_C99_MATH && !_GLIBCXX_USE_C99_FP_MACROS_DYNAMIC)
++      return std::signbit(__x) ? __type(3.1415926535897932384626433832795029L)
++	                       : __type();
++#else
++      return std::arg(std::complex<__type>(__x));
++#endif
++    }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    imag(_Tp)
++    { return _Tp(); }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    norm(_Tp __x)
++    {
++      typedef typename __gnu_cxx::__promote<_Tp>::__type __type;
++      return __type(__x) * __type(__x);
++    }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    real(_Tp __x)
++    { return __x; }
++
++  template<typename _Tp, typename _Up>
++    inline std::complex<typename __gnu_cxx::__promote_2<_Tp, _Up>::__type>
++    pow(const std::complex<_Tp>& __x, const _Up& __y)
++    {
++      typedef typename __gnu_cxx::__promote_2<_Tp, _Up>::__type __type;
++      return std::pow(std::complex<__type>(__x), __type(__y));
++    }
++
++  template<typename _Tp, typename _Up>
++    inline std::complex<typename __gnu_cxx::__promote_2<_Tp, _Up>::__type>
++    pow(const _Tp& __x, const std::complex<_Up>& __y)
++    {
++      typedef typename __gnu_cxx::__promote_2<_Tp, _Up>::__type __type;
++      return std::pow(__type(__x), std::complex<__type>(__y));
++    }
++
++  template<typename _Tp, typename _Up>
++    inline std::complex<typename __gnu_cxx::__promote_2<_Tp, _Up>::__type>
++    pow(const std::complex<_Tp>& __x, const std::complex<_Up>& __y)
++    {
++      typedef typename __gnu_cxx::__promote_2<_Tp, _Up>::__type __type;
++      return std::pow(std::complex<__type>(__x),
++		      std::complex<__type>(__y));
++    }
++
++  // Forward declarations.
++  // DR 781.
++  template<typename _Tp> std::complex<_Tp> proj(const std::complex<_Tp>&);
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_proj(const std::complex<_Tp>& __z)
++    {
++      const _Tp __den = (__z.real() * __z.real()
++			 + __z.imag() * __z.imag() + _Tp(1.0));
++
++      return std::complex<_Tp>((_Tp(2.0) * __z.real()) / __den,
++			       (_Tp(2.0) * __z.imag()) / __den);
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_proj(__complex__ float __z)
++  { return __builtin_cprojf(__z); }
++
++  inline __complex__ double
++  __complex_proj(__complex__ double __z)
++  { return __builtin_cproj(__z); }
++
++  inline __complex__ long double
++  __complex_proj(const __complex__ long double& __z)
++  { return __builtin_cprojl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    proj(const std::complex<_Tp>& __z)
++    { return __complex_proj(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    proj(const std::complex<_Tp>& __z)
++    { return __complex_proj(__z); }
++#endif
++
++  // DR 1137.
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    proj(_Tp __x)
++    { return __x; }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    conj(_Tp __x)
++    { return __x; }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#endif  // __GXX_EXPERIMENTAL_CXX0X__
++
++#endif  /* _GLIBCXX_COMPLEX */
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/emmintrin.h gccxml/GCC_XML/Support/GCC/4.7/emmintrin.h
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/emmintrin.h	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/emmintrin.h	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,1515 @@
++/* Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010
++   Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GCC is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Implemented from the specification included in the Intel C++ Compiler
++   User Guide and Reference, version 9.0.  */
++
++#ifndef _EMMINTRIN_H_INCLUDED
++#define _EMMINTRIN_H_INCLUDED
++
++#ifndef __SSE2__
++# error "SSE2 instruction set not enabled"
++#else
++
++/* We need definitions from the SSE header files*/
++#include <xmmintrin.h>
++
++/* SSE2 */
++typedef double __v2df __attribute__ ((__vector_size__ (16)));
++typedef long long __v2di __attribute__ ((__vector_size__ (16)));
++typedef int __v4si __attribute__ ((__vector_size__ (16)));
++typedef short __v8hi __attribute__ ((__vector_size__ (16)));
++typedef char __v16qi __attribute__ ((__vector_size__ (16)));
++
++/* The Intel API is flexible enough that we must allow aliasing with other
++   vector types, and their scalar components.  */
++typedef long long __m128i __attribute__ ((__vector_size__ (16), __may_alias__));
++typedef double __m128d __attribute__ ((__vector_size__ (16), __may_alias__));
++
++/* Create a selector for use with the SHUFPD instruction.  */
++#define _MM_SHUFFLE2(fp1,fp0) \
++ (((fp1) << 1) | (fp0))
++
++/* Create a vector with element 0 as F and the rest zero.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_sd (double __F)
++{
++  return __extension__ (__m128d){ __F, 0.0 };
++}
++
++/* Create a vector with both elements equal to F.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pd (double __F)
++{
++  return __extension__ (__m128d){ __F, __F };
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pd1 (double __F)
++{
++  return _mm_set1_pd (__F);
++}
++
++/* Create a vector with the lower value X and upper value W.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pd (double __W, double __X)
++{
++  return __extension__ (__m128d){ __X, __W };
++}
++
++/* Create a vector with the lower value W and upper value X.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pd (double __W, double __X)
++{
++  return __extension__ (__m128d){ __W, __X };
++}
++
++/* Create a vector of zeros.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_pd (void)
++{
++  return __extension__ (__m128d){ 0.0, 0.0 };
++}
++
++/* Sets the low DPFP value of A from the low value of B.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_move_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df)__A, (__v2df)__B);
++}
++
++/* Load two DPFP values from P.  The address must be 16-byte aligned.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_pd (double const *__P)
++{
++  return *(__m128d *)__P;
++}
++
++/* Load two DPFP values from P.  The address need not be 16-byte aligned.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadu_pd (double const *__P)
++{
++  return __builtin_ia32_loadupd (__P);
++}
++
++/* Create a vector with all two elements equal to *P.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load1_pd (double const *__P)
++{
++  return _mm_set1_pd (*__P);
++}
++
++/* Create a vector with element 0 as *P and the rest zero.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_sd (double const *__P)
++{
++  return _mm_set_sd (*__P);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_pd1 (double const *__P)
++{
++  return _mm_load1_pd (__P);
++}
++
++/* Load two DPFP values in reverse order.  The address must be aligned.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadr_pd (double const *__P)
++{
++  __m128d __tmp = _mm_load_pd (__P);
++  return __builtin_ia32_shufpd (__tmp, __tmp, _MM_SHUFFLE2 (0,1));
++}
++
++/* Store two DPFP values.  The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_pd (double *__P, __m128d __A)
++{
++  *(__m128d *)__P = __A;
++}
++
++/* Store two DPFP values.  The address need not be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeu_pd (double *__P, __m128d __A)
++{
++  __builtin_ia32_storeupd (__P, __A);
++}
++
++/* Stores the lower DPFP value.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_sd (double *__P, __m128d __A)
++{
++  *__P = __builtin_ia32_vec_ext_v2df (__A, 0);
++}
++
++extern __inline double __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_f64 (__m128d __A)
++{
++  return __builtin_ia32_vec_ext_v2df (__A, 0);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storel_pd (double *__P, __m128d __A)
++{
++  _mm_store_sd (__P, __A);
++}
++
++/* Stores the upper DPFP value.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeh_pd (double *__P, __m128d __A)
++{
++  *__P = __builtin_ia32_vec_ext_v2df (__A, 1);
++}
++
++/* Store the lower DPFP value across two words.
++   The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store1_pd (double *__P, __m128d __A)
++{
++  _mm_store_pd (__P, __builtin_ia32_shufpd (__A, __A, _MM_SHUFFLE2 (0,0)));
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_pd1 (double *__P, __m128d __A)
++{
++  _mm_store1_pd (__P, __A);
++}
++
++/* Store two DPFP values in reverse order.  The address must be aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storer_pd (double *__P, __m128d __A)
++{
++  _mm_store_pd (__P, __builtin_ia32_shufpd (__A, __A, _MM_SHUFFLE2 (0,1)));
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi128_si32 (__m128i __A)
++{
++  return __builtin_ia32_vec_ext_v4si ((__v4si)__A, 0);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi128_si64 (__m128i __A)
++{
++  return __builtin_ia32_vec_ext_v2di ((__v2di)__A, 0);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi128_si64x (__m128i __A)
++{
++  return __builtin_ia32_vec_ext_v2di ((__v2di)__A, 0);
++}
++#endif
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_addpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_addsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_subpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_subsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_mulpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_mulsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_divpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_divsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_pd (__m128d __A)
++{
++  return (__m128d)__builtin_ia32_sqrtpd ((__v2df)__A);
++}
++
++/* Return pair {sqrt (A[0), B[1]}.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_sd (__m128d __A, __m128d __B)
++{
++  __v2df __tmp = __builtin_ia32_movsd ((__v2df)__A, (__v2df)__B);
++  return (__m128d)__builtin_ia32_sqrtsd ((__v2df)__tmp);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_minpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_minsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_maxpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_maxsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_andpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_andnpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_orpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_xorpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpeqpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpltpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmplepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpgtpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpgepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpneqpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnltpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnlepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpngtpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpngepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpordpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpunordpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpeqsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpltsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmplesd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmpltsd ((__v2df) __B,
++								 (__v2df)
++								 __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmplesd ((__v2df) __B,
++								 (__v2df)
++								 __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpneqsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnltsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnlesd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmpnltsd ((__v2df) __B,
++								  (__v2df)
++								  __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmpnlesd ((__v2df) __B,
++								  (__v2df)
++								  __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpordsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpunordsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comieq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdeq ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comilt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdlt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comile_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdle ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comigt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdgt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comige_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdge ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comineq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdneq ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomieq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdeq ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomilt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdlt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomile_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdle ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomigt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdgt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomige_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdge ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomineq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdneq ((__v2df)__A, (__v2df)__B);
++}
++
++/* Create a vector of Qi, where i is the element number.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi64x (long long __q1, long long __q0)
++{
++  return __extension__ (__m128i)(__v2di){ __q0, __q1 };
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi64 (__m64 __q1,  __m64 __q0)
++{
++  return _mm_set_epi64x ((long long)__q1, (long long)__q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi32 (int __q3, int __q2, int __q1, int __q0)
++{
++  return __extension__ (__m128i)(__v4si){ __q0, __q1, __q2, __q3 };
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi16 (short __q7, short __q6, short __q5, short __q4,
++	       short __q3, short __q2, short __q1, short __q0)
++{
++  return __extension__ (__m128i)(__v8hi){
++    __q0, __q1, __q2, __q3, __q4, __q5, __q6, __q7 };
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi8 (char __q15, char __q14, char __q13, char __q12,
++	      char __q11, char __q10, char __q09, char __q08,
++	      char __q07, char __q06, char __q05, char __q04,
++	      char __q03, char __q02, char __q01, char __q00)
++{
++  return __extension__ (__m128i)(__v16qi){
++    __q00, __q01, __q02, __q03, __q04, __q05, __q06, __q07,
++    __q08, __q09, __q10, __q11, __q12, __q13, __q14, __q15
++  };
++}
++
++/* Set all of the elements of the vector to A.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi64x (long long __A)
++{
++  return _mm_set_epi64x (__A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi64 (__m64 __A)
++{
++  return _mm_set_epi64 (__A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi32 (int __A)
++{
++  return _mm_set_epi32 (__A, __A, __A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi16 (short __A)
++{
++  return _mm_set_epi16 (__A, __A, __A, __A, __A, __A, __A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi8 (char __A)
++{
++  return _mm_set_epi8 (__A, __A, __A, __A, __A, __A, __A, __A,
++		       __A, __A, __A, __A, __A, __A, __A, __A);
++}
++
++/* Create a vector of Qi, where i is the element number.
++   The parameter order is reversed from the _mm_set_epi* functions.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi64 (__m64 __q0, __m64 __q1)
++{
++  return _mm_set_epi64 (__q1, __q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi32 (int __q0, int __q1, int __q2, int __q3)
++{
++  return _mm_set_epi32 (__q3, __q2, __q1, __q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi16 (short __q0, short __q1, short __q2, short __q3,
++	        short __q4, short __q5, short __q6, short __q7)
++{
++  return _mm_set_epi16 (__q7, __q6, __q5, __q4, __q3, __q2, __q1, __q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi8 (char __q00, char __q01, char __q02, char __q03,
++	       char __q04, char __q05, char __q06, char __q07,
++	       char __q08, char __q09, char __q10, char __q11,
++	       char __q12, char __q13, char __q14, char __q15)
++{
++  return _mm_set_epi8 (__q15, __q14, __q13, __q12, __q11, __q10, __q09, __q08,
++		       __q07, __q06, __q05, __q04, __q03, __q02, __q01, __q00);
++}
++
++/* Create a vector with element 0 as *P and the rest zero.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_si128 (__m128i const *__P)
++{
++  return *__P;
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadu_si128 (__m128i const *__P)
++{
++  return (__m128i) __builtin_ia32_loaddqu ((char const *)__P);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadl_epi64 (__m128i const *__P)
++{
++  return _mm_set_epi64 ((__m64)0LL, *(__m64 *)__P);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_si128 (__m128i *__P, __m128i __B)
++{
++  *__P = __B;
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeu_si128 (__m128i *__P, __m128i __B)
++{
++  __builtin_ia32_storedqu ((char *)__P, (__v16qi)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storel_epi64 (__m128i *__P, __m128i __B)
++{
++  *(long long *)__P = __builtin_ia32_vec_ext_v2di ((__v2di)__B, 0);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movepi64_pi64 (__m128i __B)
++{
++  return (__m64) __builtin_ia32_vec_ext_v2di ((__v2di)__B, 0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movpi64_epi64 (__m64 __A)
++{
++  return _mm_set_epi64 ((__m64)0LL, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_move_epi64 (__m128i __A);
++
++/* Create a vector of zeros.  */
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_si128 (void)
++{
++  return __extension__ (__m128i)(__v4si){ 0, 0, 0, 0 };
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtepi32_pd (__m128i __A)
++{
++  return (__m128d)__builtin_ia32_cvtdq2pd ((__v4si) __A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtepi32_ps (__m128i __A)
++{
++  return (__m128)__builtin_ia32_cvtdq2ps ((__v4si) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpd_epi32 (__m128d __A)
++{
++  return (__m128i)__builtin_ia32_cvtpd2dq ((__v2df) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpd_pi32 (__m128d __A)
++{
++  return (__m64)__builtin_ia32_cvtpd2pi ((__v2df) __A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpd_ps (__m128d __A)
++{
++  return (__m128)__builtin_ia32_cvtpd2ps ((__v2df) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttpd_epi32 (__m128d __A)
++{
++  return (__m128i)__builtin_ia32_cvttpd2dq ((__v2df) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttpd_pi32 (__m128d __A)
++{
++  return (__m64)__builtin_ia32_cvttpd2pi ((__v2df) __A);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi32_pd (__m64 __A)
++{
++  return (__m128d)__builtin_ia32_cvtpi2pd ((__v2si) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_epi32 (__m128 __A)
++{
++  return (__m128i)__builtin_ia32_cvtps2dq ((__v4sf) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttps_epi32 (__m128 __A)
++{
++  return (__m128i)__builtin_ia32_cvttps2dq ((__v4sf) __A);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pd (__m128 __A)
++{
++  return (__m128d)__builtin_ia32_cvtps2pd ((__v4sf) __A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_si32 (__m128d __A)
++{
++  return __builtin_ia32_cvtsd2si ((__v2df) __A);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_si64 (__m128d __A)
++{
++  return __builtin_ia32_cvtsd2si64 ((__v2df) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_si64x (__m128d __A)
++{
++  return __builtin_ia32_cvtsd2si64 ((__v2df) __A);
++}
++#endif
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttsd_si32 (__m128d __A)
++{
++  return __builtin_ia32_cvttsd2si ((__v2df) __A);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttsd_si64 (__m128d __A)
++{
++  return __builtin_ia32_cvttsd2si64 ((__v2df) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttsd_si64x (__m128d __A)
++{
++  return __builtin_ia32_cvttsd2si64 ((__v2df) __A);
++}
++#endif
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_ss (__m128 __A, __m128d __B)
++{
++  return (__m128)__builtin_ia32_cvtsd2ss ((__v4sf) __A, (__v2df) __B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_sd (__m128d __A, int __B)
++{
++  return (__m128d)__builtin_ia32_cvtsi2sd ((__v2df) __A, __B);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_sd (__m128d __A, long long __B)
++{
++  return (__m128d)__builtin_ia32_cvtsi642sd ((__v2df) __A, __B);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_sd (__m128d __A, long long __B)
++{
++  return (__m128d)__builtin_ia32_cvtsi642sd ((__v2df) __A, __B);
++}
++#endif
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_sd (__m128d __A, __m128 __B)
++{
++  return (__m128d)__builtin_ia32_cvtss2sd ((__v2df) __A, (__v4sf)__B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_pd(__m128d __A, __m128d __B, const int __mask)
++{
++  return (__m128d)__builtin_ia32_shufpd ((__v2df)__A, (__v2df)__B, __mask);
++}
++#else
++#define _mm_shuffle_pd(A, B, N)						\
++  ((__m128d)__builtin_ia32_shufpd ((__v2df)(__m128d)(A),		\
++				   (__v2df)(__m128d)(B), (int)(N)))
++#endif
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_unpckhpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_unpcklpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadh_pd (__m128d __A, double const *__B)
++{
++  return (__m128d)__builtin_ia32_loadhpd ((__v2df)__A, __B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadl_pd (__m128d __A, double const *__B)
++{
++  return (__m128d)__builtin_ia32_loadlpd ((__v2df)__A, __B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_pd (__m128d __A)
++{
++  return __builtin_ia32_movmskpd ((__v2df)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_packsswb128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_packssdw128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packus_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_packuswb128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhbw128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhwd128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhdq128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhqdq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpcklbw128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpcklwd128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckldq128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpcklqdq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddd128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddsb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddusb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddusw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubd128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubsb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubusb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubusw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_madd_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmaddwd128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmulhw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mullo_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmullw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_su32 (__m64 __A, __m64 __B)
++{
++  return (__m64)__builtin_ia32_pmuludq ((__v2si)__A, (__v2si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_epu32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmuludq128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_epi16 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psllwi128 ((__v8hi)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_epi32 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_pslldi128 ((__v4si)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_epi64 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psllqi128 ((__v2di)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_epi16 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrawi128 ((__v8hi)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_epi32 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psradi128 ((__v4si)__A, __B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_si128 (__m128i __A, const int __N)
++{
++  return (__m128i)__builtin_ia32_psrldqi128 (__A, __N * 8);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_si128 (__m128i __A, const int __N)
++{
++  return (__m128i)__builtin_ia32_pslldqi128 (__A, __N * 8);
++}
++#else
++#define _mm_srli_si128(A, N) \
++  ((__m128i)__builtin_ia32_psrldqi128 ((__m128i)(A), (int)(N) * 8))
++#define _mm_slli_si128(A, N) \
++  ((__m128i)__builtin_ia32_pslldqi128 ((__m128i)(A), (int)(N) * 8))
++#endif
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_epi16 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrlwi128 ((__v8hi)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_epi32 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrldi128 ((__v4si)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_epi64 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrlqi128 ((__v2di)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psllw128((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pslld128((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psllq128((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psraw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrad128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrlw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrld128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrlq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pand128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pandn128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_por128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pxor128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpeqb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpeqw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpeqd128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtb128 ((__v16qi)__B, (__v16qi)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtw128 ((__v8hi)__B, (__v8hi)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtd128 ((__v4si)__B, (__v4si)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtd128 ((__v4si)__A, (__v4si)__B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_extract_epi16 (__m128i const __A, int const __N)
++{
++  return (unsigned short) __builtin_ia32_vec_ext_v8hi ((__v8hi)__A, __N);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_insert_epi16 (__m128i const __A, int const __D, int const __N)
++{
++  return (__m128i) __builtin_ia32_vec_set_v8hi ((__v8hi)__A, __D, __N);
++}
++#else
++#define _mm_extract_epi16(A, N) \
++  ((int) (unsigned short) __builtin_ia32_vec_ext_v8hi ((__v8hi)(__m128i)(A), (int)(N)))
++#define _mm_insert_epi16(A, D, N)				\
++  ((__m128i) __builtin_ia32_vec_set_v8hi ((__v8hi)(__m128i)(A),	\
++					  (int)(D), (int)(N)))
++#endif
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmaxsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmaxub128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pminsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pminub128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_epi8 (__m128i __A)
++{
++  return __builtin_ia32_pmovmskb128 ((__v16qi)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmulhuw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shufflehi_epi16 (__m128i __A, const int __mask)
++{
++  return (__m128i)__builtin_ia32_pshufhw ((__v8hi)__A, __mask);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shufflelo_epi16 (__m128i __A, const int __mask)
++{
++  return (__m128i)__builtin_ia32_pshuflw ((__v8hi)__A, __mask);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_epi32 (__m128i __A, const int __mask)
++{
++  return (__m128i)__builtin_ia32_pshufd ((__v4si)__A, __mask);
++}
++#else
++#define _mm_shufflehi_epi16(A, N) \
++  ((__m128i)__builtin_ia32_pshufhw ((__v8hi)(__m128i)(A), (int)(N)))
++#define _mm_shufflelo_epi16(A, N) \
++  ((__m128i)__builtin_ia32_pshuflw ((__v8hi)(__m128i)(A), (int)(N)))
++#define _mm_shuffle_epi32(A, N) \
++  ((__m128i)__builtin_ia32_pshufd ((__v4si)(__m128i)(A), (int)(N)))
++#endif
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_maskmoveu_si128 (__m128i __A, __m128i __B, char *__C)
++{
++  __builtin_ia32_maskmovdqu ((__v16qi)__A, (__v16qi)__B, __C);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pavgb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pavgw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sad_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psadbw128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_si32 (int *__A, int __B)
++{
++  __builtin_ia32_movnti (__A, __B);
++}
++
++#ifdef __x86_64__
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_si64 (long long int *__A, long long int __B);
++#endif
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_si128 (__m128i *__A, __m128i __B)
++{
++  __builtin_ia32_movntdq ((__v2di *)__A, (__v2di)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_pd (double *__A, __m128d __B)
++{
++  __builtin_ia32_movntpd (__A, (__v2df)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_clflush (void const *__A)
++{
++  __builtin_ia32_clflush (__A);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_lfence (void)
++{
++  __builtin_ia32_lfence ();
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mfence (void)
++{
++  __builtin_ia32_mfence ();
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_si128 (int __A)
++{
++  return _mm_set_epi32 (0, 0, 0, __A);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_si128 (long long __A)
++{
++  return _mm_set_epi64x (0, __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_si128 (long long __A)
++{
++  return _mm_set_epi64x (0, __A);
++}
++#endif
++
++/* Casts between various SP, DP, INT vector types.  Note that these do no
++   conversion of values, they just change the type.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castpd_ps(__m128d __A)
++{
++  return (__m128) __A;
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castpd_si128(__m128d __A)
++{
++  return (__m128i) __A;
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castps_pd(__m128 __A)
++{
++  return (__m128d) __A;
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castps_si128(__m128 __A)
++{
++  return (__m128i) __A;
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castsi128_ps(__m128i __A)
++{
++  return (__m128) __A;
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castsi128_pd(__m128i __A)
++{
++  return (__m128d) __A;
++}
++
++#endif /* __SSE2__  */
++
++#endif /* _EMMINTRIN_H_INCLUDED */
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/ext/atomicity.h gccxml/GCC_XML/Support/GCC/4.7/ext/atomicity.h
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/ext/atomicity.h	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/ext/atomicity.h	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,116 @@
++// Support for atomic operations -*- C++ -*-
++
++// Copyright (C) 2004, 2005, 2006, 2008, 2009, 2010, 2011, 2012
++// Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file ext/atomicity.h
++ *  This file is a GNU extension to the Standard C++ Library.
++ */
++
++#ifndef _GLIBCXX_ATOMICITY_H
++#define _GLIBCXX_ATOMICITY_H	1
++
++#include <bits/c++config.h>
++#include <bits/gthr.h>
++#include <bits/atomic_word.h>
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // Functions for portable atomic access.
++  // To abstract locking primitives across all thread policies, use:
++  // __exchange_and_add_dispatch
++  // __atomic_add_dispatch
++#ifdef _GLIBCXX_ATOMIC_BUILTINS
++  static inline _Atomic_word 
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val)
++  { return __sync_fetch_and_add(__mem, __val, __ATOMIC_ACQ_REL); }
++
++  static inline void
++  __atomic_add(volatile _Atomic_word* __mem, int __val)
++  { __sync_fetch_and_add(__mem, __val, __ATOMIC_ACQ_REL); }
++#else
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word*, int) throw ();
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word*, int) throw ();
++#endif
++
++  static inline _Atomic_word
++  __exchange_and_add_single(_Atomic_word* __mem, int __val)
++  {
++    _Atomic_word __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  static inline void
++  __atomic_add_single(_Atomic_word* __mem, int __val)
++  { *__mem += __val; }
++
++  static inline _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add_dispatch(_Atomic_word* __mem, int __val)
++  {
++#ifdef __GTHREADS
++    if (__gthread_active_p())
++      return __exchange_and_add(__mem, __val);
++    else
++      return __exchange_and_add_single(__mem, __val);
++#else
++    return __exchange_and_add_single(__mem, __val);
++#endif
++  }
++
++  static inline void
++  __attribute__ ((__unused__))
++  __atomic_add_dispatch(_Atomic_word* __mem, int __val)
++  {
++#ifdef __GTHREADS
++    if (__gthread_active_p())
++      __atomic_add(__mem, __val);
++    else
++      __atomic_add_single(__mem, __val);
++#else
++    __atomic_add_single(__mem, __val);
++#endif
++  }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++// Even if the CPU doesn't need a memory barrier, we need to ensure
++// that the compiler doesn't reorder memory accesses across the
++// barriers.
++#ifndef _GLIBCXX_READ_MEM_BARRIER
++#define _GLIBCXX_READ_MEM_BARRIER __asm __volatile ("":::"memory")
++#endif
++#ifndef _GLIBCXX_WRITE_MEM_BARRIER
++#define _GLIBCXX_WRITE_MEM_BARRIER __asm __volatile ("":::"memory")
++#endif
++
++#endif 
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/gccxml_builtins.h gccxml/GCC_XML/Support/GCC/4.7/gccxml_builtins.h
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/gccxml_builtins.h	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/gccxml_builtins.h	2011-02-10 14:59:45.000000000 +0100
+@@ -0,0 +1,160 @@
++#define __builtin_apply(x,y,z) ((void*)0)
++#define __builtin_nan(x) (0.0)
++#define __builtin_nanf(x) (0.0f)
++#define __builtin_nanl(x) (0.0l)
++#define __builtin_huge_val(x) (0.0)
++#define __builtin_huge_valf(x) (0.0f)
++#define __builtin_huge_vall(x) (0.0l)
++#define __builtin_apply_args(x) ((void*)0)
++#define __builtin_types_compatible_p(x,y) 0
++#define __builtin_choose_expr(x,y,z) int
++#define __builtin_constant_p(x) 0
++void* __builtin_memchr(void const*, int, unsigned int);
++void __builtin_return (void *RESULT);
++void * __builtin_return_address (unsigned int LEVEL);
++void * __builtin_frame_address (unsigned int LEVEL);
++long __builtin_expect (long EXP, long C);
++void __builtin_prefetch (const void *ADDR, ...);
++double __builtin_inf (void);
++float __builtin_inff (void);
++long double __builtin_infl (void);
++double __builtin_nans (const char *str);
++float __builtin_nansf (const char *str);
++long double __builtin_nansl (const char *str);
++double      __builtin_acos(double);
++float       __builtin_acosf(float);
++long double __builtin_acosl(long double);
++double      __builtin_asin(double);
++float       __builtin_asinf(float);
++long double __builtin_asinl(long double);
++double      __builtin_atan(double);
++double      __builtin_atan2(double, double);
++float       __builtin_atan2f(float, float);
++long double __builtin_atan2l(long double, long double);
++float       __builtin_atanf(float);
++long double __builtin_atanl(long double);
++double      __builtin_ceil(double);
++float       __builtin_ceilf(float);
++long double __builtin_ceill(long double);
++double      __builtin_cos(double);
++float       __builtin_cosf(float);
++double      __builtin_cosh(double);
++float       __builtin_coshf(float);
++long double __builtin_coshl(long double);
++long double __builtin_cosl(long double);
++double      __builtin_exp(double);
++float       __builtin_expf(float);
++long double __builtin_expl(long double);
++double      __builtin_fabs(double);
++float       __builtin_fabsf(float);
++long double __builtin_fabsl(long double);
++double      __builtin_floor(double);
++float       __builtin_floorf(float);
++long double __builtin_floorl(long double);
++float       __builtin_fmodf(float, float);
++long double __builtin_fmodl(long double, long double);
++double      __builtin_frexp(double, int*);
++float       __builtin_frexpf(float, int*);
++long double __builtin_frexpl(long double, int*);
++double      __builtin_ldexp(double, int);
++float       __builtin_ldexpf(float, int);
++long double __builtin_ldexpl(long double, int);
++double      __builtin_log(double);
++double      __builtin_log10(double);
++float       __builtin_log10f(float);
++long double __builtin_log10l(long double);
++float       __builtin_logf(float);
++long double __builtin_logl(long double);
++float       __builtin_modff(float, float*);
++long double __builtin_modfl(long double, long double*);
++float       __builtin_powf(float, float);
++long double __builtin_powl(long double, long double);
++double      __builtin_powi(double, int);
++float       __builtin_powif(float, int);
++long double __builtin_powil(long double, int);
++double      __builtin_sin(double);
++float       __builtin_sinf(float);
++double      __builtin_sinh(double);
++float       __builtin_sinhf(float);
++long double __builtin_sinhl(long double);
++long double __builtin_sinl(long double);
++double      __builtin_sqrt(double);
++float       __builtin_sqrtf(float);
++long double __builtin_sqrtl(long double);
++double      __builtin_tan(double);
++float       __builtin_tanf(float);
++double      __builtin_tanh(double);
++float       __builtin_tanhf(float);
++long double __builtin_tanhl(long double);
++long double __builtin_tanl(long double);
++float       __builtin_cabsf(float __complex__);
++double      __builtin_cabs(double __complex__);
++long double __builtin_cabsl(long double __complex__);
++float       __builtin_cargf(float __complex__);
++double      __builtin_carg(double __complex__);
++long double __builtin_cargl(long double __complex__);
++int         __builtin_ctz(int);
++int         __builtin_ctzl(long);
++int         __builtin_ctzll(long long);
++int         __builtin_popcount(int);
++int         __builtin_popcountl(long);
++int         __builtin_popcountll(long long);
++float       __complex__ __builtin_ccosf(float __complex__);
++double      __complex__ __builtin_ccos(double __complex__);
++long double __complex__ __builtin_ccosl(long double __complex__);
++float       __complex__ __builtin_ccoshf(float __complex__);
++double      __complex__ __builtin_ccosh(double __complex__);
++long double __complex__ __builtin_ccoshl(long double __complex__);
++float       __complex__ __builtin_cexpf(float __complex__);
++double      __complex__ __builtin_cexp(double __complex__);
++long double __complex__ __builtin_cexpl(long double __complex__);
++float       __complex__ __builtin_clogf(float __complex__);
++double      __complex__ __builtin_clog(double __complex__);
++long double __complex__ __builtin_clogl(long double __complex__);
++float       __complex__ __builtin_csinf(float __complex__);
++double      __complex__ __builtin_csin(double __complex__);
++long double __complex__ __builtin_csinl(long double __complex__);
++float       __complex__ __builtin_csinhf(float __complex__);
++double      __complex__ __builtin_csinh(double __complex__);
++long double __complex__ __builtin_csinhl(long double __complex__);
++float       __complex__ __builtin_csqrtf(float __complex__);
++double      __complex__ __builtin_csqrt(double __complex__);
++long double __complex__ __builtin_csqrtl(long double __complex__);
++float       __complex__ __builtin_ctanf(float __complex__);
++double      __complex__ __builtin_ctan(double __complex__);
++long double __complex__ __builtin_ctanl(long double __complex__);
++float       __complex__ __builtin_ctanhf(float __complex__);
++double      __complex__ __builtin_ctanh(double __complex__);
++long double __complex__ __builtin_ctanhl(long double __complex__);
++float       __complex__ __builtin_cpowf(float __complex__, float __complex__);
++double      __complex__ __builtin_cpow(double __complex__, double __complex__);
++long double __complex__ __builtin_cpowl(long double __complex__, long double __complex__);
++
++/* The GCC 4.5 parser hard-codes handling of these, so they do not
++   have real signatures.  */
++bool __builtin_fpclassify(...);
++bool __builtin_isfinite(...);
++bool __builtin_isgreater(...);
++bool __builtin_isgreaterequal(...);
++bool __builtin_isinf(...);
++bool __builtin_isinf_sign(...);
++bool __builtin_isless(...);
++bool __builtin_islessequal(...);
++bool __builtin_islessgreater(...);
++bool __builtin_isnan(...);
++bool __builtin_isnormal(...);
++bool __builtin_isunordered(...);
++bool __builtin_va_arg_pack(...);
++int  __builtin_va_arg_pack_len(...);
++
++/* We fake some constant expressions from GCC 4.5 parser.  */
++#define __is_empty(x) false
++#define __is_pod(x) false
++#define __is_trivial(x) false
++#define __has_trivial_destructor(x) false
++#define __has_trivial_constructor(x) false
++
++#ifdef __llvm__
++extern unsigned int  __builtin_bswap32(unsigned int _data);
++extern unsigned long __builtin_bswap64(unsigned long _data);
++#endif
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/iomanip gccxml/GCC_XML/Support/GCC/4.7/iomanip
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/iomanip	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/iomanip	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,377 @@
++// Standard stream manipulators -*- C++ -*-
++
++// Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005
++// 2006, 2007, 2008, 2009, 2010, 2011
++// Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file include/iomanip
++ *  This is a Standard C++ Library header.
++ */
++
++//
++// ISO C++ 14882: 27.6.3  Standard manipulators
++//
++
++#ifndef _GLIBCXX_IOMANIP
++#define _GLIBCXX_IOMANIP 1
++
++#pragma GCC system_header
++
++#include <bits/c++config.h>
++#include <iosfwd>
++#include <bits/ios_base.h>
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++#include <locale>
++#endif
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // [27.6.3] standard manipulators
++  // Also see DR 183.
++
++  struct _Resetiosflags { ios_base::fmtflags _M_mask; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  __mask  A format flags mask.
++   *
++   *  Sent to a stream object, this manipulator resets the specified flags,
++   *  via @e stream.setf(0,__mask).
++  */
++  inline _Resetiosflags 
++  resetiosflags(ios_base::fmtflags __mask)
++  { _Resetiosflags r = { __mask }; return r; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Resetiosflags __f)
++    { 
++      __is.setf(ios_base::fmtflags(0), __f._M_mask); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Resetiosflags __f)
++    { 
++      __os.setf(ios_base::fmtflags(0), __f._M_mask); 
++      return __os; 
++    }
++
++
++  struct _Setiosflags { ios_base::fmtflags _M_mask; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  __mask  A format flags mask.
++   *
++   *  Sent to a stream object, this manipulator sets the format flags
++   *  to @a __mask.
++  */
++  inline _Setiosflags 
++  setiosflags(ios_base::fmtflags __mask)
++  { _Setiosflags s = { __mask }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setiosflags __f)
++    { 
++      __is.setf(__f._M_mask); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setiosflags __f)
++    { 
++      __os.setf(__f._M_mask); 
++      return __os; 
++    }
++
++
++  struct _Setbase { int _M_base; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  __base  A numeric base.
++   *
++   *  Sent to a stream object, this manipulator changes the
++   *  @c ios_base::basefield flags to @c oct, @c dec, or @c hex when @a base
++   *  is 8, 10, or 16, accordingly, and to 0 if @a __base is any other value.
++  */
++  inline _Setbase 
++  setbase(int __base)
++  { _Setbase s = { __base }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setbase __f)
++    {
++      __is.setf(__f._M_base ==  8 ? ios_base::oct : 
++		__f._M_base == 10 ? ios_base::dec : 
++		__f._M_base == 16 ? ios_base::hex : 
++		ios_base::fmtflags(0), ios_base::basefield);
++      return __is; 
++    }
++  
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setbase __f)
++    {
++      __os.setf(__f._M_base ==  8 ? ios_base::oct : 
++		__f._M_base == 10 ? ios_base::dec : 
++		__f._M_base == 16 ? ios_base::hex : 
++		ios_base::fmtflags(0), ios_base::basefield);
++      return __os; 
++    }
++  
++
++  template<typename _CharT>
++    struct _Setfill { _CharT _M_c; };
++
++  /**
++   *  @brief  Manipulator for @c fill.
++   *  @param  __c  The new fill character.
++   *
++   *  Sent to a stream object, this manipulator calls @c fill(__c) for that
++   *  object.
++  */
++  template<typename _CharT>
++    inline _Setfill<_CharT>
++    setfill(_CharT __c)
++    { _Setfill<_CharT> s = { __c }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setfill<_CharT> __f)
++    { 
++      __is.fill(__f._M_c); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setfill<_CharT> __f)
++    { 
++      __os.fill(__f._M_c); 
++      return __os; 
++    }
++
++
++  struct _Setprecision { int _M_n; };
++
++  /**
++   *  @brief  Manipulator for @c precision.
++   *  @param  __n  The new precision.
++   *
++   *  Sent to a stream object, this manipulator calls @c precision(__n) for
++   *  that object.
++  */
++  inline _Setprecision 
++  setprecision(int __n)
++  { _Setprecision s = { __n }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setprecision __f)
++    { 
++      __is.precision(__f._M_n); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setprecision __f)
++    { 
++      __os.precision(__f._M_n); 
++      return __os; 
++    }
++
++
++  struct _Setw { int _M_n; };
++
++  /**
++   *  @brief  Manipulator for @c width.
++   *  @param  __n  The new width.
++   *
++   *  Sent to a stream object, this manipulator calls @c width(__n) for
++   *  that object.
++  */
++  inline _Setw 
++  setw(int __n)
++  { _Setw s = {__n} ; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setw __f)
++    {
++      __is.width(__f._M_n);
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setw __f)
++    {
++      __os.width(__f._M_n);
++      return __os; 
++    }
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++  
++  template<typename _MoneyT>
++    struct _Get_money { _MoneyT& _M_mon; bool _M_intl; };
++
++  /**
++   *  @brief  Extended manipulator for extracting money.
++   *  @param  __mon  Either long double or a specialization of @c basic_string.
++   *  @param  __intl A bool indicating whether international format 
++   *                 is to be used.
++   *
++   *  Sent to a stream object, this manipulator extracts @a __mon.
++  */
++  template<typename _MoneyT>
++    inline _Get_money<_MoneyT>
++    get_money(_MoneyT& __mon, bool __intl = false)
++    { return { __mon, __intl }; }
++
++  template<typename _CharT, typename _Traits, typename _MoneyT>
++    basic_istream<_CharT, _Traits>&
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Get_money<_MoneyT> __f)
++    {
++      typename basic_istream<_CharT, _Traits>::sentry __cerb(__is, false);
++      if (__cerb)
++	{
++	  ios_base::iostate __err = ios_base::goodbit;
++	  __try
++	    {
++	      typedef istreambuf_iterator<_CharT, _Traits>   _Iter;
++	      typedef money_get<_CharT, _Iter>               _MoneyGet;
++
++	      const _MoneyGet& __mg = use_facet<_MoneyGet>(__is.getloc());
++	      __mg.get(_Iter(__is.rdbuf()), _Iter(), __f._M_intl,
++		       __is, __err, __f._M_mon);
++	    }
++	  __catch(__cxxabiv1::__forced_unwind&)
++	    {
++	      __is._M_setstate(ios_base::badbit);
++	      __throw_exception_again;
++	    }
++	  __catch(...)
++	    { __is._M_setstate(ios_base::badbit); }
++	  if (__err)
++	    __is.setstate(__err);
++	}
++      return __is; 
++    }
++
++
++  template<typename _MoneyT>
++    struct _Put_money { const _MoneyT& _M_mon; bool _M_intl; };
++
++  /**
++   *  @brief  Extended manipulator for inserting money.
++   *  @param  __mon  Either long double or a specialization of @c basic_string.
++   *  @param  __intl A bool indicating whether international format 
++   *                 is to be used.
++   *
++   *  Sent to a stream object, this manipulator inserts @a __mon.
++  */
++  template<typename _MoneyT>
++    inline _Put_money<_MoneyT>
++    put_money(const _MoneyT& __mon, bool __intl = false)
++    { return { __mon, __intl }; }
++
++  template<typename _CharT, typename _Traits, typename _MoneyT>
++    basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Put_money<_MoneyT> __f)
++    {
++      typename basic_ostream<_CharT, _Traits>::sentry __cerb(__os);
++      if (__cerb)
++	{
++	  ios_base::iostate __err = ios_base::goodbit;
++	  __try
++	    {
++	      typedef ostreambuf_iterator<_CharT, _Traits>   _Iter;
++	      typedef money_put<_CharT, _Iter>               _MoneyPut;
++
++	      const _MoneyPut& __mp = use_facet<_MoneyPut>(__os.getloc());
++	      if (__mp.put(_Iter(__os.rdbuf()), __f._M_intl, __os,
++			   __os.fill(), __f._M_mon).failed())
++		__err |= ios_base::badbit;
++	    }
++	  __catch(__cxxabiv1::__forced_unwind&)
++	    {
++	      __os._M_setstate(ios_base::badbit);
++	      __throw_exception_again;
++	    }
++	  __catch(...)
++	    { __os._M_setstate(ios_base::badbit); }
++	  if (__err)
++	    __os.setstate(__err);
++	}
++      return __os; 
++    }
++
++#endif
++
++  // Inhibit implicit instantiations for required instantiations,
++  // which are defined via explicit instantiations elsewhere.  
++  // NB:  This syntax is a GNU extension.
++#if _GLIBCXX_EXTERN_TEMPLATE
++  extern template ostream& operator<<(ostream&, _Setfill<char>);
++  extern template ostream& operator<<(ostream&, _Setiosflags);
++  extern template ostream& operator<<(ostream&, _Resetiosflags);
++  extern template ostream& operator<<(ostream&, _Setbase);
++  extern template ostream& operator<<(ostream&, _Setprecision);
++  extern template ostream& operator<<(ostream&, _Setw);
++  extern template istream& operator>>(istream&, _Setfill<char>);
++  extern template istream& operator>>(istream&, _Setiosflags);
++  extern template istream& operator>>(istream&, _Resetiosflags);
++  extern template istream& operator>>(istream&, _Setbase);
++  extern template istream& operator>>(istream&, _Setprecision);
++  extern template istream& operator>>(istream&, _Setw);
++
++#ifdef _GLIBCXX_USE_WCHAR_T
++  extern template wostream& operator<<(wostream&, _Setfill<wchar_t>);
++  extern template wostream& operator<<(wostream&, _Setiosflags);
++  extern template wostream& operator<<(wostream&, _Resetiosflags);
++  extern template wostream& operator<<(wostream&, _Setbase);
++  extern template wostream& operator<<(wostream&, _Setprecision);
++  extern template wostream& operator<<(wostream&, _Setw);
++  extern template wistream& operator>>(wistream&, _Setfill<wchar_t>);
++  extern template wistream& operator>>(wistream&, _Setiosflags);
++  extern template wistream& operator>>(wistream&, _Resetiosflags);
++  extern template wistream& operator>>(wistream&, _Setbase);
++  extern template wistream& operator>>(wistream&, _Setprecision);
++  extern template wistream& operator>>(wistream&, _Setw);
++#endif
++#endif
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#endif /* _GLIBCXX_IOMANIP */
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/mmintrin.h gccxml/GCC_XML/Support/GCC/4.7/mmintrin.h
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/mmintrin.h	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/mmintrin.h	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,867 @@
++/* Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009
++   Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GCC is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Implemented from the specification included in the Intel C++ Compiler
++   User Guide and Reference, version 9.0.  */
++
++#ifndef _MMINTRIN_H_INCLUDED
++#define _MMINTRIN_H_INCLUDED
++
++#ifndef __MMX__
++# error "MMX instruction set not enabled"
++#else
++/* The Intel API is flexible enough that we must allow aliasing with other
++   vector types, and their scalar components.  */
++typedef int __m64 __attribute__ ((__vector_size__ (8), __may_alias__));
++
++/* Internal data types for implementing the intrinsics.  */
++typedef int __v2si __attribute__ ((__vector_size__ (8)));
++typedef short __v4hi __attribute__ ((__vector_size__ (8)));
++typedef char __v8qi __attribute__ ((__vector_size__ (8)));
++typedef long long __v1di __attribute__ ((__vector_size__ (8)));
++typedef float __v2sf __attribute__ ((__vector_size__ (8)));
++
++/* Empty the multimedia state.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_empty (void)
++{
++  __builtin_ia32_emms ();
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_empty (void)
++{
++  _mm_empty ();
++}
++
++/* Convert I to a __m64 object.  The integer is zero-extended to 64-bits.  */
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_si64 (int __i)
++{
++  return (__m64) __builtin_ia32_vec_init_v2si (__i, 0);
++}
++
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_from_int (int __i)
++{
++  return _mm_cvtsi32_si64 (__i);
++}
++
++#ifdef __x86_64__
++/* Convert I to a __m64 object.  */
++
++/* Intel intrinsic.  */
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_from_int64 (long long __i)
++{
++  return (__m64) __i;
++}
++
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_m64 (long long __i)
++{
++  return (__m64) __i;
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_si64 (long long __i)
++{
++  return (__m64) __i;
++}
++
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi64x (long long __i)
++{
++  return (__m64) __i;
++}
++#endif
++
++/* Convert the lower 32 bits of the __m64 object into an integer.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_si32 (__m64 __i)
++{
++  return __builtin_ia32_vec_ext_v2si ((__v2si)__i, 0);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_to_int (__m64 __i)
++{
++  return _mm_cvtsi64_si32 (__i);
++}
++
++#ifdef __x86_64__
++/* Convert the __m64 object to a 64bit integer.  */
++
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_to_int64 (__m64 __i)
++{
++  return (long long)__i;
++}
++
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtm64_si64 (__m64 __i)
++{
++  return (long long)__i;
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_si64x (__m64 __i)
++{
++  return (long long)__i;
++}
++#endif
++
++/* Pack the four 16-bit values from M1 into the lower four 8-bit values of
++   the result, and the four 16-bit values from M2 into the upper four 8-bit
++   values of the result, all with signed saturation.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_packsswb ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_packsswb (__m64 __m1, __m64 __m2)
++{
++  return _mm_packs_pi16 (__m1, __m2);
++}
++
++/* Pack the two 32-bit values from M1 in to the lower two 16-bit values of
++   the result, and the two 32-bit values from M2 into the upper two 16-bit
++   values of the result, all with signed saturation.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_packssdw ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_packssdw (__m64 __m1, __m64 __m2)
++{
++  return _mm_packs_pi32 (__m1, __m2);
++}
++
++/* Pack the four 16-bit values from M1 into the lower four 8-bit values of
++   the result, and the four 16-bit values from M2 into the upper four 8-bit
++   values of the result, all with unsigned saturation.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_pu16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_packuswb ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_packuswb (__m64 __m1, __m64 __m2)
++{
++  return _mm_packs_pu16 (__m1, __m2);
++}
++
++/* Interleave the four 8-bit values from the high half of M1 with the four
++   8-bit values from the high half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckhbw ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckhbw (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpackhi_pi8 (__m1, __m2);
++}
++
++/* Interleave the two 16-bit values from the high half of M1 with the two
++   16-bit values from the high half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckhwd ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckhwd (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpackhi_pi16 (__m1, __m2);
++}
++
++/* Interleave the 32-bit value from the high half of M1 with the 32-bit
++   value from the high half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckhdq ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckhdq (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpackhi_pi32 (__m1, __m2);
++}
++
++/* Interleave the four 8-bit values from the low half of M1 with the four
++   8-bit values from the low half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpcklbw ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpcklbw (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpacklo_pi8 (__m1, __m2);
++}
++
++/* Interleave the two 16-bit values from the low half of M1 with the two
++   16-bit values from the low half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpcklwd ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpcklwd (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpacklo_pi16 (__m1, __m2);
++}
++
++/* Interleave the 32-bit value from the low half of M1 with the 32-bit
++   value from the low half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckldq ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckldq (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpacklo_pi32 (__m1, __m2);
++}
++
++/* Add the 8-bit values in M1 to the 8-bit values in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddb (__m64 __m1, __m64 __m2)
++{
++  return _mm_add_pi8 (__m1, __m2);
++}
++
++/* Add the 16-bit values in M1 to the 16-bit values in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddw (__m64 __m1, __m64 __m2)
++{
++  return _mm_add_pi16 (__m1, __m2);
++}
++
++/* Add the 32-bit values in M1 to the 32-bit values in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddd (__m64 __m1, __m64 __m2)
++{
++  return _mm_add_pi32 (__m1, __m2);
++}
++
++/* Add the 64-bit values in M1 to the 64-bit values in M2.  */
++#ifdef __SSE2__
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_si64 (__m64 __m1, __m64 __m2);
++#endif
++
++/* Add the 8-bit values in M1 to the 8-bit values in M2 using signed
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddsb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddsb (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pi8 (__m1, __m2);
++}
++
++/* Add the 16-bit values in M1 to the 16-bit values in M2 using signed
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddsw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddsw (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pi16 (__m1, __m2);
++}
++
++/* Add the 8-bit values in M1 to the 8-bit values in M2 using unsigned
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pu8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddusb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddusb (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pu8 (__m1, __m2);
++}
++
++/* Add the 16-bit values in M1 to the 16-bit values in M2 using unsigned
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pu16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddusw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddusw (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pu16 (__m1, __m2);
++}
++
++/* Subtract the 8-bit values in M2 from the 8-bit values in M1.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubb (__m64 __m1, __m64 __m2)
++{
++  return _mm_sub_pi8 (__m1, __m2);
++}
++
++/* Subtract the 16-bit values in M2 from the 16-bit values in M1.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubw (__m64 __m1, __m64 __m2)
++{
++  return _mm_sub_pi16 (__m1, __m2);
++}
++
++/* Subtract the 32-bit values in M2 from the 32-bit values in M1.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubd (__m64 __m1, __m64 __m2)
++{
++  return _mm_sub_pi32 (__m1, __m2);
++}
++
++/* Add the 64-bit values in M1 to the 64-bit values in M2.  */
++#ifdef __SSE2__
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_si64 (__m64 __m1, __m64 __m2);
++#endif
++
++/* Subtract the 8-bit values in M2 from the 8-bit values in M1 using signed
++   saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubsb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubsb (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pi8 (__m1, __m2);
++}
++
++/* Subtract the 16-bit values in M2 from the 16-bit values in M1 using
++   signed saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubsw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubsw (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pi16 (__m1, __m2);
++}
++
++/* Subtract the 8-bit values in M2 from the 8-bit values in M1 using
++   unsigned saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pu8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubusb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubusb (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pu8 (__m1, __m2);
++}
++
++/* Subtract the 16-bit values in M2 from the 16-bit values in M1 using
++   unsigned saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pu16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubusw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubusw (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pu16 (__m1, __m2);
++}
++
++/* Multiply four 16-bit values in M1 by four 16-bit values in M2 producing
++   four 32-bit intermediate results, which are then summed by pairs to
++   produce two 32-bit results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_madd_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pmaddwd ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmaddwd (__m64 __m1, __m64 __m2)
++{
++  return _mm_madd_pi16 (__m1, __m2);
++}
++
++/* Multiply four signed 16-bit values in M1 by four signed 16-bit values in
++   M2 and produce the high 16 bits of the 32-bit results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pmulhw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmulhw (__m64 __m1, __m64 __m2)
++{
++  return _mm_mulhi_pi16 (__m1, __m2);
++}
++
++/* Multiply four 16-bit values in M1 by four 16-bit values in M2 and produce
++   the low 16 bits of the results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mullo_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pmullw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmullw (__m64 __m1, __m64 __m2)
++{
++  return _mm_mullo_pi16 (__m1, __m2);
++}
++
++/* Shift four 16-bit values in M left by COUNT.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_pi16 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllw (__m64 __m, __m64 __count)
++{
++  return _mm_sll_pi16 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_pi16 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllwi (__m64 __m, int __count)
++{
++  return _mm_slli_pi16 (__m, __count);
++}
++
++/* Shift two 32-bit values in M left by COUNT.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_pi32 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pslld (__m64 __m, __m64 __count)
++{
++  return _mm_sll_pi32 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_pi32 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pslldi (__m64 __m, int __count)
++{
++  return _mm_slli_pi32 (__m, __count);
++}
++
++/* Shift the 64-bit value in M left by COUNT.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_si64 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllq (__m64 __m, __m64 __count)
++{
++  return _mm_sll_si64 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_si64 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllqi (__m64 __m, int __count)
++{
++  return _mm_slli_si64 (__m, __count);
++}
++
++/* Shift four 16-bit values in M right by COUNT; shift in the sign bit.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_pi16 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psraw (__m64 __m, __m64 __count)
++{
++  return _mm_sra_pi16 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_pi16 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrawi (__m64 __m, int __count)
++{
++  return _mm_srai_pi16 (__m, __count);
++}
++
++/* Shift two 32-bit values in M right by COUNT; shift in the sign bit.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_pi32 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrad (__m64 __m, __m64 __count)
++{
++  return _mm_sra_pi32 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_pi32 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psradi (__m64 __m, int __count)
++{
++  return _mm_srai_pi32 (__m, __count);
++}
++
++/* Shift four 16-bit values in M right by COUNT; shift in zeros.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_pi16 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlw (__m64 __m, __m64 __count)
++{
++  return _mm_srl_pi16 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_pi16 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlwi (__m64 __m, int __count)
++{
++  return _mm_srli_pi16 (__m, __count);
++}
++
++/* Shift two 32-bit values in M right by COUNT; shift in zeros.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_pi32 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrld (__m64 __m, __m64 __count)
++{
++  return _mm_srl_pi32 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_pi32 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrldi (__m64 __m, int __count)
++{
++  return _mm_srli_pi32 (__m, __count);
++}
++
++/* Shift the 64-bit value in M left by COUNT; shift in zeros.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_si64 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlq (__m64 __m, __m64 __count)
++{
++  return _mm_srl_si64 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_si64 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlqi (__m64 __m, int __count)
++{
++  return _mm_srli_si64 (__m, __count);
++}
++
++/* Bit-wise AND the 64-bit values in M1 and M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_pand (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pand (__m64 __m1, __m64 __m2)
++{
++  return _mm_and_si64 (__m1, __m2);
++}
++
++/* Bit-wise complement the 64-bit value in M1 and bit-wise AND it with the
++   64-bit value in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_pandn (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pandn (__m64 __m1, __m64 __m2)
++{
++  return _mm_andnot_si64 (__m1, __m2);
++}
++
++/* Bit-wise inclusive OR the 64-bit values in M1 and M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_por (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_por (__m64 __m1, __m64 __m2)
++{
++  return _mm_or_si64 (__m1, __m2);
++}
++
++/* Bit-wise exclusive OR the 64-bit values in M1 and M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_pxor (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pxor (__m64 __m1, __m64 __m2)
++{
++  return _mm_xor_si64 (__m1, __m2);
++}
++
++/* Compare eight 8-bit values.  The result of the comparison is 0xFF if the
++   test is true and zero if false.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpeqb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpeqb (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpeq_pi8 (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpgtb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpgtb (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpgt_pi8 (__m1, __m2);
++}
++
++/* Compare four 16-bit values.  The result of the comparison is 0xFFFF if
++   the test is true and zero if false.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpeqw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpeqw (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpeq_pi16 (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpgtw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpgtw (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpgt_pi16 (__m1, __m2);
++}
++
++/* Compare two 32-bit values.  The result of the comparison is 0xFFFFFFFF if
++   the test is true and zero if false.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpeqd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpeqd (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpeq_pi32 (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpgtd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpgtd (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpgt_pi32 (__m1, __m2);
++}
++
++/* Creates a 64-bit zero.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_si64 (void)
++{
++  return (__m64)0LL;
++}
++
++/* Creates a vector of two 32-bit values; I0 is least significant.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi32 (int __i1, int __i0)
++{
++  return (__m64) __builtin_ia32_vec_init_v2si (__i0, __i1);
++}
++
++/* Creates a vector of four 16-bit values; W0 is least significant.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi16 (short __w3, short __w2, short __w1, short __w0)
++{
++  return (__m64) __builtin_ia32_vec_init_v4hi (__w0, __w1, __w2, __w3);
++}
++
++/* Creates a vector of eight 8-bit values; B0 is least significant.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi8 (char __b7, char __b6, char __b5, char __b4,
++	     char __b3, char __b2, char __b1, char __b0)
++{
++  return (__m64) __builtin_ia32_vec_init_v8qi (__b0, __b1, __b2, __b3,
++					       __b4, __b5, __b6, __b7);
++}
++
++/* Similar, but with the arguments in reverse order.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pi32 (int __i0, int __i1)
++{
++  return _mm_set_pi32 (__i1, __i0);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pi16 (short __w0, short __w1, short __w2, short __w3)
++{
++  return _mm_set_pi16 (__w3, __w2, __w1, __w0);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pi8 (char __b0, char __b1, char __b2, char __b3,
++	      char __b4, char __b5, char __b6, char __b7)
++{
++  return _mm_set_pi8 (__b7, __b6, __b5, __b4, __b3, __b2, __b1, __b0);
++}
++
++/* Creates a vector of two 32-bit values, both elements containing I.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pi32 (int __i)
++{
++  return _mm_set_pi32 (__i, __i);
++}
++
++/* Creates a vector of four 16-bit values, all elements containing W.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pi16 (short __w)
++{
++  return _mm_set_pi16 (__w, __w, __w, __w);
++}
++
++/* Creates a vector of eight 8-bit values, all elements containing B.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pi8 (char __b)
++{
++  return _mm_set_pi8 (__b, __b, __b, __b, __b, __b, __b, __b);
++}
++
++#endif /* __MMX__ */
++#endif /* _MMINTRIN_H_INCLUDED */
+diff -arupN gccxml.orig/GCC_XML/Support/GCC/4.7/xmmintrin.h gccxml/GCC_XML/Support/GCC/4.7/xmmintrin.h
+--- gccxml.orig/GCC_XML/Support/GCC/4.7/xmmintrin.h	1970-01-01 01:00:00.000000000 +0100
++++ gccxml/GCC_XML/Support/GCC/4.7/xmmintrin.h	2012-03-15 08:27:31.000000000 +0100
+@@ -0,0 +1,1239 @@
++/* Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010
++   Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GCC is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Implemented from the specification included in the Intel C++ Compiler
++   User Guide and Reference, version 9.0.  */
++
++#ifndef _XMMINTRIN_H_INCLUDED
++#define _XMMINTRIN_H_INCLUDED
++
++#ifndef __SSE__
++# error "SSE instruction set not enabled"
++#else
++
++/* We need type definitions from the MMX header file.  */
++#include <mmintrin.h>
++
++/* Get _mm_malloc () and _mm_free ().  */
++#include <mm_malloc.h>
++
++/* The Intel API is flexible enough that we must allow aliasing with other
++   vector types, and their scalar components.  */
++typedef float __m128 __attribute__ ((__vector_size__ (16), __may_alias__));
++
++/* Internal data types for implementing the intrinsics.  */
++typedef float __v4sf __attribute__ ((__vector_size__ (16)));
++
++/* Create a selector for use with the SHUFPS instruction.  */
++#define _MM_SHUFFLE(fp3,fp2,fp1,fp0) \
++ (((fp3) << 6) | ((fp2) << 4) | ((fp1) << 2) | (fp0))
++
++/* Constants for use with _mm_prefetch.  */
++enum _mm_hint
++{
++  _MM_HINT_T0 = 3,
++  _MM_HINT_T1 = 2,
++  _MM_HINT_T2 = 1,
++  _MM_HINT_NTA = 0
++};
++
++/* Bits in the MXCSR.  */
++#define _MM_EXCEPT_MASK       0x003f
++#define _MM_EXCEPT_INVALID    0x0001
++#define _MM_EXCEPT_DENORM     0x0002
++#define _MM_EXCEPT_DIV_ZERO   0x0004
++#define _MM_EXCEPT_OVERFLOW   0x0008
++#define _MM_EXCEPT_UNDERFLOW  0x0010
++#define _MM_EXCEPT_INEXACT    0x0020
++
++#define _MM_MASK_MASK         0x1f80
++#define _MM_MASK_INVALID      0x0080
++#define _MM_MASK_DENORM       0x0100
++#define _MM_MASK_DIV_ZERO     0x0200
++#define _MM_MASK_OVERFLOW     0x0400
++#define _MM_MASK_UNDERFLOW    0x0800
++#define _MM_MASK_INEXACT      0x1000
++
++#define _MM_ROUND_MASK        0x6000
++#define _MM_ROUND_NEAREST     0x0000
++#define _MM_ROUND_DOWN        0x2000
++#define _MM_ROUND_UP          0x4000
++#define _MM_ROUND_TOWARD_ZERO 0x6000
++
++#define _MM_FLUSH_ZERO_MASK   0x8000
++#define _MM_FLUSH_ZERO_ON     0x8000
++#define _MM_FLUSH_ZERO_OFF    0x0000
++
++/* Create a vector of zeros.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_ps (void)
++{
++  return __extension__ (__m128){ 0.0f, 0.0f, 0.0f, 0.0f };
++}
++
++/* Perform the respective operation on the lower SPFP (single-precision
++   floating-point) values of A and B; the upper three SPFP values are
++   passed through from A.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_addss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_subss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_mulss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_divss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_ss (__m128 __A)
++{
++  return (__m128) __builtin_ia32_sqrtss ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rcp_ss (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rcpss ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rsqrt_ss (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rsqrtss ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_minss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_maxss ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Perform the respective operation on the four SPFP values in A and B.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_addps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_subps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_mulps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_divps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_ps (__m128 __A)
++{
++  return (__m128) __builtin_ia32_sqrtps ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rcp_ps (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rcpps ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rsqrt_ps (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rsqrtps ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_minps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_maxps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Perform logical bit-wise operations on 128-bit values.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_andps (__A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_andnps (__A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_orps (__A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_xorps (__A, __B);
++}
++
++/* Perform a comparison on the lower SPFP values of A and B.  If the
++   comparison is true, place a mask of all ones in the result, otherwise a
++   mask of zeros.  The upper three SPFP values are passed through from A.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpeqss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpltss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpless ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpltss ((__v4sf) __B,
++								(__v4sf)
++								__A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpless ((__v4sf) __B,
++								(__v4sf)
++								__A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpneqss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnltss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnless ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpnltss ((__v4sf) __B,
++								 (__v4sf)
++								 __A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpnless ((__v4sf) __B,
++								 (__v4sf)
++								 __A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpordss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpunordss ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Perform a comparison on the four SPFP values of A and B.  For each
++   element, if the comparison is true, place a mask of all ones in the
++   result, otherwise a mask of zeros.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpeqps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpltps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpleps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpgtps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpgeps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpneqps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnltps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnleps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpngtps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpngeps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpordps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpunordps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Compare the lower SPFP values of A and B and return 1 if true
++   and 0 if false.  */
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comieq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comieq ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comilt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comilt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comile_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comile ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comigt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comigt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comige_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comige ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comineq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comineq ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomieq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomieq ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomilt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomilt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomile_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomile ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomigt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomigt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomige_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomige ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomineq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomineq ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Convert the lower SPFP value to a 32-bit integer according to the current
++   rounding mode.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_si32 (__m128 __A)
++{
++  return __builtin_ia32_cvtss2si ((__v4sf) __A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_ss2si (__m128 __A)
++{
++  return _mm_cvtss_si32 (__A);
++}
++
++#ifdef __x86_64__
++/* Convert the lower SPFP value to a 32-bit integer according to the
++   current rounding mode.  */
++
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_si64 (__m128 __A)
++{
++  return __builtin_ia32_cvtss2si64 ((__v4sf) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_si64x (__m128 __A)
++{
++  return __builtin_ia32_cvtss2si64 ((__v4sf) __A);
++}
++#endif
++
++/* Convert the two lower SPFP values to 32-bit integers according to the
++   current rounding mode.  Return the integers in packed form.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pi32 (__m128 __A)
++{
++  return (__m64) __builtin_ia32_cvtps2pi ((__v4sf) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_ps2pi (__m128 __A)
++{
++  return _mm_cvtps_pi32 (__A);
++}
++
++/* Truncate the lower SPFP value to a 32-bit integer.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttss_si32 (__m128 __A)
++{
++  return __builtin_ia32_cvttss2si ((__v4sf) __A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtt_ss2si (__m128 __A)
++{
++  return _mm_cvttss_si32 (__A);
++}
++
++#ifdef __x86_64__
++/* Truncate the lower SPFP value to a 32-bit integer.  */
++
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttss_si64 (__m128 __A)
++{
++  return __builtin_ia32_cvttss2si64 ((__v4sf) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttss_si64x (__m128 __A)
++{
++  return __builtin_ia32_cvttss2si64 ((__v4sf) __A);
++}
++#endif
++
++/* Truncate the two lower SPFP values to 32-bit integers.  Return the
++   integers in packed form.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttps_pi32 (__m128 __A)
++{
++  return (__m64) __builtin_ia32_cvttps2pi ((__v4sf) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtt_ps2pi (__m128 __A)
++{
++  return _mm_cvttps_pi32 (__A);
++}
++
++/* Convert B to a SPFP value and insert it as element zero in A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_ss (__m128 __A, int __B)
++{
++  return (__m128) __builtin_ia32_cvtsi2ss ((__v4sf) __A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_si2ss (__m128 __A, int __B)
++{
++  return _mm_cvtsi32_ss (__A, __B);
++}
++
++#ifdef __x86_64__
++/* Convert B to a SPFP value and insert it as element zero in A.  */
++
++/* Intel intrinsic.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_ss (__m128 __A, long long __B)
++{
++  return (__m128) __builtin_ia32_cvtsi642ss ((__v4sf) __A, __B);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_ss (__m128 __A, long long __B)
++{
++  return (__m128) __builtin_ia32_cvtsi642ss ((__v4sf) __A, __B);
++}
++#endif
++
++/* Convert the two 32-bit values in B to SPFP form and insert them
++   as the two lower elements in A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi32_ps (__m128 __A, __m64 __B)
++{
++  return (__m128) __builtin_ia32_cvtpi2ps ((__v4sf) __A, (__v2si)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_pi2ps (__m128 __A, __m64 __B)
++{
++  return _mm_cvtpi32_ps (__A, __B);
++}
++
++/* Convert the four signed 16-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi16_ps (__m64 __A)
++{
++  __v4hi __sign;
++  __v2si __hisi, __losi;
++  __v4sf __zero, __ra, __rb;
++
++  /* This comparison against zero gives us a mask that can be used to
++     fill in the missing sign bits in the unpack operations below, so
++     that we get signed values after unpacking.  */
++  __sign = __builtin_ia32_pcmpgtw ((__v4hi)0LL, (__v4hi)__A);
++
++  /* Convert the four words to doublewords.  */
++  __losi = (__v2si) __builtin_ia32_punpcklwd ((__v4hi)__A, __sign);
++  __hisi = (__v2si) __builtin_ia32_punpckhwd ((__v4hi)__A, __sign);
++
++  /* Convert the doublewords to floating point two at a time.  */
++  __zero = (__v4sf) _mm_setzero_ps ();
++  __ra = __builtin_ia32_cvtpi2ps (__zero, __losi);
++  __rb = __builtin_ia32_cvtpi2ps (__ra, __hisi);
++
++  return (__m128) __builtin_ia32_movlhps (__ra, __rb);
++}
++
++/* Convert the four unsigned 16-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpu16_ps (__m64 __A)
++{
++  __v2si __hisi, __losi;
++  __v4sf __zero, __ra, __rb;
++
++  /* Convert the four words to doublewords.  */
++  __losi = (__v2si) __builtin_ia32_punpcklwd ((__v4hi)__A, (__v4hi)0LL);
++  __hisi = (__v2si) __builtin_ia32_punpckhwd ((__v4hi)__A, (__v4hi)0LL);
++
++  /* Convert the doublewords to floating point two at a time.  */
++  __zero = (__v4sf) _mm_setzero_ps ();
++  __ra = __builtin_ia32_cvtpi2ps (__zero, __losi);
++  __rb = __builtin_ia32_cvtpi2ps (__ra, __hisi);
++
++  return (__m128) __builtin_ia32_movlhps (__ra, __rb);
++}
++
++/* Convert the low four signed 8-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi8_ps (__m64 __A)
++{
++  __v8qi __sign;
++
++  /* This comparison against zero gives us a mask that can be used to
++     fill in the missing sign bits in the unpack operations below, so
++     that we get signed values after unpacking.  */
++  __sign = __builtin_ia32_pcmpgtb ((__v8qi)0LL, (__v8qi)__A);
++
++  /* Convert the four low bytes to words.  */
++  __A = (__m64) __builtin_ia32_punpcklbw ((__v8qi)__A, __sign);
++
++  return _mm_cvtpi16_ps(__A);
++}
++
++/* Convert the low four unsigned 8-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpu8_ps(__m64 __A)
++{
++  __A = (__m64) __builtin_ia32_punpcklbw ((__v8qi)__A, (__v8qi)0LL);
++  return _mm_cvtpu16_ps(__A);
++}
++
++/* Convert the four signed 32-bit values in A and B to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi32x2_ps(__m64 __A, __m64 __B)
++{
++  __v4sf __zero = (__v4sf) _mm_setzero_ps ();
++  __v4sf __sfa = __builtin_ia32_cvtpi2ps (__zero, (__v2si)__A);
++  __v4sf __sfb = __builtin_ia32_cvtpi2ps (__sfa, (__v2si)__B);
++  return (__m128) __builtin_ia32_movlhps (__sfa, __sfb);
++}
++
++/* Convert the four SPFP values in A to four signed 16-bit integers.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pi16(__m128 __A)
++{
++  __v4sf __hisf = (__v4sf)__A;
++  __v4sf __losf = __builtin_ia32_movhlps (__hisf, __hisf);
++  __v2si __hisi = __builtin_ia32_cvtps2pi (__hisf);
++  __v2si __losi = __builtin_ia32_cvtps2pi (__losf);
++  return (__m64) __builtin_ia32_packssdw (__hisi, __losi);
++}
++
++/* Convert the four SPFP values in A to four signed 8-bit integers.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pi8(__m128 __A)
++{
++  __v4hi __tmp = (__v4hi) _mm_cvtps_pi16 (__A);
++  return (__m64) __builtin_ia32_packsswb (__tmp, (__v4hi)0LL);
++}
++
++/* Selects four specific SPFP values from A and B based on MASK.  */
++#ifdef __OPTIMIZE__
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_ps (__m128 __A, __m128 __B, int const __mask)
++{
++  return (__m128) __builtin_ia32_shufps ((__v4sf)__A, (__v4sf)__B, __mask);
++}
++#else
++#define _mm_shuffle_ps(A, B, MASK)					\
++  ((__m128) __builtin_ia32_shufps ((__v4sf)(__m128)(A),			\
++				   (__v4sf)(__m128)(B), (int)(MASK)))
++#endif
++
++/* Selects and interleaves the upper two SPFP values from A and B.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_unpckhps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Selects and interleaves the lower two SPFP values from A and B.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_unpcklps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Sets the upper two SPFP values with 64-bits of data loaded from P;
++   the lower two values are passed through from A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadh_pi (__m128 __A, __m64 const *__P);
++
++/* Stores the upper two SPFP values of A into P.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeh_pi (__m64 *__P, __m128 __A);
++
++/* Moves the upper two values of B into the lower two values of A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movehl_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movhlps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Moves the lower two values of B into the upper two values of A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movelh_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movlhps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Sets the lower two SPFP values with 64-bits of data loaded from P;
++   the upper two values are passed through from A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadl_pi (__m128 __A, __m64 const *__P);
++
++/* Stores the lower two SPFP values of A into P.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storel_pi (__m64 *__P, __m128 __A);
++
++/* Creates a 4-bit mask from the most significant bits of the SPFP values.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_ps (__m128 __A)
++{
++  return __builtin_ia32_movmskps ((__v4sf)__A);
++}
++
++/* Return the contents of the control register.  */
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_getcsr (void)
++{
++  return __builtin_ia32_stmxcsr ();
++}
++
++/* Read exception bits from the control register.  */
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_EXCEPTION_STATE (void)
++{
++  return _mm_getcsr() & _MM_EXCEPT_MASK;
++}
++
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_EXCEPTION_MASK (void)
++{
++  return _mm_getcsr() & _MM_MASK_MASK;
++}
++
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_ROUNDING_MODE (void)
++{
++  return _mm_getcsr() & _MM_ROUND_MASK;
++}
++
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_FLUSH_ZERO_MODE (void)
++{
++  return _mm_getcsr() & _MM_FLUSH_ZERO_MASK;
++}
++
++/* Set the control register to I.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setcsr (unsigned int __I)
++{
++  __builtin_ia32_ldmxcsr (__I);
++}
++
++/* Set exception bits in the control register.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_EXCEPTION_STATE(unsigned int __mask)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_EXCEPT_MASK) | __mask);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_EXCEPTION_MASK (unsigned int __mask)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_MASK_MASK) | __mask);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_ROUNDING_MODE (unsigned int __mode)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_ROUND_MASK) | __mode);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_FLUSH_ZERO_MODE (unsigned int __mode)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_FLUSH_ZERO_MASK) | __mode);
++}
++
++/* Create a vector with element 0 as F and the rest zero.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_ss (float __F)
++{
++  return __extension__ (__m128)(__v4sf){ __F, 0.0f, 0.0f, 0.0f };
++}
++
++/* Create a vector with all four elements equal to F.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_ps (float __F)
++{
++  return __extension__ (__m128)(__v4sf){ __F, __F, __F, __F };
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_ps1 (float __F)
++{
++  return _mm_set1_ps (__F);
++}
++
++/* Create a vector with element 0 as *P and the rest zero.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_ss (float const *__P)
++{
++  return _mm_set_ss (*__P);
++}
++
++/* Create a vector with all four elements equal to *P.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load1_ps (float const *__P)
++{
++  return _mm_set1_ps (*__P);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_ps1 (float const *__P)
++{
++  return _mm_load1_ps (__P);
++}
++
++/* Load four SPFP values from P.  The address must be 16-byte aligned.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_ps (float const *__P)
++{
++  return (__m128) *(__v4sf *)__P;
++}
++
++/* Load four SPFP values from P.  The address need not be 16-byte aligned.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadu_ps (float const *__P)
++{
++  return (__m128) __builtin_ia32_loadups (__P);
++}
++
++/* Load four SPFP values in reverse order.  The address must be aligned.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadr_ps (float const *__P)
++{
++  __v4sf __tmp = *(__v4sf *)__P;
++  return (__m128) __builtin_ia32_shufps (__tmp, __tmp, _MM_SHUFFLE (0,1,2,3));
++}
++
++/* Create the vector [Z Y X W].  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_ps (const float __Z, const float __Y, const float __X, const float __W)
++{
++  return __extension__ (__m128)(__v4sf){ __W, __X, __Y, __Z };
++}
++
++/* Create the vector [W X Y Z].  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_ps (float __Z, float __Y, float __X, float __W)
++{
++  return __extension__ (__m128)(__v4sf){ __Z, __Y, __X, __W };
++}
++
++/* Stores the lower SPFP value.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_ss (float *__P, __m128 __A)
++{
++  *__P = __builtin_ia32_vec_ext_v4sf ((__v4sf)__A, 0);
++}
++
++extern __inline float __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_f32 (__m128 __A)
++{
++  return __builtin_ia32_vec_ext_v4sf ((__v4sf)__A, 0);
++}
++
++/* Store four SPFP values.  The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_ps (float *__P, __m128 __A)
++{
++  *(__v4sf *)__P = (__v4sf)__A;
++}
++
++/* Store four SPFP values.  The address need not be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeu_ps (float *__P, __m128 __A)
++{
++  __builtin_ia32_storeups (__P, (__v4sf)__A);
++}
++
++/* Store the lower SPFP value across four words.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store1_ps (float *__P, __m128 __A)
++{
++  __v4sf __va = (__v4sf)__A;
++  __v4sf __tmp = __builtin_ia32_shufps (__va, __va, _MM_SHUFFLE (0,0,0,0));
++  _mm_storeu_ps (__P, __tmp);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_ps1 (float *__P, __m128 __A)
++{
++  _mm_store1_ps (__P, __A);
++}
++
++/* Store four SPFP values in reverse order.  The address must be aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storer_ps (float *__P, __m128 __A)
++{
++  __v4sf __va = (__v4sf)__A;
++  __v4sf __tmp = __builtin_ia32_shufps (__va, __va, _MM_SHUFFLE (0,1,2,3));
++  _mm_store_ps (__P, __tmp);
++}
++
++/* Sets the low SPFP value of A from the low value of B.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_move_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Extracts one of the four words of A.  The selector N must be immediate.  */
++#ifdef __OPTIMIZE__
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_extract_pi16 (__m64 const __A, int const __N)
++{
++  return __builtin_ia32_vec_ext_v4hi ((__v4hi)__A, __N);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pextrw (__m64 const __A, int const __N)
++{
++  return _mm_extract_pi16 (__A, __N);
++}
++#else
++#define _mm_extract_pi16(A, N)	\
++  ((int) __builtin_ia32_vec_ext_v4hi ((__v4hi)(__m64)(A), (int)(N)))
++
++#define _m_pextrw(A, N) _mm_extract_pi16(A, N)
++#endif
++
++/* Inserts word D into one of four words of A.  The selector N must be
++   immediate.  */
++#ifdef __OPTIMIZE__
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_insert_pi16 (__m64 const __A, int const __D, int const __N)
++{
++  return (__m64) __builtin_ia32_vec_set_v4hi ((__v4hi)__A, __D, __N);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pinsrw (__m64 const __A, int const __D, int const __N)
++{
++  return _mm_insert_pi16 (__A, __D, __N);
++}
++#else
++#define _mm_insert_pi16(A, D, N)				\
++  ((__m64) __builtin_ia32_vec_set_v4hi ((__v4hi)(__m64)(A),	\
++					(int)(D), (int)(N)))
++
++#define _m_pinsrw(A, D, N) _mm_insert_pi16(A, D, N)
++#endif
++
++/* Compute the element-wise maximum of signed 16-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_pi16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pmaxsw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmaxsw (__m64 __A, __m64 __B)
++{
++  return _mm_max_pi16 (__A, __B);
++}
++
++/* Compute the element-wise maximum of unsigned 8-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pmaxub ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmaxub (__m64 __A, __m64 __B)
++{
++  return _mm_max_pu8 (__A, __B);
++}
++
++/* Compute the element-wise minimum of signed 16-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_pi16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pminsw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pminsw (__m64 __A, __m64 __B)
++{
++  return _mm_min_pi16 (__A, __B);
++}
++
++/* Compute the element-wise minimum of unsigned 8-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pminub ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pminub (__m64 __A, __m64 __B)
++{
++  return _mm_min_pu8 (__A, __B);
++}
++
++/* Create an 8-bit mask of the signs of 8-bit values.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_pi8 (__m64 __A)
++{
++  return __builtin_ia32_pmovmskb ((__v8qi)__A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmovmskb (__m64 __A)
++{
++  return _mm_movemask_pi8 (__A);
++}
++
++/* Multiply four unsigned 16-bit values in A by four unsigned 16-bit values
++   in B and produce the high 16 bits of the 32-bit results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_pu16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pmulhuw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmulhuw (__m64 __A, __m64 __B)
++{
++  return _mm_mulhi_pu16 (__A, __B);
++}
++
++/* Return a combination of the four 16-bit values in A.  The selector
++   must be an immediate.  */
++#ifdef __OPTIMIZE__
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_pi16 (__m64 __A, int const __N)
++{
++  return (__m64) __builtin_ia32_pshufw ((__v4hi)__A, __N);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pshufw (__m64 __A, int const __N)
++{
++  return _mm_shuffle_pi16 (__A, __N);
++}
++#else
++#define _mm_shuffle_pi16(A, N) \
++  ((__m64) __builtin_ia32_pshufw ((__v4hi)(__m64)(A), (int)(N)))
++
++#define _m_pshufw(A, N) _mm_shuffle_pi16 (A, N)
++#endif
++
++/* Conditionally store byte elements of A into P.  The high bit of each
++   byte in the selector N determines whether the corresponding byte from
++   A is stored.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_maskmove_si64 (__m64 __A, __m64 __N, char *__P)
++{
++  __builtin_ia32_maskmovq ((__v8qi)__A, (__v8qi)__N, __P);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_maskmovq (__m64 __A, __m64 __N, char *__P)
++{
++  _mm_maskmove_si64 (__A, __N, __P);
++}
++
++/* Compute the rounded averages of the unsigned 8-bit values in A and B.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pavgb ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pavgb (__m64 __A, __m64 __B)
++{
++  return _mm_avg_pu8 (__A, __B);
++}
++
++/* Compute the rounded averages of the unsigned 16-bit values in A and B.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_pu16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pavgw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pavgw (__m64 __A, __m64 __B)
++{
++  return _mm_avg_pu16 (__A, __B);
++}
++
++/* Compute the sum of the absolute differences of the unsigned 8-bit
++   values in A and B.  Return the value in the lower 16-bit word; the
++   upper words are cleared.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sad_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_psadbw ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psadbw (__m64 __A, __m64 __B)
++{
++  return _mm_sad_pu8 (__A, __B);
++}
++
++/* Loads one cache line from address P to a location "closer" to the
++   processor.  The selector I specifies the type of prefetch operation.  */
++#ifdef __OPTIMIZE__
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_prefetch (const void *__P, enum _mm_hint __I)
++{
++  __builtin_prefetch (__P, 0, __I);
++}
++#else
++#define _mm_prefetch(P, I) \
++  __builtin_prefetch ((P), 0, (I))
++#endif
++
++/* Stores the data in A to the address P without polluting the caches.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_pi (__m64 *__P, __m64 __A)
++{
++  __builtin_ia32_movntq ((unsigned long long *)__P, (unsigned long long)__A);
++}
++
++/* Likewise.  The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_ps (float *__P, __m128 __A)
++{
++  __builtin_ia32_movntps (__P, (__v4sf)__A);
++}
++
++/* Guarantees that every preceding store is globally visible before
++   any subsequent store.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sfence (void)
++{
++  __builtin_ia32_sfence ();
++}
++
++/* The execution of the next instruction is delayed by an implementation
++   specific amount of time.  The instruction does not modify the
++   architectural state.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_pause (void)
++{
++  __asm__ __volatile__ ("rep; nop" : : );
++}
++
++/* Transpose the 4x4 matrix composed of row[0-3].  */
++#define _MM_TRANSPOSE4_PS(row0, row1, row2, row3)			\
++do {									\
++  __v4sf __r0 = (row0), __r1 = (row1), __r2 = (row2), __r3 = (row3);	\
++  __v4sf __t0 = __builtin_ia32_unpcklps (__r0, __r1);			\
++  __v4sf __t1 = __builtin_ia32_unpcklps (__r2, __r3);			\
++  __v4sf __t2 = __builtin_ia32_unpckhps (__r0, __r1);			\
++  __v4sf __t3 = __builtin_ia32_unpckhps (__r2, __r3);			\
++  (row0) = __builtin_ia32_movlhps (__t0, __t1);				\
++  (row1) = __builtin_ia32_movhlps (__t1, __t0);				\
++  (row2) = __builtin_ia32_movlhps (__t2, __t3);				\
++  (row3) = __builtin_ia32_movhlps (__t3, __t2);				\
++} while (0)
++
++/* For backward source compatibility.  */
++#ifdef __SSE2__
++# include <emmintrin.h>
++#endif
++
++#endif /* __SSE__ */
++#endif /* _XMMINTRIN_H_INCLUDED */

--- a/gccxml-add-gcc49-support.patch
+++ b/gccxml-add-gcc49-support.patch
@@ -1,0 +1,13429 @@
+From 605db9f2d713f54891d93ac992efd25239c0206a Mon Sep 17 00:00:00 2001
+From: David Abdurachmanov <David.Abdurachmanov@cern.ch>
+Date: Fri, 24 Jan 2014 15:18:52 +0100
+Subject: [PATCH] Add GCC 4.9 (r206686) support
+
+Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>
+
+diff --git a/GCC_XML/Support/GCC/4.9/bits/c++config.h b/GCC_XML/Support/GCC/4.9/bits/c++config.h
+new file mode 100644
+index 0000000..8737dea
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/bits/c++config.h
+@@ -0,0 +1,11 @@
++#ifdef __LONG_DOUBLE_128__
++/* Avoid using inline namespace not supported by GCC 4.2 */
++#undef __LONG_DOUBLE_128__
++#include_next <bits/c++config.h>
++#define __LONG_DOUBLE_128__ 1
++#else
++#include_next <bits/c++config.h>
++#endif
++
++/* GCC 4.2 parser does not support __int128 */
++#undef _GLIBCXX_USE_INT128
+diff --git a/GCC_XML/Support/GCC/4.9/bits/stl_algo.h b/GCC_XML/Support/GCC/4.9/bits/stl_algo.h
+new file mode 100644
+index 0000000..1799fcf
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/bits/stl_algo.h
+@@ -0,0 +1,5514 @@
++// Algorithm implementation -*- C++ -*-
++
++// Copyright (C) 2001-2014 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/*
++ *
++ * Copyright (c) 1994
++ * Hewlett-Packard Company
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Hewlett-Packard Company makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ *
++ *
++ * Copyright (c) 1996
++ * Silicon Graphics Computer Systems, Inc.
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Silicon Graphics makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ */
++
++/** @file bits/stl_algo.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{algorithm}
++ */
++
++#ifndef _STL_ALGO_H
++#define _STL_ALGO_H 1
++
++#include <cstdlib>             // for rand
++#include <bits/algorithmfwd.h>
++#include <bits/stl_heap.h>
++#include <bits/stl_tempbuf.h>  // for _Temporary_buffer
++#include <bits/predefined_ops.h>
++
++#if __cplusplus >= 201103L
++#include <random>     // for std::uniform_int_distribution
++#endif
++
++// See concept_check.h for the __glibcxx_*_requires macros.
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  /// Swaps the median value of *__a, *__b and *__c under __comp to *__result
++  template<typename _Iterator, typename _Compare>
++    void
++    __move_median_to_first(_Iterator __result,_Iterator __a, _Iterator __b,
++			   _Iterator __c, _Compare __comp)
++    {
++      if (__comp(__a, __b))
++	{
++	  if (__comp(__b, __c))
++	    std::iter_swap(__result, __b);
++	  else if (__comp(__a, __c))
++	    std::iter_swap(__result, __c);
++	  else
++	    std::iter_swap(__result, __a);
++	}
++      else if (__comp(__a, __c))
++	std::iter_swap(__result, __a);
++      else if (__comp(__b, __c))
++	std::iter_swap(__result, __c);
++      else
++	std::iter_swap(__result, __b);
++    }
++
++  /// This is an overload used by find algos for the Input Iterator case.
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    __find_if(_InputIterator __first, _InputIterator __last,
++	      _Predicate __pred, input_iterator_tag)
++    {
++      while (__first != __last && !__pred(__first))
++	++__first;
++      return __first;
++    }
++
++  /// This is an overload used by find algos for the RAI case.
++  template<typename _RandomAccessIterator, typename _Predicate>
++    _RandomAccessIterator
++    __find_if(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	      _Predicate __pred, random_access_iterator_tag)
++    {
++      typename iterator_traits<_RandomAccessIterator>::difference_type
++	__trip_count = (__last - __first) >> 2;
++
++      for (; __trip_count > 0; --__trip_count)
++	{
++	  if (__pred(__first))
++	    return __first;
++	  ++__first;
++
++	  if (__pred(__first))
++	    return __first;
++	  ++__first;
++
++	  if (__pred(__first))
++	    return __first;
++	  ++__first;
++
++	  if (__pred(__first))
++	    return __first;
++	  ++__first;
++	}
++
++      switch (__last - __first)
++	{
++	case 3:
++	  if (__pred(__first))
++	    return __first;
++	  ++__first;
++	case 2:
++	  if (__pred(__first))
++	    return __first;
++	  ++__first;
++	case 1:
++	  if (__pred(__first))
++	    return __first;
++	  ++__first;
++	case 0:
++	default:
++	  return __last;
++	}
++    }
++
++  template<typename _Iterator, typename _Predicate>
++    inline _Iterator
++    __find_if(_Iterator __first, _Iterator __last, _Predicate __pred)
++    {
++      return __find_if(__first, __last, __pred,
++		       std::__iterator_category(__first));
++    }
++
++  /// Provided for stable_partition to use.
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    __find_if_not(_InputIterator __first, _InputIterator __last,
++		  _Predicate __pred)
++    {
++      return std::__find_if(__first, __last,
++			    __gnu_cxx::__ops::__negate(__pred),
++			    std::__iterator_category(__first));
++    }
++
++  /// Like find_if_not(), but uses and updates a count of the
++  /// remaining range length instead of comparing against an end
++  /// iterator.
++  template<typename _InputIterator, typename _Predicate, typename _Distance>
++    _InputIterator
++    __find_if_not_n(_InputIterator __first, _Distance& __len, _Predicate __pred)
++    {
++      for (; __len; --__len, ++__first)
++	if (!__pred(__first))
++	  break;
++      return __first;
++    }
++
++  // set_difference
++  // set_intersection
++  // set_symmetric_difference
++  // set_union
++  // for_each
++  // find
++  // find_if
++  // find_first_of
++  // adjacent_find
++  // count
++  // count_if
++  // search
++
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    _ForwardIterator1
++    __search(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	     _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	     _BinaryPredicate  __predicate)
++    {
++      // Test for empty ranges
++      if (__first1 == __last1 || __first2 == __last2)
++	return __first1;
++
++      // Test for a pattern of length 1.
++      _ForwardIterator2 __p1(__first2);
++      if (++__p1 == __last2)
++	return std::__find_if(__first1, __last1,
++		__gnu_cxx::__ops::__iter_comp_iter(__predicate, __first2));
++
++      // General case.
++      _ForwardIterator2 __p;
++      _ForwardIterator1 __current = __first1;
++
++      for (;;)
++	{
++	  __first1 =
++	    std::__find_if(__first1, __last1,
++		__gnu_cxx::__ops::__iter_comp_iter(__predicate, __first2));
++
++	  if (__first1 == __last1)
++	    return __last1;
++
++	  __p = __p1;
++	  __current = __first1;
++	  if (++__current == __last1)
++	    return __last1;
++
++	  while (__predicate(__current, __p))
++	    {
++	      if (++__p == __last2)
++		return __first1;
++	      if (++__current == __last1)
++		return __last1;
++	    }
++	  ++__first1;
++	}
++      return __first1;
++    }
++
++  // search_n
++
++  /**
++   *  This is an helper function for search_n overloaded for forward iterators.
++  */
++  template<typename _ForwardIterator, typename _Integer,
++	   typename _UnaryPredicate>
++    _ForwardIterator
++    __search_n_aux(_ForwardIterator __first, _ForwardIterator __last,
++		   _Integer __count, _UnaryPredicate __unary_pred,
++		   std::forward_iterator_tag)
++    {
++      __first = std::__find_if(__first, __last, __unary_pred);
++      while (__first != __last)
++	{
++	  typename iterator_traits<_ForwardIterator>::difference_type
++	    __n = __count;
++	  _ForwardIterator __i = __first;
++	  ++__i;
++	  while (__i != __last && __n != 1 && __unary_pred(__i))
++	    {
++	      ++__i;
++	      --__n;
++	    }
++	  if (__n == 1)
++	    return __first;
++	  if (__i == __last)
++	    return __last;
++	  __first = std::__find_if(++__i, __last, __unary_pred);
++	}
++      return __last;
++    }
++
++  /**
++   *  This is an helper function for search_n overloaded for random access
++   *  iterators.
++  */
++  template<typename _RandomAccessIter, typename _Integer,
++	   typename _UnaryPredicate>
++    _RandomAccessIter
++    __search_n_aux(_RandomAccessIter __first, _RandomAccessIter __last,
++		   _Integer __count, _UnaryPredicate __unary_pred,
++		   std::random_access_iterator_tag)
++    {
++      typedef typename std::iterator_traits<_RandomAccessIter>::difference_type
++	_DistanceType;
++
++      _DistanceType __tailSize = __last - __first;
++      _DistanceType __remainder = __count;
++
++      while (__remainder <= __tailSize) // the main loop...
++	{
++	  __first += __remainder;
++	  __tailSize -= __remainder;
++	  // __first here is always pointing to one past the last element of
++	  // next possible match.
++	  _RandomAccessIter __backTrack = __first; 
++	  while (__unary_pred(--__backTrack))
++	    {
++	      if (--__remainder == 0)
++	        return (__first - __count); // Success
++	    }
++	  __remainder = __count + 1 - (__first - __backTrack);
++	}
++      return __last; // Failure
++    }
++
++  template<typename _ForwardIterator, typename _Integer,
++           typename _UnaryPredicate>
++    _ForwardIterator
++    __search_n(_ForwardIterator __first, _ForwardIterator __last,
++	       _Integer __count,
++	       _UnaryPredicate __unary_pred)
++    {
++      if (__count <= 0)
++	return __first;
++
++      if (__count == 1)
++	return std::__find_if(__first, __last, __unary_pred);
++
++      return std::__search_n_aux(__first, __last, __count, __unary_pred,
++				 std::__iterator_category(__first));
++    }
++
++  // find_end for forward iterators.
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    _ForwardIterator1
++    __find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	       _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	       forward_iterator_tag, forward_iterator_tag,
++	       _BinaryPredicate __comp)
++    {
++      if (__first2 == __last2)
++	return __last1;
++
++      _ForwardIterator1 __result = __last1;
++      while (1)
++	{
++	  _ForwardIterator1 __new_result
++	    = std::__search(__first1, __last1, __first2, __last2, __comp);
++	  if (__new_result == __last1)
++	    return __result;
++	  else
++	    {
++	      __result = __new_result;
++	      __first1 = __new_result;
++	      ++__first1;
++	    }
++	}
++    }
++
++  // find_end for bidirectional iterators (much faster).
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2,
++	   typename _BinaryPredicate>
++    _BidirectionalIterator1
++    __find_end(_BidirectionalIterator1 __first1,
++	       _BidirectionalIterator1 __last1,
++	       _BidirectionalIterator2 __first2,
++	       _BidirectionalIterator2 __last2,
++	       bidirectional_iterator_tag, bidirectional_iterator_tag,
++	       _BinaryPredicate __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator1>)
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator2>)
++
++      typedef reverse_iterator<_BidirectionalIterator1> _RevIterator1;
++      typedef reverse_iterator<_BidirectionalIterator2> _RevIterator2;
++
++      _RevIterator1 __rlast1(__first1);
++      _RevIterator2 __rlast2(__first2);
++      _RevIterator1 __rresult = std::__search(_RevIterator1(__last1), __rlast1,
++					      _RevIterator2(__last2), __rlast2,
++					      __comp);
++
++      if (__rresult == __rlast1)
++	return __last1;
++      else
++	{
++	  _BidirectionalIterator1 __result = __rresult.base();
++	  std::advance(__result, -std::distance(__first2, __last2));
++	  return __result;
++	}
++    }
++
++  /**
++   *  @brief  Find last matching subsequence in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of sequence to match.
++   *  @param  __last2   End of sequence to match.
++   *  @return   The last iterator @c i in the range
++   *  @p [__first1,__last1-(__last2-__first2)) such that @c *(i+N) ==
++   *  @p *(__first2+N) for each @c N in the range @p
++   *  [0,__last2-__first2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2) and returns an iterator to the __first
++   *  element of the sub-sequence, or @p __last1 if the sub-sequence
++   *  is not found.  The sub-sequence will be the last such
++   *  subsequence contained in [__first1,__last1).
++   *
++   *  Because the sub-sequence must lie completely within the range @p
++   *  [__first1,__last1) it must start at a position less than @p
++   *  __last1-(__last2-__first2) where @p __last2-__first2 is the
++   *  length of the sub-sequence.  This means that the returned
++   *  iterator @c i will be in the range @p
++   *  [__first1,__last1-(__last2-__first2))
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    inline _ForwardIterator1
++    find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	     _ForwardIterator2 __first2, _ForwardIterator2 __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__find_end(__first1, __last1, __first2, __last2,
++			     std::__iterator_category(__first1),
++			     std::__iterator_category(__first2),
++			     __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief  Find last matching subsequence in a sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of sequence to match.
++   *  @param  __last2   End of sequence to match.
++   *  @param  __comp    The predicate to use.
++   *  @return The last iterator @c i in the range @p
++   *  [__first1,__last1-(__last2-__first2)) such that @c
++   *  predicate(*(i+N), @p (__first2+N)) is true for each @c N in the
++   *  range @p [0,__last2-__first2), or @p __last1 if no such iterator
++   *  exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2) using comp as a predicate and returns an
++   *  iterator to the first element of the sub-sequence, or @p __last1
++   *  if the sub-sequence is not found.  The sub-sequence will be the
++   *  last such subsequence contained in [__first,__last1).
++   *
++   *  Because the sub-sequence must lie completely within the range @p
++   *  [__first1,__last1) it must start at a position less than @p
++   *  __last1-(__last2-__first2) where @p __last2-__first2 is the
++   *  length of the sub-sequence.  This means that the returned
++   *  iterator @c i will be in the range @p
++   *  [__first1,__last1-(__last2-__first2))
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    inline _ForwardIterator1
++    find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	     _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	     _BinaryPredicate __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__find_end(__first1, __last1, __first2, __last2,
++			     std::__iterator_category(__first1),
++			     std::__iterator_category(__first2),
++			     __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++#if __cplusplus >= 201103L
++  /**
++   *  @brief  Checks that a predicate is true for all the elements
++   *          of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __pred    A predicate.
++   *  @return  True if the check is true, false otherwise.
++   *
++   *  Returns true if @p __pred is true for each element in the range
++   *  @p [__first,__last), and false otherwise.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    all_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    { return __last == std::find_if_not(__first, __last, __pred); }
++
++  /**
++   *  @brief  Checks that a predicate is false for all the elements
++   *          of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __pred    A predicate.
++   *  @return  True if the check is true, false otherwise.
++   *
++   *  Returns true if @p __pred is false for each element in the range
++   *  @p [__first,__last), and false otherwise.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    none_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    { return __last == _GLIBCXX_STD_A::find_if(__first, __last, __pred); }
++
++  /**
++   *  @brief  Checks that a predicate is false for at least an element
++   *          of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __pred    A predicate.
++   *  @return  True if the check is true, false otherwise.
++   *
++   *  Returns true if an element exists in the range @p
++   *  [__first,__last) such that @p __pred is true, and false
++   *  otherwise.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    any_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    { return !std::none_of(__first, __last, __pred); }
++
++  /**
++   *  @brief  Find the first element in a sequence for which a
++   *          predicate is false.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return   The first iterator @c i in the range @p [__first,__last)
++   *  such that @p __pred(*i) is false, or @p __last if no such iterator exists.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    find_if_not(_InputIterator __first, _InputIterator __last,
++		_Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	      typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      return std::__find_if_not(__first, __last,
++				__gnu_cxx::__ops::__pred_iter(__pred));
++    }
++
++  /**
++   *  @brief  Checks whether the sequence is partitioned.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return  True if the range @p [__first,__last) is partioned by @p __pred,
++   *  i.e. if all elements that satisfy @p __pred appear before those that
++   *  do not.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline bool
++    is_partitioned(_InputIterator __first, _InputIterator __last,
++		   _Predicate __pred)
++    {
++      __first = std::find_if_not(__first, __last, __pred);
++      return std::none_of(__first, __last, __pred);
++    }
++
++  /**
++   *  @brief  Find the partition point of a partitioned range.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __pred    A predicate.
++   *  @return  An iterator @p mid such that @p all_of(__first, mid, __pred)
++   *           and @p none_of(mid, __last, __pred) are both true.
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    partition_point(_ForwardIterator __first, _ForwardIterator __last,
++		    _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	      typename iterator_traits<_ForwardIterator>::value_type>)
++
++      // A specific debug-mode test will be necessary...
++      __glibcxx_requires_valid_range(__first, __last);
++
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      _DistanceType __len = std::distance(__first, __last);
++      _DistanceType __half;
++      _ForwardIterator __middle;
++
++      while (__len > 0)
++	{
++	  __half = __len >> 1;
++	  __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__pred(*__middle))
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else
++	    __len = __half;
++	}
++      return __first;
++    }
++#endif
++
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate>
++    _OutputIterator
++    __remove_copy_if(_InputIterator __first, _InputIterator __last,
++		     _OutputIterator __result, _Predicate __pred)
++    {
++      for (; __first != __last; ++__first)
++	if (!__pred(__first))
++	  {
++	    *__result = *__first;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++  /**
++   *  @brief Copy a sequence, removing elements of a given value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @param  __value   The value to be removed.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) not equal
++   *  to @p __value to the range beginning at @p __result.
++   *  remove_copy() is stable, so the relative order of elements that
++   *  are copied is unchanged.
++  */
++  template<typename _InputIterator, typename _OutputIterator, typename _Tp>
++    inline _OutputIterator
++    remove_copy(_InputIterator __first, _InputIterator __last,
++		_OutputIterator __result, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__remove_copy_if(__first, __last, __result,
++	__gnu_cxx::__ops::__iter_equals_val(__value));
++    }
++
++  /**
++   *  @brief Copy a sequence, removing elements for which a predicate is true.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @param  __pred    A predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) for which
++   *  @p __pred returns false to the range beginning at @p __result.
++   *
++   *  remove_copy_if() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate>
++    inline _OutputIterator
++    remove_copy_if(_InputIterator __first, _InputIterator __last,
++		   _OutputIterator __result, _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__remove_copy_if(__first, __last, __result,
++				   __gnu_cxx::__ops::__pred_iter(__pred));
++    }
++
++#if __cplusplus >= 201103L
++  /**
++   *  @brief Copy the elements of a sequence for which a predicate is true.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @param  __pred    A predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) for which
++   *  @p __pred returns true to the range beginning at @p __result.
++   *
++   *  copy_if() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate>
++    _OutputIterator
++    copy_if(_InputIterator __first, _InputIterator __last,
++	    _OutputIterator __result, _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (__pred(*__first))
++	  {
++	    *__result = *__first;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++  template<typename _InputIterator, typename _Size, typename _OutputIterator>
++    _OutputIterator
++    __copy_n(_InputIterator __first, _Size __n,
++	     _OutputIterator __result, input_iterator_tag)
++    {
++      if (__n > 0)
++	{
++	  while (true)
++	    {
++	      *__result = *__first;
++	      ++__result;
++	      if (--__n > 0)
++		++__first;
++	      else
++		break;
++	    }
++	}
++      return __result;
++    }
++
++  template<typename _RandomAccessIterator, typename _Size,
++	   typename _OutputIterator>
++    inline _OutputIterator
++    __copy_n(_RandomAccessIterator __first, _Size __n,
++	     _OutputIterator __result, random_access_iterator_tag)
++    { return std::copy(__first, __first + __n, __result); }
++
++  /**
++   *  @brief Copies the range [first,first+n) into [result,result+n).
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __n      The number of elements to copy.
++   *  @param  __result An output iterator.
++   *  @return  result+n.
++   *
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).
++  */
++  template<typename _InputIterator, typename _Size, typename _OutputIterator>
++    inline _OutputIterator
++    copy_n(_InputIterator __first, _Size __n, _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++
++      return std::__copy_n(__first, __n, __result,
++			   std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief Copy the elements of a sequence to separate output sequences
++   *         depending on the truth value of a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __out_true   An output iterator.
++   *  @param  __out_false  An output iterator.
++   *  @param  __pred    A predicate.
++   *  @return   A pair designating the ends of the resulting sequences.
++   *
++   *  Copies each element in the range @p [__first,__last) for which
++   *  @p __pred returns true to the range beginning at @p out_true
++   *  and each element for which @p __pred returns false to @p __out_false.
++  */
++  template<typename _InputIterator, typename _OutputIterator1,
++	   typename _OutputIterator2, typename _Predicate>
++    pair<_OutputIterator1, _OutputIterator2>
++    partition_copy(_InputIterator __first, _InputIterator __last,
++		   _OutputIterator1 __out_true, _OutputIterator2 __out_false,
++		   _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator1,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator2,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++      
++      for (; __first != __last; ++__first)
++	if (__pred(*__first))
++	  {
++	    *__out_true = *__first;
++	    ++__out_true;
++	  }
++	else
++	  {
++	    *__out_false = *__first;
++	    ++__out_false;
++	  }
++
++      return pair<_OutputIterator1, _OutputIterator2>(__out_true, __out_false);
++    }
++#endif
++
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    __remove_if(_ForwardIterator __first, _ForwardIterator __last,
++		_Predicate __pred)
++    {
++      __first = std::__find_if(__first, __last, __pred);
++      if (__first == __last)
++        return __first;
++      _ForwardIterator __result = __first;
++      ++__first;
++      for (; __first != __last; ++__first)
++        if (!__pred(__first))
++          {
++            *__result = _GLIBCXX_MOVE(*__first);
++            ++__result;
++          }
++      return __result;
++    }
++
++  /**
++   *  @brief Remove elements from a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __value  The value to be removed.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  All elements equal to @p __value are removed from the range
++   *  @p [__first,__last).
++   *
++   *  remove() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    inline _ForwardIterator
++    remove(_ForwardIterator __first, _ForwardIterator __last,
++	   const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__remove_if(__first, __last,
++		__gnu_cxx::__ops::__iter_equals_val(__value));
++    }
++
++  /**
++   *  @brief Remove elements from a sequence using a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __pred   A predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  All elements for which @p __pred returns true are removed from the range
++   *  @p [__first,__last).
++   *
++   *  remove_if() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    inline _ForwardIterator
++    remove_if(_ForwardIterator __first, _ForwardIterator __last,
++	      _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__remove_if(__first, __last,
++			      __gnu_cxx::__ops::__pred_iter(__pred));
++    }
++
++  template<typename _ForwardIterator, typename _BinaryPredicate>
++    _ForwardIterator
++    __adjacent_find(_ForwardIterator __first, _ForwardIterator __last,
++		    _BinaryPredicate __binary_pred)
++    {
++      if (__first == __last)
++	return __last;
++      _ForwardIterator __next = __first;
++      while (++__next != __last)
++	{
++	  if (__binary_pred(__first, __next))
++	    return __first;
++	  __first = __next;
++	}
++      return __last;
++    }
++
++  template<typename _ForwardIterator, typename _BinaryPredicate>
++    _ForwardIterator
++    __unique(_ForwardIterator __first, _ForwardIterator __last,
++	     _BinaryPredicate __binary_pred)
++    {
++      // Skip the beginning, if already unique.
++      __first = std::__adjacent_find(__first, __last, __binary_pred);
++      if (__first == __last)
++	return __last;
++
++      // Do the real copy work.
++      _ForwardIterator __dest = __first;
++      ++__first;
++      while (++__first != __last)
++	if (!__binary_pred(__dest, __first))
++	  *++__dest = _GLIBCXX_MOVE(*__first);
++      return ++__dest;
++    }
++
++  /**
++   *  @brief Remove consecutive duplicate values from a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @return  An iterator designating the end of the resulting sequence.
++   *
++   *  Removes all but the first element from each group of consecutive
++   *  values that compare equal.
++   *  unique() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator>
++    inline _ForwardIterator
++    unique(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_EqualityComparableConcept<
++		     typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__unique(__first, __last,
++			   __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief Remove consecutive values from a sequence using a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first        A forward iterator.
++   *  @param  __last         A forward iterator.
++   *  @param  __binary_pred  A binary predicate.
++   *  @return  An iterator designating the end of the resulting sequence.
++   *
++   *  Removes all but the first element from each group of consecutive
++   *  values for which @p __binary_pred returns true.
++   *  unique() is stable, so the relative order of elements that are
++   *  not removed is unchanged.
++   *  Elements between the end of the resulting sequence and @p __last
++   *  are still present, but their value is unspecified.
++  */
++  template<typename _ForwardIterator, typename _BinaryPredicate>
++    inline _ForwardIterator
++    unique(_ForwardIterator __first, _ForwardIterator __last,
++           _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++		typename iterator_traits<_ForwardIterator>::value_type,
++		typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__unique(__first, __last,
++			   __gnu_cxx::__ops::__iter_comp_iter(__binary_pred));
++    }
++
++  /**
++   *  This is an uglified
++   *  unique_copy(_InputIterator, _InputIterator, _OutputIterator,
++   *              _BinaryPredicate)
++   *  overloaded for forward iterators and output iterator as result.
++  */
++  template<typename _ForwardIterator, typename _OutputIterator,
++	   typename _BinaryPredicate>
++    _OutputIterator
++    __unique_copy(_ForwardIterator __first, _ForwardIterator __last,
++		  _OutputIterator __result, _BinaryPredicate __binary_pred,
++		  forward_iterator_tag, output_iterator_tag)
++    {
++      // concept requirements -- iterators already checked
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	  typename iterator_traits<_ForwardIterator>::value_type,
++	  typename iterator_traits<_ForwardIterator>::value_type>)
++
++      _ForwardIterator __next = __first;
++      *__result = *__first;
++      while (++__next != __last)
++	if (!__binary_pred(__first, __next))
++	  {
++	    __first = __next;
++	    *++__result = *__first;
++	  }
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified
++   *  unique_copy(_InputIterator, _InputIterator, _OutputIterator,
++   *              _BinaryPredicate)
++   *  overloaded for input iterators and output iterator as result.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _BinaryPredicate>
++    _OutputIterator
++    __unique_copy(_InputIterator __first, _InputIterator __last,
++		  _OutputIterator __result, _BinaryPredicate __binary_pred,
++		  input_iterator_tag, output_iterator_tag)
++    {
++      // concept requirements -- iterators already checked
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	  typename iterator_traits<_InputIterator>::value_type,
++	  typename iterator_traits<_InputIterator>::value_type>)
++
++      typename iterator_traits<_InputIterator>::value_type __value = *__first;
++      *__result = __value;
++      while (++__first != __last)
++	if (!__rebound_pred(__first, __value))
++	  {
++	    __value = *__first;
++	    *++__result = __value;
++	  }
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified
++   *  unique_copy(_InputIterator, _InputIterator, _OutputIterator,
++   *              _BinaryPredicate)
++   *  overloaded for input iterators and forward iterator as result.
++  */
++  template<typename _InputIterator, typename _ForwardIterator,
++	   typename _BinaryPredicate>
++    _ForwardIterator
++    __unique_copy(_InputIterator __first, _InputIterator __last,
++		  _ForwardIterator __result, _BinaryPredicate __binary_pred,
++		  input_iterator_tag, forward_iterator_tag)
++    {
++      // concept requirements -- iterators already checked
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	  typename iterator_traits<_ForwardIterator>::value_type,
++	  typename iterator_traits<_InputIterator>::value_type>)
++      *__result = *__first;
++      while (++__first != __last)
++	if (!__binary_pred(__result, __first))
++	  *++__result = *__first;
++      return ++__result;
++    }
++
++  /**
++   *  This is an uglified reverse(_BidirectionalIterator,
++   *                              _BidirectionalIterator)
++   *  overloaded for bidirectional iterators.
++  */
++  template<typename _BidirectionalIterator>
++    void
++    __reverse(_BidirectionalIterator __first, _BidirectionalIterator __last,
++	      bidirectional_iterator_tag)
++    {
++      while (true)
++	if (__first == __last || __first == --__last)
++	  return;
++	else
++	  {
++	    std::iter_swap(__first, __last);
++	    ++__first;
++	  }
++    }
++
++  /**
++   *  This is an uglified reverse(_BidirectionalIterator,
++   *                              _BidirectionalIterator)
++   *  overloaded for random access iterators.
++  */
++  template<typename _RandomAccessIterator>
++    void
++    __reverse(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	      random_access_iterator_tag)
++    {
++      if (__first == __last)
++	return;
++      --__last;
++      while (__first < __last)
++	{
++	  std::iter_swap(__first, __last);
++	  ++__first;
++	  --__last;
++	}
++    }
++
++  /**
++   *  @brief Reverse a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A bidirectional iterator.
++   *  @param  __last   A bidirectional iterator.
++   *  @return   reverse() returns no value.
++   *
++   *  Reverses the order of the elements in the range @p [__first,__last),
++   *  so that the first element becomes the last etc.
++   *  For every @c i such that @p 0<=i<=(__last-__first)/2), @p reverse()
++   *  swaps @p *(__first+i) and @p *(__last-(i+1))
++  */
++  template<typename _BidirectionalIterator>
++    inline void
++    reverse(_BidirectionalIterator __first, _BidirectionalIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++      std::__reverse(__first, __last, std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief Copy a sequence, reversing its elements.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A bidirectional iterator.
++   *  @param  __last    A bidirectional iterator.
++   *  @param  __result  An output iterator.
++   *  @return  An iterator designating the end of the resulting sequence.
++   *
++   *  Copies the elements in the range @p [__first,__last) to the
++   *  range @p [__result,__result+(__last-__first)) such that the
++   *  order of the elements is reversed.  For every @c i such that @p
++   *  0<=i<=(__last-__first), @p reverse_copy() performs the
++   *  assignment @p *(__result+(__last-__first)-1-i) = *(__first+i).
++   *  The ranges @p [__first,__last) and @p
++   *  [__result,__result+(__last-__first)) must not overlap.
++  */
++  template<typename _BidirectionalIterator, typename _OutputIterator>
++    _OutputIterator
++    reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last,
++		 _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++		typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      while (__first != __last)
++	{
++	  --__last;
++	  *__result = *__last;
++	  ++__result;
++	}
++      return __result;
++    }
++
++  /**
++   *  This is a helper function for the rotate algorithm specialized on RAIs.
++   *  It returns the greatest common divisor of two integer values.
++  */
++  template<typename _EuclideanRingElement>
++    _EuclideanRingElement
++    __gcd(_EuclideanRingElement __m, _EuclideanRingElement __n)
++    {
++      while (__n != 0)
++	{
++	  _EuclideanRingElement __t = __m % __n;
++	  __m = __n;
++	  __n = __t;
++	}
++      return __m;
++    }
++
++  /// This is a helper function for the rotate algorithm.
++  template<typename _ForwardIterator>
++    void
++    __rotate(_ForwardIterator __first,
++	     _ForwardIterator __middle,
++	     _ForwardIterator __last,
++	     forward_iterator_tag)
++    {
++      if (__first == __middle || __last  == __middle)
++	return;
++
++      _ForwardIterator __first2 = __middle;
++      do
++	{
++	  std::iter_swap(__first, __first2);
++	  ++__first;
++	  ++__first2;
++	  if (__first == __middle)
++	    __middle = __first2;
++	}
++      while (__first2 != __last);
++
++      __first2 = __middle;
++
++      while (__first2 != __last)
++	{
++	  std::iter_swap(__first, __first2);
++	  ++__first;
++	  ++__first2;
++	  if (__first == __middle)
++	    __middle = __first2;
++	  else if (__first2 == __last)
++	    __first2 = __middle;
++	}
++    }
++
++   /// This is a helper function for the rotate algorithm.
++  template<typename _BidirectionalIterator>
++    void
++    __rotate(_BidirectionalIterator __first,
++	     _BidirectionalIterator __middle,
++	     _BidirectionalIterator __last,
++	      bidirectional_iterator_tag)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++
++      if (__first == __middle || __last  == __middle)
++	return;
++
++      std::__reverse(__first,  __middle, bidirectional_iterator_tag());
++      std::__reverse(__middle, __last,   bidirectional_iterator_tag());
++
++      while (__first != __middle && __middle != __last)
++	{
++	  std::iter_swap(__first, --__last);
++	  ++__first;
++	}
++
++      if (__first == __middle)
++	std::__reverse(__middle, __last,   bidirectional_iterator_tag());
++      else
++	std::__reverse(__first,  __middle, bidirectional_iterator_tag());
++    }
++
++  /// This is a helper function for the rotate algorithm.
++  template<typename _RandomAccessIterator>
++    void
++    __rotate(_RandomAccessIterator __first,
++	     _RandomAccessIterator __middle,
++	     _RandomAccessIterator __last,
++	     random_access_iterator_tag)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++
++      if (__first == __middle || __last  == __middle)
++	return;
++
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_Distance;
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++
++      _Distance __n = __last   - __first;
++      _Distance __k = __middle - __first;
++
++      if (__k == __n - __k)
++	{
++	  std::swap_ranges(__first, __middle, __middle);
++	  return;
++	}
++
++      _RandomAccessIterator __p = __first;
++
++      for (;;)
++	{
++	  if (__k < __n - __k)
++	    {
++	      if (__is_pod(_ValueType) && __k == 1)
++		{
++		  _ValueType __t = _GLIBCXX_MOVE(*__p);
++		  _GLIBCXX_MOVE3(__p + 1, __p + __n, __p);
++		  *(__p + __n - 1) = _GLIBCXX_MOVE(__t);
++		  return;
++		}
++	      _RandomAccessIterator __q = __p + __k;
++	      for (_Distance __i = 0; __i < __n - __k; ++ __i)
++		{
++		  std::iter_swap(__p, __q);
++		  ++__p;
++		  ++__q;
++		}
++	      __n %= __k;
++	      if (__n == 0)
++		return;
++	      std::swap(__n, __k);
++	      __k = __n - __k;
++	    }
++	  else
++	    {
++	      __k = __n - __k;
++	      if (__is_pod(_ValueType) && __k == 1)
++		{
++		  _ValueType __t = _GLIBCXX_MOVE(*(__p + __n - 1));
++		  _GLIBCXX_MOVE_BACKWARD3(__p, __p + __n - 1, __p + __n);
++		  *__p = _GLIBCXX_MOVE(__t);
++		  return;
++		}
++	      _RandomAccessIterator __q = __p + __n;
++	      __p = __q - __k;
++	      for (_Distance __i = 0; __i < __n - __k; ++ __i)
++		{
++		  --__p;
++		  --__q;
++		  std::iter_swap(__p, __q);
++		}
++	      __n %= __k;
++	      if (__n == 0)
++		return;
++	      std::swap(__n, __k);
++	    }
++	}
++    }
++
++  /**
++   *  @brief Rotate the elements of a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __middle  A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @return  Nothing.
++   *
++   *  Rotates the elements of the range @p [__first,__last) by 
++   *  @p (__middle - __first) positions so that the element at @p __middle
++   *  is moved to @p __first, the element at @p __middle+1 is moved to
++   *  @p __first+1 and so on for each element in the range
++   *  @p [__first,__last).
++   *
++   *  This effectively swaps the ranges @p [__first,__middle) and
++   *  @p [__middle,__last).
++   *
++   *  Performs
++   *   @p *(__first+(n+(__last-__middle))%(__last-__first))=*(__first+n)
++   *  for each @p n in the range @p [0,__last-__first).
++  */
++  template<typename _ForwardIterator>
++    inline void
++    rotate(_ForwardIterator __first, _ForwardIterator __middle,
++	   _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      std::__rotate(__first, __middle, __last,
++		    std::__iterator_category(__first));
++    }
++
++  /**
++   *  @brief Copy a sequence, rotating its elements.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __middle  A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __result  An output iterator.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies the elements of the range @p [__first,__last) to the
++   *  range beginning at @result, rotating the copied elements by 
++   *  @p (__middle-__first) positions so that the element at @p __middle
++   *  is moved to @p __result, the element at @p __middle+1 is moved
++   *  to @p __result+1 and so on for each element in the range @p
++   *  [__first,__last).
++   *
++   *  Performs 
++   *  @p *(__result+(n+(__last-__middle))%(__last-__first))=*(__first+n)
++   *  for each @p n in the range @p [0,__last-__first).
++  */
++  template<typename _ForwardIterator, typename _OutputIterator>
++    inline _OutputIterator
++    rotate_copy(_ForwardIterator __first, _ForwardIterator __middle,
++                _ForwardIterator __last, _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++		typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      return std::copy(__first, __middle,
++                       std::copy(__middle, __last, __result));
++    }
++
++  /// This is a helper function...
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    __partition(_ForwardIterator __first, _ForwardIterator __last,
++		_Predicate __pred, forward_iterator_tag)
++    {
++      if (__first == __last)
++	return __first;
++
++      while (__pred(*__first))
++	if (++__first == __last)
++	  return __first;
++
++      _ForwardIterator __next = __first;
++
++      while (++__next != __last)
++	if (__pred(*__next))
++	  {
++	    std::iter_swap(__first, __next);
++	    ++__first;
++	  }
++
++      return __first;
++    }
++
++  /// This is a helper function...
++  template<typename _BidirectionalIterator, typename _Predicate>
++    _BidirectionalIterator
++    __partition(_BidirectionalIterator __first, _BidirectionalIterator __last,
++		_Predicate __pred, bidirectional_iterator_tag)
++    {
++      while (true)
++	{
++	  while (true)
++	    if (__first == __last)
++	      return __first;
++	    else if (__pred(*__first))
++	      ++__first;
++	    else
++	      break;
++	  --__last;
++	  while (true)
++	    if (__first == __last)
++	      return __first;
++	    else if (!bool(__pred(*__last)))
++	      --__last;
++	    else
++	      break;
++	  std::iter_swap(__first, __last);
++	  ++__first;
++	}
++    }
++
++  // partition
++
++  /// This is a helper function...
++  /// Requires __len != 0 and !__pred(*__first),
++  /// same as __stable_partition_adaptive.
++  template<typename _ForwardIterator, typename _Predicate, typename _Distance>
++    _ForwardIterator
++    __inplace_stable_partition(_ForwardIterator __first,
++			       _Predicate __pred, _Distance __len)
++    {
++      if (__len == 1)
++	return __first;
++      _ForwardIterator __middle = __first;
++      std::advance(__middle, __len / 2);
++      _ForwardIterator __left_split =
++	std::__inplace_stable_partition(__first, __pred, __len / 2);
++      // Advance past true-predicate values to satisfy this
++      // function's preconditions.
++      _Distance __right_len = __len - __len / 2;
++      _ForwardIterator __right_split =
++	std::__find_if_not_n(__middle, __right_len, __pred);
++      if (__right_len)
++	__right_split = std::__inplace_stable_partition(__middle,
++							__pred,
++							__right_len);
++      std::rotate(__left_split, __middle, __right_split);
++      std::advance(__left_split, std::distance(__middle, __right_split));
++      return __left_split;
++    }
++
++  /// This is a helper function...
++  /// Requires __first != __last and !__pred(__first)
++  /// and __len == distance(__first, __last).
++  ///
++  /// !__pred(__first) allows us to guarantee that we don't
++  /// move-assign an element onto itself.
++  template<typename _ForwardIterator, typename _Pointer, typename _Predicate,
++	   typename _Distance>
++    _ForwardIterator
++    __stable_partition_adaptive(_ForwardIterator __first,
++				_ForwardIterator __last,
++				_Predicate __pred, _Distance __len,
++				_Pointer __buffer,
++				_Distance __buffer_size)
++    {
++      if (__len <= __buffer_size)
++	{
++	  _ForwardIterator __result1 = __first;
++	  _Pointer __result2 = __buffer;
++	  // The precondition guarantees that !__pred(__first), so
++	  // move that element to the buffer before starting the loop.
++	  // This ensures that we only call __pred once per element.
++	  *__result2 = _GLIBCXX_MOVE(*__first);
++	  ++__result2;
++	  ++__first;
++	  for (; __first != __last; ++__first)
++	    if (__pred(__first))
++	      {
++		*__result1 = _GLIBCXX_MOVE(*__first);
++		++__result1;
++	      }
++	    else
++	      {
++		*__result2 = _GLIBCXX_MOVE(*__first);
++		++__result2;
++	      }
++	  _GLIBCXX_MOVE3(__buffer, __result2, __result1);
++	  return __result1;
++	}
++      else
++	{
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __len / 2);
++	  _ForwardIterator __left_split =
++	    std::__stable_partition_adaptive(__first, __middle, __pred,
++					     __len / 2, __buffer,
++					     __buffer_size);
++	  // Advance past true-predicate values to satisfy this
++	  // function's preconditions.
++	  _Distance __right_len = __len - __len / 2;
++	  _ForwardIterator __right_split =
++	    std::__find_if_not_n(__middle, __right_len, __pred);
++	  if (__right_len)
++	    __right_split =
++	      std::__stable_partition_adaptive(__right_split, __last, __pred,
++					       __right_len,
++					       __buffer, __buffer_size);
++	  std::rotate(__left_split, __middle, __right_split);
++	  std::advance(__left_split, std::distance(__middle, __right_split));
++	  return __left_split;
++	}
++    }
++
++  template<typename _ForwardIterator, typename _Predicate>
++    _ForwardIterator
++    __stable_partition(_ForwardIterator __first, _ForwardIterator __last,
++		       _Predicate __pred)
++    {
++      __first = std::__find_if_not(__first, __last, __pred);
++
++      if (__first == __last)
++	return __first;
++
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      _Temporary_buffer<_ForwardIterator, _ValueType> __buf(__first, __last);
++      if (__buf.size() > 0)
++	return
++	  std::__stable_partition_adaptive(__first, __last, __pred,
++					   _DistanceType(__buf.requested_size()),
++					   __buf.begin(),
++					   _DistanceType(__buf.size()));
++      else
++	return
++	  std::__inplace_stable_partition(__first, __pred,
++					  _DistanceType(__buf.requested_size()));
++    }
++
++  /**
++   *  @brief Move elements for which a predicate is true to the beginning
++   *         of a sequence, preserving relative ordering.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __pred    A predicate functor.
++   *  @return  An iterator @p middle such that @p __pred(i) is true for each
++   *  iterator @p i in the range @p [first,middle) and false for each @p i
++   *  in the range @p [middle,last).
++   *
++   *  Performs the same function as @p partition() with the additional
++   *  guarantee that the relative ordering of elements in each group is
++   *  preserved, so any two elements @p x and @p y in the range
++   *  @p [__first,__last) such that @p __pred(x)==__pred(y) will have the same
++   *  relative ordering after calling @p stable_partition().
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    inline _ForwardIterator
++    stable_partition(_ForwardIterator __first, _ForwardIterator __last,
++		     _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__stable_partition(__first, __last,
++				     __gnu_cxx::__ops::__pred_iter(__pred));
++    }
++
++  /// This is a helper function for the sort routines.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __heap_select(_RandomAccessIterator __first,
++		  _RandomAccessIterator __middle,
++		  _RandomAccessIterator __last, _Compare __comp)
++    {
++      std::__make_heap(__first, __middle, __comp);
++      for (_RandomAccessIterator __i = __middle; __i < __last; ++__i)
++	if (__comp(__i, __first))
++	  std::__pop_heap(__first, __middle, __i, __comp);
++    }
++
++  // partial_sort
++
++  template<typename _InputIterator, typename _RandomAccessIterator,
++	   typename _Compare>
++    _RandomAccessIterator
++    __partial_sort_copy(_InputIterator __first, _InputIterator __last,
++			_RandomAccessIterator __result_first,
++			_RandomAccessIterator __result_last,
++			_Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator>::value_type
++	_InputValueType;
++      typedef iterator_traits<_RandomAccessIterator> _RItTraits;
++      typedef typename _RItTraits::difference_type _DistanceType;
++
++      if (__result_first == __result_last)
++	return __result_last;
++      _RandomAccessIterator __result_real_last = __result_first;
++      while (__first != __last && __result_real_last != __result_last)
++	{
++	  *__result_real_last = *__first;
++	  ++__result_real_last;
++	  ++__first;
++	}
++      
++      std::__make_heap(__result_first, __result_real_last, __comp);
++      while (__first != __last)
++	{
++	  if (__comp(__first, __result_first))
++	    std::__adjust_heap(__result_first, _DistanceType(0),
++			       _DistanceType(__result_real_last
++					     - __result_first),
++			       _InputValueType(*__first), __comp);
++	  ++__first;
++	}
++      std::__sort_heap(__result_first, __result_real_last, __comp);
++      return __result_real_last;
++    }
++
++  /**
++   *  @brief Copy the smallest elements of a sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __result_first   A random-access iterator.
++   *  @param  __result_last    Another random-access iterator.
++   *  @return   An iterator indicating the end of the resulting sequence.
++   *
++   *  Copies and sorts the smallest N values from the range @p [__first,__last)
++   *  to the range beginning at @p __result_first, where the number of
++   *  elements to be copied, @p N, is the smaller of @p (__last-__first) and
++   *  @p (__result_last-__result_first).
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__result_first,__result_first+N) such that i precedes j then
++   *  *j<*i is false.
++   *  The value returned is @p __result_first+N.
++  */
++  template<typename _InputIterator, typename _RandomAccessIterator>
++    inline _RandomAccessIterator
++    partial_sort_copy(_InputIterator __first, _InputIterator __last,
++		      _RandomAccessIterator __result_first,
++		      _RandomAccessIterator __result_last)
++    {
++      typedef typename iterator_traits<_InputIterator>::value_type
++	_InputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_OutputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_ConvertibleConcept<_InputValueType,
++				  _OutputValueType>)
++      __glibcxx_function_requires(_LessThanOpConcept<_InputValueType,
++				                     _OutputValueType>)
++      __glibcxx_function_requires(_LessThanComparableConcept<_OutputValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++      __glibcxx_requires_valid_range(__result_first, __result_last);
++
++      return std::__partial_sort_copy(__first, __last,
++				      __result_first, __result_last,
++				      __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Copy the smallest elements of a sequence using a predicate for
++   *         comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    Another input iterator.
++   *  @param  __result_first   A random-access iterator.
++   *  @param  __result_last    Another random-access iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return   An iterator indicating the end of the resulting sequence.
++   *
++   *  Copies and sorts the smallest N values from the range @p [__first,__last)
++   *  to the range beginning at @p result_first, where the number of
++   *  elements to be copied, @p N, is the smaller of @p (__last-__first) and
++   *  @p (__result_last-__result_first).
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__result_first,__result_first+N) such that i precedes j then
++   *  @p __comp(*j,*i) is false.
++   *  The value returned is @p __result_first+N.
++  */
++  template<typename _InputIterator, typename _RandomAccessIterator,
++	   typename _Compare>
++    inline _RandomAccessIterator
++    partial_sort_copy(_InputIterator __first, _InputIterator __last,
++		      _RandomAccessIterator __result_first,
++		      _RandomAccessIterator __result_last,
++		      _Compare __comp)
++    {
++      typedef typename iterator_traits<_InputIterator>::value_type
++	_InputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_OutputValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++      __glibcxx_function_requires(_ConvertibleConcept<_InputValueType,
++				  _OutputValueType>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _InputValueType, _OutputValueType>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _OutputValueType, _OutputValueType>)
++      __glibcxx_requires_valid_range(__first, __last);
++      __glibcxx_requires_valid_range(__result_first, __result_last);
++
++      return std::__partial_sort_copy(__first, __last,
++				      __result_first, __result_last,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __unguarded_linear_insert(_RandomAccessIterator __last,
++			      _Compare __comp)
++    {
++      typename iterator_traits<_RandomAccessIterator>::value_type
++	__val = _GLIBCXX_MOVE(*__last);
++      _RandomAccessIterator __next = __last;
++      --__next;
++      while (__comp(__val, __next))
++	{
++	  *__last = _GLIBCXX_MOVE(*__next);
++	  __last = __next;
++	  --__next;
++	}
++      *__last = _GLIBCXX_MOVE(__val);
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __insertion_sort(_RandomAccessIterator __first,
++		     _RandomAccessIterator __last, _Compare __comp)
++    {
++      if (__first == __last) return;
++
++      for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	{
++	  if (__comp(__i, __first))
++	    {
++	      typename iterator_traits<_RandomAccessIterator>::value_type
++		__val = _GLIBCXX_MOVE(*__i);
++	      _GLIBCXX_MOVE_BACKWARD3(__first, __i, __i + 1);
++	      *__first = _GLIBCXX_MOVE(__val);
++	    }
++	  else
++	    std::__unguarded_linear_insert(__i,
++				__gnu_cxx::__ops::__val_comp_iter(__comp));
++	}
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    __unguarded_insertion_sort(_RandomAccessIterator __first,
++			       _RandomAccessIterator __last, _Compare __comp)
++    {
++      for (_RandomAccessIterator __i = __first; __i != __last; ++__i)
++	std::__unguarded_linear_insert(__i,
++				__gnu_cxx::__ops::__val_comp_iter(__comp));
++    }
++
++  /**
++   *  @doctodo
++   *  This controls some aspect of the sort routines.
++  */
++  enum { _S_threshold = 16 };
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __final_insertion_sort(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last, _Compare __comp)
++    {
++      if (__last - __first > int(_S_threshold))
++	{
++	  std::__insertion_sort(__first, __first + int(_S_threshold), __comp);
++	  std::__unguarded_insertion_sort(__first + int(_S_threshold), __last,
++					  __comp);
++	}
++      else
++	std::__insertion_sort(__first, __last, __comp);
++    }
++
++  /// This is a helper function...
++  template<typename _RandomAccessIterator, typename _Compare>
++    _RandomAccessIterator
++    __unguarded_partition(_RandomAccessIterator __first,
++			  _RandomAccessIterator __last,
++			  _RandomAccessIterator __pivot, _Compare __comp)
++    {
++      while (true)
++	{
++	  while (__comp(__first, __pivot))
++	    ++__first;
++	  --__last;
++	  while (__comp(__pivot, __last))
++	    --__last;
++	  if (!(__first < __last))
++	    return __first;
++	  std::iter_swap(__first, __last);
++	  ++__first;
++	}
++    }
++
++  /// This is a helper function...
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline _RandomAccessIterator
++    __unguarded_partition_pivot(_RandomAccessIterator __first,
++				_RandomAccessIterator __last, _Compare __comp)
++    {
++      _RandomAccessIterator __mid = __first + (__last - __first) / 2;
++      std::__move_median_to_first(__first, __first + 1, __mid, __last - 1,
++				  __comp);
++      return std::__unguarded_partition(__first + 1, __last, __first, __comp);
++    }
++
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    __partial_sort(_RandomAccessIterator __first,
++		   _RandomAccessIterator __middle,
++		   _RandomAccessIterator __last,
++		   _Compare __comp)
++    {
++      std::__heap_select(__first, __middle, __last, __comp);
++      std::__sort_heap(__first, __middle, __comp);
++    }
++
++  /// This is a helper function for the sort routine.
++  template<typename _RandomAccessIterator, typename _Size, typename _Compare>
++    void
++    __introsort_loop(_RandomAccessIterator __first,
++		     _RandomAccessIterator __last,
++		     _Size __depth_limit, _Compare __comp)
++    {
++      while (__last - __first > int(_S_threshold))
++	{
++	  if (__depth_limit == 0)
++	    {
++	      std::__partial_sort(__first, __last, __last, __comp);
++	      return;
++	    }
++	  --__depth_limit;
++	  _RandomAccessIterator __cut =
++	    std::__unguarded_partition_pivot(__first, __last, __comp);
++	  std::__introsort_loop(__cut, __last, __depth_limit, __comp);
++	  __last = __cut;
++	}
++    }
++
++  // sort
++
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    __sort(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	   _Compare __comp)
++    {
++      if (__first != __last)
++	{
++	  std::__introsort_loop(__first, __last,
++				std::__lg(__last - __first) * 2,
++				__comp);
++	  std::__final_insertion_sort(__first, __last, __comp);
++	}
++    }
++
++  template<typename _RandomAccessIterator, typename _Size, typename _Compare>
++    void
++    __introselect(_RandomAccessIterator __first, _RandomAccessIterator __nth,
++		  _RandomAccessIterator __last, _Size __depth_limit,
++		  _Compare __comp)
++    {
++      while (__last - __first > 3)
++	{
++	  if (__depth_limit == 0)
++	    {
++	      std::__heap_select(__first, __nth + 1, __last, __comp);
++	      // Place the nth largest element in its final position.
++	      std::iter_swap(__first, __nth);
++	      return;
++	    }
++	  --__depth_limit;
++	  _RandomAccessIterator __cut =
++	    std::__unguarded_partition_pivot(__first, __last, __comp);
++	  if (__cut <= __nth)
++	    __first = __cut;
++	  else
++	    __last = __cut;
++	}
++      std::__insertion_sort(__first, __last, __comp);
++    }
++
++  // nth_element
++
++  // lower_bound moved to stl_algobase.h
++
++  /**
++   *  @brief Finds the first position in which @p __val could be inserted
++   *         without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return An iterator pointing to the first element <em>not less
++   *           than</em> @p __val, or end() if every element is less
++   *           than @p __val.
++   *  @ingroup binary_search_algorithms
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    inline _ForwardIterator
++    lower_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType, _Tp>)
++      __glibcxx_requires_partitioned_lower_pred(__first, __last,
++						__val, __comp);
++
++      return std::__lower_bound(__first, __last, __val,
++				__gnu_cxx::__ops::__iter_comp_val(__comp));
++    }
++
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    _ForwardIterator
++    __upper_bound(_ForwardIterator __first, _ForwardIterator __last,
++		  const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__comp(__val, __middle))
++	    __len = __half;
++	  else
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	}
++      return __first;
++    }
++
++  /**
++   *  @brief Finds the last position in which @p __val could be inserted
++   *         without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return  An iterator pointing to the first element greater than @p __val,
++   *           or end() if no elements are greater than @p __val.
++   *  @ingroup binary_search_algorithms
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    inline _ForwardIterator
++    upper_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<_Tp, _ValueType>)
++      __glibcxx_requires_partitioned_upper(__first, __last, __val);
++
++      return std::__upper_bound(__first, __last, __val,
++				__gnu_cxx::__ops::__val_less_iter());
++    }
++
++  /**
++   *  @brief Finds the last position in which @p __val could be inserted
++   *         without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  An iterator pointing to the first element greater than @p __val,
++   *           or end() if no elements are greater than @p __val.
++   *  @ingroup binary_search_algorithms
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    inline _ForwardIterator
++    upper_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _Tp, _ValueType>)
++      __glibcxx_requires_partitioned_upper_pred(__first, __last,
++						__val, __comp);
++
++      return std::__upper_bound(__first, __last, __val,
++				__gnu_cxx::__ops::__val_comp_iter(__comp));
++    }
++
++  template<typename _ForwardIterator, typename _Tp,
++	   typename _CompareItTp, typename _CompareTpIt>
++    pair<_ForwardIterator, _ForwardIterator>
++    __equal_range(_ForwardIterator __first, _ForwardIterator __last,
++		  const _Tp& __val,
++		  _CompareItTp __comp_it_val, _CompareTpIt __comp_val_it)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__comp_it_val(__middle, __val))
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else if (__comp_val_it(__val, __middle))
++	    __len = __half;
++	  else
++	    {
++	      _ForwardIterator __left
++		= std::__lower_bound(__first, __middle, __val, __comp_it_val);
++	      std::advance(__first, __len);
++	      _ForwardIterator __right
++		= std::__upper_bound(++__middle, __first, __val, __comp_val_it);
++	      return pair<_ForwardIterator, _ForwardIterator>(__left, __right);
++	    }
++	}
++      return pair<_ForwardIterator, _ForwardIterator>(__first, __first);
++    }
++
++  /**
++   *  @brief Finds the largest subrange in which @p __val could be inserted
++   *         at any place in it without changing the ordering.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return  An pair of iterators defining the subrange.
++   *  @ingroup binary_search_algorithms
++   *
++   *  This is equivalent to
++   *  @code
++   *    std::make_pair(lower_bound(__first, __last, __val),
++   *                   upper_bound(__first, __last, __val))
++   *  @endcode
++   *  but does not actually call those functions.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    inline pair<_ForwardIterator, _ForwardIterator>
++    equal_range(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType, _Tp>)
++      __glibcxx_function_requires(_LessThanOpConcept<_Tp, _ValueType>)
++      __glibcxx_requires_partitioned_lower(__first, __last, __val);
++      __glibcxx_requires_partitioned_upper(__first, __last, __val);      
++
++      return std::__equal_range(__first, __last, __val,
++				__gnu_cxx::__ops::__iter_less_val(),
++				__gnu_cxx::__ops::__val_less_iter());
++    }
++
++  /**
++   *  @brief Finds the largest subrange in which @p __val could be inserted
++   *         at any place in it without changing the ordering.
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  An pair of iterators defining the subrange.
++   *  @ingroup binary_search_algorithms
++   *
++   *  This is equivalent to
++   *  @code
++   *    std::make_pair(lower_bound(__first, __last, __val, __comp),
++   *                   upper_bound(__first, __last, __val, __comp))
++   *  @endcode
++   *  but does not actually call those functions.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    inline pair<_ForwardIterator, _ForwardIterator>
++    equal_range(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _ValueType, _Tp>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _Tp, _ValueType>)
++      __glibcxx_requires_partitioned_lower_pred(__first, __last,
++						__val, __comp);
++      __glibcxx_requires_partitioned_upper_pred(__first, __last,
++						__val, __comp);
++
++      return std::__equal_range(__first, __last, __val,
++				__gnu_cxx::__ops::__iter_comp_val(__comp),
++				__gnu_cxx::__ops::__val_comp_iter(__comp));
++    }
++
++  /**
++   *  @brief Determines whether an element exists in a range.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return True if @p __val (or its equivalent) is in [@p
++   *  __first,@p __last ].
++   *
++   *  Note that this does not actually return an iterator to @p __val.  For
++   *  that, use std::find or a container's specialized find member functions.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    bool
++    binary_search(_ForwardIterator __first, _ForwardIterator __last,
++                  const _Tp& __val)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<_Tp, _ValueType>)
++      __glibcxx_requires_partitioned_lower(__first, __last, __val);
++      __glibcxx_requires_partitioned_upper(__first, __last, __val);
++
++      _ForwardIterator __i
++	= std::__lower_bound(__first, __last, __val,
++			     __gnu_cxx::__ops::__iter_less_val());
++      return __i != __last && !(__val < *__i);
++    }
++
++  /**
++   *  @brief Determines whether an element exists in a range.
++   *  @ingroup binary_search_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  True if @p __val (or its equivalent) is in @p [__first,__last].
++   *
++   *  Note that this does not actually return an iterator to @p __val.  For
++   *  that, use std::find or a container's specialized find member functions.
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    bool
++    binary_search(_ForwardIterator __first, _ForwardIterator __last,
++                  const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::value_type
++	_ValueType;
++
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++				  _Tp, _ValueType>)
++      __glibcxx_requires_partitioned_lower_pred(__first, __last,
++						__val, __comp);
++      __glibcxx_requires_partitioned_upper_pred(__first, __last,
++						__val, __comp);
++
++      _ForwardIterator __i
++	= std::__lower_bound(__first, __last, __val,
++			     __gnu_cxx::__ops::__iter_comp_val(__comp));
++      return __i != __last && !bool(__comp(__val, *__i));
++    }
++
++  // merge
++
++  /// This is a helper function for the __merge_adaptive routines.
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    void
++    __move_merge_adaptive(_InputIterator1 __first1, _InputIterator1 __last1,
++			  _InputIterator2 __first2, _InputIterator2 __last2,
++			  _OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(__first2, __first1))
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first2);
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first1);
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      if (__first1 != __last1)
++	_GLIBCXX_MOVE3(__first1, __last1, __result);
++    }
++
++  /// This is a helper function for the __merge_adaptive routines.
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2,
++	   typename _BidirectionalIterator3, typename _Compare>
++    void
++    __move_merge_adaptive_backward(_BidirectionalIterator1 __first1,
++				   _BidirectionalIterator1 __last1,
++				   _BidirectionalIterator2 __first2,
++				   _BidirectionalIterator2 __last2,
++				   _BidirectionalIterator3 __result,
++				   _Compare __comp)
++    {
++      if (__first1 == __last1)
++	{
++	  _GLIBCXX_MOVE_BACKWARD3(__first2, __last2, __result);
++	  return;
++	}
++      else if (__first2 == __last2)
++	return;
++
++      --__last1;
++      --__last2;
++      while (true)
++	{
++	  if (__comp(__last2, __last1))
++	    {
++	      *--__result = _GLIBCXX_MOVE(*__last1);
++	      if (__first1 == __last1)
++		{
++		  _GLIBCXX_MOVE_BACKWARD3(__first2, ++__last2, __result);
++		  return;
++		}
++	      --__last1;
++	    }
++	  else
++	    {
++	      *--__result = _GLIBCXX_MOVE(*__last2);
++	      if (__first2 == __last2)
++		return;
++	      --__last2;
++	    }
++	}
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator1, typename _BidirectionalIterator2,
++	   typename _Distance>
++    _BidirectionalIterator1
++    __rotate_adaptive(_BidirectionalIterator1 __first,
++		      _BidirectionalIterator1 __middle,
++		      _BidirectionalIterator1 __last,
++		      _Distance __len1, _Distance __len2,
++		      _BidirectionalIterator2 __buffer,
++		      _Distance __buffer_size)
++    {
++      _BidirectionalIterator2 __buffer_end;
++      if (__len1 > __len2 && __len2 <= __buffer_size)
++	{
++	  if (__len2)
++	    {
++	      __buffer_end = _GLIBCXX_MOVE3(__middle, __last, __buffer);
++	      _GLIBCXX_MOVE_BACKWARD3(__first, __middle, __last);
++	      return _GLIBCXX_MOVE3(__buffer, __buffer_end, __first);
++	    }
++	  else
++	    return __first;
++	}
++      else if (__len1 <= __buffer_size)
++	{
++	  if (__len1)
++	    {
++	      __buffer_end = _GLIBCXX_MOVE3(__first, __middle, __buffer);
++	      _GLIBCXX_MOVE3(__middle, __last, __first);
++	      return _GLIBCXX_MOVE_BACKWARD3(__buffer, __buffer_end, __last);
++	    }
++	  else
++	    return __last;
++	}
++      else
++	{
++	  std::rotate(__first, __middle, __last);
++	  std::advance(__first, std::distance(__middle, __last));
++	  return __first;
++	}
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator, typename _Distance, 
++	   typename _Pointer, typename _Compare>
++    void
++    __merge_adaptive(_BidirectionalIterator __first,
++                     _BidirectionalIterator __middle,
++		     _BidirectionalIterator __last,
++		     _Distance __len1, _Distance __len2,
++		     _Pointer __buffer, _Distance __buffer_size,
++		     _Compare __comp)
++    {
++      if (__len1 <= __len2 && __len1 <= __buffer_size)
++	{
++	  _Pointer __buffer_end = _GLIBCXX_MOVE3(__first, __middle, __buffer);
++	  std::__move_merge_adaptive(__buffer, __buffer_end, __middle, __last,
++				     __first, __comp);
++	}
++      else if (__len2 <= __buffer_size)
++	{
++	  _Pointer __buffer_end = _GLIBCXX_MOVE3(__middle, __last, __buffer);
++	  std::__move_merge_adaptive_backward(__first, __middle, __buffer,
++					      __buffer_end, __last, __comp);
++	}
++      else
++	{
++	  _BidirectionalIterator __first_cut = __first;
++	  _BidirectionalIterator __second_cut = __middle;
++	  _Distance __len11 = 0;
++	  _Distance __len22 = 0;
++	  if (__len1 > __len2)
++	    {
++	      __len11 = __len1 / 2;
++	      std::advance(__first_cut, __len11);
++	      __second_cut
++		= std::__lower_bound(__middle, __last, *__first_cut,
++				     __gnu_cxx::__ops::__iter_comp_val(__comp));
++	      __len22 = std::distance(__middle, __second_cut);
++	    }
++	  else
++	    {
++	      __len22 = __len2 / 2;
++	      std::advance(__second_cut, __len22);
++	      __first_cut
++		= std::__upper_bound(__first, __middle, *__second_cut,
++				     __gnu_cxx::__ops::__val_comp_iter(__comp));
++	      __len11 = std::distance(__first, __first_cut);
++	    }
++	  _BidirectionalIterator __new_middle
++	    = std::__rotate_adaptive(__first_cut, __middle, __second_cut,
++				     __len1 - __len11, __len22, __buffer,
++				     __buffer_size);
++	  std::__merge_adaptive(__first, __first_cut, __new_middle, __len11,
++				__len22, __buffer, __buffer_size, __comp);
++	  std::__merge_adaptive(__new_middle, __second_cut, __last,
++				__len1 - __len11,
++				__len2 - __len22, __buffer,
++				__buffer_size, __comp);
++	}
++    }
++
++  /// This is a helper function for the merge routines.
++  template<typename _BidirectionalIterator, typename _Distance,
++	   typename _Compare>
++    void
++    __merge_without_buffer(_BidirectionalIterator __first,
++                           _BidirectionalIterator __middle,
++			   _BidirectionalIterator __last,
++			   _Distance __len1, _Distance __len2,
++			   _Compare __comp)
++    {
++      if (__len1 == 0 || __len2 == 0)
++	return;
++      if (__len1 + __len2 == 2)
++	{
++	  if (__comp(__middle, __first))
++	    std::iter_swap(__first, __middle);
++	  return;
++	}
++      _BidirectionalIterator __first_cut = __first;
++      _BidirectionalIterator __second_cut = __middle;
++      _Distance __len11 = 0;
++      _Distance __len22 = 0;
++      if (__len1 > __len2)
++	{
++	  __len11 = __len1 / 2;
++	  std::advance(__first_cut, __len11);
++	  __second_cut
++	    = std::__lower_bound(__middle, __last, *__first_cut,
++				 __gnu_cxx::__ops::__iter_comp_val(__comp));
++	  __len22 = std::distance(__middle, __second_cut);
++	}
++      else
++	{
++	  __len22 = __len2 / 2;
++	  std::advance(__second_cut, __len22);
++	  __first_cut
++	    = std::__upper_bound(__first, __middle, *__second_cut,
++				 __gnu_cxx::__ops::__val_comp_iter(__comp));
++	  __len11 = std::distance(__first, __first_cut);
++	}
++      std::rotate(__first_cut, __middle, __second_cut);
++      _BidirectionalIterator __new_middle = __first_cut;
++      std::advance(__new_middle, std::distance(__middle, __second_cut));
++      std::__merge_without_buffer(__first, __first_cut, __new_middle,
++				  __len11, __len22, __comp);
++      std::__merge_without_buffer(__new_middle, __second_cut, __last,
++				  __len1 - __len11, __len2 - __len22, __comp);
++    }
++
++  template<typename _BidirectionalIterator, typename _Compare>
++    void
++    __inplace_merge(_BidirectionalIterator __first,
++		    _BidirectionalIterator __middle,
++		    _BidirectionalIterator __last,
++		    _Compare __comp)
++    {
++      typedef typename iterator_traits<_BidirectionalIterator>::value_type
++          _ValueType;
++      typedef typename iterator_traits<_BidirectionalIterator>::difference_type
++          _DistanceType;
++
++      if (__first == __middle || __middle == __last)
++	return;
++
++      const _DistanceType __len1 = std::distance(__first, __middle);
++      const _DistanceType __len2 = std::distance(__middle, __last);
++
++      typedef _Temporary_buffer<_BidirectionalIterator, _ValueType> _TmpBuf;
++      _TmpBuf __buf(__first, __last);
++
++      if (__buf.begin() == 0)
++	std::__merge_without_buffer
++	  (__first, __middle, __last, __len1, __len2, __comp);
++      else
++	std::__merge_adaptive
++	  (__first, __middle, __last, __len1, __len2, __buf.begin(),
++	   _DistanceType(__buf.size()), __comp);
++    }
++
++  /**
++   *  @brief Merges two sorted ranges in place.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Merges two sorted and consecutive ranges, [__first,__middle) and
++   *  [__middle,__last), and puts the result in [__first,__last).  The
++   *  output will be sorted.  The sort is @e stable, that is, for
++   *  equivalent elements in the two ranges, elements from the first
++   *  range will always come before elements from the second.
++   *
++   *  If enough additional memory is available, this takes (__last-__first)-1
++   *  comparisons.  Otherwise an NlogN algorithm is used, where N is
++   *  distance(__first,__last).
++  */
++  template<typename _BidirectionalIterator>
++    inline void
++    inplace_merge(_BidirectionalIterator __first,
++		  _BidirectionalIterator __middle,
++		  _BidirectionalIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++	    _BidirectionalIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_sorted(__first, __middle);
++      __glibcxx_requires_sorted(__middle, __last);
++
++      std::__inplace_merge(__first, __middle, __last,
++			   __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Merges two sorted ranges in place.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return  Nothing.
++   *
++   *  Merges two sorted and consecutive ranges, [__first,__middle) and
++   *  [middle,last), and puts the result in [__first,__last).  The output will
++   *  be sorted.  The sort is @e stable, that is, for equivalent
++   *  elements in the two ranges, elements from the first range will always
++   *  come before elements from the second.
++   *
++   *  If enough additional memory is available, this takes (__last-__first)-1
++   *  comparisons.  Otherwise an NlogN algorithm is used, where N is
++   *  distance(__first,__last).
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _BidirectionalIterator, typename _Compare>
++    inline void
++    inplace_merge(_BidirectionalIterator __first,
++		  _BidirectionalIterator __middle,
++		  _BidirectionalIterator __last,
++		  _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<
++	    _BidirectionalIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_BidirectionalIterator>::value_type,
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_sorted_pred(__first, __middle, __comp);
++      __glibcxx_requires_sorted_pred(__middle, __last, __comp);
++
++      std::__inplace_merge(__first, __middle, __last,
++			   __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++
++  /// This is a helper function for the __merge_sort_loop routines.
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Compare>
++    _OutputIterator
++    __move_merge(_InputIterator __first1, _InputIterator __last1,
++		 _InputIterator __first2, _InputIterator __last2,
++		 _OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(__first2, __first1))
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first2);
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = _GLIBCXX_MOVE(*__first1);
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      return _GLIBCXX_MOVE3(__first2, __last2,
++			    _GLIBCXX_MOVE3(__first1, __last1,
++					   __result));
++    }
++
++  template<typename _RandomAccessIterator1, typename _RandomAccessIterator2,
++	   typename _Distance, typename _Compare>
++    void
++    __merge_sort_loop(_RandomAccessIterator1 __first,
++		      _RandomAccessIterator1 __last,
++		      _RandomAccessIterator2 __result, _Distance __step_size,
++		      _Compare __comp)
++    {
++      const _Distance __two_step = 2 * __step_size;
++
++      while (__last - __first >= __two_step)
++	{
++	  __result = std::__move_merge(__first, __first + __step_size,
++				       __first + __step_size,
++				       __first + __two_step,
++				       __result, __comp);
++	  __first += __two_step;
++	}
++      __step_size = std::min(_Distance(__last - __first), __step_size);
++
++      std::__move_merge(__first, __first + __step_size,
++			__first + __step_size, __last, __result, __comp);
++    }
++
++  template<typename _RandomAccessIterator, typename _Distance,
++	   typename _Compare>
++    void
++    __chunk_insertion_sort(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last,
++			   _Distance __chunk_size, _Compare __comp)
++    {
++      while (__last - __first >= __chunk_size)
++	{
++	  std::__insertion_sort(__first, __first + __chunk_size, __comp);
++	  __first += __chunk_size;
++	}
++      std::__insertion_sort(__first, __last, __comp);
++    }
++
++  enum { _S_chunk_size = 7 };
++
++  template<typename _RandomAccessIterator, typename _Pointer, typename _Compare>
++    void
++    __merge_sort_with_buffer(_RandomAccessIterator __first,
++			     _RandomAccessIterator __last,
++                             _Pointer __buffer, _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_Distance;
++
++      const _Distance __len = __last - __first;
++      const _Pointer __buffer_last = __buffer + __len;
++
++      _Distance __step_size = _S_chunk_size;
++      std::__chunk_insertion_sort(__first, __last, __step_size, __comp);
++
++      while (__step_size < __len)
++	{
++	  std::__merge_sort_loop(__first, __last, __buffer,
++				 __step_size, __comp);
++	  __step_size *= 2;
++	  std::__merge_sort_loop(__buffer, __buffer_last, __first,
++				 __step_size, __comp);
++	  __step_size *= 2;
++	}
++    }
++
++  template<typename _RandomAccessIterator, typename _Pointer,
++	   typename _Distance, typename _Compare>
++    void
++    __stable_sort_adaptive(_RandomAccessIterator __first,
++			   _RandomAccessIterator __last,
++                           _Pointer __buffer, _Distance __buffer_size,
++                           _Compare __comp)
++    {
++      const _Distance __len = (__last - __first + 1) / 2;
++      const _RandomAccessIterator __middle = __first + __len;
++      if (__len > __buffer_size)
++	{
++	  std::__stable_sort_adaptive(__first, __middle, __buffer,
++				      __buffer_size, __comp);
++	  std::__stable_sort_adaptive(__middle, __last, __buffer,
++				      __buffer_size, __comp);
++	}
++      else
++	{
++	  std::__merge_sort_with_buffer(__first, __middle, __buffer, __comp);
++	  std::__merge_sort_with_buffer(__middle, __last, __buffer, __comp);
++	}
++      std::__merge_adaptive(__first, __middle, __last,
++			    _Distance(__middle - __first),
++			    _Distance(__last - __middle),
++			    __buffer, __buffer_size,
++			    __comp);
++    }
++
++  /// This is a helper function for the stable sorting routines.
++  template<typename _RandomAccessIterator, typename _Compare>
++    void
++    __inplace_stable_sort(_RandomAccessIterator __first,
++			  _RandomAccessIterator __last, _Compare __comp)
++    {
++      if (__last - __first < 15)
++	{
++	  std::__insertion_sort(__first, __last, __comp);
++	  return;
++	}
++      _RandomAccessIterator __middle = __first + (__last - __first) / 2;
++      std::__inplace_stable_sort(__first, __middle, __comp);
++      std::__inplace_stable_sort(__middle, __last, __comp);
++      std::__merge_without_buffer(__first, __middle, __last,
++				  __middle - __first,
++				  __last - __middle,
++				  __comp);
++    }
++
++  // stable_sort
++
++  // Set algorithms: includes, set_union, set_intersection, set_difference,
++  // set_symmetric_difference.  All of these algorithms have the precondition
++  // that their input ranges are sorted and the postcondition that their output
++  // ranges are sorted.
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _Compare>
++    bool
++    __includes(_InputIterator1 __first1, _InputIterator1 __last1,
++	       _InputIterator2 __first2, _InputIterator2 __last2,
++	       _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(__first2, __first1))
++	  return false;
++	else if (__comp(__first1, __first2))
++	  ++__first1;
++	else
++	  ++__first1, ++__first2;
++
++      return __first2 == __last2;
++    }
++
++  /**
++   *  @brief Determines whether all elements of a sequence exists in a range.
++   *  @param  __first1  Start of search range.
++   *  @param  __last1   End of search range.
++   *  @param  __first2  Start of sequence
++   *  @param  __last2   End of sequence.
++   *  @return  True if each element in [__first2,__last2) is contained in order
++   *  within [__first1,__last1).  False otherwise.
++   *  @ingroup set_algorithms
++   *
++   *  This operation expects both [__first1,__last1) and
++   *  [__first2,__last2) to be sorted.  Searches for the presence of
++   *  each element in [__first2,__last2) within [__first1,__last1).
++   *  The iterators over each range only move forward, so this is a
++   *  linear algorithm.  If an element in [__first2,__last2) is not
++   *  found before the search iterator reaches @p __last2, false is
++   *  returned.
++  */
++  template<typename _InputIterator1, typename _InputIterator2>
++    inline bool
++    includes(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _InputIterator2 __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      return std::__includes(__first1, __last1, __first2, __last2,
++			     __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Determines whether all elements of a sequence exists in a range
++   *  using comparison.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of search range.
++   *  @param  __last1   End of search range.
++   *  @param  __first2  Start of sequence
++   *  @param  __last2   End of sequence.
++   *  @param  __comp    Comparison function to use.
++   *  @return True if each element in [__first2,__last2) is contained
++   *  in order within [__first1,__last1) according to comp.  False
++   *  otherwise.  @ingroup set_algorithms
++   *
++   *  This operation expects both [__first1,__last1) and
++   *  [__first2,__last2) to be sorted.  Searches for the presence of
++   *  each element in [__first2,__last2) within [__first1,__last1),
++   *  using comp to decide.  The iterators over each range only move
++   *  forward, so this is a linear algorithm.  If an element in
++   *  [__first2,__last2) is not found before the search iterator
++   *  reaches @p __last2, false is returned.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _Compare>
++    inline bool
++    includes(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _InputIterator2 __last2,
++	     _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      return std::__includes(__first1, __last1, __first2, __last2,
++			     __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  // nth_element
++  // merge
++  // set_difference
++  // set_intersection
++  // set_union
++  // stable_sort
++  // set_symmetric_difference
++  // min_element
++  // max_element
++
++  template<typename _BidirectionalIterator, typename _Compare>
++    bool
++    __next_permutation(_BidirectionalIterator __first,
++		       _BidirectionalIterator __last, _Compare __comp)
++    {
++      if (__first == __last)
++	return false;
++      _BidirectionalIterator __i = __first;
++      ++__i;
++      if (__i == __last)
++	return false;
++      __i = __last;
++      --__i;
++
++      for(;;)
++	{
++	  _BidirectionalIterator __ii = __i;
++	  --__i;
++	  if (__comp(__i, __ii))
++	    {
++	      _BidirectionalIterator __j = __last;
++	      while (!__comp(__i, --__j))
++		{}
++	      std::iter_swap(__i, __j);
++	      std::__reverse(__ii, __last,
++			     std::__iterator_category(__first));
++	      return true;
++	    }
++	  if (__i == __first)
++	    {
++	      std::__reverse(__first, __last,
++			     std::__iterator_category(__first));
++	      return false;
++	    }
++	}
++    }
++
++  /**
++   *  @brief  Permute range into the next @e dictionary ordering.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  False if wrapped to first permutation, true otherwise.
++   *
++   *  Treats all permutations of the range as a set of @e dictionary sorted
++   *  sequences.  Permutes the current sequence into the next one of this set.
++   *  Returns true if there are more sequences to generate.  If the sequence
++   *  is the largest of the set, the smallest is generated and false returned.
++  */
++  template<typename _BidirectionalIterator>
++    inline bool
++    next_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__next_permutation
++	(__first, __last, __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Permute range into the next @e dictionary ordering using
++   *          comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   A comparison functor.
++   *  @return  False if wrapped to first permutation, true otherwise.
++   *
++   *  Treats all permutations of the range [__first,__last) as a set of
++   *  @e dictionary sorted sequences ordered by @p __comp.  Permutes the current
++   *  sequence into the next one of this set.  Returns true if there are more
++   *  sequences to generate.  If the sequence is the largest of the set, the
++   *  smallest is generated and false returned.
++  */
++  template<typename _BidirectionalIterator, typename _Compare>
++    inline bool
++    next_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_BidirectionalIterator>::value_type,
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__next_permutation
++	(__first, __last, __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _BidirectionalIterator, typename _Compare>
++    bool
++    __prev_permutation(_BidirectionalIterator __first,
++		       _BidirectionalIterator __last, _Compare __comp)
++    {
++      if (__first == __last)
++	return false;
++      _BidirectionalIterator __i = __first;
++      ++__i;
++      if (__i == __last)
++	return false;
++      __i = __last;
++      --__i;
++
++      for(;;)
++	{
++	  _BidirectionalIterator __ii = __i;
++	  --__i;
++	  if (__comp(__ii, __i))
++	    {
++	      _BidirectionalIterator __j = __last;
++	      while (!__comp(--__j, __i))
++		{}
++	      std::iter_swap(__i, __j);
++	      std::__reverse(__ii, __last,
++			     std::__iterator_category(__first));
++	      return true;
++	    }
++	  if (__i == __first)
++	    {
++	      std::__reverse(__first, __last,
++			     std::__iterator_category(__first));
++	      return false;
++	    }
++	}
++    }
++
++  /**
++   *  @brief  Permute range into the previous @e dictionary ordering.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  False if wrapped to last permutation, true otherwise.
++   *
++   *  Treats all permutations of the range as a set of @e dictionary sorted
++   *  sequences.  Permutes the current sequence into the previous one of this
++   *  set.  Returns true if there are more sequences to generate.  If the
++   *  sequence is the smallest of the set, the largest is generated and false
++   *  returned.
++  */
++  template<typename _BidirectionalIterator>
++    inline bool
++    prev_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__prev_permutation(__first, __last,
++				     __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Permute range into the previous @e dictionary ordering using
++   *          comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   A comparison functor.
++   *  @return  False if wrapped to last permutation, true otherwise.
++   *
++   *  Treats all permutations of the range [__first,__last) as a set of
++   *  @e dictionary sorted sequences ordered by @p __comp.  Permutes the current
++   *  sequence into the previous one of this set.  Returns true if there are
++   *  more sequences to generate.  If the sequence is the smallest of the set,
++   *  the largest is generated and false returned.
++  */
++  template<typename _BidirectionalIterator, typename _Compare>
++    inline bool
++    prev_permutation(_BidirectionalIterator __first,
++		     _BidirectionalIterator __last, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<
++				  _BidirectionalIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_BidirectionalIterator>::value_type,
++	    typename iterator_traits<_BidirectionalIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__prev_permutation(__first, __last,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  // replace
++  // replace_if
++
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate, typename _Tp>
++    _OutputIterator
++    __replace_copy_if(_InputIterator __first, _InputIterator __last,
++		      _OutputIterator __result,
++		      _Predicate __pred, const _Tp& __new_value)
++    {
++      for (; __first != __last; ++__first, ++__result)
++	if (__pred(__first))
++	  *__result = __new_value;
++	else
++	  *__result = *__first;
++      return __result;
++    }
++
++  /**
++   *  @brief Copy a sequence, replacing each element of one value with another
++   *         value.
++   *  @param  __first      An input iterator.
++   *  @param  __last       An input iterator.
++   *  @param  __result     An output iterator.
++   *  @param  __old_value  The value to be replaced.
++   *  @param  __new_value  The replacement value.
++   *  @return   The end of the output sequence, @p result+(last-first).
++   *
++   *  Copies each element in the input range @p [__first,__last) to the
++   *  output range @p [__result,__result+(__last-__first)) replacing elements
++   *  equal to @p __old_value with @p __new_value.
++  */
++  template<typename _InputIterator, typename _OutputIterator, typename _Tp>
++    inline _OutputIterator
++    replace_copy(_InputIterator __first, _InputIterator __last,
++		 _OutputIterator __result,
++		 const _Tp& __old_value, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__replace_copy_if(__first, __last, __result,
++			__gnu_cxx::__ops::__iter_equals_val(__old_value),
++					      __new_value);
++    }
++
++  /**
++   *  @brief Copy a sequence, replacing each value for which a predicate
++   *         returns true with another value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first      An input iterator.
++   *  @param  __last       An input iterator.
++   *  @param  __result     An output iterator.
++   *  @param  __pred       A predicate.
++   *  @param  __new_value  The replacement value.
++   *  @return   The end of the output sequence, @p __result+(__last-__first).
++   *
++   *  Copies each element in the range @p [__first,__last) to the range
++   *  @p [__result,__result+(__last-__first)) replacing elements for which
++   *  @p __pred returns true with @p __new_value.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _Predicate, typename _Tp>
++    inline _OutputIterator
++    replace_copy_if(_InputIterator __first, _InputIterator __last,
++		    _OutputIterator __result,
++		    _Predicate __pred, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__replace_copy_if(__first, __last, __result,
++				__gnu_cxx::__ops::__pred_iter(__pred),
++					      __new_value);
++    }
++
++  template<typename _InputIterator, typename _Predicate>
++    typename iterator_traits<_InputIterator>::difference_type
++    __count_if(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    {
++      typename iterator_traits<_InputIterator>::difference_type __n = 0;
++      for (; __first != __last; ++__first)
++	if (__pred(__first))
++	  ++__n;
++      return __n;
++    }
++
++#if __cplusplus >= 201103L
++  /**
++   *  @brief  Determines whether the elements of a sequence are sorted.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  True if the elements are sorted, false otherwise.
++  */
++  template<typename _ForwardIterator>
++    inline bool
++    is_sorted(_ForwardIterator __first, _ForwardIterator __last)
++    { return std::is_sorted_until(__first, __last) == __last; }
++
++  /**
++   *  @brief  Determines whether the elements of a sequence are sorted
++   *          according to a comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  True if the elements are sorted, false otherwise.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    inline bool
++    is_sorted(_ForwardIterator __first, _ForwardIterator __last,
++	      _Compare __comp)
++    { return std::is_sorted_until(__first, __last, __comp) == __last; }
++
++  template<typename _ForwardIterator, typename _Compare>
++    _ForwardIterator
++    __is_sorted_until(_ForwardIterator __first, _ForwardIterator __last,
++		      _Compare __comp)
++    {
++      if (__first == __last)
++	return __last;
++
++      _ForwardIterator __next = __first;
++      for (++__next; __next != __last; __first = __next, ++__next)
++	if (__comp(__next, __first))
++	  return __next;
++      return __next;
++    }
++
++  /**
++   *  @brief  Determines the end of a sorted sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  An iterator pointing to the last iterator i in [__first, __last)
++   *           for which the range [__first, i) is sorted.
++  */
++  template<typename _ForwardIterator>
++    inline _ForwardIterator
++    is_sorted_until(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__is_sorted_until(__first, __last,
++				    __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Determines the end of a sorted sequence using comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  An iterator pointing to the last iterator i in [__first, __last)
++   *           for which the range [__first, i) is sorted.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    inline _ForwardIterator
++    is_sorted_until(_ForwardIterator __first, _ForwardIterator __last,
++		    _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__is_sorted_until(__first, __last,
++				    __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  /**
++   *  @brief  Determines min and max at once as an ordered pair.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @return A pair(__b, __a) if __b is smaller than __a, pair(__a,
++   *  __b) otherwise.
++  */
++  template<typename _Tp>
++    inline pair<const _Tp&, const _Tp&>
++    minmax(const _Tp& __a, const _Tp& __b)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_LessThanComparableConcept<_Tp>)
++
++      return __b < __a ? pair<const _Tp&, const _Tp&>(__b, __a)
++	               : pair<const _Tp&, const _Tp&>(__a, __b);
++    }
++
++  /**
++   *  @brief  Determines min and max at once as an ordered pair.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @param  __comp  A @link comparison_functors comparison functor @endlink.
++   *  @return A pair(__b, __a) if __b is smaller than __a, pair(__a,
++   *  __b) otherwise.
++  */
++  template<typename _Tp, typename _Compare>
++    inline pair<const _Tp&, const _Tp&>
++    minmax(const _Tp& __a, const _Tp& __b, _Compare __comp)
++    {
++      return __comp(__b, __a) ? pair<const _Tp&, const _Tp&>(__b, __a)
++	                      : pair<const _Tp&, const _Tp&>(__a, __b);
++    }
++
++  template<typename _ForwardIterator, typename _Compare>
++    pair<_ForwardIterator, _ForwardIterator>
++    __minmax_element(_ForwardIterator __first, _ForwardIterator __last,
++		     _Compare __comp)
++    {
++      _ForwardIterator __next = __first;
++      if (__first == __last
++	  || ++__next == __last)
++	return std::make_pair(__first, __first);
++
++      _ForwardIterator __min, __max;
++      if (__comp(__next, __first))
++	{
++	  __min = __next;
++	  __max = __first;
++	}
++      else
++	{
++	  __min = __first;
++	  __max = __next;
++	}
++
++      __first = __next;
++      ++__first;
++
++      while (__first != __last)
++	{
++	  __next = __first;
++	  if (++__next == __last)
++	    {
++	      if (__comp(__first, __min))
++		__min = __first;
++	      else if (!__comp(__first, __max))
++		__max = __first;
++	      break;
++	    }
++
++	  if (__comp(__next, __first))
++	    {
++	      if (__comp(__next, __min))
++		__min = __next;
++	      if (!__comp(__first, __max))
++		__max = __first;
++	    }
++	  else
++	    {
++	      if (__comp(__first, __min))
++		__min = __first;
++	      if (!__comp(__next, __max))
++		__max = __next;
++	    }
++
++	  __first = __next;
++	  ++__first;
++	}
++
++      return std::make_pair(__min, __max);
++    }
++
++  /**
++   *  @brief  Return a pair of iterators pointing to the minimum and maximum
++   *          elements in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  make_pair(m, M), where m is the first iterator i in 
++   *           [__first, __last) such that no other element in the range is
++   *           smaller, and where M is the last iterator i in [__first, __last)
++   *           such that no other element in the range is larger.
++  */
++  template<typename _ForwardIterator>
++    inline pair<_ForwardIterator, _ForwardIterator>
++    minmax_element(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__minmax_element(__first, __last,
++				   __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Return a pair of iterators pointing to the minimum and maximum
++   *          elements in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   Comparison functor.
++   *  @return  make_pair(m, M), where m is the first iterator i in 
++   *           [__first, __last) such that no other element in the range is
++   *           smaller, and where M is the last iterator i in [__first, __last)
++   *           such that no other element in the range is larger.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    inline pair<_ForwardIterator, _ForwardIterator>
++    minmax_element(_ForwardIterator __first, _ForwardIterator __last,
++		   _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__minmax_element(__first, __last,
++				   __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  // N2722 + DR 915.
++  template<typename _Tp>
++    inline _Tp
++    min(initializer_list<_Tp> __l)
++    { return *std::min_element(__l.begin(), __l.end()); }
++
++  template<typename _Tp, typename _Compare>
++    inline _Tp
++    min(initializer_list<_Tp> __l, _Compare __comp)
++    { return *std::min_element(__l.begin(), __l.end(), __comp); }
++
++  template<typename _Tp>
++    inline _Tp
++    max(initializer_list<_Tp> __l)
++    { return *std::max_element(__l.begin(), __l.end()); }
++
++  template<typename _Tp, typename _Compare>
++    inline _Tp
++    max(initializer_list<_Tp> __l, _Compare __comp)
++    { return *std::max_element(__l.begin(), __l.end(), __comp); }
++
++  template<typename _Tp>
++    inline pair<_Tp, _Tp>
++    minmax(initializer_list<_Tp> __l)
++    {
++      pair<const _Tp*, const _Tp*> __p =
++	std::minmax_element(__l.begin(), __l.end());
++      return std::make_pair(*__p.first, *__p.second);
++    }
++
++  template<typename _Tp, typename _Compare>
++    inline pair<_Tp, _Tp>
++    minmax(initializer_list<_Tp> __l, _Compare __comp)
++    {
++      pair<const _Tp*, const _Tp*> __p =
++	std::minmax_element(__l.begin(), __l.end(), __comp);
++      return std::make_pair(*__p.first, *__p.second);
++    }
++
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    bool
++    __is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		     _ForwardIterator2 __first2, _BinaryPredicate __pred)
++    {
++      // Efficiently compare identical prefixes:  O(N) if sequences
++      // have the same elements in the same order.
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	if (!__pred(__first1, __first2))
++	  break;
++
++      if (__first1 == __last1)
++	return true;
++
++      // Establish __last2 assuming equal ranges by iterating over the
++      // rest of the list.
++      _ForwardIterator2 __last2 = __first2;
++      std::advance(__last2, std::distance(__first1, __last1));
++      for (_ForwardIterator1 __scan = __first1; __scan != __last1; ++__scan)
++	{
++	  if (__scan != std::__find_if(__first1, __scan,
++			  __gnu_cxx::__ops::__iter_comp_iter(__pred, __scan)))
++	    continue; // We've seen this one before.
++	  
++	  auto __matches
++	    = std::__count_if(__first2, __last2,
++			__gnu_cxx::__ops::__iter_comp_iter(__pred, __scan));
++	  if (0 == __matches ||
++	      std::__count_if(__scan, __last1,
++			__gnu_cxx::__ops::__iter_comp_iter(__pred, __scan))
++	      != __matches)
++	    return false;
++	}
++      return true;
++    }
++
++  /**
++   *  @brief  Checks whether a permutation of the second sequence is equal
++   *          to the first sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @return true if there exists a permutation of the elements in the range
++   *          [__first2, __first2 + (__last1 - __first1)), beginning with 
++   *          ForwardIterator2 begin, such that equal(__first1, __last1, begin)
++   *          returns true; otherwise, returns false.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    inline bool
++    is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		   _ForwardIterator2 __first2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++		typename iterator_traits<_ForwardIterator1>::value_type,
++		typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      return std::__is_permutation(__first1, __last1, __first2,
++				   __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief  Checks whether a permutation of the second sequence is equal
++   *          to the first sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __pred    A binary predicate.
++   *  @return true if there exists a permutation of the elements in
++   *          the range [__first2, __first2 + (__last1 - __first1)),
++   *          beginning with ForwardIterator2 begin, such that
++   *          equal(__first1, __last1, __begin, __pred) returns true;
++   *          otherwise, returns false.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    inline bool
++    is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		   _ForwardIterator2 __first2, _BinaryPredicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      return std::__is_permutation(__first1, __last1, __first2,
++				   __gnu_cxx::__ops::__iter_comp_iter(__pred));
++    }
++
++#if __cplusplus > 201103L
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    bool
++    __is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		     _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++		     _BinaryPredicate __pred)
++    {
++      using _Cat1
++	= typename iterator_traits<_ForwardIterator1>::iterator_category;
++      using _Cat2
++	= typename iterator_traits<_ForwardIterator2>::iterator_category;
++      using _It1_is_RA = is_same<_Cat1, random_access_iterator_tag>;
++      using _It2_is_RA = is_same<_Cat2, random_access_iterator_tag>;
++      constexpr bool __ra_iters = _It1_is_RA() && _It2_is_RA();
++      if (__ra_iters)
++	{
++	  auto __d1 = std::distance(__first1, __last1);
++	  auto __d2 = std::distance(__first2, __last2);
++	  if (__d1 != __d2)
++	    return false;
++	}
++
++      // Efficiently compare identical prefixes:  O(N) if sequences
++      // have the same elements in the same order.
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	if (!__pred(__first1, __first2))
++	  break;
++
++      if (__ra_iters)
++	{
++	  if (__first1 == __last1)
++	    return true;
++	}
++      else
++	{
++	  auto __d1 = std::distance(__first1, __last1);
++	  auto __d2 = std::distance(__first2, __last2);
++	  if (__d1 == 0 && __d2 == 0)
++	    return true;
++	  if (__d1 != __d2)
++	    return false;
++	}
++
++      for (_ForwardIterator1 __scan = __first1; __scan != __last1; ++__scan)
++	{
++	  if (__scan != std::__find_if(__first1, __scan,
++			__gnu_cxx::__ops::__iter_comp_iter(__pred, __scan)))
++	    continue; // We've seen this one before.
++
++	  auto __matches = std::__count_if(__first2, __last2,
++		__gnu_cxx::__ops::__iter_comp_iter(__pred, __scan));
++	  if (0 == __matches
++	      || std::__count_if(__scan, __last1,
++			__gnu_cxx::__ops::__iter_comp_iter(__pred, __scan))
++	      != __matches)
++	    return false;
++	}
++      return true;
++    }
++
++  /**
++   *  @brief  Checks whether a permutaion of the second sequence is equal
++   *          to the first sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of first range.
++   *  @return true if there exists a permutation of the elements in the range
++   *          [__first2, __last2), beginning with ForwardIterator2 begin,
++   *          such that equal(__first1, __last1, begin) returns true;
++   *          otherwise, returns false.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    inline bool
++    is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		   _ForwardIterator2 __first2, _ForwardIterator2 __last2)
++    {
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return
++	std::__is_permutation(__first1, __last1, __first2, __last2,
++			      __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief  Checks whether a permutation of the second sequence is equal
++   *          to the first sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of first range.
++   *  @param  __pred    A binary predicate.
++   *  @return true if there exists a permutation of the elements in the range
++   *          [__first2, __last2), beginning with ForwardIterator2 begin,
++   *          such that equal(__first1, __last1, __begin, __pred) returns true;
++   *          otherwise, returns false.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    inline bool
++    is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		   _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++		   _BinaryPredicate __pred)
++    {
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__is_permutation(__first1, __last1, __first2, __last2,
++				   __gnu_cxx::__ops::__iter_comp_iter(__pred));
++    }
++#endif
++
++#ifdef _GLIBCXX_USE_C99_STDINT_TR1
++  /**
++   *  @brief Shuffle the elements of a sequence using a uniform random
++   *         number generator.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __g       A UniformRandomNumberGenerator (26.5.1.3).
++   *  @return  Nothing.
++   *
++   *  Reorders the elements in the range @p [__first,__last) using @p __g to
++   *  provide random numbers.
++  */
++  template<typename _RandomAccessIterator,
++	   typename _UniformRandomNumberGenerator>
++    void
++    shuffle(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	    _UniformRandomNumberGenerator&& __g)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return;
++
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      typedef typename std::make_unsigned<_DistanceType>::type __ud_type;
++      typedef typename std::uniform_int_distribution<__ud_type> __distr_type;
++      typedef typename __distr_type::param_type __p_type;
++      __distr_type __d;
++
++      for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	std::iter_swap(__i, __first + __d(__g, __p_type(0, __i - __first)));
++    }
++#endif
++
++#endif // C++11
++
++_GLIBCXX_END_NAMESPACE_VERSION
++
++_GLIBCXX_BEGIN_NAMESPACE_ALGO
++
++  /**
++   *  @brief Apply a function to every element of a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __f      A unary function object.
++   *  @return   @p __f (std::move(@p __f) in C++0x).
++   *
++   *  Applies the function object @p __f to each element in the range
++   *  @p [first,last).  @p __f must not modify the order of the sequence.
++   *  If @p __f has a return value it is ignored.
++  */
++  template<typename _InputIterator, typename _Function>
++    _Function
++    for_each(_InputIterator __first, _InputIterator __last, _Function __f)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++      for (; __first != __last; ++__first)
++	__f(*__first);
++      return _GLIBCXX_MOVE(__f);
++    }
++
++  /**
++   *  @brief Find the first occurrence of a value in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __val    The value to find.
++   *  @return   The first iterator @c i in the range @p [__first,__last)
++   *  such that @c *i == @p __val, or @p __last if no such iterator exists.
++  */
++  template<typename _InputIterator, typename _Tp>
++    inline _InputIterator
++    find(_InputIterator __first, _InputIterator __last,
++	 const _Tp& __val)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++		typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++      return std::__find_if(__first, __last,
++			    __gnu_cxx::__ops::__iter_equals_val(__val));
++    }
++
++  /**
++   *  @brief Find the first element in a sequence for which a
++   *         predicate is true.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return   The first iterator @c i in the range @p [__first,__last)
++   *  such that @p __pred(*i) is true, or @p __last if no such iterator exists.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline _InputIterator
++    find_if(_InputIterator __first, _InputIterator __last,
++	    _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	      typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__find_if(__first, __last,
++			    __gnu_cxx::__ops::__pred_iter(__pred));
++    }
++
++  /**
++   *  @brief  Find element from a set in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of match candidates.
++   *  @param  __last2   End of match candidates.
++   *  @return   The first iterator @c i in the range
++   *  @p [__first1,__last1) such that @c *i == @p *(i2) such that i2 is an
++   *  iterator in [__first2,__last2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for an element that is
++   *  equal to some element in the range [__first2,__last2).  If
++   *  found, returns an iterator in the range [__first1,__last1),
++   *  otherwise returns @p __last1.
++  */
++  template<typename _InputIterator, typename _ForwardIterator>
++    _InputIterator
++    find_first_of(_InputIterator __first1, _InputIterator __last1,
++		  _ForwardIterator __first2, _ForwardIterator __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      for (; __first1 != __last1; ++__first1)
++	for (_ForwardIterator __iter = __first2; __iter != __last2; ++__iter)
++	  if (*__first1 == *__iter)
++	    return __first1;
++      return __last1;
++    }
++
++  /**
++   *  @brief  Find element from a set in a sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  Start of range to search.
++   *  @param  __last1   End of range to search.
++   *  @param  __first2  Start of match candidates.
++   *  @param  __last2   End of match candidates.
++   *  @param  __comp    Predicate to use.
++   *  @return   The first iterator @c i in the range
++   *  @p [__first1,__last1) such that @c comp(*i, @p *(i2)) is true
++   *  and i2 is an iterator in [__first2,__last2), or @p __last1 if no
++   *  such iterator exists.
++   *
++
++   *  Searches the range @p [__first1,__last1) for an element that is
++   *  equal to some element in the range [__first2,__last2).  If
++   *  found, returns an iterator in the range [__first1,__last1),
++   *  otherwise returns @p __last1.
++  */
++  template<typename _InputIterator, typename _ForwardIterator,
++	   typename _BinaryPredicate>
++    _InputIterator
++    find_first_of(_InputIterator __first1, _InputIterator __last1,
++		  _ForwardIterator __first2, _ForwardIterator __last2,
++		  _BinaryPredicate __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_InputIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      for (; __first1 != __last1; ++__first1)
++	for (_ForwardIterator __iter = __first2; __iter != __last2; ++__iter)
++	  if (__comp(*__first1, *__iter))
++	    return __first1;
++      return __last1;
++    }
++
++  /**
++   *  @brief Find two adjacent values in a sequence that are equal.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @return   The first iterator @c i such that @c i and @c i+1 are both
++   *  valid iterators in @p [__first,__last) and such that @c *i == @c *(i+1),
++   *  or @p __last if no such iterator exists.
++  */
++  template<typename _ForwardIterator>
++    inline _ForwardIterator
++    adjacent_find(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_EqualityComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__adjacent_find(__first, __last,
++				  __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief Find two adjacent values in a sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first         A forward iterator.
++   *  @param  __last          A forward iterator.
++   *  @param  __binary_pred   A binary predicate.
++   *  @return   The first iterator @c i such that @c i and @c i+1 are both
++   *  valid iterators in @p [__first,__last) and such that
++   *  @p __binary_pred(*i,*(i+1)) is true, or @p __last if no such iterator
++   *  exists.
++  */
++  template<typename _ForwardIterator, typename _BinaryPredicate>
++    inline _ForwardIterator
++    adjacent_find(_ForwardIterator __first, _ForwardIterator __last,
++		  _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__adjacent_find(__first, __last,
++			__gnu_cxx::__ops::__iter_comp_iter(__binary_pred));
++    }
++
++  /**
++   *  @brief Count the number of copies of a value in a sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __value  The value to be counted.
++   *  @return   The number of iterators @c i in the range @p [__first,__last)
++   *  for which @c *i == @p __value
++  */
++  template<typename _InputIterator, typename _Tp>
++    inline typename iterator_traits<_InputIterator>::difference_type
++    count(_InputIterator __first, _InputIterator __last, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__count_if(__first, __last,
++			     __gnu_cxx::__ops::__iter_equals_val(__value));
++    }
++
++  /**
++   *  @brief Count the elements of a sequence for which a predicate is true.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __pred   A predicate.
++   *  @return   The number of iterators @c i in the range @p [__first,__last)
++   *  for which @p __pred(*i) is true.
++  */
++  template<typename _InputIterator, typename _Predicate>
++    inline typename iterator_traits<_InputIterator>::difference_type
++    count_if(_InputIterator __first, _InputIterator __last, _Predicate __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__count_if(__first, __last,
++			     __gnu_cxx::__ops::__pred_iter(__pred));
++    }
++
++  /**
++   *  @brief Search a sequence for a matching sub-sequence.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  A forward iterator.
++   *  @param  __last1   A forward iterator.
++   *  @param  __first2  A forward iterator.
++   *  @param  __last2   A forward iterator.
++   *  @return The first iterator @c i in the range @p
++   *  [__first1,__last1-(__last2-__first2)) such that @c *(i+N) == @p
++   *  *(__first2+N) for each @c N in the range @p
++   *  [0,__last2-__first2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2) and returns an iterator to the first element
++   *  of the sub-sequence, or @p __last1 if the sub-sequence is not
++   *  found.
++   *
++   *  Because the sub-sequence must lie completely within the range @p
++   *  [__first1,__last1) it must start at a position less than @p
++   *  __last1-(__last2-__first2) where @p __last2-__first2 is the
++   *  length of the sub-sequence.
++   *
++   *  This means that the returned iterator @c i will be in the range
++   *  @p [__first1,__last1-(__last2-__first2))
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    inline _ForwardIterator1
++    search(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	   _ForwardIterator2 __first2, _ForwardIterator2 __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__search(__first1, __last1, __first2, __last2,
++			   __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief Search a sequence for a matching sub-sequence using a predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1     A forward iterator.
++   *  @param  __last1      A forward iterator.
++   *  @param  __first2     A forward iterator.
++   *  @param  __last2      A forward iterator.
++   *  @param  __predicate  A binary predicate.
++   *  @return   The first iterator @c i in the range
++   *  @p [__first1,__last1-(__last2-__first2)) such that
++   *  @p __predicate(*(i+N),*(__first2+N)) is true for each @c N in the range
++   *  @p [0,__last2-__first2), or @p __last1 if no such iterator exists.
++   *
++   *  Searches the range @p [__first1,__last1) for a sub-sequence that
++   *  compares equal value-by-value with the sequence given by @p
++   *  [__first2,__last2), using @p __predicate to determine equality,
++   *  and returns an iterator to the first element of the
++   *  sub-sequence, or @p __last1 if no such iterator exists.
++   *
++   *  @see search(_ForwardIter1, _ForwardIter1, _ForwardIter2, _ForwardIter2)
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2,
++	   typename _BinaryPredicate>
++    inline _ForwardIterator1
++    search(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++	   _ForwardIterator2 __first2, _ForwardIterator2 __last2,
++	   _BinaryPredicate  __predicate)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator1>)
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator2>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator1>::value_type,
++	    typename iterator_traits<_ForwardIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__search(__first1, __last1, __first2, __last2,
++			   __gnu_cxx::__ops::__iter_comp_iter(__predicate));
++    }
++
++  /**
++   *  @brief Search a sequence for a number of consecutive values.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __count  The number of consecutive values.
++   *  @param  __val    The value to find.
++   *  @return The first iterator @c i in the range @p
++   *  [__first,__last-__count) such that @c *(i+N) == @p __val for
++   *  each @c N in the range @p [0,__count), or @p __last if no such
++   *  iterator exists.
++   *
++   *  Searches the range @p [__first,__last) for @p count consecutive elements
++   *  equal to @p __val.
++  */
++  template<typename _ForwardIterator, typename _Integer, typename _Tp>
++    inline _ForwardIterator
++    search_n(_ForwardIterator __first, _ForwardIterator __last,
++	     _Integer __count, const _Tp& __val)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__search_n(__first, __last, __count,
++			     __gnu_cxx::__ops::__iter_equals_val(__val));
++    }
++
++
++  /**
++   *  @brief Search a sequence for a number of consecutive values using a
++   *         predicate.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first        A forward iterator.
++   *  @param  __last         A forward iterator.
++   *  @param  __count        The number of consecutive values.
++   *  @param  __val          The value to find.
++   *  @param  __binary_pred  A binary predicate.
++   *  @return The first iterator @c i in the range @p
++   *  [__first,__last-__count) such that @p
++   *  __binary_pred(*(i+N),__val) is true for each @c N in the range
++   *  @p [0,__count), or @p __last if no such iterator exists.
++   *
++   *  Searches the range @p [__first,__last) for @p __count
++   *  consecutive elements for which the predicate returns true.
++  */
++  template<typename _ForwardIterator, typename _Integer, typename _Tp,
++           typename _BinaryPredicate>
++    inline _ForwardIterator
++    search_n(_ForwardIterator __first, _ForwardIterator __last,
++	     _Integer __count, const _Tp& __val,
++	     _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_BinaryPredicate,
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__search_n(__first, __last, __count,
++		__gnu_cxx::__ops::__iter_comp_val(__binary_pred, __val));
++    }
++
++
++  /**
++   *  @brief Perform an operation on a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first     An input iterator.
++   *  @param  __last      An input iterator.
++   *  @param  __result    An output iterator.
++   *  @param  __unary_op  A unary operator.
++   *  @return   An output iterator equal to @p __result+(__last-__first).
++   *
++   *  Applies the operator to each element in the input range and assigns
++   *  the results to successive elements of the output sequence.
++   *  Evaluates @p *(__result+N)=unary_op(*(__first+N)) for each @c N in the
++   *  range @p [0,__last-__first).
++   *
++   *  @p unary_op must not alter its argument.
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _UnaryOperation>
++    _OutputIterator
++    transform(_InputIterator __first, _InputIterator __last,
++	      _OutputIterator __result, _UnaryOperation __unary_op)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++            // "the type returned by a _UnaryOperation"
++            __typeof__(__unary_op(*__first))>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first, ++__result)
++	*__result = __unary_op(*__first);
++      return __result;
++    }
++
++  /**
++   *  @brief Perform an operation on corresponding elements of two sequences.
++   *  @ingroup mutating_algorithms
++   *  @param  __first1     An input iterator.
++   *  @param  __last1      An input iterator.
++   *  @param  __first2     An input iterator.
++   *  @param  __result     An output iterator.
++   *  @param  __binary_op  A binary operator.
++   *  @return   An output iterator equal to @p result+(last-first).
++   *
++   *  Applies the operator to the corresponding elements in the two
++   *  input ranges and assigns the results to successive elements of the
++   *  output sequence.
++   *  Evaluates @p
++   *  *(__result+N)=__binary_op(*(__first1+N),*(__first2+N)) for each
++   *  @c N in the range @p [0,__last1-__first1).
++   *
++   *  @p binary_op must not alter either of its arguments.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _BinaryOperation>
++    _OutputIterator
++    transform(_InputIterator1 __first1, _InputIterator1 __last1,
++	      _InputIterator2 __first2, _OutputIterator __result,
++	      _BinaryOperation __binary_op)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++            // "the type returned by a _BinaryOperation"
++            __typeof__(__binary_op(*__first1,*__first2))>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      for (; __first1 != __last1; ++__first1, ++__first2, ++__result)
++	*__result = __binary_op(*__first1, *__first2);
++      return __result;
++    }
++
++  /**
++   *  @brief Replace each occurrence of one value in a sequence with another
++   *         value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first      A forward iterator.
++   *  @param  __last       A forward iterator.
++   *  @param  __old_value  The value to be replaced.
++   *  @param  __new_value  The replacement value.
++   *  @return   replace() returns no value.
++   *
++   *  For each iterator @c i in the range @p [__first,__last) if @c *i ==
++   *  @p __old_value then the assignment @c *i = @p __new_value is performed.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    void
++    replace(_ForwardIterator __first, _ForwardIterator __last,
++	    const _Tp& __old_value, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_function_requires(_ConvertibleConcept<_Tp,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (*__first == __old_value)
++	  *__first = __new_value;
++    }
++
++  /**
++   *  @brief Replace each value in a sequence for which a predicate returns
++   *         true with another value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first      A forward iterator.
++   *  @param  __last       A forward iterator.
++   *  @param  __pred       A predicate.
++   *  @param  __new_value  The replacement value.
++   *  @return   replace_if() returns no value.
++   *
++   *  For each iterator @c i in the range @p [__first,__last) if @p __pred(*i)
++   *  is true then the assignment @c *i = @p __new_value is performed.
++  */
++  template<typename _ForwardIterator, typename _Predicate, typename _Tp>
++    void
++    replace_if(_ForwardIterator __first, _ForwardIterator __last,
++	       _Predicate __pred, const _Tp& __new_value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_ConvertibleConcept<_Tp,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	if (__pred(*__first))
++	  *__first = __new_value;
++    }
++
++  /**
++   *  @brief Assign the result of a function object to each value in a
++   *         sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __gen    A function object taking no arguments and returning
++   *                 std::iterator_traits<_ForwardIterator>::value_type
++   *  @return   generate() returns no value.
++   *
++   *  Performs the assignment @c *i = @p __gen() for each @c i in the range
++   *  @p [__first,__last).
++  */
++  template<typename _ForwardIterator, typename _Generator>
++    void
++    generate(_ForwardIterator __first, _ForwardIterator __last,
++	     _Generator __gen)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_GeneratorConcept<_Generator,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      for (; __first != __last; ++__first)
++	*__first = __gen();
++    }
++
++  /**
++   *  @brief Assign the result of a function object to each value in a
++   *         sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __n      The length of the sequence.
++   *  @param  __gen    A function object taking no arguments and returning
++   *                 std::iterator_traits<_ForwardIterator>::value_type
++   *  @return   The end of the sequence, @p __first+__n
++   *
++   *  Performs the assignment @c *i = @p __gen() for each @c i in the range
++   *  @p [__first,__first+__n).
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 865. More algorithms that throw away information
++  */
++  template<typename _OutputIterator, typename _Size, typename _Generator>
++    _OutputIterator
++    generate_n(_OutputIterator __first, _Size __n, _Generator __gen)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++            // "the type returned by a _Generator"
++            __typeof__(__gen())>)
++
++      for (; __n > 0; --__n, ++__first)
++	*__first = __gen();
++      return __first;
++    }
++
++  /**
++   *  @brief Copy a sequence, removing consecutive duplicate values.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   An input iterator.
++   *  @param  __last    An input iterator.
++   *  @param  __result  An output iterator.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) to the range
++   *  beginning at @p __result, except that only the first element is copied
++   *  from groups of consecutive elements that compare equal.
++   *  unique_copy() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 241. Does unique_copy() require CopyConstructible and Assignable?
++   *  
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 538. 241 again: Does unique_copy() require CopyConstructible and 
++   *  Assignable?
++  */
++  template<typename _InputIterator, typename _OutputIterator>
++    inline _OutputIterator
++    unique_copy(_InputIterator __first, _InputIterator __last,
++		_OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_function_requires(_EqualityComparableConcept<
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __result;
++      return std::__unique_copy(__first, __last, __result,
++				__gnu_cxx::__ops::__iter_equal_to_iter(),
++				std::__iterator_category(__first),
++				std::__iterator_category(__result));
++    }
++
++  /**
++   *  @brief Copy a sequence, removing consecutive values using a predicate.
++   *  @ingroup mutating_algorithms
++   *  @param  __first        An input iterator.
++   *  @param  __last         An input iterator.
++   *  @param  __result       An output iterator.
++   *  @param  __binary_pred  A binary predicate.
++   *  @return   An iterator designating the end of the resulting sequence.
++   *
++   *  Copies each element in the range @p [__first,__last) to the range
++   *  beginning at @p __result, except that only the first element is copied
++   *  from groups of consecutive elements for which @p __binary_pred returns
++   *  true.
++   *  unique_copy() is stable, so the relative order of elements that are
++   *  copied is unchanged.
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 241. Does unique_copy() require CopyConstructible and Assignable?
++  */
++  template<typename _InputIterator, typename _OutputIterator,
++	   typename _BinaryPredicate>
++    inline _OutputIterator
++    unique_copy(_InputIterator __first, _InputIterator __last,
++		_OutputIterator __result,
++		_BinaryPredicate __binary_pred)
++    {
++      // concept requirements -- predicates checked later
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return __result;
++      return std::__unique_copy(__first, __last, __result,
++			__gnu_cxx::__ops::__iter_comp_iter(__binary_pred),
++				std::__iterator_category(__first),
++				std::__iterator_category(__result));
++    }
++
++  /**
++   *  @brief Randomly shuffle the elements of a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @return  Nothing.
++   *
++   *  Reorder the elements in the range @p [__first,__last) using a random
++   *  distribution, so that every possible ordering of the sequence is
++   *  equally likely.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    random_shuffle(_RandomAccessIterator __first, _RandomAccessIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first != __last)
++	for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	  std::iter_swap(__i, __first + (std::rand() % ((__i - __first) + 1)));
++    }
++
++  /**
++   *  @brief Shuffle the elements of a sequence using a random number
++   *         generator.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __rand    The RNG functor or function.
++   *  @return  Nothing.
++   *
++   *  Reorders the elements in the range @p [__first,__last) using @p __rand to
++   *  provide a random distribution. Calling @p __rand(N) for a positive
++   *  integer @p N should return a randomly chosen integer from the
++   *  range [0,N).
++  */
++  template<typename _RandomAccessIterator, typename _RandomNumberGenerator>
++    void
++    random_shuffle(_RandomAccessIterator __first, _RandomAccessIterator __last,
++#if __cplusplus >= 201103L
++		   _RandomNumberGenerator&& __rand)
++#else
++		   _RandomNumberGenerator& __rand)
++#endif
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      if (__first == __last)
++	return;
++      for (_RandomAccessIterator __i = __first + 1; __i != __last; ++__i)
++	std::iter_swap(__i, __first + __rand((__i - __first) + 1));
++    }
++
++
++  /**
++   *  @brief Move elements for which a predicate is true to the beginning
++   *         of a sequence.
++   *  @ingroup mutating_algorithms
++   *  @param  __first   A forward iterator.
++   *  @param  __last    A forward iterator.
++   *  @param  __pred    A predicate functor.
++   *  @return  An iterator @p middle such that @p __pred(i) is true for each
++   *  iterator @p i in the range @p [__first,middle) and false for each @p i
++   *  in the range @p [middle,__last).
++   *
++   *  @p __pred must not modify its operand. @p partition() does not preserve
++   *  the relative ordering of elements in each group, use
++   *  @p stable_partition() if this is needed.
++  */
++  template<typename _ForwardIterator, typename _Predicate>
++    inline _ForwardIterator
++    partition(_ForwardIterator __first, _ForwardIterator __last,
++	      _Predicate   __pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_function_requires(_UnaryPredicateConcept<_Predicate,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__partition(__first, __last, __pred,
++			      std::__iterator_category(__first));
++    }
++
++
++  /**
++   *  @brief Sort the smallest elements of a sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Sorts the smallest @p (__middle-__first) elements in the range
++   *  @p [first,last) and moves them to the range @p [__first,__middle). The
++   *  order of the remaining elements in the range @p [__middle,__last) is
++   *  undefined.
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__first,__middle) such that i precedes j and @e k is an iterator in
++   *  the range @p [__middle,__last) then *j<*i and *k<*i are both false.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    partial_sort(_RandomAccessIterator __first,
++		 _RandomAccessIterator __middle,
++		 _RandomAccessIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      std::__partial_sort(__first, __middle, __last,
++			  __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Sort the smallest elements of a sequence using a predicate
++   *         for comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __middle  Another iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Sorts the smallest @p (__middle-__first) elements in the range
++   *  @p [__first,__last) and moves them to the range @p [__first,__middle). The
++   *  order of the remaining elements in the range @p [__middle,__last) is
++   *  undefined.
++   *  After the sort if @e i and @e j are iterators in the range
++   *  @p [__first,__middle) such that i precedes j and @e k is an iterator in
++   *  the range @p [__middle,__last) then @p *__comp(j,*i) and @p __comp(*k,*i)
++   *  are both false.
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    partial_sort(_RandomAccessIterator __first,
++		 _RandomAccessIterator __middle,
++		 _RandomAccessIterator __last,
++		 _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_RandomAccessIterator>::value_type,
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __middle);
++      __glibcxx_requires_valid_range(__middle, __last);
++
++      std::__partial_sort(__first, __middle, __last,
++			  __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  /**
++   *  @brief Sort a sequence just enough to find a particular position.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __nth     Another iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Rearranges the elements in the range @p [__first,__last) so that @p *__nth
++   *  is the same element that would have been in that position had the
++   *  whole sequence been sorted. The elements either side of @p *__nth are
++   *  not completely sorted, but for any iterator @e i in the range
++   *  @p [__first,__nth) and any iterator @e j in the range @p [__nth,__last) it
++   *  holds that *j < *i is false.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth,
++		_RandomAccessIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __nth);
++      __glibcxx_requires_valid_range(__nth, __last);
++
++      if (__first == __last || __nth == __last)
++	return;
++
++      std::__introselect(__first, __nth, __last,
++			 std::__lg(__last - __first) * 2,
++			 __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Sort a sequence just enough to find a particular position
++   *         using a predicate for comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __nth     Another iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Rearranges the elements in the range @p [__first,__last) so that @p *__nth
++   *  is the same element that would have been in that position had the
++   *  whole sequence been sorted. The elements either side of @p *__nth are
++   *  not completely sorted, but for any iterator @e i in the range
++   *  @p [__first,__nth) and any iterator @e j in the range @p [__nth,__last) it
++   *  holds that @p __comp(*j,*i) is false.
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth,
++		_RandomAccessIterator __last, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++				  _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_RandomAccessIterator>::value_type,
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __nth);
++      __glibcxx_requires_valid_range(__nth, __last);
++
++      if (__first == __last || __nth == __last)
++	return;
++
++      std::__introselect(__first, __nth, __last,
++			 std::__lg(__last - __first) * 2,
++			 __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  /**
++   *  @brief Sort the elements of a sequence.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that for each iterator @e i in the range @p [__first,__last-1),  
++   *  *(i+1)<*i is false.
++   *
++   *  The relative ordering of equivalent elements is not preserved, use
++   *  @p stable_sort() if this is needed.
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    sort(_RandomAccessIterator __first, _RandomAccessIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      std::__sort(__first, __last, __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Sort the elements of a sequence using a predicate for comparison.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that @p __comp(*(i+1),*i) is false for every iterator @e i in the
++   *  range @p [__first,__last-1).
++   *
++   *  The relative ordering of equivalent elements is not preserved, use
++   *  @p stable_sort() if this is needed.
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    sort(_RandomAccessIterator __first, _RandomAccessIterator __last,
++	 _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_RandomAccessIterator>::value_type,
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      std::__sort(__first, __last, __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    _OutputIterator
++    __merge(_InputIterator1 __first1, _InputIterator1 __last1,
++	    _InputIterator2 __first2, _InputIterator2 __last2,
++	    _OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(__first2, __first1))
++	    {
++	      *__result = *__first2;
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	    }
++	  ++__result;
++	}
++      return std::copy(__first2, __last2,
++		       std::copy(__first1, __last1, __result));
++    }
++
++  /**
++   *  @brief Merges two sorted ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An iterator.
++   *  @param  __first2  Another iterator.
++   *  @param  __last1   Another iterator.
++   *  @param  __last2   Another iterator.
++   *  @param  __result  An iterator pointing to the end of the merged range.
++   *  @return         An iterator pointing to the first element <em>not less
++   *                  than</em> @e val.
++   *
++   *  Merges the ranges @p [__first1,__last1) and @p [__first2,__last2) into
++   *  the sorted range @p [__result, __result + (__last1-__first1) +
++   *  (__last2-__first2)).  Both input ranges must be sorted, and the
++   *  output range must not overlap with either of the input ranges.
++   *  The sort is @e stable, that is, for equivalent elements in the
++   *  two ranges, elements from the first range will always come
++   *  before elements from the second.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    inline _OutputIterator
++    merge(_InputIterator1 __first1, _InputIterator1 __last1,
++	  _InputIterator2 __first2, _InputIterator2 __last2,
++	  _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)	
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      return _GLIBCXX_STD_A::__merge(__first1, __last1,
++				     __first2, __last2, __result,
++				     __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Merges two sorted ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An iterator.
++   *  @param  __first2  Another iterator.
++   *  @param  __last1   Another iterator.
++   *  @param  __last2   Another iterator.
++   *  @param  __result  An iterator pointing to the end of the merged range.
++   *  @param  __comp    A functor to use for comparisons.
++   *  @return         An iterator pointing to the first element "not less
++   *                  than" @e val.
++   *
++   *  Merges the ranges @p [__first1,__last1) and @p [__first2,__last2) into
++   *  the sorted range @p [__result, __result + (__last1-__first1) +
++   *  (__last2-__first2)).  Both input ranges must be sorted, and the
++   *  output range must not overlap with either of the input ranges.
++   *  The sort is @e stable, that is, for equivalent elements in the
++   *  two ranges, elements from the first range will always come
++   *  before elements from the second.
++   *
++   *  The comparison function should have the same effects on ordering as
++   *  the function used for the initial sort.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    inline _OutputIterator
++    merge(_InputIterator1 __first1, _InputIterator1 __last1,
++	  _InputIterator2 __first2, _InputIterator2 __last2,
++	  _OutputIterator __result, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      return _GLIBCXX_STD_A::__merge(__first1, __last1,
++				__first2, __last2, __result,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    __stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last,
++		  _Compare __comp)
++    {
++      typedef typename iterator_traits<_RandomAccessIterator>::value_type
++	_ValueType;
++      typedef typename iterator_traits<_RandomAccessIterator>::difference_type
++	_DistanceType;
++
++      typedef _Temporary_buffer<_RandomAccessIterator, _ValueType> _TmpBuf;
++      _TmpBuf __buf(__first, __last);
++
++      if (__buf.begin() == 0)
++	std::__inplace_stable_sort(__first, __last, __comp);
++      else
++	std::__stable_sort_adaptive(__first, __last, __buf.begin(),
++				    _DistanceType(__buf.size()), __comp);
++    }
++
++  /**
++   *  @brief Sort the elements of a sequence, preserving the relative order
++   *         of equivalent elements.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that for each iterator @p i in the range @p [__first,__last-1),
++   *  @p *(i+1)<*i is false.
++   *
++   *  The relative ordering of equivalent elements is preserved, so any two
++   *  elements @p x and @p y in the range @p [__first,__last) such that
++   *  @p x<y is false and @p y<x is false will have the same relative
++   *  ordering after calling @p stable_sort().
++  */
++  template<typename _RandomAccessIterator>
++    inline void
++    stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      _GLIBCXX_STD_A::__stable_sort(__first, __last,
++				    __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Sort the elements of a sequence using a predicate for comparison,
++   *         preserving the relative order of equivalent elements.
++   *  @ingroup sorting_algorithms
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __comp    A comparison functor.
++   *  @return  Nothing.
++   *
++   *  Sorts the elements in the range @p [__first,__last) in ascending order,
++   *  such that for each iterator @p i in the range @p [__first,__last-1),
++   *  @p __comp(*(i+1),*i) is false.
++   *
++   *  The relative ordering of equivalent elements is preserved, so any two
++   *  elements @p x and @p y in the range @p [__first,__last) such that
++   *  @p __comp(x,y) is false and @p __comp(y,x) is false will have the same
++   *  relative ordering after calling @p stable_sort().
++  */
++  template<typename _RandomAccessIterator, typename _Compare>
++    inline void
++    stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last,
++		_Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_RandomAccessIteratorConcept<
++	    _RandomAccessIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_RandomAccessIterator>::value_type,
++	    typename iterator_traits<_RandomAccessIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      _GLIBCXX_STD_A::__stable_sort(__first, __last,
++				    __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator,
++	   typename _Compare>
++    _OutputIterator
++    __set_union(_InputIterator1 __first1, _InputIterator1 __last1,
++		_InputIterator2 __first2, _InputIterator2 __last2,
++		_OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	{
++	  if (__comp(__first1, __first2))
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	    }
++	  else if (__comp(__first2, __first1))
++	    {
++	      *__result = *__first2;
++	      ++__first2;
++	    }
++	  else
++	    {
++	      *__result = *__first1;
++	      ++__first1;
++	      ++__first2;
++	    }
++	  ++__result;
++	}
++      return std::copy(__first2, __last2,
++		       std::copy(__first1, __last1, __result));
++    }
++
++  /**
++   *  @brief Return the union of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  each range in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other,
++   *  that element is copied and the iterator advanced.  If an element is
++   *  contained in both ranges, the element from the first range is copied and
++   *  both ranges advance.  The output range may not overlap either input
++   *  range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    inline _OutputIterator
++    set_union(_InputIterator1 __first1, _InputIterator1 __last1,
++	      _InputIterator2 __first2, _InputIterator2 __last2,
++	      _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      return _GLIBCXX_STD_A::__set_union(__first1, __last1,
++				__first2, __last2, __result,
++				__gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Return the union of two sorted ranges using a comparison functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  each range in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other
++   *  according to @p __comp, that element is copied and the iterator advanced.
++   *  If an equivalent element according to @p __comp is contained in both
++   *  ranges, the element from the first range is copied and both ranges
++   *  advance.  The output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    inline _OutputIterator
++    set_union(_InputIterator1 __first1, _InputIterator1 __last1,
++	      _InputIterator2 __first2, _InputIterator2 __last2,
++	      _OutputIterator __result, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      return _GLIBCXX_STD_A::__set_union(__first1, __last1,
++				__first2, __last2, __result,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator,
++	   typename _Compare>
++    _OutputIterator
++    __set_intersection(_InputIterator1 __first1, _InputIterator1 __last1,
++		       _InputIterator2 __first2, _InputIterator2 __last2,
++		       _OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(__first1, __first2))
++	  ++__first1;
++	else if (__comp(__first2, __first1))
++	  ++__first2;
++	else
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__first2;
++	    ++__result;
++	  }
++      return __result;
++    }
++
++  /**
++   *  @brief Return the intersection of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  both ranges in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other,
++   *  that iterator advances.  If an element is contained in both ranges, the
++   *  element from the first range is copied and both ranges advance.  The
++   *  output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    inline _OutputIterator
++    set_intersection(_InputIterator1 __first1, _InputIterator1 __last1,
++		     _InputIterator2 __first2, _InputIterator2 __last2,
++		     _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      return _GLIBCXX_STD_A::__set_intersection(__first1, __last1,
++				     __first2, __last2, __result,
++				     __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief Return the intersection of two sorted ranges using comparison
++   *  functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  both ranges in order to the output range.  Iterators increment for each
++   *  range.  When the current element of one range is less than the other
++   *  according to @p __comp, that iterator advances.  If an element is
++   *  contained in both ranges according to @p __comp, the element from the
++   *  first range is copied and both ranges advance.  The output range may not
++   *  overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    inline _OutputIterator
++    set_intersection(_InputIterator1 __first1, _InputIterator1 __last1,
++		     _InputIterator2 __first2, _InputIterator2 __last2,
++		     _OutputIterator __result, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      return _GLIBCXX_STD_A::__set_intersection(__first1, __last1,
++				__first2, __last2, __result,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator,
++	   typename _Compare>
++    _OutputIterator
++    __set_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++		     _InputIterator2 __first2, _InputIterator2 __last2,
++		     _OutputIterator __result, _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(__first1, __first2))
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__result;
++	  }
++	else if (__comp(__first2, __first1))
++	  ++__first2;
++	else
++	  {
++	    ++__first1;
++	    ++__first2;
++	  }
++      return std::copy(__first1, __last1, __result);
++    }
++
++  /**
++   *  @brief Return the difference of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  the first range but not the second in order to the output range.
++   *  Iterators increment for each range.  When the current element of the
++   *  first range is less than the second, that element is copied and the
++   *  iterator advances.  If the current element of the second range is less,
++   *  the iterator advances, but no element is copied.  If an element is
++   *  contained in both ranges, no elements are copied and both ranges
++   *  advance.  The output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    inline _OutputIterator
++    set_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++		   _InputIterator2 __first2, _InputIterator2 __last2,
++		   _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)	
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      return _GLIBCXX_STD_A::__set_difference(__first1, __last1,
++				   __first2, __last2, __result,
++				   __gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Return the difference of two sorted ranges using comparison
++   *  functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  the first range but not the second in order to the output range.
++   *  Iterators increment for each range.  When the current element of the
++   *  first range is less than the second according to @p __comp, that element
++   *  is copied and the iterator advances.  If the current element of the
++   *  second range is less, no element is copied and the iterator advances.
++   *  If an element is contained in both ranges according to @p __comp, no
++   *  elements are copied and both ranges advance.  The output range may not
++   *  overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    inline _OutputIterator
++    set_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++		   _InputIterator2 __first2, _InputIterator2 __last2,
++		   _OutputIterator __result, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      return _GLIBCXX_STD_A::__set_difference(__first1, __last1,
++				   __first2, __last2, __result,
++				   __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator,
++	   typename _Compare>
++    _OutputIterator
++    __set_symmetric_difference(_InputIterator1 __first1,
++			       _InputIterator1 __last1,
++			       _InputIterator2 __first2,
++			       _InputIterator2 __last2,
++			       _OutputIterator __result,
++			       _Compare __comp)
++    {
++      while (__first1 != __last1 && __first2 != __last2)
++	if (__comp(__first1, __first2))
++	  {
++	    *__result = *__first1;
++	    ++__first1;
++	    ++__result;
++	  }
++	else if (__comp(__first2, __first1))
++	  {
++	    *__result = *__first2;
++	    ++__first2;
++	    ++__result;
++	  }
++	else
++	  {
++	    ++__first1;
++	    ++__first2;
++	  }
++      return std::copy(__first2, __last2, 
++		       std::copy(__first1, __last1, __result));
++    }
++
++  /**
++   *  @brief  Return the symmetric difference of two sorted ranges.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  one range but not the other in order to the output range.  Iterators
++   *  increment for each range.  When the current element of one range is less
++   *  than the other, that element is copied and the iterator advances.  If an
++   *  element is contained in both ranges, no elements are copied and both
++   *  ranges advance.  The output range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator>
++    inline _OutputIterator
++    set_symmetric_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++			     _InputIterator2 __first2, _InputIterator2 __last2,
++			     _OutputIterator __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)	
++      __glibcxx_requires_sorted_set(__first1, __last1, __first2);
++      __glibcxx_requires_sorted_set(__first2, __last2, __first1);
++
++      return _GLIBCXX_STD_A::__set_symmetric_difference(__first1, __last1,
++					__first2, __last2, __result,
++					__gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Return the symmetric difference of two sorted ranges using
++   *  comparison functor.
++   *  @ingroup set_algorithms
++   *  @param  __first1  Start of first range.
++   *  @param  __last1   End of first range.
++   *  @param  __first2  Start of second range.
++   *  @param  __last2   End of second range.
++   *  @param  __comp    The comparison functor.
++   *  @return  End of the output range.
++   *  @ingroup set_algorithms
++   *
++   *  This operation iterates over both ranges, copying elements present in
++   *  one range but not the other in order to the output range.  Iterators
++   *  increment for each range.  When the current element of one range is less
++   *  than the other according to @p comp, that element is copied and the
++   *  iterator advances.  If an element is contained in both ranges according
++   *  to @p __comp, no elements are copied and both ranges advance.  The output
++   *  range may not overlap either input range.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _OutputIterator, typename _Compare>
++    inline _OutputIterator
++    set_symmetric_difference(_InputIterator1 __first1, _InputIterator1 __last1,
++			     _InputIterator2 __first2, _InputIterator2 __last2,
++			     _OutputIterator __result,
++			     _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_InputIterator2>::value_type,
++	    typename iterator_traits<_InputIterator1>::value_type>)
++      __glibcxx_requires_sorted_set_pred(__first1, __last1, __first2, __comp);
++      __glibcxx_requires_sorted_set_pred(__first2, __last2, __first1, __comp);
++
++      return _GLIBCXX_STD_A::__set_symmetric_difference(__first1, __last1,
++				__first2, __last2, __result,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _ForwardIterator, typename _Compare>
++    _ForwardIterator
++    __min_element(_ForwardIterator __first, _ForwardIterator __last,
++		  _Compare __comp)
++    {
++      if (__first == __last)
++	return __first;
++      _ForwardIterator __result = __first;
++      while (++__first != __last)
++	if (__comp(__first, __result))
++	  __result = __first;
++      return __result;
++    }
++
++  /**
++   *  @brief  Return the minimum element in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  Iterator referencing the first instance of the smallest value.
++  */
++  template<typename _ForwardIterator>
++    _ForwardIterator
++    inline min_element(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return _GLIBCXX_STD_A::__min_element(__first, __last,
++				__gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Return the minimum element in a range using comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   Comparison functor.
++   *  @return  Iterator referencing the first instance of the smallest value
++   *  according to __comp.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    inline _ForwardIterator
++    min_element(_ForwardIterator __first, _ForwardIterator __last,
++		_Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return _GLIBCXX_STD_A::__min_element(__first, __last,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _ForwardIterator, typename _Compare>
++    _ForwardIterator
++    __max_element(_ForwardIterator __first, _ForwardIterator __last,
++		  _Compare __comp)
++    {
++      if (__first == __last) return __first;
++      _ForwardIterator __result = __first;
++      while (++__first != __last)
++	if (__comp(__result, __first))
++	  __result = __first;
++      return __result;
++    }
++
++  /**
++   *  @brief  Return the maximum element in a range.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @return  Iterator referencing the first instance of the largest value.
++  */
++  template<typename _ForwardIterator>
++    inline _ForwardIterator
++    max_element(_ForwardIterator __first, _ForwardIterator __last)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanComparableConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return _GLIBCXX_STD_A::__max_element(__first, __last,
++				__gnu_cxx::__ops::__iter_less_iter());
++    }
++
++  /**
++   *  @brief  Return the maximum element in a range using comparison functor.
++   *  @ingroup sorting_algorithms
++   *  @param  __first  Start of range.
++   *  @param  __last   End of range.
++   *  @param  __comp   Comparison functor.
++   *  @return  Iterator referencing the first instance of the largest value
++   *  according to __comp.
++  */
++  template<typename _ForwardIterator, typename _Compare>
++    inline _ForwardIterator
++    max_element(_ForwardIterator __first, _ForwardIterator __last,
++		_Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_BinaryPredicateConcept<_Compare,
++	    typename iterator_traits<_ForwardIterator>::value_type,
++	    typename iterator_traits<_ForwardIterator>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return _GLIBCXX_STD_A::__max_element(__first, __last,
++				__gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++_GLIBCXX_END_NAMESPACE_ALGO
++} // namespace std
++
++#endif /* _STL_ALGO_H */
+diff --git a/GCC_XML/Support/GCC/4.9/bits/stl_algobase.h b/GCC_XML/Support/GCC/4.9/bits/stl_algobase.h
+new file mode 100644
+index 0000000..9e87115
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/bits/stl_algobase.h
+@@ -0,0 +1,1422 @@
++// Core algorithmic facilities -*- C++ -*-
++
++// Copyright (C) 2001-2014 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/*
++ *
++ * Copyright (c) 1994
++ * Hewlett-Packard Company
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Hewlett-Packard Company makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ *
++ *
++ * Copyright (c) 1996-1998
++ * Silicon Graphics Computer Systems, Inc.
++ *
++ * Permission to use, copy, modify, distribute and sell this software
++ * and its documentation for any purpose is hereby granted without fee,
++ * provided that the above copyright notice appear in all copies and
++ * that both that copyright notice and this permission notice appear
++ * in supporting documentation.  Silicon Graphics makes no
++ * representations about the suitability of this software for any
++ * purpose.  It is provided "as is" without express or implied warranty.
++ */
++
++/** @file bits/stl_algobase.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{algorithm}
++ */
++
++#ifndef _STL_ALGOBASE_H
++#define _STL_ALGOBASE_H 1
++
++#include <bits/c++config.h>
++#include <bits/functexcept.h>
++#include <bits/cpp_type_traits.h>
++#include <ext/type_traits.h>
++#include <ext/numeric_traits.h>
++#include <bits/stl_pair.h>
++#include <bits/stl_iterator_base_types.h>
++#include <bits/stl_iterator_base_funcs.h>
++#include <bits/stl_iterator.h>
++#include <bits/concept_check.h>
++#include <debug/debug.h>
++#include <bits/move.h> // For std::swap and _GLIBCXX_MOVE
++#include <bits/predefined_ops.h>
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++#if __cplusplus < 201103L
++  // See http://gcc.gnu.org/ml/libstdc++/2004-08/msg00167.html: in a
++  // nutshell, we are partially implementing the resolution of DR 187,
++  // when it's safe, i.e., the value_types are equal.
++  template<bool _BoolType>
++    struct __iter_swap
++    {
++      template<typename _ForwardIterator1, typename _ForwardIterator2>
++        static void
++        iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
++        {
++          typedef typename iterator_traits<_ForwardIterator1>::value_type
++            _ValueType1;
++          _ValueType1 __tmp = _GLIBCXX_MOVE(*__a);
++          *__a = _GLIBCXX_MOVE(*__b);
++          *__b = _GLIBCXX_MOVE(__tmp);
++	}
++    };
++
++  template<>
++    struct __iter_swap<true>
++    {
++      template<typename _ForwardIterator1, typename _ForwardIterator2>
++        static void 
++        iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
++        {
++          swap(*__a, *__b);
++        }
++    };
++#endif
++
++  /**
++   *  @brief Swaps the contents of two iterators.
++   *  @ingroup mutating_algorithms
++   *  @param  __a  An iterator.
++   *  @param  __b  Another iterator.
++   *  @return   Nothing.
++   *
++   *  This function swaps the values pointed to by two iterators, not the
++   *  iterators themselves.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    inline void
++    iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator1>)
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator2>)
++
++#if __cplusplus < 201103L
++      typedef typename iterator_traits<_ForwardIterator1>::value_type
++	_ValueType1;
++      typedef typename iterator_traits<_ForwardIterator2>::value_type
++	_ValueType2;
++
++      __glibcxx_function_requires(_ConvertibleConcept<_ValueType1,
++				  _ValueType2>)
++      __glibcxx_function_requires(_ConvertibleConcept<_ValueType2,
++				  _ValueType1>)
++
++      typedef typename iterator_traits<_ForwardIterator1>::reference
++	_ReferenceType1;
++      typedef typename iterator_traits<_ForwardIterator2>::reference
++	_ReferenceType2;
++      std::__iter_swap<__are_same<_ValueType1, _ValueType2>::__value
++	&& __are_same<_ValueType1&, _ReferenceType1>::__value
++	&& __are_same<_ValueType2&, _ReferenceType2>::__value>::
++	iter_swap(__a, __b);
++#else
++      swap(*__a, *__b);
++#endif
++    }
++
++  /**
++   *  @brief Swap the elements of two sequences.
++   *  @ingroup mutating_algorithms
++   *  @param  __first1  A forward iterator.
++   *  @param  __last1   A forward iterator.
++   *  @param  __first2  A forward iterator.
++   *  @return   An iterator equal to @p first2+(last1-first1).
++   *
++   *  Swaps each element in the range @p [first1,last1) with the
++   *  corresponding element in the range @p [first2,(last1-first1)).
++   *  The ranges must not overlap.
++  */
++  template<typename _ForwardIterator1, typename _ForwardIterator2>
++    _ForwardIterator2
++    swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1,
++		_ForwardIterator2 __first2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator1>)
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	std::iter_swap(__first1, __first2);
++      return __first2;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @return   The lesser of the parameters.
++   *
++   *  This is the simple classic generic implementation.  It will work on
++   *  temporary expressions, since they are only evaluated once, unlike a
++   *  preprocessor macro.
++  */
++  template<typename _Tp>
++    inline const _Tp&
++    min(const _Tp& __a, const _Tp& __b)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_LessThanComparableConcept<_Tp>)
++      //return __b < __a ? __b : __a;
++      if (__b < __a)
++	return __b;
++      return __a;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @return   The greater of the parameters.
++   *
++   *  This is the simple classic generic implementation.  It will work on
++   *  temporary expressions, since they are only evaluated once, unlike a
++   *  preprocessor macro.
++  */
++  template<typename _Tp>
++    inline const _Tp&
++    max(const _Tp& __a, const _Tp& __b)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_LessThanComparableConcept<_Tp>)
++      //return  __a < __b ? __b : __a;
++      if (__a < __b)
++	return __b;
++      return __a;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @param  __comp  A @link comparison_functors comparison functor@endlink.
++   *  @return   The lesser of the parameters.
++   *
++   *  This will work on temporary expressions, since they are only evaluated
++   *  once, unlike a preprocessor macro.
++  */
++  template<typename _Tp, typename _Compare>
++    inline const _Tp&
++    min(const _Tp& __a, const _Tp& __b, _Compare __comp)
++    {
++      //return __comp(__b, __a) ? __b : __a;
++      if (__comp(__b, __a))
++	return __b;
++      return __a;
++    }
++
++  /**
++   *  @brief This does what you think it does.
++   *  @ingroup sorting_algorithms
++   *  @param  __a  A thing of arbitrary type.
++   *  @param  __b  Another thing of arbitrary type.
++   *  @param  __comp  A @link comparison_functors comparison functor@endlink.
++   *  @return   The greater of the parameters.
++   *
++   *  This will work on temporary expressions, since they are only evaluated
++   *  once, unlike a preprocessor macro.
++  */
++  template<typename _Tp, typename _Compare>
++    inline const _Tp&
++    max(const _Tp& __a, const _Tp& __b, _Compare __comp)
++    {
++      //return __comp(__a, __b) ? __b : __a;
++      if (__comp(__a, __b))
++	return __b;
++      return __a;
++    }
++
++  // If _Iterator is a __normal_iterator return its base (a plain pointer,
++  // normally) otherwise return it untouched.  See copy, fill, ... 
++  template<typename _Iterator>
++    struct _Niter_base
++    : _Iter_base<_Iterator, __is_normal_iterator<_Iterator>::__value>
++    { };
++
++  template<typename _Iterator>
++    inline typename _Niter_base<_Iterator>::iterator_type
++    __niter_base(_Iterator __it)
++    { return std::_Niter_base<_Iterator>::_S_base(__it); }
++
++  // Likewise, for move_iterator.
++  template<typename _Iterator>
++    struct _Miter_base
++    : _Iter_base<_Iterator, __is_move_iterator<_Iterator>::__value>
++    { };
++
++  template<typename _Iterator>
++    inline typename _Miter_base<_Iterator>::iterator_type
++    __miter_base(_Iterator __it)
++    { return std::_Miter_base<_Iterator>::_S_base(__it); }
++
++  // All of these auxiliary structs serve two purposes.  (1) Replace
++  // calls to copy with memmove whenever possible.  (Memmove, not memcpy,
++  // because the input and output ranges are permitted to overlap.)
++  // (2) If we're using random access iterators, then write the loop as
++  // a for loop with an explicit count.
++
++  template<bool, bool, typename>
++    struct __copy_move
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        {
++	  for (; __first != __last; ++__result, ++__first)
++	    *__result = *__first;
++	  return __result;
++	}
++    };
++
++#if __cplusplus >= 201103L
++  template<typename _Category>
++    struct __copy_move<true, false, _Category>
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        {
++	  for (; __first != __last; ++__result, ++__first)
++	    *__result = std::move(*__first);
++	  return __result;
++	}
++    };
++#endif
++
++  template<>
++    struct __copy_move<false, false, random_access_iterator_tag>
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        { 
++	  typedef typename iterator_traits<_II>::difference_type _Distance;
++	  for(_Distance __n = __last - __first; __n > 0; --__n)
++	    {
++	      *__result = *__first;
++	      ++__first;
++	      ++__result;
++	    }
++	  return __result;
++	}
++    };
++
++#if __cplusplus >= 201103L
++  template<>
++    struct __copy_move<true, false, random_access_iterator_tag>
++    {
++      template<typename _II, typename _OI>
++        static _OI
++        __copy_m(_II __first, _II __last, _OI __result)
++        { 
++	  typedef typename iterator_traits<_II>::difference_type _Distance;
++	  for(_Distance __n = __last - __first; __n > 0; --__n)
++	    {
++	      *__result = std::move(*__first);
++	      ++__first;
++	      ++__result;
++	    }
++	  return __result;
++	}
++    };
++#endif
++
++  template<bool _IsMove>
++    struct __copy_move<_IsMove, true, random_access_iterator_tag>
++    {
++      template<typename _Tp>
++        static _Tp*
++        __copy_m(const _Tp* __first, const _Tp* __last, _Tp* __result)
++        {
++#if __cplusplus >= 201103L
++	  // trivial types can have deleted assignment
++	  static_assert( is_copy_assignable<_Tp>::value,
++	                 "type is not assignable" );
++#endif
++	  const ptrdiff_t _Num = __last - __first;
++	  if (_Num)
++	    __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
++	  return __result + _Num;
++	}
++    };
++
++  template<bool _IsMove, typename _II, typename _OI>
++    inline _OI
++    __copy_move_a(_II __first, _II __last, _OI __result)
++    {
++      typedef typename iterator_traits<_II>::value_type _ValueTypeI;
++      typedef typename iterator_traits<_OI>::value_type _ValueTypeO;
++      typedef typename iterator_traits<_II>::iterator_category _Category;
++      const bool __simple = (__is_trivial(_ValueTypeI)
++	                     && __is_pointer<_II>::__value
++	                     && __is_pointer<_OI>::__value
++			     && __are_same<_ValueTypeI, _ValueTypeO>::__value);
++
++      return std::__copy_move<_IsMove, __simple,
++	                      _Category>::__copy_m(__first, __last, __result);
++    }
++
++  // Helpers for streambuf iterators (either istream or ostream).
++  // NB: avoid including <iosfwd>, relatively large.
++  template<typename _CharT>
++    struct char_traits;
++
++  template<typename _CharT, typename _Traits>
++    class istreambuf_iterator;
++
++  template<typename _CharT, typename _Traits>
++    class ostreambuf_iterator;
++
++  template<bool _IsMove, typename _CharT>
++    typename __gnu_cxx::__enable_if<__is_char<_CharT>::__value, 
++	     ostreambuf_iterator<_CharT, char_traits<_CharT> > >::__type
++    __copy_move_a2(_CharT*, _CharT*,
++		   ostreambuf_iterator<_CharT, char_traits<_CharT> >);
++
++  template<bool _IsMove, typename _CharT>
++    typename __gnu_cxx::__enable_if<__is_char<_CharT>::__value, 
++	     ostreambuf_iterator<_CharT, char_traits<_CharT> > >::__type
++    __copy_move_a2(const _CharT*, const _CharT*,
++		   ostreambuf_iterator<_CharT, char_traits<_CharT> >);
++
++  template<bool _IsMove, typename _CharT>
++    typename __gnu_cxx::__enable_if<__is_char<_CharT>::__value,
++				    _CharT*>::__type
++    __copy_move_a2(istreambuf_iterator<_CharT, char_traits<_CharT> >,
++		   istreambuf_iterator<_CharT, char_traits<_CharT> >, _CharT*);
++
++  template<bool _IsMove, typename _II, typename _OI>
++    inline _OI
++    __copy_move_a2(_II __first, _II __last, _OI __result)
++    {
++      return _OI(std::__copy_move_a<_IsMove>(std::__niter_base(__first),
++					     std::__niter_base(__last),
++					     std::__niter_base(__result)));
++    }
++
++  /**
++   *  @brief Copies the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __result An output iterator.
++   *  @return   result + (first - last)
++   *
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).  Result may not be contained within
++   *  [first,last); the copy_backward function should be used instead.
++   *
++   *  Note that the end of the output range is permitted to be contained
++   *  within [first,last).
++  */
++  template<typename _II, typename _OI>
++    inline _OI
++    copy(_II __first, _II __last, _OI __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OI,
++	    typename iterator_traits<_II>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return (std::__copy_move_a2<__is_move_iterator<_II>::__value>
++	      (std::__miter_base(__first), std::__miter_base(__last),
++	       __result));
++    }
++
++#if __cplusplus >= 201103L
++  /**
++   *  @brief Moves the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An input iterator.
++   *  @param  __last   An input iterator.
++   *  @param  __result An output iterator.
++   *  @return   result + (first - last)
++   *
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).  Result may not be contained within
++   *  [first,last); the move_backward function should be used instead.
++   *
++   *  Note that the end of the output range is permitted to be contained
++   *  within [first,last).
++  */
++  template<typename _II, typename _OI>
++    inline _OI
++    move(_II __first, _II __last, _OI __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II>)
++      __glibcxx_function_requires(_OutputIteratorConcept<_OI,
++	    typename iterator_traits<_II>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__copy_move_a2<true>(std::__miter_base(__first),
++				       std::__miter_base(__last), __result);
++    }
++
++#define _GLIBCXX_MOVE3(_Tp, _Up, _Vp) std::move(_Tp, _Up, _Vp)
++#else
++#define _GLIBCXX_MOVE3(_Tp, _Up, _Vp) std::copy(_Tp, _Up, _Vp)
++#endif
++
++  template<bool, bool, typename>
++    struct __copy_move_backward
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  while (__first != __last)
++	    *--__result = *--__last;
++	  return __result;
++	}
++    };
++
++#if __cplusplus >= 201103L
++  template<typename _Category>
++    struct __copy_move_backward<true, false, _Category>
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  while (__first != __last)
++	    *--__result = std::move(*--__last);
++	  return __result;
++	}
++    };
++#endif
++
++  template<>
++    struct __copy_move_backward<false, false, random_access_iterator_tag>
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  typename iterator_traits<_BI1>::difference_type __n;
++	  for (__n = __last - __first; __n > 0; --__n)
++	    *--__result = *--__last;
++	  return __result;
++	}
++    };
++
++#if __cplusplus >= 201103L
++  template<>
++    struct __copy_move_backward<true, false, random_access_iterator_tag>
++    {
++      template<typename _BI1, typename _BI2>
++        static _BI2
++        __copy_move_b(_BI1 __first, _BI1 __last, _BI2 __result)
++        {
++	  typename iterator_traits<_BI1>::difference_type __n;
++	  for (__n = __last - __first; __n > 0; --__n)
++	    *--__result = std::move(*--__last);
++	  return __result;
++	}
++    };
++#endif
++
++  template<bool _IsMove>
++    struct __copy_move_backward<_IsMove, true, random_access_iterator_tag>
++    {
++      template<typename _Tp>
++        static _Tp*
++        __copy_move_b(const _Tp* __first, const _Tp* __last, _Tp* __result)
++        {
++#if __cplusplus >= 201103L
++	  // trivial types can have deleted assignment
++	  static_assert( is_copy_assignable<_Tp>::value,
++	                 "type is not assignable" );
++#endif
++	  const ptrdiff_t _Num = __last - __first;
++	  if (_Num)
++	    __builtin_memmove(__result - _Num, __first, sizeof(_Tp) * _Num);
++	  return __result - _Num;
++	}
++    };
++
++  template<bool _IsMove, typename _BI1, typename _BI2>
++    inline _BI2
++    __copy_move_backward_a(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      typedef typename iterator_traits<_BI1>::value_type _ValueType1;
++      typedef typename iterator_traits<_BI2>::value_type _ValueType2;
++      typedef typename iterator_traits<_BI1>::iterator_category _Category;
++      const bool __simple = (__is_trivial(_ValueType1)
++	                     && __is_pointer<_BI1>::__value
++	                     && __is_pointer<_BI2>::__value
++			     && __are_same<_ValueType1, _ValueType2>::__value);
++
++      return std::__copy_move_backward<_IsMove, __simple,
++	                               _Category>::__copy_move_b(__first,
++								 __last,
++								 __result);
++    }
++
++  template<bool _IsMove, typename _BI1, typename _BI2>
++    inline _BI2
++    __copy_move_backward_a2(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      return _BI2(std::__copy_move_backward_a<_IsMove>
++		  (std::__niter_base(__first), std::__niter_base(__last),
++		   std::__niter_base(__result)));
++    }
++
++  /**
++   *  @brief Copies the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A bidirectional iterator.
++   *  @param  __last   A bidirectional iterator.
++   *  @param  __result A bidirectional iterator.
++   *  @return   result - (first - last)
++   *
++   *  The function has the same effect as copy, but starts at the end of the
++   *  range and works its way to the start, returning the start of the result.
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).
++   *
++   *  Result may not be in the range (first,last].  Use copy instead.  Note
++   *  that the start of the output range may overlap [first,last).
++  */
++  template<typename _BI1, typename _BI2>
++    inline _BI2
++    copy_backward(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<_BI1>)
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<_BI2>)
++      __glibcxx_function_requires(_ConvertibleConcept<
++	    typename iterator_traits<_BI1>::value_type,
++	    typename iterator_traits<_BI2>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return (std::__copy_move_backward_a2<__is_move_iterator<_BI1>::__value>
++	      (std::__miter_base(__first), std::__miter_base(__last),
++	       __result));
++    }
++
++#if __cplusplus >= 201103L
++  /**
++   *  @brief Moves the range [first,last) into result.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A bidirectional iterator.
++   *  @param  __last   A bidirectional iterator.
++   *  @param  __result A bidirectional iterator.
++   *  @return   result - (first - last)
++   *
++   *  The function has the same effect as move, but starts at the end of the
++   *  range and works its way to the start, returning the start of the result.
++   *  This inline function will boil down to a call to @c memmove whenever
++   *  possible.  Failing that, if random access iterators are passed, then the
++   *  loop count will be known (and therefore a candidate for compiler
++   *  optimizations such as unrolling).
++   *
++   *  Result may not be in the range (first,last].  Use move instead.  Note
++   *  that the start of the output range may overlap [first,last).
++  */
++  template<typename _BI1, typename _BI2>
++    inline _BI2
++    move_backward(_BI1 __first, _BI1 __last, _BI2 __result)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_BidirectionalIteratorConcept<_BI1>)
++      __glibcxx_function_requires(_Mutable_BidirectionalIteratorConcept<_BI2>)
++      __glibcxx_function_requires(_ConvertibleConcept<
++	    typename iterator_traits<_BI1>::value_type,
++	    typename iterator_traits<_BI2>::value_type>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      return std::__copy_move_backward_a2<true>(std::__miter_base(__first),
++						std::__miter_base(__last),
++						__result);
++    }
++
++#define _GLIBCXX_MOVE_BACKWARD3(_Tp, _Up, _Vp) std::move_backward(_Tp, _Up, _Vp)
++#else
++#define _GLIBCXX_MOVE_BACKWARD3(_Tp, _Up, _Vp) std::copy_backward(_Tp, _Up, _Vp)
++#endif
++
++  template<typename _ForwardIterator, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<!__is_scalar<_Tp>::__value, void>::__type
++    __fill_a(_ForwardIterator __first, _ForwardIterator __last,
++ 	     const _Tp& __value)
++    {
++      for (; __first != __last; ++__first)
++	*__first = __value;
++    }
++    
++  template<typename _ForwardIterator, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_scalar<_Tp>::__value, void>::__type
++    __fill_a(_ForwardIterator __first, _ForwardIterator __last,
++	     const _Tp& __value)
++    {
++      const _Tp __tmp = __value;
++      for (; __first != __last; ++__first)
++	*__first = __tmp;
++    }
++
++  // Specialization: for char types we can use memset.
++  template<typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_byte<_Tp>::__value, void>::__type
++    __fill_a(_Tp* __first, _Tp* __last, const _Tp& __c)
++    {
++      const _Tp __tmp = __c;
++      __builtin_memset(__first, static_cast<unsigned char>(__tmp),
++		       __last - __first);
++    }
++
++  /**
++   *  @brief Fills the range [first,last) with copies of value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  A forward iterator.
++   *  @param  __last   A forward iterator.
++   *  @param  __value  A reference-to-const of arbitrary type.
++   *  @return   Nothing.
++   *
++   *  This function fills a range with copies of the same value.  For char
++   *  types filling contiguous areas of memory, this becomes an inline call
++   *  to @c memset or @c wmemset.
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    inline void
++    fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_Mutable_ForwardIteratorConcept<
++				  _ForwardIterator>)
++      __glibcxx_requires_valid_range(__first, __last);
++
++      std::__fill_a(std::__niter_base(__first), std::__niter_base(__last),
++		    __value);
++    }
++
++  template<typename _OutputIterator, typename _Size, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<!__is_scalar<_Tp>::__value, _OutputIterator>::__type
++    __fill_n_a(_OutputIterator __first, _Size __n, const _Tp& __value)
++    {
++      for (; __n > 0; --__n, ++__first)
++	*__first = __value;
++      return __first;
++    }
++
++  template<typename _OutputIterator, typename _Size, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_scalar<_Tp>::__value, _OutputIterator>::__type
++    __fill_n_a(_OutputIterator __first, _Size __n, const _Tp& __value)
++    {
++      const _Tp __tmp = __value;
++      for (; __n > 0; --__n, ++__first)
++	*__first = __tmp;
++      return __first;
++    }
++
++  template<typename _Size, typename _Tp>
++    inline typename
++    __gnu_cxx::__enable_if<__is_byte<_Tp>::__value, _Tp*>::__type
++    __fill_n_a(_Tp* __first, _Size __n, const _Tp& __c)
++    {
++      std::__fill_a(__first, __first + __n, __c);
++      return __first + __n;
++    }
++
++  /**
++   *  @brief Fills the range [first,first+n) with copies of value.
++   *  @ingroup mutating_algorithms
++   *  @param  __first  An output iterator.
++   *  @param  __n      The count of copies to perform.
++   *  @param  __value  A reference-to-const of arbitrary type.
++   *  @return   The iterator at first+n.
++   *
++   *  This function fills a range with copies of the same value.  For char
++   *  types filling contiguous areas of memory, this becomes an inline call
++   *  to @c memset or @ wmemset.
++   *
++   *  _GLIBCXX_RESOLVE_LIB_DEFECTS
++   *  DR 865. More algorithms that throw away information
++  */
++  template<typename _OI, typename _Size, typename _Tp>
++    inline _OI
++    fill_n(_OI __first, _Size __n, const _Tp& __value)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_OutputIteratorConcept<_OI, _Tp>)
++
++      return _OI(std::__fill_n_a(std::__niter_base(__first), __n, __value));
++    }
++
++  template<bool _BoolType>
++    struct __equal
++    {
++      template<typename _II1, typename _II2>
++        static bool
++        equal(_II1 __first1, _II1 __last1, _II2 __first2)
++        {
++	  for (; __first1 != __last1; ++__first1, ++__first2)
++	    if (!(*__first1 == *__first2))
++	      return false;
++	  return true;
++	}
++    };
++
++  template<>
++    struct __equal<true>
++    {
++      template<typename _Tp>
++        static bool
++        equal(const _Tp* __first1, const _Tp* __last1, const _Tp* __first2)
++        {
++	  return !__builtin_memcmp(__first1, __first2, sizeof(_Tp)
++				   * (__last1 - __first1));
++	}
++    };
++
++  template<typename _II1, typename _II2>
++    inline bool
++    __equal_aux(_II1 __first1, _II1 __last1, _II2 __first2)
++    {
++      typedef typename iterator_traits<_II1>::value_type _ValueType1;
++      typedef typename iterator_traits<_II2>::value_type _ValueType2;
++      const bool __simple = ((__is_integer<_ValueType1>::__value
++			      || __is_pointer<_ValueType1>::__value)
++	                     && __is_pointer<_II1>::__value
++	                     && __is_pointer<_II2>::__value
++			     && __are_same<_ValueType1, _ValueType2>::__value);
++
++      return std::__equal<__simple>::equal(__first1, __last1, __first2);
++    }
++
++  template<typename, typename>
++    struct __lc_rai
++    {
++      template<typename _II1, typename _II2>
++        static _II1
++        __newlast1(_II1, _II1 __last1, _II2, _II2)
++        { return __last1; }
++
++      template<typename _II>
++        static bool
++        __cnd2(_II __first, _II __last)
++        { return __first != __last; }
++    };
++
++  template<>
++    struct __lc_rai<random_access_iterator_tag, random_access_iterator_tag>
++    {
++      template<typename _RAI1, typename _RAI2>
++        static _RAI1
++        __newlast1(_RAI1 __first1, _RAI1 __last1,
++		   _RAI2 __first2, _RAI2 __last2)
++        {
++	  const typename iterator_traits<_RAI1>::difference_type
++	    __diff1 = __last1 - __first1;
++	  const typename iterator_traits<_RAI2>::difference_type
++	    __diff2 = __last2 - __first2;
++	  return __diff2 < __diff1 ? __first1 + __diff2 : __last1;
++	}
++
++      template<typename _RAI>
++        static bool
++        __cnd2(_RAI, _RAI)
++        { return true; }
++    };
++
++  template<typename _II1, typename _II2, typename _Compare>
++    bool
++    __lexicographical_compare_impl(_II1 __first1, _II1 __last1,
++				   _II2 __first2, _II2 __last2,
++				   _Compare __comp)
++    {
++      typedef typename iterator_traits<_II1>::iterator_category _Category1;
++      typedef typename iterator_traits<_II2>::iterator_category _Category2;
++      typedef std::__lc_rai<_Category1, _Category2> __rai_type;
++
++      __last1 = __rai_type::__newlast1(__first1, __last1, __first2, __last2);
++      for (; __first1 != __last1 && __rai_type::__cnd2(__first2, __last2);
++	   ++__first1, ++__first2)
++	{
++	  if (__comp(__first1, __first2))
++	    return true;
++	  if (__comp(__first2, __first1))
++	    return false;
++	}
++      return __first1 == __last1 && __first2 != __last2;
++    }
++
++  template<bool _BoolType>
++    struct __lexicographical_compare
++    {
++      template<typename _II1, typename _II2>
++        static bool __lc(_II1, _II1, _II2, _II2);
++    };
++
++  template<bool _BoolType>
++    template<typename _II1, typename _II2>
++      bool
++      __lexicographical_compare<_BoolType>::
++      __lc(_II1 __first1, _II1 __last1, _II2 __first2, _II2 __last2)
++      {
++	return std::__lexicographical_compare_impl(__first1, __last1,
++						   __first2, __last2,
++					__gnu_cxx::__ops::__iter_less_iter());
++      }
++
++  template<>
++    struct __lexicographical_compare<true>
++    {
++      template<typename _Tp, typename _Up>
++        static bool
++        __lc(const _Tp* __first1, const _Tp* __last1,
++	     const _Up* __first2, const _Up* __last2)
++	{
++	  const size_t __len1 = __last1 - __first1;
++	  const size_t __len2 = __last2 - __first2;
++	  const int __result = __builtin_memcmp(__first1, __first2,
++						std::min(__len1, __len2));
++	  return __result != 0 ? __result < 0 : __len1 < __len2;
++	}
++    };
++
++  template<typename _II1, typename _II2>
++    inline bool
++    __lexicographical_compare_aux(_II1 __first1, _II1 __last1,
++				  _II2 __first2, _II2 __last2)
++    {
++      typedef typename iterator_traits<_II1>::value_type _ValueType1;
++      typedef typename iterator_traits<_II2>::value_type _ValueType2;
++      const bool __simple =
++	(__is_byte<_ValueType1>::__value && __is_byte<_ValueType2>::__value
++	 && !__gnu_cxx::__numeric_traits<_ValueType1>::__is_signed
++	 && !__gnu_cxx::__numeric_traits<_ValueType2>::__is_signed
++	 && __is_pointer<_II1>::__value
++	 && __is_pointer<_II2>::__value);
++
++      return std::__lexicographical_compare<__simple>::__lc(__first1, __last1,
++							    __first2, __last2);
++    }
++
++  template<typename _ForwardIterator, typename _Tp, typename _Compare>
++    _ForwardIterator
++    __lower_bound(_ForwardIterator __first, _ForwardIterator __last,
++		  const _Tp& __val, _Compare __comp)
++    {
++      typedef typename iterator_traits<_ForwardIterator>::difference_type
++	_DistanceType;
++
++      _DistanceType __len = std::distance(__first, __last);
++
++      while (__len > 0)
++	{
++	  _DistanceType __half = __len >> 1;
++	  _ForwardIterator __middle = __first;
++	  std::advance(__middle, __half);
++	  if (__comp(__middle, __val))
++	    {
++	      __first = __middle;
++	      ++__first;
++	      __len = __len - __half - 1;
++	    }
++	  else
++	    __len = __half;
++	}
++      return __first;
++    }
++
++  /**
++   *  @brief Finds the first position in which @a val could be inserted
++   *         without changing the ordering.
++   *  @param  __first   An iterator.
++   *  @param  __last    Another iterator.
++   *  @param  __val     The search term.
++   *  @return         An iterator pointing to the first element <em>not less
++   *                  than</em> @a val, or end() if every element is less than 
++   *                  @a val.
++   *  @ingroup binary_search_algorithms
++  */
++  template<typename _ForwardIterator, typename _Tp>
++    inline _ForwardIterator
++    lower_bound(_ForwardIterator __first, _ForwardIterator __last,
++		const _Tp& __val)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
++      __glibcxx_function_requires(_LessThanOpConcept<
++	    typename iterator_traits<_ForwardIterator>::value_type, _Tp>)
++      __glibcxx_requires_partitioned_lower(__first, __last, __val);
++
++      return std::__lower_bound(__first, __last, __val,
++				__gnu_cxx::__ops::__iter_less_val());
++    }
++
++  /// This is a helper function for the sort routines and for random.tcc.
++  //  Precondition: __n > 0.
++  inline _GLIBCXX_CONSTEXPR int
++  __lg(int __n)
++  { return sizeof(int) * __CHAR_BIT__  - 1 - __builtin_clz(__n); }
++
++  inline _GLIBCXX_CONSTEXPR unsigned
++  __lg(unsigned __n)
++  { return sizeof(int) * __CHAR_BIT__  - 1 - __builtin_clz(__n); }
++
++  inline _GLIBCXX_CONSTEXPR long
++  __lg(long __n)
++  { return sizeof(long) * __CHAR_BIT__ - 1 - __builtin_clzl(__n); }
++
++  inline _GLIBCXX_CONSTEXPR unsigned long
++  __lg(unsigned long __n)
++  { return sizeof(long) * __CHAR_BIT__ - 1 - __builtin_clzl(__n); }
++
++  inline _GLIBCXX_CONSTEXPR long long
++  __lg(long long __n)
++  { return sizeof(long long) * __CHAR_BIT__ - 1 - __builtin_clzll(__n); }
++
++  inline _GLIBCXX_CONSTEXPR unsigned long long
++  __lg(unsigned long long __n)
++  { return sizeof(long long) * __CHAR_BIT__ - 1 - __builtin_clzll(__n); }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++
++_GLIBCXX_BEGIN_NAMESPACE_ALGO
++
++  /**
++   *  @brief Tests a range for element-wise equality.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @return   A boolean true or false.
++   *
++   *  This compares the elements of two ranges using @c == and returns true or
++   *  false depending on whether all of the corresponding elements of the
++   *  ranges are equal.
++  */
++  template<typename _II1, typename _II2>
++    inline bool
++    equal(_II1 __first1, _II1 __last1, _II2 __first2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_II2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_II1>::value_type,
++	    typename iterator_traits<_II2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      return std::__equal_aux(std::__niter_base(__first1),
++			      std::__niter_base(__last1),
++			      std::__niter_base(__first2));
++    }
++
++  /**
++   *  @brief Tests a range for element-wise equality.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param __binary_pred A binary predicate @link functors
++   *                  functor@endlink.
++   *  @return         A boolean true or false.
++   *
++   *  This compares the elements of two ranges using the binary_pred
++   *  parameter, and returns true or
++   *  false depending on whether all of the corresponding elements of the
++   *  ranges are equal.
++  */
++  template<typename _IIter1, typename _IIter2, typename _BinaryPredicate>
++    inline bool
++    equal(_IIter1 __first1, _IIter1 __last1,
++	  _IIter2 __first2, _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_IIter1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_IIter2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      for (; __first1 != __last1; ++__first1, ++__first2)
++	if (!bool(__binary_pred(*__first1, *__first2)))
++	  return false;
++      return true;
++    }
++
++#if __cplusplus > 201103L
++  /**
++   *  @brief Tests a range for element-wise equality.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @return   A boolean true or false.
++   *
++   *  This compares the elements of two ranges using @c == and returns true or
++   *  false depending on whether all of the corresponding elements of the
++   *  ranges are equal.
++  */
++  template<typename _II1, typename _II2>
++    inline bool
++    equal(_II1 __first1, _II1 __last1, _II2 __first2, _II2 __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_II2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_II1>::value_type,
++	    typename iterator_traits<_II2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      using _RATag = random_access_iterator_tag;
++      using _Cat1 = typename iterator_traits<_II1>::iterator_category;
++      using _Cat2 = typename iterator_traits<_II2>::iterator_category;
++      using _RAIters = __and_<is_same<_Cat1, _RATag>, is_same<_Cat2, _RATag>>;
++      if (_RAIters())
++	{
++	  auto __d1 = std::distance(__first1, __last1);
++	  auto __d2 = std::distance(__first2, __last2);
++	  if (__d1 != __d2)
++	    return false;
++	  return _GLIBCXX_STD_A::equal(__first1, __last1, __first2);
++	}
++
++      for (; __first1 != __last1 && __first2 != __last2; ++__first1, ++__first2)
++	if (!(*__first1 == *__first2))
++	  return false;
++      return __first1 == __last1 && __first2 == __last2;
++    }
++
++  /**
++   *  @brief Tests a range for element-wise equality.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @param __binary_pred A binary predicate @link functors
++   *                  functor@endlink.
++   *  @return         A boolean true or false.
++   *
++   *  This compares the elements of two ranges using the binary_pred
++   *  parameter, and returns true or
++   *  false depending on whether all of the corresponding elements of the
++   *  ranges are equal.
++  */
++  template<typename _IIter1, typename _IIter2, typename _BinaryPredicate>
++    inline bool
++    equal(_IIter1 __first1, _IIter1 __last1,
++	  _IIter2 __first2, _IIter2 __last2, _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_IIter1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_IIter2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      using _RATag = random_access_iterator_tag;
++      using _Cat1 = typename iterator_traits<_IIter1>::iterator_category;
++      using _Cat2 = typename iterator_traits<_IIter2>::iterator_category;
++      using _RAIters = __and_<is_same<_Cat1, _RATag>, is_same<_Cat2, _RATag>>;
++      if (_RAIters())
++	{
++	  auto __d1 = std::distance(__first1, __last1);
++	  auto __d2 = std::distance(__first2, __last2);
++	  if (__d1 != __d2)
++	    return false;
++	  return _GLIBCXX_STD_A::equal(__first1, __last1, __first2,
++				       __binary_pred);
++	}
++
++      for (; __first1 != __last1 && __first2 != __last2; ++__first1, ++__first2)
++	if (!bool(__binary_pred(*__first1, *__first2)))
++	  return false;
++      return __first1 == __last1 && __first2 == __last2;
++    }
++#endif
++
++  /**
++   *  @brief Performs @b dictionary comparison on ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @return   A boolean true or false.
++   *
++   *  <em>Returns true if the sequence of elements defined by the range
++   *  [first1,last1) is lexicographically less than the sequence of elements
++   *  defined by the range [first2,last2).  Returns false otherwise.</em>
++   *  (Quoted from [25.3.8]/1.)  If the iterators are all character pointers,
++   *  then this is an inline call to @c memcmp.
++  */
++  template<typename _II1, typename _II2>
++    inline bool
++    lexicographical_compare(_II1 __first1, _II1 __last1,
++			    _II2 __first2, _II2 __last2)
++    {
++#ifdef _GLIBCXX_CONCEPT_CHECKS
++      // concept requirements
++      typedef typename iterator_traits<_II1>::value_type _ValueType1;
++      typedef typename iterator_traits<_II2>::value_type _ValueType2;
++#endif
++      __glibcxx_function_requires(_InputIteratorConcept<_II1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_II2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType1, _ValueType2>)
++      __glibcxx_function_requires(_LessThanOpConcept<_ValueType2, _ValueType1>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__lexicographical_compare_aux(std::__niter_base(__first1),
++						std::__niter_base(__last1),
++						std::__niter_base(__first2),
++						std::__niter_base(__last2));
++    }
++
++  /**
++   *  @brief Performs @b dictionary comparison on ranges.
++   *  @ingroup sorting_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @param  __comp  A @link comparison_functors comparison functor@endlink.
++   *  @return   A boolean true or false.
++   *
++   *  The same as the four-parameter @c lexicographical_compare, but uses the
++   *  comp parameter instead of @c <.
++  */
++  template<typename _II1, typename _II2, typename _Compare>
++    inline bool
++    lexicographical_compare(_II1 __first1, _II1 __last1,
++			    _II2 __first2, _II2 __last2, _Compare __comp)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_II1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_II2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return std::__lexicographical_compare_impl
++	(__first1, __last1, __first2, __last2,
++	 __gnu_cxx::__ops::__iter_comp_iter(__comp));
++    }
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _BinaryPredicate>
++    pair<_InputIterator1, _InputIterator2>
++    __mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	       _InputIterator2 __first2, _BinaryPredicate __binary_pred)
++    {
++      while (__first1 != __last1 && __binary_pred(__first1, __first2))
++        {
++	  ++__first1;
++	  ++__first2;
++        }
++      return pair<_InputIterator1, _InputIterator2>(__first1, __first2);
++    }
++
++  /**
++   *  @brief Finds the places in ranges which don't match.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @return   A pair of iterators pointing to the first mismatch.
++   *
++   *  This compares the elements of two ranges using @c == and returns a pair
++   *  of iterators.  The first iterator points into the first range, the
++   *  second iterator points into the second range, and the elements pointed
++   *  to by the iterators are not equal.
++  */
++  template<typename _InputIterator1, typename _InputIterator2>
++    inline pair<_InputIterator1, _InputIterator2>
++    mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      return _GLIBCXX_STD_A::__mismatch(__first1, __last1, __first2,
++			     __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief Finds the places in ranges which don't match.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param __binary_pred A binary predicate @link functors
++   *         functor@endlink.
++   *  @return   A pair of iterators pointing to the first mismatch.
++   *
++   *  This compares the elements of two ranges using the binary_pred
++   *  parameter, and returns a pair
++   *  of iterators.  The first iterator points into the first range, the
++   *  second iterator points into the second range, and the elements pointed
++   *  to by the iterators are not equal.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _BinaryPredicate>
++    inline pair<_InputIterator1, _InputIterator2>
++    mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++
++      return _GLIBCXX_STD_A::__mismatch(__first1, __last1, __first2,
++	__gnu_cxx::__ops::__iter_comp_iter(__binary_pred));
++    }
++
++#if __cplusplus > 201103L
++
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _BinaryPredicate>
++    pair<_InputIterator1, _InputIterator2>
++    __mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	       _InputIterator2 __first2, _InputIterator2 __last2,
++	       _BinaryPredicate __binary_pred)
++    {
++      while (__first1 != __last1 && __first2 != __last2
++	     && __binary_pred(__first1, __first2))
++        {
++	  ++__first1;
++	  ++__first2;
++        }
++      return pair<_InputIterator1, _InputIterator2>(__first1, __first2);
++    }
++
++  /**
++   *  @brief Finds the places in ranges which don't match.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @return   A pair of iterators pointing to the first mismatch.
++   *
++   *  This compares the elements of two ranges using @c == and returns a pair
++   *  of iterators.  The first iterator points into the first range, the
++   *  second iterator points into the second range, and the elements pointed
++   *  to by the iterators are not equal.
++  */
++  template<typename _InputIterator1, typename _InputIterator2>
++    inline pair<_InputIterator1, _InputIterator2>
++    mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _InputIterator2 __last2)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_function_requires(_EqualOpConcept<
++	    typename iterator_traits<_InputIterator1>::value_type,
++	    typename iterator_traits<_InputIterator2>::value_type>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return _GLIBCXX_STD_A::__mismatch(__first1, __last1, __first2, __last2,
++			     __gnu_cxx::__ops::__iter_equal_to_iter());
++    }
++
++  /**
++   *  @brief Finds the places in ranges which don't match.
++   *  @ingroup non_mutating_algorithms
++   *  @param  __first1  An input iterator.
++   *  @param  __last1   An input iterator.
++   *  @param  __first2  An input iterator.
++   *  @param  __last2   An input iterator.
++   *  @param __binary_pred A binary predicate @link functors
++   *         functor@endlink.
++   *  @return   A pair of iterators pointing to the first mismatch.
++   *
++   *  This compares the elements of two ranges using the binary_pred
++   *  parameter, and returns a pair
++   *  of iterators.  The first iterator points into the first range, the
++   *  second iterator points into the second range, and the elements pointed
++   *  to by the iterators are not equal.
++  */
++  template<typename _InputIterator1, typename _InputIterator2,
++	   typename _BinaryPredicate>
++    inline pair<_InputIterator1, _InputIterator2>
++    mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
++	     _InputIterator2 __first2, _InputIterator2 __last2,
++	     _BinaryPredicate __binary_pred)
++    {
++      // concept requirements
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator1>)
++      __glibcxx_function_requires(_InputIteratorConcept<_InputIterator2>)
++      __glibcxx_requires_valid_range(__first1, __last1);
++      __glibcxx_requires_valid_range(__first2, __last2);
++
++      return _GLIBCXX_STD_A::__mismatch(__first1, __last1, __first2, __last2,
++			     __gnu_cxx::__ops::__iter_comp_iter(__binary_pred));
++    }
++#endif
++
++_GLIBCXX_END_NAMESPACE_ALGO
++} // namespace std
++
++// NB: This file is included within many other C++ includes, as a way
++// of getting the base algorithms. So, make sure that parallel bits
++// come in too if requested. 
++#ifdef _GLIBCXX_PARALLEL
++# include <parallel/algobase.h>
++#endif
++
++#endif
+diff --git a/GCC_XML/Support/GCC/4.9/complex b/GCC_XML/Support/GCC/4.9/complex
+new file mode 100644
+index 0000000..37a2741
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/complex
+@@ -0,0 +1,1954 @@
++// The template and inlines for the -*- C++ -*- complex number classes.
++
++// Copyright (C) 1997-2014 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file include/complex
++ *  This is a Standard C++ Library header.
++ */
++
++//
++// ISO C++ 14882: 26.2  Complex Numbers
++// Note: this is not a conforming implementation.
++// Initially implemented by Ulrich Drepper <drepper@cygnus.com>
++// Improved by Gabriel Dos Reis <dosreis@cmla.ens-cachan.fr>
++//
++
++#ifndef _GLIBCXX_COMPLEX
++#define _GLIBCXX_COMPLEX 1
++
++#pragma GCC system_header
++
++#include <bits/c++config.h>
++#include <bits/cpp_type_traits.h>
++#include <ext/type_traits.h>
++#include <cmath>
++#include <sstream>
++
++// Get rid of a macro possibly defined in <complex.h>
++#undef complex
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  /**
++   * @defgroup complex_numbers Complex Numbers
++   * @ingroup numerics
++   *
++   * Classes and functions for complex numbers.
++   * @{
++   */
++
++  // Forward declarations.
++  template<typename _Tp> class complex;
++  template<> class complex<float>;
++  template<> class complex<double>;
++  template<> class complex<long double>;
++
++  ///  Return magnitude of @a z.
++  template<typename _Tp> _Tp abs(const complex<_Tp>&);
++  ///  Return phase angle of @a z.
++  template<typename _Tp> _Tp arg(const complex<_Tp>&);
++  ///  Return @a z magnitude squared.
++  template<typename _Tp> _Tp norm(const complex<_Tp>&);
++
++  ///  Return complex conjugate of @a z.
++  template<typename _Tp> complex<_Tp> conj(const complex<_Tp>&);
++  ///  Return complex with magnitude @a rho and angle @a theta.
++  template<typename _Tp> complex<_Tp> polar(const _Tp&, const _Tp& = 0);
++
++  // Transcendentals:
++  /// Return complex cosine of @a z.
++  template<typename _Tp> complex<_Tp> cos(const complex<_Tp>&);
++  /// Return complex hyperbolic cosine of @a z.
++  template<typename _Tp> complex<_Tp> cosh(const complex<_Tp>&);
++  /// Return complex base e exponential of @a z.
++  template<typename _Tp> complex<_Tp> exp(const complex<_Tp>&);
++  /// Return complex natural logarithm of @a z.
++  template<typename _Tp> complex<_Tp> log(const complex<_Tp>&);
++  /// Return complex base 10 logarithm of @a z.
++  template<typename _Tp> complex<_Tp> log10(const complex<_Tp>&);
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const complex<_Tp>&, int);
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const complex<_Tp>&, const _Tp&);
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const complex<_Tp>&, 
++                                          const complex<_Tp>&);
++  /// Return @a x to the @a y'th power.
++  template<typename _Tp> complex<_Tp> pow(const _Tp&, const complex<_Tp>&);
++  /// Return complex sine of @a z.
++  template<typename _Tp> complex<_Tp> sin(const complex<_Tp>&);
++  /// Return complex hyperbolic sine of @a z.
++  template<typename _Tp> complex<_Tp> sinh(const complex<_Tp>&);
++  /// Return complex square root of @a z.
++  template<typename _Tp> complex<_Tp> sqrt(const complex<_Tp>&);
++  /// Return complex tangent of @a z.
++  template<typename _Tp> complex<_Tp> tan(const complex<_Tp>&);
++  /// Return complex hyperbolic tangent of @a z.
++  template<typename _Tp> complex<_Tp> tanh(const complex<_Tp>&);
++    
++    
++  // 26.2.2  Primary template class complex
++  /**
++   *  Template to represent complex numbers.
++   *
++   *  Specializations for float, double, and long double are part of the
++   *  library.  Results with any other type are not guaranteed.
++   *
++   *  @param  Tp  Type of real and imaginary values.
++  */
++  template<typename _Tp>
++    struct complex
++    {
++      /// Value typedef.
++      typedef _Tp value_type;
++      
++      ///  Default constructor.  First parameter is x, second parameter is y.
++      ///  Unspecified parameters default to 0.
++      _GLIBCXX_CONSTEXPR complex(const _Tp& __r = _Tp(), const _Tp& __i = _Tp())
++      : _M_real(__r), _M_imag(__i) { }
++
++      // Lets the compiler synthesize the copy constructor   
++      // complex (const complex<_Tp>&);
++      ///  Copy constructor.
++      template<typename _Up>
++        _GLIBCXX_CONSTEXPR complex(const complex<_Up>& __z)
++	: _M_real(__z.real()), _M_imag(__z.imag()) { }
++
++#if __cplusplus >= 201103L
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      _GLIBCXX_ABI_TAG_CXX11
++      constexpr _Tp 
++      real() { return _M_real; }
++
++      _GLIBCXX_ABI_TAG_CXX11
++      constexpr _Tp 
++      imag() { return _M_imag; }
++#else
++      ///  Return real part of complex number.
++      _Tp& 
++      real() { return _M_real; }
++
++      ///  Return real part of complex number.
++      const _Tp& 
++      real() const { return _M_real; }
++
++      ///  Return imaginary part of complex number.
++      _Tp& 
++      imag() { return _M_imag; }
++
++      ///  Return imaginary part of complex number.
++      const _Tp& 
++      imag() const { return _M_imag; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(_Tp __val) { _M_real = __val; }
++
++      void 
++      imag(_Tp __val) { _M_imag = __val; }
++
++      /// Assign this complex number to scalar @a t.
++      complex<_Tp>& operator=(const _Tp&);
++      
++      /// Add @a t to this complex number.
++      // 26.2.5/1
++      complex<_Tp>&
++      operator+=(const _Tp& __t)
++      {
++	_M_real += __t;
++	return *this;
++      }
++
++      /// Subtract @a t from this complex number.
++      // 26.2.5/3
++      complex<_Tp>&
++      operator-=(const _Tp& __t)
++      {
++	_M_real -= __t;
++	return *this;
++      }
++
++      /// Multiply this complex number by @a t.
++      complex<_Tp>& operator*=(const _Tp&);
++      /// Divide this complex number by @a t.
++      complex<_Tp>& operator/=(const _Tp&);
++
++      // Lets the compiler synthesize the
++      // copy and assignment operator
++      // complex<_Tp>& operator= (const complex<_Tp>&);
++      /// Assign this complex number to complex @a z.
++      template<typename _Up>
++        complex<_Tp>& operator=(const complex<_Up>&);
++      /// Add @a z to this complex number.
++      template<typename _Up>
++        complex<_Tp>& operator+=(const complex<_Up>&);
++      /// Subtract @a z from this complex number.
++      template<typename _Up>
++        complex<_Tp>& operator-=(const complex<_Up>&);
++      /// Multiply this complex number by @a z.
++      template<typename _Up>
++        complex<_Tp>& operator*=(const complex<_Up>&);
++      /// Divide this complex number by @a z.
++      template<typename _Up>
++        complex<_Tp>& operator/=(const complex<_Up>&);
++
++      _GLIBCXX_USE_CONSTEXPR complex __rep() const
++      { return *this; }
++
++    private:
++      _Tp _M_real;
++      _Tp _M_imag;
++    };
++
++  template<typename _Tp>
++    complex<_Tp>&
++    complex<_Tp>::operator=(const _Tp& __t)
++    {
++     _M_real = __t;
++     _M_imag = _Tp();
++     return *this;
++    } 
++
++  // 26.2.5/5
++  template<typename _Tp>
++    complex<_Tp>&
++    complex<_Tp>::operator*=(const _Tp& __t)
++    {
++      _M_real *= __t;
++      _M_imag *= __t;
++      return *this;
++    }
++
++  // 26.2.5/7
++  template<typename _Tp>
++    complex<_Tp>&
++    complex<_Tp>::operator/=(const _Tp& __t)
++    {
++      _M_real /= __t;
++      _M_imag /= __t;
++      return *this;
++    }
++
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator=(const complex<_Up>& __z)
++    {
++      _M_real = __z.real();
++      _M_imag = __z.imag();
++      return *this;
++    }
++
++  // 26.2.5/9
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator+=(const complex<_Up>& __z)
++    {
++      _M_real += __z.real();
++      _M_imag += __z.imag();
++      return *this;
++    }
++
++  // 26.2.5/11
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator-=(const complex<_Up>& __z)
++    {
++      _M_real -= __z.real();
++      _M_imag -= __z.imag();
++      return *this;
++    }
++
++  // 26.2.5/13
++  // XXX: This is a grammar school implementation.
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator*=(const complex<_Up>& __z)
++    {
++      const _Tp __r = _M_real * __z.real() - _M_imag * __z.imag();
++      _M_imag = _M_real * __z.imag() + _M_imag * __z.real();
++      _M_real = __r;
++      return *this;
++    }
++
++  // 26.2.5/15
++  // XXX: This is a grammar school implementation.
++  template<typename _Tp>
++    template<typename _Up>
++    complex<_Tp>&
++    complex<_Tp>::operator/=(const complex<_Up>& __z)
++    {
++      const _Tp __r =  _M_real * __z.real() + _M_imag * __z.imag();
++      const _Tp __n = std::norm(__z);
++      _M_imag = (_M_imag * __z.real() - _M_real * __z.imag()) / __n;
++      _M_real = __r / __n;
++      return *this;
++    }
++    
++  // Operators:
++  //@{
++  ///  Return new complex value @a x plus @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r += __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r += __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __y;
++      __r += __x;
++      return __r;
++    }
++  //@}
++
++  //@{
++  ///  Return new complex value @a x minus @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r -= __y;
++      return __r;
++    }
++    
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r -= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r(__x, -__y.imag());
++      __r -= __y.real();
++      return __r;
++    }
++  //@}
++
++  //@{
++  ///  Return new complex value @a x times @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator*(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r *= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator*(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r *= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator*(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __y;
++      __r *= __x;
++      return __r;
++    }
++  //@}
++
++  //@{
++  ///  Return new complex value @a x divided by @a y.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator/(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r /= __y;
++      return __r;
++    }
++    
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator/(const complex<_Tp>& __x, const _Tp& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r /= __y;
++      return __r;
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator/(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      complex<_Tp> __r = __x;
++      __r /= __y;
++      return __r;
++    }
++  //@}
++
++  ///  Return @a x.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator+(const complex<_Tp>& __x)
++    { return __x; }
++
++  ///  Return complex negation of @a x.
++  template<typename _Tp>
++    inline complex<_Tp>
++    operator-(const complex<_Tp>& __x)
++    {  return complex<_Tp>(-__x.real(), -__x.imag()); }
++
++  //@{
++  ///  Return true if @a x is equal to @a y.
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator==(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __x.real() == __y.real() && __x.imag() == __y.imag(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator==(const complex<_Tp>& __x, const _Tp& __y)
++    { return __x.real() == __y && __x.imag() == _Tp(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator==(const _Tp& __x, const complex<_Tp>& __y)
++    { return __x == __y.real() && _Tp() == __y.imag(); }
++  //@}
++
++  //@{
++  ///  Return false if @a x is equal to @a y.
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator!=(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __x.real() != __y.real() || __x.imag() != __y.imag(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator!=(const complex<_Tp>& __x, const _Tp& __y)
++    { return __x.real() != __y || __x.imag() != _Tp(); }
++
++  template<typename _Tp>
++    inline _GLIBCXX_CONSTEXPR bool
++    operator!=(const _Tp& __x, const complex<_Tp>& __y)
++    { return __x != __y.real() || _Tp() != __y.imag(); }
++  //@}
++
++  ///  Extraction operator for complex values.
++  template<typename _Tp, typename _CharT, class _Traits>
++    basic_istream<_CharT, _Traits>&
++    operator>>(basic_istream<_CharT, _Traits>& __is, complex<_Tp>& __x)
++    {
++      _Tp __re_x, __im_x;
++      _CharT __ch;
++      __is >> __ch;
++      if (__ch == '(') 
++	{
++	  __is >> __re_x >> __ch;
++	  if (__ch == ',') 
++	    {
++	      __is >> __im_x >> __ch;
++	      if (__ch == ')') 
++		__x = complex<_Tp>(__re_x, __im_x);
++	      else
++		__is.setstate(ios_base::failbit);
++	    }
++	  else if (__ch == ')') 
++	    __x = __re_x;
++	  else
++	    __is.setstate(ios_base::failbit);
++	}
++      else 
++	{
++	  __is.putback(__ch);
++	  __is >> __re_x;
++	  __x = __re_x;
++	}
++      return __is;
++    }
++
++  ///  Insertion operator for complex values.
++  template<typename _Tp, typename _CharT, class _Traits>
++    basic_ostream<_CharT, _Traits>&
++    operator<<(basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x)
++    {
++      basic_ostringstream<_CharT, _Traits> __s;
++      __s.flags(__os.flags());
++      __s.imbue(__os.getloc());
++      __s.precision(__os.precision());
++      __s << '(' << __x.real() << ',' << __x.imag() << ')';
++      return __os << __s.str();
++    }
++
++  // Values
++#if __cplusplus >= 201103L
++  template<typename _Tp>
++    constexpr _Tp
++    real(const complex<_Tp>& __z)
++    { return __z.real(); }
++
++  template<typename _Tp>
++    constexpr _Tp
++    imag(const complex<_Tp>& __z)
++    { return __z.imag(); }
++#else
++  template<typename _Tp>
++    inline _Tp&
++    real(complex<_Tp>& __z)
++    { return __z.real(); }
++    
++  template<typename _Tp>
++    inline const _Tp&
++    real(const complex<_Tp>& __z)
++    { return __z.real(); }
++    
++  template<typename _Tp>
++    inline _Tp&
++    imag(complex<_Tp>& __z)
++    { return __z.imag(); }
++    
++  template<typename _Tp>
++    inline const _Tp&
++    imag(const complex<_Tp>& __z)
++    { return __z.imag(); }
++#endif
++
++  // 26.2.7/3 abs(__z):  Returns the magnitude of __z.
++  template<typename _Tp>
++    inline _Tp
++    __complex_abs(const complex<_Tp>& __z)
++    {
++      _Tp __x = __z.real();
++      _Tp __y = __z.imag();
++      const _Tp __s = std::max(abs(__x), abs(__y));
++      if (__s == _Tp())  // well ...
++        return __s;
++      __x /= __s; 
++      __y /= __s;
++      return __s * sqrt(__x * __x + __y * __y);
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline float
++  __complex_abs(__complex__ float __z) { return __builtin_cabsf(__z); }
++
++  inline double
++  __complex_abs(__complex__ double __z) { return __builtin_cabs(__z); }
++
++  inline long double
++  __complex_abs(const __complex__ long double& __z)
++  { return __builtin_cabsl(__z); }
++
++  template<typename _Tp>
++    inline _Tp
++    abs(const complex<_Tp>& __z) { return __complex_abs(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline _Tp
++    abs(const complex<_Tp>& __z) { return __complex_abs(__z); }
++#endif  
++
++
++  // 26.2.7/4: arg(__z): Returns the phase angle of __z.
++  template<typename _Tp>
++    inline _Tp
++    __complex_arg(const complex<_Tp>& __z)
++    { return  atan2(__z.imag(), __z.real()); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline float
++  __complex_arg(__complex__ float __z) { return __builtin_cargf(__z); }
++
++  inline double
++  __complex_arg(__complex__ double __z) { return __builtin_carg(__z); }
++
++  inline long double
++  __complex_arg(const __complex__ long double& __z)
++  { return __builtin_cargl(__z); }
++
++  template<typename _Tp>
++    inline _Tp
++    arg(const complex<_Tp>& __z) { return __complex_arg(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline _Tp
++    arg(const complex<_Tp>& __z) { return __complex_arg(__z); }
++#endif
++
++  // 26.2.7/5: norm(__z) returns the squared magnitude of __z.
++  //     As defined, norm() is -not- a norm is the common mathematical
++  //     sens used in numerics.  The helper class _Norm_helper<> tries to
++  //     distinguish between builtin floating point and the rest, so as
++  //     to deliver an answer as close as possible to the real value.
++  template<bool>
++    struct _Norm_helper
++    {
++      template<typename _Tp>
++        static inline _Tp _S_do_it(const complex<_Tp>& __z)
++        {
++          const _Tp __x = __z.real();
++          const _Tp __y = __z.imag();
++          return __x * __x + __y * __y;
++        }
++    };
++
++  template<>
++    struct _Norm_helper<true>
++    {
++      template<typename _Tp>
++        static inline _Tp _S_do_it(const complex<_Tp>& __z)
++        {
++          _Tp __res = std::abs(__z);
++          return __res * __res;
++        }
++    };
++  
++  template<typename _Tp>
++    inline _Tp
++    norm(const complex<_Tp>& __z)
++    {
++      return _Norm_helper<__is_floating<_Tp>::__value 
++	&& !_GLIBCXX_FAST_MATH>::_S_do_it(__z);
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    polar(const _Tp& __rho, const _Tp& __theta)
++    { return complex<_Tp>(__rho * cos(__theta), __rho * sin(__theta)); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    conj(const complex<_Tp>& __z)
++    { return complex<_Tp>(__z.real(), -__z.imag()); }
++  
++  // Transcendentals
++
++  // 26.2.8/1 cos(__z):  Returns the cosine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_cos(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp __y = __z.imag();
++      return complex<_Tp>(cos(__x) * cosh(__y), -sin(__x) * sinh(__y));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_cos(__complex__ float __z) { return __builtin_ccosf(__z); }
++
++  inline __complex__ double
++  __complex_cos(__complex__ double __z) { return __builtin_ccos(__z); }
++
++  inline __complex__ long double
++  __complex_cos(const __complex__ long double& __z)
++  { return __builtin_ccosl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    cos(const complex<_Tp>& __z) { return __complex_cos(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    cos(const complex<_Tp>& __z) { return __complex_cos(__z); }
++#endif
++
++  // 26.2.8/2 cosh(__z): Returns the hyperbolic cosine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_cosh(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp __y = __z.imag();
++      return complex<_Tp>(cosh(__x) * cos(__y), sinh(__x) * sin(__y));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_cosh(__complex__ float __z) { return __builtin_ccoshf(__z); }
++
++  inline __complex__ double
++  __complex_cosh(__complex__ double __z) { return __builtin_ccosh(__z); }
++
++  inline __complex__ long double
++  __complex_cosh(const __complex__ long double& __z)
++  { return __builtin_ccoshl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    cosh(const complex<_Tp>& __z) { return __complex_cosh(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    cosh(const complex<_Tp>& __z) { return __complex_cosh(__z); }
++#endif
++
++  // 26.2.8/3 exp(__z): Returns the complex base e exponential of x
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_exp(const complex<_Tp>& __z)
++    { return std::polar(exp(__z.real()), __z.imag()); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_exp(__complex__ float __z) { return __builtin_cexpf(__z); }
++
++  inline __complex__ double
++  __complex_exp(__complex__ double __z) { return __builtin_cexp(__z); }
++
++  inline __complex__ long double
++  __complex_exp(const __complex__ long double& __z)
++  { return __builtin_cexpl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    exp(const complex<_Tp>& __z) { return __complex_exp(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    exp(const complex<_Tp>& __z) { return __complex_exp(__z); }
++#endif
++
++  // 26.2.8/5 log(__z): Returns the natural complex logarithm of __z.
++  //                    The branch cut is along the negative axis.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_log(const complex<_Tp>& __z)
++    { return complex<_Tp>(log(std::abs(__z)), std::arg(__z)); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_log(__complex__ float __z) { return __builtin_clogf(__z); }
++
++  inline __complex__ double
++  __complex_log(__complex__ double __z) { return __builtin_clog(__z); }
++
++  inline __complex__ long double
++  __complex_log(const __complex__ long double& __z)
++  { return __builtin_clogl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    log(const complex<_Tp>& __z) { return __complex_log(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    log(const complex<_Tp>& __z) { return __complex_log(__z); }
++#endif
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    log10(const complex<_Tp>& __z)
++    { return std::log(__z) / log(_Tp(10.0)); }
++
++  // 26.2.8/10 sin(__z): Returns the sine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_sin(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp __y = __z.imag();
++      return complex<_Tp>(sin(__x) * cosh(__y), cos(__x) * sinh(__y)); 
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_sin(__complex__ float __z) { return __builtin_csinf(__z); }
++
++  inline __complex__ double
++  __complex_sin(__complex__ double __z) { return __builtin_csin(__z); }
++
++  inline __complex__ long double
++  __complex_sin(const __complex__ long double& __z)
++  { return __builtin_csinl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    sin(const complex<_Tp>& __z) { return __complex_sin(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    sin(const complex<_Tp>& __z) { return __complex_sin(__z); }
++#endif
++
++  // 26.2.8/11 sinh(__z): Returns the hyperbolic sine of __z.
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_sinh(const complex<_Tp>& __z)
++    {
++      const _Tp __x = __z.real();
++      const _Tp  __y = __z.imag();
++      return complex<_Tp>(sinh(__x) * cos(__y), cosh(__x) * sin(__y));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_sinh(__complex__ float __z) { return __builtin_csinhf(__z); }      
++
++  inline __complex__ double
++  __complex_sinh(__complex__ double __z) { return __builtin_csinh(__z); }      
++
++  inline __complex__ long double
++  __complex_sinh(const __complex__ long double& __z)
++  { return __builtin_csinhl(__z); }      
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    sinh(const complex<_Tp>& __z) { return __complex_sinh(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    sinh(const complex<_Tp>& __z) { return __complex_sinh(__z); }
++#endif
++
++  // 26.2.8/13 sqrt(__z): Returns the complex square root of __z.
++  //                     The branch cut is on the negative axis.
++  template<typename _Tp>
++    complex<_Tp>
++    __complex_sqrt(const complex<_Tp>& __z)
++    {
++      _Tp __x = __z.real();
++      _Tp __y = __z.imag();
++
++      if (__x == _Tp())
++        {
++          _Tp __t = sqrt(abs(__y) / 2);
++          return complex<_Tp>(__t, __y < _Tp() ? -__t : __t);
++        }
++      else
++        {
++          _Tp __t = sqrt(2 * (std::abs(__z) + abs(__x)));
++          _Tp __u = __t / 2;
++          return __x > _Tp()
++            ? complex<_Tp>(__u, __y / __t)
++            : complex<_Tp>(abs(__y) / __t, __y < _Tp() ? -__u : __u);
++        }
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_sqrt(__complex__ float __z) { return __builtin_csqrtf(__z); }
++
++  inline __complex__ double
++  __complex_sqrt(__complex__ double __z) { return __builtin_csqrt(__z); }
++
++  inline __complex__ long double
++  __complex_sqrt(const __complex__ long double& __z)
++  { return __builtin_csqrtl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    sqrt(const complex<_Tp>& __z) { return __complex_sqrt(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    sqrt(const complex<_Tp>& __z) { return __complex_sqrt(__z); }
++#endif
++
++  // 26.2.8/14 tan(__z):  Return the complex tangent of __z.
++  
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_tan(const complex<_Tp>& __z)
++    { return std::sin(__z) / std::cos(__z); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_tan(__complex__ float __z) { return __builtin_ctanf(__z); }
++
++  inline __complex__ double
++  __complex_tan(__complex__ double __z) { return __builtin_ctan(__z); }
++
++  inline __complex__ long double
++  __complex_tan(const __complex__ long double& __z)
++  { return __builtin_ctanl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    tan(const complex<_Tp>& __z) { return __complex_tan(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    tan(const complex<_Tp>& __z) { return __complex_tan(__z); }
++#endif
++
++
++  // 26.2.8/15 tanh(__z):  Returns the hyperbolic tangent of __z.
++  
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_tanh(const complex<_Tp>& __z)
++    { return std::sinh(__z) / std::cosh(__z); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_tanh(__complex__ float __z) { return __builtin_ctanhf(__z); }
++
++  inline __complex__ double
++  __complex_tanh(__complex__ double __z) { return __builtin_ctanh(__z); }
++
++  inline __complex__ long double
++  __complex_tanh(const __complex__ long double& __z)
++  { return __builtin_ctanhl(__z); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    tanh(const complex<_Tp>& __z) { return __complex_tanh(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    tanh(const complex<_Tp>& __z) { return __complex_tanh(__z); }
++#endif
++
++
++  // 26.2.8/9  pow(__x, __y): Returns the complex power base of __x
++  //                          raised to the __y-th power.  The branch
++  //                          cut is on the negative axis.
++  template<typename _Tp>
++    complex<_Tp>
++    __complex_pow_unsigned(complex<_Tp> __x, unsigned __n)
++    {
++      complex<_Tp> __y = __n % 2 ? __x : complex<_Tp>(1);
++
++      while (__n >>= 1)
++        {
++          __x *= __x;
++          if (__n % 2)
++            __y *= __x;
++        }
++
++      return __y;
++    }
++
++  // In C++11 mode we used to implement the resolution of
++  // DR 844. complex pow return type is ambiguous.
++  // thus the following overload was disabled in that mode.  However, doing
++  // that causes all sorts of issues, see, for example:
++  //   http://gcc.gnu.org/ml/libstdc++/2013-01/msg00058.html
++  // and also PR57974.
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const complex<_Tp>& __z, int __n)
++    {
++      return __n < 0
++	? complex<_Tp>(1) / std::__complex_pow_unsigned(__z, -(unsigned)__n)
++        : std::__complex_pow_unsigned(__z, __n);
++    }
++
++  template<typename _Tp>
++    complex<_Tp>
++    pow(const complex<_Tp>& __x, const _Tp& __y)
++    {
++#ifndef _GLIBCXX_USE_C99_COMPLEX
++      if (__x == _Tp())
++	return _Tp();
++#endif
++      if (__x.imag() == _Tp() && __x.real() > _Tp())
++        return pow(__x.real(), __y);
++
++      complex<_Tp> __t = std::log(__x);
++      return std::polar(exp(__y * __t.real()), __y * __t.imag());
++    }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    __complex_pow(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __x == _Tp() ? _Tp() : std::exp(__y * std::log(__x)); }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_pow(__complex__ float __x, __complex__ float __y)
++  { return __builtin_cpowf(__x, __y); }
++
++  inline __complex__ double
++  __complex_pow(__complex__ double __x, __complex__ double __y)
++  { return __builtin_cpow(__x, __y); }
++
++  inline __complex__ long double
++  __complex_pow(const __complex__ long double& __x,
++		const __complex__ long double& __y)
++  { return __builtin_cpowl(__x, __y); }
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __complex_pow(__x.__rep(), __y.__rep()); }
++#else
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const complex<_Tp>& __x, const complex<_Tp>& __y)
++    { return __complex_pow(__x, __y); }
++#endif
++
++  template<typename _Tp>
++    inline complex<_Tp>
++    pow(const _Tp& __x, const complex<_Tp>& __y)
++    {
++      return __x > _Tp() ? std::polar(pow(__x, __y.real()),
++				      __y.imag() * log(__x))
++	                 : std::pow(complex<_Tp>(__x), __y);
++    }
++
++  /// 26.2.3  complex specializations
++  /// complex<float> specialization
++  template<>
++    struct complex<float>
++    {
++      typedef float value_type;
++      typedef __complex__ float _ComplexT;
++
++      _GLIBCXX_CONSTEXPR complex(_ComplexT __z) : _M_value(__z) { }
++
++      _GLIBCXX_CONSTEXPR complex(float __r = 0.0f, float __i = 0.0f)
++#if __cplusplus >= 201103L
++      : _M_value{ __r, __i } { }
++#else
++      {
++	__real__ _M_value = __r;
++	__imag__ _M_value = __i;
++      }
++#endif
++
++      explicit _GLIBCXX_CONSTEXPR complex(const complex<double>&);
++      explicit _GLIBCXX_CONSTEXPR complex(const complex<long double>&);	
++
++#if __cplusplus >= 201103L
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      __attribute ((__abi_tag__ ("cxx11")))
++      constexpr float 
++      real() const { return __real__ _M_value; }
++
++      __attribute ((__abi_tag__ ("cxx11")))
++      constexpr float 
++      imag() const { return __imag__ _M_value; }
++#else
++      float& 
++      real() { return __real__ _M_value; }
++
++      const float& 
++      real() const { return __real__ _M_value; }      
++
++      float& 
++      imag() { return __imag__ _M_value; }
++
++      const float& 
++      imag() const { return __imag__ _M_value; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(float __val) { __real__ _M_value = __val; }
++
++      void 
++      imag(float __val) { __imag__ _M_value = __val; }
++
++      complex&
++      operator=(float __f);
++
++      complex&
++      operator+=(float __f)
++      {
++	_M_value += __f;
++	return *this;
++      }
++
++      complex&
++      operator-=(float __f)
++      {
++	_M_value -= __f;
++	return *this;
++      }
++
++      complex&
++      operator*=(float __f)
++      {
++	_M_value *= __f;
++	return *this;
++      }
++
++      complex&
++      operator/=(float __f)
++      {
++	_M_value /= __f;
++	return *this;
++      }
++
++      // Let the compiler synthesize the copy and assignment
++      // operator.  It always does a pretty good job.
++      // complex& operator=(const complex&);
++
++      template<typename _Tp>
++        complex&
++        operator=(const complex<_Tp>&  __z)
++	{
++	  __real__ _M_value = __z.real();
++	  __imag__ _M_value = __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator+=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value += __z.real();
++	  __imag__ _M_value += __z.imag();
++	  return *this;
++	}
++
++      template<class _Tp>
++        complex&
++        operator-=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value -= __z.real();
++	  __imag__ _M_value -= __z.imag();
++	  return *this;
++	}
++
++      template<class _Tp>
++        complex&
++        operator*=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value *= __t;
++	  return *this;
++	}
++
++      template<class _Tp>
++        complex&
++        operator/=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value /= __t;
++	  return *this;
++	}
++
++      _GLIBCXX_USE_CONSTEXPR _ComplexT __rep() const { return _M_value; }
++
++    private:
++      _ComplexT _M_value;
++    };
++
++  /// 26.2.3  complex specializations
++  /// complex<double> specialization
++  template<>
++    struct complex<double>
++    {
++      typedef double value_type;
++      typedef __complex__ double _ComplexT;
++
++      _GLIBCXX_CONSTEXPR complex(_ComplexT __z) : _M_value(__z) { }
++
++      _GLIBCXX_CONSTEXPR complex(double __r = 0.0, double __i = 0.0)
++#if __cplusplus >= 201103L
++      : _M_value{ __r, __i } { }
++#else
++      {
++	__real__ _M_value = __r;
++	__imag__ _M_value = __i;
++      }
++#endif
++
++      _GLIBCXX_CONSTEXPR complex(const complex<float>& __z)
++      : _M_value(__z.__rep()) { }
++
++      explicit _GLIBCXX_CONSTEXPR complex(const complex<long double>&);	
++
++#if __cplusplus >= 201103L
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      __attribute ((__abi_tag__ ("cxx11")))
++      constexpr double 
++      real() const { return __real__ _M_value; }
++
++      __attribute ((__abi_tag__ ("cxx11")))
++      constexpr double 
++      imag() const { return __imag__ _M_value; }
++#else
++      double& 
++      real() { return __real__ _M_value; }
++
++      const double& 
++      real() const { return __real__ _M_value; }
++
++      double& 
++      imag() { return __imag__ _M_value; }
++
++      const double& 
++      imag() const { return __imag__ _M_value; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(double __val) { __real__ _M_value = __val; }
++
++      void 
++      imag(double __val) { __imag__ _M_value = __val; }
++
++      complex&
++      operator=(double __d);
++
++      complex&
++      operator+=(double __d)
++      {
++	_M_value += __d;
++	return *this;
++      }
++	
++      complex&
++      operator-=(double __d)
++      {
++	_M_value -= __d;
++	return *this;
++      }
++
++      complex&
++      operator*=(double __d)
++      {
++	_M_value *= __d;
++	return *this;
++      }
++
++      complex&
++      operator/=(double __d)
++      {
++	_M_value /= __d;
++	return *this;
++      }
++
++      // The compiler will synthesize this, efficiently.
++      // complex& operator=(const complex&);
++
++      template<typename _Tp>
++        complex&
++        operator=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value = __z.real();
++	  __imag__ _M_value = __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator+=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value += __z.real();
++	  __imag__ _M_value += __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator-=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value -= __z.real();
++	  __imag__ _M_value -= __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator*=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value *= __t;
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++        operator/=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value /= __t;
++	  return *this;
++	}
++
++      _GLIBCXX_USE_CONSTEXPR _ComplexT __rep() const { return _M_value; }
++
++    private:
++      _ComplexT _M_value;
++    };
++
++  /// 26.2.3  complex specializations
++  /// complex<long double> specialization
++  template<>
++    struct complex<long double>
++    {
++      typedef long double value_type;
++      typedef __complex__ long double _ComplexT;
++
++      _GLIBCXX_CONSTEXPR complex(_ComplexT __z) : _M_value(__z) { }
++
++      _GLIBCXX_CONSTEXPR complex(long double __r = 0.0L, 
++				 long double __i = 0.0L)
++#if __cplusplus >= 201103L
++      : _M_value{ __r, __i } { }
++#else
++      {
++	__real__ _M_value = __r;
++	__imag__ _M_value = __i;
++      }
++#endif
++
++      _GLIBCXX_CONSTEXPR complex(const complex<float>& __z)
++      : _M_value(__z.__rep()) { }
++
++      _GLIBCXX_CONSTEXPR complex(const complex<double>& __z)
++      : _M_value(__z.__rep()) { }
++
++#if __cplusplus >= 201103L
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      __attribute ((__abi_tag__ ("cxx11")))
++      constexpr long double 
++      real() const { return __real__ _M_value; }
++
++      __attribute ((__abi_tag__ ("cxx11")))
++      constexpr long double 
++      imag() const { return __imag__ _M_value; }
++#else
++      long double& 
++      real() { return __real__ _M_value; }
++
++      const long double& 
++      real() const { return __real__ _M_value; }
++
++      long double& 
++      imag() { return __imag__ _M_value; }
++
++      const long double& 
++      imag() const { return __imag__ _M_value; }
++#endif
++
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // DR 387. std::complex over-encapsulated.
++      void 
++      real(long double __val) { __real__ _M_value = __val; }
++
++      void 
++      imag(long double __val) { __imag__ _M_value = __val; }
++
++      complex&
++      operator=(long double __r);
++
++      complex&
++      operator+=(long double __r)
++      {
++	_M_value += __r;
++	return *this;
++      }
++
++      complex&
++      operator-=(long double __r)
++      {
++	_M_value -= __r;
++	return *this;
++      }
++
++      complex&
++      operator*=(long double __r)
++      {
++	_M_value *= __r;
++	return *this;
++      }
++
++      complex&
++      operator/=(long double __r)
++      {
++	_M_value /= __r;
++	return *this;
++      }
++
++      // The compiler knows how to do this efficiently
++      // complex& operator=(const complex&);
++
++      template<typename _Tp>
++        complex&
++        operator=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value = __z.real();
++	  __imag__ _M_value = __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator+=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value += __z.real();
++	  __imag__ _M_value += __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator-=(const complex<_Tp>& __z)
++	{
++	  __real__ _M_value -= __z.real();
++	  __imag__ _M_value -= __z.imag();
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator*=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value *= __t;
++	  return *this;
++	}
++
++      template<typename _Tp>
++        complex&
++	operator/=(const complex<_Tp>& __z)
++	{
++	  _ComplexT __t;
++	  __real__ __t = __z.real();
++	  __imag__ __t = __z.imag();
++	  _M_value /= __t;
++	  return *this;
++	}
++
++      _GLIBCXX_USE_CONSTEXPR _ComplexT __rep() const { return _M_value; }
++
++    private:
++      _ComplexT _M_value;
++    };
++
++  // These bits have to be at the end of this file, so that the
++  // specializations have all been defined.
++  inline _GLIBCXX_CONSTEXPR
++  complex<float>::complex(const complex<double>& __z)
++  : _M_value(__z.__rep()) { }
++
++  inline _GLIBCXX_CONSTEXPR
++  complex<float>::complex(const complex<long double>& __z)
++  : _M_value(__z.__rep()) { }
++
++  inline _GLIBCXX_CONSTEXPR
++  complex<double>::complex(const complex<long double>& __z)
++  : _M_value(__z.__rep()) { }
++
++  // Inhibit implicit instantiations for required instantiations,
++  // which are defined via explicit instantiations elsewhere.
++  // NB:  This syntax is a GNU extension.
++#if _GLIBCXX_EXTERN_TEMPLATE
++  extern template istream& operator>>(istream&, complex<float>&);
++  extern template ostream& operator<<(ostream&, const complex<float>&);
++  extern template istream& operator>>(istream&, complex<double>&);
++  extern template ostream& operator<<(ostream&, const complex<double>&);
++  extern template istream& operator>>(istream&, complex<long double>&);
++  extern template ostream& operator<<(ostream&, const complex<long double>&);
++
++#ifdef _GLIBCXX_USE_WCHAR_T
++  extern template wistream& operator>>(wistream&, complex<float>&);
++  extern template wostream& operator<<(wostream&, const complex<float>&);
++  extern template wistream& operator>>(wistream&, complex<double>&);
++  extern template wostream& operator<<(wostream&, const complex<double>&);
++  extern template wistream& operator>>(wistream&, complex<long double>&);
++  extern template wostream& operator<<(wostream&, const complex<long double>&);
++#endif
++#endif
++
++  // @} group complex_numbers
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // See ext/type_traits.h for the primary template.
++  template<typename _Tp, typename _Up>
++    struct __promote_2<std::complex<_Tp>, _Up>
++    {
++    public:
++      typedef std::complex<typename __promote_2<_Tp, _Up>::__type> __type;
++    };
++
++  template<typename _Tp, typename _Up>
++    struct __promote_2<_Tp, std::complex<_Up> >
++    {
++    public:
++      typedef std::complex<typename __promote_2<_Tp, _Up>::__type> __type;
++    };
++  
++  template<typename _Tp, typename _Up>
++    struct __promote_2<std::complex<_Tp>, std::complex<_Up> >
++    {
++    public:
++      typedef std::complex<typename __promote_2<_Tp, _Up>::__type> __type;
++    };
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#if __cplusplus >= 201103L
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // Forward declarations.
++  template<typename _Tp> std::complex<_Tp> acos(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> asin(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> atan(const std::complex<_Tp>&);
++
++  template<typename _Tp> std::complex<_Tp> acosh(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> asinh(const std::complex<_Tp>&);
++  template<typename _Tp> std::complex<_Tp> atanh(const std::complex<_Tp>&);
++  // DR 595.
++  template<typename _Tp> _Tp               fabs(const std::complex<_Tp>&);
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    __complex_acos(const std::complex<_Tp>& __z)
++    {
++      const std::complex<_Tp> __t = std::asin(__z);
++      const _Tp __pi_2 = 1.5707963267948966192313216916397514L;
++      return std::complex<_Tp>(__pi_2 - __t.real(), -__t.imag());
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_acos(__complex__ float __z)
++  { return __builtin_cacosf(__z); }
++
++  inline __complex__ double
++  __complex_acos(__complex__ double __z)
++  { return __builtin_cacos(__z); }
++
++  inline __complex__ long double
++  __complex_acos(const __complex__ long double& __z)
++  { return __builtin_cacosl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acos(const std::complex<_Tp>& __z)
++    { return __complex_acos(__z.__rep()); }
++#else
++  /// acos(__z) [8.1.2].
++  //  Effects:  Behaves the same as C99 function cacos, defined
++  //            in subclause 7.3.5.1.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acos(const std::complex<_Tp>& __z)
++    { return __complex_acos(__z); }
++#endif
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    __complex_asin(const std::complex<_Tp>& __z)
++    {
++      std::complex<_Tp> __t(-__z.imag(), __z.real());
++      __t = std::asinh(__t);
++      return std::complex<_Tp>(__t.imag(), -__t.real());
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_asin(__complex__ float __z)
++  { return __builtin_casinf(__z); }
++
++  inline __complex__ double
++  __complex_asin(__complex__ double __z)
++  { return __builtin_casin(__z); }
++
++  inline __complex__ long double
++  __complex_asin(const __complex__ long double& __z)
++  { return __builtin_casinl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asin(const std::complex<_Tp>& __z)
++    { return __complex_asin(__z.__rep()); }
++#else
++  /// asin(__z) [8.1.3].
++  //  Effects:  Behaves the same as C99 function casin, defined
++  //            in subclause 7.3.5.2.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asin(const std::complex<_Tp>& __z)
++    { return __complex_asin(__z); }
++#endif
++  
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_atan(const std::complex<_Tp>& __z)
++    {
++      const _Tp __r2 = __z.real() * __z.real();
++      const _Tp __x = _Tp(1.0) - __r2 - __z.imag() * __z.imag();
++
++      _Tp __num = __z.imag() + _Tp(1.0);
++      _Tp __den = __z.imag() - _Tp(1.0);
++
++      __num = __r2 + __num * __num;
++      __den = __r2 + __den * __den;
++
++      return std::complex<_Tp>(_Tp(0.5) * atan2(_Tp(2.0) * __z.real(), __x),
++			       _Tp(0.25) * log(__num / __den));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_atan(__complex__ float __z)
++  { return __builtin_catanf(__z); }
++
++  inline __complex__ double
++  __complex_atan(__complex__ double __z)
++  { return __builtin_catan(__z); }
++
++  inline __complex__ long double
++  __complex_atan(const __complex__ long double& __z)
++  { return __builtin_catanl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atan(const std::complex<_Tp>& __z)
++    { return __complex_atan(__z.__rep()); }
++#else
++  /// atan(__z) [8.1.4].
++  //  Effects:  Behaves the same as C99 function catan, defined
++  //            in subclause 7.3.5.3.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atan(const std::complex<_Tp>& __z)
++    { return __complex_atan(__z); }
++#endif
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_acosh(const std::complex<_Tp>& __z)
++    {
++      // Kahan's formula.
++      return _Tp(2.0) * std::log(std::sqrt(_Tp(0.5) * (__z + _Tp(1.0)))
++				 + std::sqrt(_Tp(0.5) * (__z - _Tp(1.0))));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_acosh(__complex__ float __z)
++  { return __builtin_cacoshf(__z); }
++
++  inline __complex__ double
++  __complex_acosh(__complex__ double __z)
++  { return __builtin_cacosh(__z); }
++
++  inline __complex__ long double
++  __complex_acosh(const __complex__ long double& __z)
++  { return __builtin_cacoshl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acosh(const std::complex<_Tp>& __z)
++    { return __complex_acosh(__z.__rep()); }
++#else
++  /// acosh(__z) [8.1.5].
++  //  Effects:  Behaves the same as C99 function cacosh, defined
++  //            in subclause 7.3.6.1.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    acosh(const std::complex<_Tp>& __z)
++    { return __complex_acosh(__z); }
++#endif
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_asinh(const std::complex<_Tp>& __z)
++    {
++      std::complex<_Tp> __t((__z.real() - __z.imag())
++			    * (__z.real() + __z.imag()) + _Tp(1.0),
++			    _Tp(2.0) * __z.real() * __z.imag());
++      __t = std::sqrt(__t);
++
++      return std::log(__t + __z);
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_asinh(__complex__ float __z)
++  { return __builtin_casinhf(__z); }
++
++  inline __complex__ double
++  __complex_asinh(__complex__ double __z)
++  { return __builtin_casinh(__z); }
++
++  inline __complex__ long double
++  __complex_asinh(const __complex__ long double& __z)
++  { return __builtin_casinhl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asinh(const std::complex<_Tp>& __z)
++    { return __complex_asinh(__z.__rep()); }
++#else
++  /// asinh(__z) [8.1.6].
++  //  Effects:  Behaves the same as C99 function casin, defined
++  //            in subclause 7.3.6.2.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    asinh(const std::complex<_Tp>& __z)
++    { return __complex_asinh(__z); }
++#endif
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_atanh(const std::complex<_Tp>& __z)
++    {
++      const _Tp __i2 = __z.imag() * __z.imag();
++      const _Tp __x = _Tp(1.0) - __i2 - __z.real() * __z.real();
++
++      _Tp __num = _Tp(1.0) + __z.real();
++      _Tp __den = _Tp(1.0) - __z.real();
++
++      __num = __i2 + __num * __num;
++      __den = __i2 + __den * __den;
++
++      return std::complex<_Tp>(_Tp(0.25) * (log(__num) - log(__den)),
++			       _Tp(0.5) * atan2(_Tp(2.0) * __z.imag(), __x));
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX_TR1
++  inline __complex__ float
++  __complex_atanh(__complex__ float __z)
++  { return __builtin_catanhf(__z); }
++
++  inline __complex__ double
++  __complex_atanh(__complex__ double __z)
++  { return __builtin_catanh(__z); }
++
++  inline __complex__ long double
++  __complex_atanh(const __complex__ long double& __z)
++  { return __builtin_catanhl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atanh(const std::complex<_Tp>& __z)
++    { return __complex_atanh(__z.__rep()); }
++#else
++  /// atanh(__z) [8.1.7].
++  //  Effects:  Behaves the same as C99 function catanh, defined
++  //            in subclause 7.3.6.3.
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    atanh(const std::complex<_Tp>& __z)
++    { return __complex_atanh(__z); }
++#endif
++
++  template<typename _Tp>
++    inline _Tp
++    /// fabs(__z) [8.1.8].
++    //  Effects:  Behaves the same as C99 function cabs, defined
++    //            in subclause 7.3.8.1.
++    fabs(const std::complex<_Tp>& __z)
++    { return std::abs(__z); }
++
++  /// Additional overloads [8.1.9].
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    arg(_Tp __x)
++    {
++      typedef typename __gnu_cxx::__promote<_Tp>::__type __type;
++#if (_GLIBCXX_USE_C99_MATH && !_GLIBCXX_USE_C99_FP_MACROS_DYNAMIC)
++      return std::signbit(__x) ? __type(3.1415926535897932384626433832795029L)
++	                       : __type();
++#else
++      return std::arg(std::complex<__type>(__x));
++#endif
++    }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    imag(_Tp)
++    { return _Tp(); }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    norm(_Tp __x)
++    {
++      typedef typename __gnu_cxx::__promote<_Tp>::__type __type;
++      return __type(__x) * __type(__x);
++    }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    real(_Tp __x)
++    { return __x; }
++
++  template<typename _Tp, typename _Up>
++    inline std::complex<typename __gnu_cxx::__promote_2<_Tp, _Up>::__type>
++    pow(const std::complex<_Tp>& __x, const _Up& __y)
++    {
++      typedef typename __gnu_cxx::__promote_2<_Tp, _Up>::__type __type;
++      return std::pow(std::complex<__type>(__x), __type(__y));
++    }
++
++  template<typename _Tp, typename _Up>
++    inline std::complex<typename __gnu_cxx::__promote_2<_Tp, _Up>::__type>
++    pow(const _Tp& __x, const std::complex<_Up>& __y)
++    {
++      typedef typename __gnu_cxx::__promote_2<_Tp, _Up>::__type __type;
++      return std::pow(__type(__x), std::complex<__type>(__y));
++    }
++
++  template<typename _Tp, typename _Up>
++    inline std::complex<typename __gnu_cxx::__promote_2<_Tp, _Up>::__type>
++    pow(const std::complex<_Tp>& __x, const std::complex<_Up>& __y)
++    {
++      typedef typename __gnu_cxx::__promote_2<_Tp, _Up>::__type __type;
++      return std::pow(std::complex<__type>(__x),
++		      std::complex<__type>(__y));
++    }
++
++  // Forward declarations.
++  // DR 781.
++  template<typename _Tp> std::complex<_Tp> proj(const std::complex<_Tp>&);
++
++  template<typename _Tp>
++    std::complex<_Tp>
++    __complex_proj(const std::complex<_Tp>& __z)
++    {
++      const _Tp __den = (__z.real() * __z.real()
++			 + __z.imag() * __z.imag() + _Tp(1.0));
++
++      return std::complex<_Tp>((_Tp(2.0) * __z.real()) / __den,
++			       (_Tp(2.0) * __z.imag()) / __den);
++    }
++
++#if _GLIBCXX_USE_C99_COMPLEX
++  inline __complex__ float
++  __complex_proj(__complex__ float __z)
++  { return __builtin_cprojf(__z); }
++
++  inline __complex__ double
++  __complex_proj(__complex__ double __z)
++  { return __builtin_cproj(__z); }
++
++  inline __complex__ long double
++  __complex_proj(const __complex__ long double& __z)
++  { return __builtin_cprojl(__z); }
++
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    proj(const std::complex<_Tp>& __z)
++    { return __complex_proj(__z.__rep()); }
++#else
++  template<typename _Tp>
++    inline std::complex<_Tp>
++    proj(const std::complex<_Tp>& __z)
++    { return __complex_proj(__z); }
++#endif
++
++  // DR 1137.
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    proj(_Tp __x)
++    { return __x; }
++
++  template<typename _Tp>
++    inline typename __gnu_cxx::__promote<_Tp>::__type
++    conj(_Tp __x)
++    { return __x; }
++
++#if __cplusplus > 201103L
++
++inline namespace literals {
++inline namespace complex_literals {
++
++  constexpr std::complex<float>
++  operator""if(long double __num)
++  { return std::complex<float>{0.0F, static_cast<float>(__num)}; }
++
++  constexpr std::complex<float>
++  operator""if(unsigned long long __num)
++  { return std::complex<float>{0.0F, static_cast<float>(__num)}; }
++
++  constexpr std::complex<double>
++  operator""i(long double __num)
++  { return std::complex<double>{0.0, static_cast<double>(__num)}; }
++
++  constexpr std::complex<double>
++  operator""i(unsigned long long __num)
++  { return std::complex<double>{0.0, static_cast<double>(__num)}; }
++
++  constexpr std::complex<long double>
++  operator""il(long double __num)
++  { return std::complex<long double>{0.0L, __num}; }
++
++  constexpr std::complex<long double>
++  operator""il(unsigned long long __num)
++  { return std::complex<long double>{0.0L, static_cast<long double>(__num)}; }
++
++} // inline namespace complex_literals
++} // inline namespace literals
++
++#endif // C++14
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#endif  // C++11
++
++#endif  /* _GLIBCXX_COMPLEX */
+diff --git a/GCC_XML/Support/GCC/4.9/emmintrin.h b/GCC_XML/Support/GCC/4.9/emmintrin.h
+new file mode 100644
+index 0000000..94dd1f9
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/emmintrin.h
+@@ -0,0 +1,1519 @@
++/* Copyright (C) 2003-2014 Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GCC is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Implemented from the specification included in the Intel C++ Compiler
++   User Guide and Reference, version 9.0.  */
++
++#ifndef _EMMINTRIN_H_INCLUDED
++#define _EMMINTRIN_H_INCLUDED
++
++/* We need definitions from the SSE header files*/
++#include <xmmintrin.h>
++
++#ifndef __SSE2__
++#pragma GCC push_options
++#pragma GCC target("sse2")
++#define __DISABLE_SSE2__
++#endif /* __SSE2__ */
++
++/* SSE2 */
++typedef double __v2df __attribute__ ((__vector_size__ (16)));
++typedef long long __v2di __attribute__ ((__vector_size__ (16)));
++typedef int __v4si __attribute__ ((__vector_size__ (16)));
++typedef short __v8hi __attribute__ ((__vector_size__ (16)));
++typedef char __v16qi __attribute__ ((__vector_size__ (16)));
++
++/* The Intel API is flexible enough that we must allow aliasing with other
++   vector types, and their scalar components.  */
++typedef long long __m128i __attribute__ ((__vector_size__ (16), __may_alias__));
++typedef double __m128d __attribute__ ((__vector_size__ (16), __may_alias__));
++
++/* Create a selector for use with the SHUFPD instruction.  */
++#define _MM_SHUFFLE2(fp1,fp0) \
++ (((fp1) << 1) | (fp0))
++
++/* Create a vector with element 0 as F and the rest zero.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_sd (double __F)
++{
++  return __extension__ (__m128d){ __F, 0.0 };
++}
++
++/* Create a vector with both elements equal to F.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pd (double __F)
++{
++  return __extension__ (__m128d){ __F, __F };
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pd1 (double __F)
++{
++  return _mm_set1_pd (__F);
++}
++
++/* Create a vector with the lower value X and upper value W.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pd (double __W, double __X)
++{
++  return __extension__ (__m128d){ __X, __W };
++}
++
++/* Create a vector with the lower value W and upper value X.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pd (double __W, double __X)
++{
++  return __extension__ (__m128d){ __W, __X };
++}
++
++/* Create a vector of zeros.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_pd (void)
++{
++  return __extension__ (__m128d){ 0.0, 0.0 };
++}
++
++/* Sets the low DPFP value of A from the low value of B.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_move_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df)__A, (__v2df)__B);
++}
++
++/* Load two DPFP values from P.  The address must be 16-byte aligned.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_pd (double const *__P)
++{
++  return *(__m128d *)__P;
++}
++
++/* Load two DPFP values from P.  The address need not be 16-byte aligned.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadu_pd (double const *__P)
++{
++  return __builtin_ia32_loadupd (__P);
++}
++
++/* Create a vector with all two elements equal to *P.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load1_pd (double const *__P)
++{
++  return _mm_set1_pd (*__P);
++}
++
++/* Create a vector with element 0 as *P and the rest zero.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_sd (double const *__P)
++{
++  return _mm_set_sd (*__P);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_pd1 (double const *__P)
++{
++  return _mm_load1_pd (__P);
++}
++
++/* Load two DPFP values in reverse order.  The address must be aligned.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadr_pd (double const *__P)
++{
++  __m128d __tmp = _mm_load_pd (__P);
++  return __builtin_ia32_shufpd (__tmp, __tmp, _MM_SHUFFLE2 (0,1));
++}
++
++/* Store two DPFP values.  The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_pd (double *__P, __m128d __A)
++{
++  *(__m128d *)__P = __A;
++}
++
++/* Store two DPFP values.  The address need not be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeu_pd (double *__P, __m128d __A)
++{
++  __builtin_ia32_storeupd (__P, __A);
++}
++
++/* Stores the lower DPFP value.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_sd (double *__P, __m128d __A)
++{
++  *__P = __builtin_ia32_vec_ext_v2df (__A, 0);
++}
++
++extern __inline double __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_f64 (__m128d __A)
++{
++  return __builtin_ia32_vec_ext_v2df (__A, 0);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storel_pd (double *__P, __m128d __A)
++{
++  _mm_store_sd (__P, __A);
++}
++
++/* Stores the upper DPFP value.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeh_pd (double *__P, __m128d __A)
++{
++  *__P = __builtin_ia32_vec_ext_v2df (__A, 1);
++}
++
++/* Store the lower DPFP value across two words.
++   The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store1_pd (double *__P, __m128d __A)
++{
++  _mm_store_pd (__P, __builtin_ia32_shufpd (__A, __A, _MM_SHUFFLE2 (0,0)));
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_pd1 (double *__P, __m128d __A)
++{
++  _mm_store1_pd (__P, __A);
++}
++
++/* Store two DPFP values in reverse order.  The address must be aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storer_pd (double *__P, __m128d __A)
++{
++  _mm_store_pd (__P, __builtin_ia32_shufpd (__A, __A, _MM_SHUFFLE2 (0,1)));
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi128_si32 (__m128i __A)
++{
++  return __builtin_ia32_vec_ext_v4si ((__v4si)__A, 0);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi128_si64 (__m128i __A)
++{
++  return __builtin_ia32_vec_ext_v2di ((__v2di)__A, 0);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi128_si64x (__m128i __A)
++{
++  return __builtin_ia32_vec_ext_v2di ((__v2di)__A, 0);
++}
++#endif
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_addpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_addsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_subpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_subsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_mulpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_mulsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_divpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_divsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_pd (__m128d __A)
++{
++  return (__m128d)__builtin_ia32_sqrtpd ((__v2df)__A);
++}
++
++/* Return pair {sqrt (A[0), B[1]}.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_sd (__m128d __A, __m128d __B)
++{
++  __v2df __tmp = __builtin_ia32_movsd ((__v2df)__A, (__v2df)__B);
++  return (__m128d)__builtin_ia32_sqrtsd ((__v2df)__tmp);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_minpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_minsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_maxpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_maxsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_andpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_andnpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_orpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_xorpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpeqpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpltpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmplepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpgtpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpgepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpneqpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnltpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnlepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpngtpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpngepd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpordpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpunordpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpeqsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpltsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmplesd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmpltsd ((__v2df) __B,
++								 (__v2df)
++								 __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmplesd ((__v2df) __B,
++								 (__v2df)
++								 __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpneqsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnltsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpnlesd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmpnltsd ((__v2df) __B,
++								  (__v2df)
++								  __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d) __builtin_ia32_movsd ((__v2df) __A,
++					 (__v2df)
++					 __builtin_ia32_cmpnlesd ((__v2df) __B,
++								  (__v2df)
++								  __A));
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpordsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_sd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_cmpunordsd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comieq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdeq ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comilt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdlt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comile_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdle ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comigt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdgt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comige_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdge ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comineq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_comisdneq ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomieq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdeq ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomilt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdlt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomile_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdle ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomigt_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdgt ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomige_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdge ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomineq_sd (__m128d __A, __m128d __B)
++{
++  return __builtin_ia32_ucomisdneq ((__v2df)__A, (__v2df)__B);
++}
++
++/* Create a vector of Qi, where i is the element number.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi64x (long long __q1, long long __q0)
++{
++  return __extension__ (__m128i)(__v2di){ __q0, __q1 };
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi64 (__m64 __q1,  __m64 __q0)
++{
++  return _mm_set_epi64x ((long long)__q1, (long long)__q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi32 (int __q3, int __q2, int __q1, int __q0)
++{
++  return __extension__ (__m128i)(__v4si){ __q0, __q1, __q2, __q3 };
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi16 (short __q7, short __q6, short __q5, short __q4,
++	       short __q3, short __q2, short __q1, short __q0)
++{
++  return __extension__ (__m128i)(__v8hi){
++    __q0, __q1, __q2, __q3, __q4, __q5, __q6, __q7 };
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_epi8 (char __q15, char __q14, char __q13, char __q12,
++	      char __q11, char __q10, char __q09, char __q08,
++	      char __q07, char __q06, char __q05, char __q04,
++	      char __q03, char __q02, char __q01, char __q00)
++{
++  return __extension__ (__m128i)(__v16qi){
++    __q00, __q01, __q02, __q03, __q04, __q05, __q06, __q07,
++    __q08, __q09, __q10, __q11, __q12, __q13, __q14, __q15
++  };
++}
++
++/* Set all of the elements of the vector to A.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi64x (long long __A)
++{
++  return _mm_set_epi64x (__A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi64 (__m64 __A)
++{
++  return _mm_set_epi64 (__A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi32 (int __A)
++{
++  return _mm_set_epi32 (__A, __A, __A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi16 (short __A)
++{
++  return _mm_set_epi16 (__A, __A, __A, __A, __A, __A, __A, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_epi8 (char __A)
++{
++  return _mm_set_epi8 (__A, __A, __A, __A, __A, __A, __A, __A,
++		       __A, __A, __A, __A, __A, __A, __A, __A);
++}
++
++/* Create a vector of Qi, where i is the element number.
++   The parameter order is reversed from the _mm_set_epi* functions.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi64 (__m64 __q0, __m64 __q1)
++{
++  return _mm_set_epi64 (__q1, __q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi32 (int __q0, int __q1, int __q2, int __q3)
++{
++  return _mm_set_epi32 (__q3, __q2, __q1, __q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi16 (short __q0, short __q1, short __q2, short __q3,
++	        short __q4, short __q5, short __q6, short __q7)
++{
++  return _mm_set_epi16 (__q7, __q6, __q5, __q4, __q3, __q2, __q1, __q0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_epi8 (char __q00, char __q01, char __q02, char __q03,
++	       char __q04, char __q05, char __q06, char __q07,
++	       char __q08, char __q09, char __q10, char __q11,
++	       char __q12, char __q13, char __q14, char __q15)
++{
++  return _mm_set_epi8 (__q15, __q14, __q13, __q12, __q11, __q10, __q09, __q08,
++		       __q07, __q06, __q05, __q04, __q03, __q02, __q01, __q00);
++}
++
++/* Create a vector with element 0 as *P and the rest zero.  */
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_si128 (__m128i const *__P)
++{
++  return *__P;
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadu_si128 (__m128i const *__P)
++{
++  return (__m128i) __builtin_ia32_loaddqu ((char const *)__P);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadl_epi64 (__m128i const *__P)
++{
++  return _mm_set_epi64 ((__m64)0LL, *(__m64 *)__P);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_si128 (__m128i *__P, __m128i __B)
++{
++  *__P = __B;
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeu_si128 (__m128i *__P, __m128i __B)
++{
++  __builtin_ia32_storedqu ((char *)__P, (__v16qi)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storel_epi64 (__m128i *__P, __m128i __B)
++{
++  *(long long *)__P = __builtin_ia32_vec_ext_v2di ((__v2di)__B, 0);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movepi64_pi64 (__m128i __B)
++{
++  return (__m64) __builtin_ia32_vec_ext_v2di ((__v2di)__B, 0);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movpi64_epi64 (__m64 __A)
++{
++  return _mm_set_epi64 ((__m64)0LL, __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_move_epi64 (__m128i __A);
++
++/* Create a vector of zeros.  */
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_si128 (void)
++{
++  return __extension__ (__m128i)(__v4si){ 0, 0, 0, 0 };
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtepi32_pd (__m128i __A)
++{
++  return (__m128d)__builtin_ia32_cvtdq2pd ((__v4si) __A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtepi32_ps (__m128i __A)
++{
++  return (__m128)__builtin_ia32_cvtdq2ps ((__v4si) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpd_epi32 (__m128d __A)
++{
++  return (__m128i)__builtin_ia32_cvtpd2dq ((__v2df) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpd_pi32 (__m128d __A)
++{
++  return (__m64)__builtin_ia32_cvtpd2pi ((__v2df) __A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpd_ps (__m128d __A)
++{
++  return (__m128)__builtin_ia32_cvtpd2ps ((__v2df) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttpd_epi32 (__m128d __A)
++{
++  return (__m128i)__builtin_ia32_cvttpd2dq ((__v2df) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttpd_pi32 (__m128d __A)
++{
++  return (__m64)__builtin_ia32_cvttpd2pi ((__v2df) __A);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi32_pd (__m64 __A)
++{
++  return (__m128d)__builtin_ia32_cvtpi2pd ((__v2si) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_epi32 (__m128 __A)
++{
++  return (__m128i)__builtin_ia32_cvtps2dq ((__v4sf) __A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttps_epi32 (__m128 __A)
++{
++  return (__m128i)__builtin_ia32_cvttps2dq ((__v4sf) __A);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pd (__m128 __A)
++{
++  return (__m128d)__builtin_ia32_cvtps2pd ((__v4sf) __A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_si32 (__m128d __A)
++{
++  return __builtin_ia32_cvtsd2si ((__v2df) __A);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_si64 (__m128d __A)
++{
++  return __builtin_ia32_cvtsd2si64 ((__v2df) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_si64x (__m128d __A)
++{
++  return __builtin_ia32_cvtsd2si64 ((__v2df) __A);
++}
++#endif
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttsd_si32 (__m128d __A)
++{
++  return __builtin_ia32_cvttsd2si ((__v2df) __A);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttsd_si64 (__m128d __A)
++{
++  return __builtin_ia32_cvttsd2si64 ((__v2df) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttsd_si64x (__m128d __A)
++{
++  return __builtin_ia32_cvttsd2si64 ((__v2df) __A);
++}
++#endif
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsd_ss (__m128 __A, __m128d __B)
++{
++  return (__m128)__builtin_ia32_cvtsd2ss ((__v4sf) __A, (__v2df) __B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_sd (__m128d __A, int __B)
++{
++  return (__m128d)__builtin_ia32_cvtsi2sd ((__v2df) __A, __B);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_sd (__m128d __A, long long __B)
++{
++  return (__m128d)__builtin_ia32_cvtsi642sd ((__v2df) __A, __B);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_sd (__m128d __A, long long __B)
++{
++  return (__m128d)__builtin_ia32_cvtsi642sd ((__v2df) __A, __B);
++}
++#endif
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_sd (__m128d __A, __m128 __B)
++{
++  return (__m128d)__builtin_ia32_cvtss2sd ((__v2df) __A, (__v4sf)__B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_pd(__m128d __A, __m128d __B, const int __mask)
++{
++  return (__m128d)__builtin_ia32_shufpd ((__v2df)__A, (__v2df)__B, __mask);
++}
++#else
++#define _mm_shuffle_pd(A, B, N)						\
++  ((__m128d)__builtin_ia32_shufpd ((__v2df)(__m128d)(A),		\
++				   (__v2df)(__m128d)(B), (int)(N)))
++#endif
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_unpckhpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pd (__m128d __A, __m128d __B)
++{
++  return (__m128d)__builtin_ia32_unpcklpd ((__v2df)__A, (__v2df)__B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadh_pd (__m128d __A, double const *__B)
++{
++  return (__m128d)__builtin_ia32_loadhpd ((__v2df)__A, __B);
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadl_pd (__m128d __A, double const *__B)
++{
++  return (__m128d)__builtin_ia32_loadlpd ((__v2df)__A, __B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_pd (__m128d __A)
++{
++  return __builtin_ia32_movmskpd ((__v2df)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_packsswb128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_packssdw128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packus_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_packuswb128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhbw128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhwd128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhdq128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckhqdq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpcklbw128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpcklwd128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpckldq128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_punpcklqdq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddd128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddsb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddusb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_paddusw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubd128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubsb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubusb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psubusw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_madd_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmaddwd128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmulhw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mullo_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmullw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_su32 (__m64 __A, __m64 __B)
++{
++  return (__m64)__builtin_ia32_pmuludq ((__v2si)__A, (__v2si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_epu32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmuludq128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_epi16 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psllwi128 ((__v8hi)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_epi32 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_pslldi128 ((__v4si)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_epi64 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psllqi128 ((__v2di)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_epi16 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrawi128 ((__v8hi)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_epi32 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psradi128 ((__v4si)__A, __B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_si128 (__m128i __A, const int __N)
++{
++  return (__m128i)__builtin_ia32_psrldqi128 (__A, __N * 8);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_si128 (__m128i __A, const int __N)
++{
++  return (__m128i)__builtin_ia32_pslldqi128 (__A, __N * 8);
++}
++#else
++#define _mm_srli_si128(A, N) \
++  ((__m128i)__builtin_ia32_psrldqi128 ((__m128i)(A), (int)(N) * 8))
++#define _mm_slli_si128(A, N) \
++  ((__m128i)__builtin_ia32_pslldqi128 ((__m128i)(A), (int)(N) * 8))
++#endif
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_epi16 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrlwi128 ((__v8hi)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_epi32 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrldi128 ((__v4si)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_epi64 (__m128i __A, int __B)
++{
++  return (__m128i)__builtin_ia32_psrlqi128 ((__v2di)__A, __B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psllw128((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pslld128((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psllq128((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psraw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrad128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrlw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrld128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_epi64 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psrlq128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pand128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pandn128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_por128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_si128 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pxor128 ((__v2di)__A, (__v2di)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpeqb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpeqw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpeqd128 ((__v4si)__A, (__v4si)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtb128 ((__v16qi)__B, (__v16qi)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtw128 ((__v8hi)__B, (__v8hi)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtd128 ((__v4si)__B, (__v4si)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_epi8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_epi32 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pcmpgtd128 ((__v4si)__A, (__v4si)__B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_extract_epi16 (__m128i const __A, int const __N)
++{
++  return (unsigned short) __builtin_ia32_vec_ext_v8hi ((__v8hi)__A, __N);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_insert_epi16 (__m128i const __A, int const __D, int const __N)
++{
++  return (__m128i) __builtin_ia32_vec_set_v8hi ((__v8hi)__A, __D, __N);
++}
++#else
++#define _mm_extract_epi16(A, N) \
++  ((int) (unsigned short) __builtin_ia32_vec_ext_v8hi ((__v8hi)(__m128i)(A), (int)(N)))
++#define _mm_insert_epi16(A, D, N)				\
++  ((__m128i) __builtin_ia32_vec_set_v8hi ((__v8hi)(__m128i)(A),	\
++					  (int)(D), (int)(N)))
++#endif
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmaxsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmaxub128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_epi16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pminsw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pminub128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_epi8 (__m128i __A)
++{
++  return __builtin_ia32_pmovmskb128 ((__v16qi)__A);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pmulhuw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++#ifdef __OPTIMIZE__
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shufflehi_epi16 (__m128i __A, const int __mask)
++{
++  return (__m128i)__builtin_ia32_pshufhw ((__v8hi)__A, __mask);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shufflelo_epi16 (__m128i __A, const int __mask)
++{
++  return (__m128i)__builtin_ia32_pshuflw ((__v8hi)__A, __mask);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_epi32 (__m128i __A, const int __mask)
++{
++  return (__m128i)__builtin_ia32_pshufd ((__v4si)__A, __mask);
++}
++#else
++#define _mm_shufflehi_epi16(A, N) \
++  ((__m128i)__builtin_ia32_pshufhw ((__v8hi)(__m128i)(A), (int)(N)))
++#define _mm_shufflelo_epi16(A, N) \
++  ((__m128i)__builtin_ia32_pshuflw ((__v8hi)(__m128i)(A), (int)(N)))
++#define _mm_shuffle_epi32(A, N) \
++  ((__m128i)__builtin_ia32_pshufd ((__v4si)(__m128i)(A), (int)(N)))
++#endif
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_maskmoveu_si128 (__m128i __A, __m128i __B, char *__C)
++{
++  __builtin_ia32_maskmovdqu ((__v16qi)__A, (__v16qi)__B, __C);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pavgb128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_epu16 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_pavgw128 ((__v8hi)__A, (__v8hi)__B);
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sad_epu8 (__m128i __A, __m128i __B)
++{
++  return (__m128i)__builtin_ia32_psadbw128 ((__v16qi)__A, (__v16qi)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_si32 (int *__A, int __B)
++{
++  __builtin_ia32_movnti (__A, __B);
++}
++
++#ifdef __x86_64__
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_si64 (long long int *__A, long long int __B);
++#endif
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_si128 (__m128i *__A, __m128i __B)
++{
++  __builtin_ia32_movntdq ((__v2di *)__A, (__v2di)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_pd (double *__A, __m128d __B)
++{
++  __builtin_ia32_movntpd (__A, (__v2df)__B);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_clflush (void const *__A)
++{
++  __builtin_ia32_clflush (__A);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_lfence (void)
++{
++  __builtin_ia32_lfence ();
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mfence (void)
++{
++  __builtin_ia32_mfence ();
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_si128 (int __A)
++{
++  return _mm_set_epi32 (0, 0, 0, __A);
++}
++
++#ifdef __x86_64__
++/* Intel intrinsic.  */
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_si128 (long long __A)
++{
++  return _mm_set_epi64x (0, __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_si128 (long long __A)
++{
++  return _mm_set_epi64x (0, __A);
++}
++#endif
++
++/* Casts between various SP, DP, INT vector types.  Note that these do no
++   conversion of values, they just change the type.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castpd_ps(__m128d __A)
++{
++  return (__m128) __A;
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castpd_si128(__m128d __A)
++{
++  return (__m128i) __A;
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castps_pd(__m128 __A)
++{
++  return (__m128d) __A;
++}
++
++extern __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castps_si128(__m128 __A)
++{
++  return (__m128i) __A;
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castsi128_ps(__m128i __A)
++{
++  return (__m128) __A;
++}
++
++extern __inline __m128d __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_castsi128_pd(__m128i __A)
++{
++  return (__m128d) __A;
++}
++
++#ifdef __DISABLE_SSE2__
++#undef __DISABLE_SSE2__
++#pragma GCC pop_options
++#endif /* __DISABLE_SSE2__ */
++
++#endif /* _EMMINTRIN_H_INCLUDED */
+diff --git a/GCC_XML/Support/GCC/4.9/ext/atomicity.h b/GCC_XML/Support/GCC/4.9/ext/atomicity.h
+new file mode 100644
+index 0000000..7094f11
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/ext/atomicity.h
+@@ -0,0 +1,117 @@
++// Support for atomic operations -*- C++ -*-
++
++// Copyright (C) 2004-2014 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file ext/atomicity.h
++ *  This file is a GNU extension to the Standard C++ Library.
++ */
++
++#ifndef _GLIBCXX_ATOMICITY_H
++#define _GLIBCXX_ATOMICITY_H	1
++
++#pragma GCC system_header
++
++#include <bits/c++config.h>
++#include <bits/gthr.h>
++#include <bits/atomic_word.h>
++
++namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // Functions for portable atomic access.
++  // To abstract locking primitives across all thread policies, use:
++  // __exchange_and_add_dispatch
++  // __atomic_add_dispatch
++#ifdef _GLIBCXX_ATOMIC_BUILTINS
++  static inline _Atomic_word 
++  __exchange_and_add(volatile _Atomic_word* __mem, int __val)
++  { return __sync_fetch_and_add(__mem, __val, __ATOMIC_ACQ_REL); }
++
++  static inline void
++  __atomic_add(volatile _Atomic_word* __mem, int __val)
++  { __sync_fetch_and_add(__mem, __val, __ATOMIC_ACQ_REL); }
++#else
++  _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add(volatile _Atomic_word*, int) throw ();
++
++  void
++  __attribute__ ((__unused__))
++  __atomic_add(volatile _Atomic_word*, int) throw ();
++#endif
++
++  static inline _Atomic_word
++  __exchange_and_add_single(_Atomic_word* __mem, int __val)
++  {
++    _Atomic_word __result = *__mem;
++    *__mem += __val;
++    return __result;
++  }
++
++  static inline void
++  __atomic_add_single(_Atomic_word* __mem, int __val)
++  { *__mem += __val; }
++
++  static inline _Atomic_word
++  __attribute__ ((__unused__))
++  __exchange_and_add_dispatch(_Atomic_word* __mem, int __val)
++  {
++#ifdef __GTHREADS
++    if (__gthread_active_p())
++      return __exchange_and_add(__mem, __val);
++    else
++      return __exchange_and_add_single(__mem, __val);
++#else
++    return __exchange_and_add_single(__mem, __val);
++#endif
++  }
++
++  static inline void
++  __attribute__ ((__unused__))
++  __atomic_add_dispatch(_Atomic_word* __mem, int __val)
++  {
++#ifdef __GTHREADS
++    if (__gthread_active_p())
++      __atomic_add(__mem, __val);
++    else
++      __atomic_add_single(__mem, __val);
++#else
++    __atomic_add_single(__mem, __val);
++#endif
++  }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++// Even if the CPU doesn't need a memory barrier, we need to ensure
++// that the compiler doesn't reorder memory accesses across the
++// barriers.
++#ifndef _GLIBCXX_READ_MEM_BARRIER
++#define _GLIBCXX_READ_MEM_BARRIER __asm __volatile ("":::"memory")
++#endif
++#ifndef _GLIBCXX_WRITE_MEM_BARRIER
++#define _GLIBCXX_WRITE_MEM_BARRIER __asm __volatile ("":::"memory")
++#endif
++
++#endif 
+diff --git a/GCC_XML/Support/GCC/4.9/gccxml_builtins.h b/GCC_XML/Support/GCC/4.9/gccxml_builtins.h
+new file mode 100644
+index 0000000..533b165
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/gccxml_builtins.h
+@@ -0,0 +1,158 @@
++#define __builtin_apply(x,y,z) ((void*)0)
++#define __builtin_nan(x) (0.0)
++#define __builtin_nanf(x) (0.0f)
++#define __builtin_nanl(x) (0.0l)
++#define __builtin_huge_val(x) (0.0)
++#define __builtin_huge_valf(x) (0.0f)
++#define __builtin_huge_vall(x) (0.0l)
++#define __builtin_apply_args(x) ((void*)0)
++#define __builtin_types_compatible_p(x,y) 0
++#define __builtin_choose_expr(x,y,z) int
++#define __builtin_constant_p(x) 0
++void* __builtin_memchr(void const*, int, unsigned int);
++void __builtin_return (void *RESULT);
++void * __builtin_return_address (unsigned int LEVEL);
++void * __builtin_frame_address (unsigned int LEVEL);
++long __builtin_expect (long EXP, long C);
++void __builtin_prefetch (const void *ADDR, ...);
++double __builtin_inf (void);
++float __builtin_inff (void);
++long double __builtin_infl (void);
++double __builtin_nans (const char *str);
++float __builtin_nansf (const char *str);
++long double __builtin_nansl (const char *str);
++double      __builtin_acos(double);
++float       __builtin_acosf(float);
++long double __builtin_acosl(long double);
++double      __builtin_asin(double);
++float       __builtin_asinf(float);
++long double __builtin_asinl(long double);
++double      __builtin_atan(double);
++double      __builtin_atan2(double, double);
++float       __builtin_atan2f(float, float);
++long double __builtin_atan2l(long double, long double);
++float       __builtin_atanf(float);
++long double __builtin_atanl(long double);
++double      __builtin_ceil(double);
++float       __builtin_ceilf(float);
++long double __builtin_ceill(long double);
++double      __builtin_cos(double);
++float       __builtin_cosf(float);
++double      __builtin_cosh(double);
++float       __builtin_coshf(float);
++long double __builtin_coshl(long double);
++long double __builtin_cosl(long double);
++double      __builtin_exp(double);
++float       __builtin_expf(float);
++long double __builtin_expl(long double);
++double      __builtin_fabs(double);
++float       __builtin_fabsf(float);
++long double __builtin_fabsl(long double);
++double      __builtin_floor(double);
++float       __builtin_floorf(float);
++long double __builtin_floorl(long double);
++float       __builtin_fmodf(float, float);
++long double __builtin_fmodl(long double, long double);
++double      __builtin_frexp(double, int*);
++float       __builtin_frexpf(float, int*);
++long double __builtin_frexpl(long double, int*);
++double      __builtin_ldexp(double, int);
++float       __builtin_ldexpf(float, int);
++long double __builtin_ldexpl(long double, int);
++double      __builtin_log(double);
++double      __builtin_log10(double);
++float       __builtin_log10f(float);
++long double __builtin_log10l(long double);
++float       __builtin_logf(float);
++long double __builtin_logl(long double);
++float       __builtin_modff(float, float*);
++long double __builtin_modfl(long double, long double*);
++float       __builtin_powf(float, float);
++long double __builtin_powl(long double, long double);
++double      __builtin_powi(double, int);
++float       __builtin_powif(float, int);
++long double __builtin_powil(long double, int);
++double      __builtin_sin(double);
++float       __builtin_sinf(float);
++double      __builtin_sinh(double);
++float       __builtin_sinhf(float);
++long double __builtin_sinhl(long double);
++long double __builtin_sinl(long double);
++double      __builtin_sqrt(double);
++float       __builtin_sqrtf(float);
++long double __builtin_sqrtl(long double);
++double      __builtin_tan(double);
++float       __builtin_tanf(float);
++double      __builtin_tanh(double);
++float       __builtin_tanhf(float);
++long double __builtin_tanhl(long double);
++long double __builtin_tanl(long double);
++float       __builtin_cabsf(float __complex__);
++double      __builtin_cabs(double __complex__);
++long double __builtin_cabsl(long double __complex__);
++float       __builtin_cargf(float __complex__);
++double      __builtin_carg(double __complex__);
++long double __builtin_cargl(long double __complex__);
++int         __builtin_ctz(int);
++int         __builtin_ctzl(long);
++int         __builtin_ctzll(long long);
++int         __builtin_popcount(int);
++int         __builtin_popcountl(long);
++int         __builtin_popcountll(long long);
++float       __complex__ __builtin_ccosf(float __complex__);
++double      __complex__ __builtin_ccos(double __complex__);
++long double __complex__ __builtin_ccosl(long double __complex__);
++float       __complex__ __builtin_ccoshf(float __complex__);
++double      __complex__ __builtin_ccosh(double __complex__);
++long double __complex__ __builtin_ccoshl(long double __complex__);
++float       __complex__ __builtin_cexpf(float __complex__);
++double      __complex__ __builtin_cexp(double __complex__);
++long double __complex__ __builtin_cexpl(long double __complex__);
++float       __complex__ __builtin_clogf(float __complex__);
++double      __complex__ __builtin_clog(double __complex__);
++long double __complex__ __builtin_clogl(long double __complex__);
++float       __complex__ __builtin_csinf(float __complex__);
++double      __complex__ __builtin_csin(double __complex__);
++long double __complex__ __builtin_csinl(long double __complex__);
++float       __complex__ __builtin_csinhf(float __complex__);
++double      __complex__ __builtin_csinh(double __complex__);
++long double __complex__ __builtin_csinhl(long double __complex__);
++float       __complex__ __builtin_csqrtf(float __complex__);
++double      __complex__ __builtin_csqrt(double __complex__);
++long double __complex__ __builtin_csqrtl(long double __complex__);
++float       __complex__ __builtin_ctanf(float __complex__);
++double      __complex__ __builtin_ctan(double __complex__);
++long double __complex__ __builtin_ctanl(long double __complex__);
++float       __complex__ __builtin_ctanhf(float __complex__);
++double      __complex__ __builtin_ctanh(double __complex__);
++long double __complex__ __builtin_ctanhl(long double __complex__);
++float       __complex__ __builtin_cpowf(float __complex__, float __complex__);
++double      __complex__ __builtin_cpow(double __complex__, double __complex__);
++long double __complex__ __builtin_cpowl(long double __complex__, long double __complex__);
++
++/* The GCC 4.5 parser hard-codes handling of these, so they do not
++   have real signatures.  */
++bool __builtin_fpclassify(...);
++bool __builtin_isfinite(...);
++bool __builtin_isgreater(...);
++bool __builtin_isgreaterequal(...);
++bool __builtin_isinf(...);
++bool __builtin_isinf_sign(...);
++bool __builtin_isless(...);
++bool __builtin_islessequal(...);
++bool __builtin_islessgreater(...);
++bool __builtin_isnan(...);
++bool __builtin_isnormal(...);
++bool __builtin_isunordered(...);
++bool __builtin_va_arg_pack(...);
++int  __builtin_va_arg_pack_len(...);
++
++/* We fake some constant expressions from GCC 4.5 parser.  */
++#define __is_empty(x) false
++#define __is_pod(x) false
++#define __is_trivial(x) false
++#define __has_trivial_destructor(x) false
++#define __has_trivial_constructor(x) false
++
++extern unsigned int  __builtin_bswap32(unsigned int _data);
++extern unsigned long __builtin_bswap64(unsigned long _data);
+diff --git a/GCC_XML/Support/GCC/4.9/iomanip b/GCC_XML/Support/GCC/4.9/iomanip
+new file mode 100644
+index 0000000..b8357e1
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/iomanip
+@@ -0,0 +1,531 @@
++// Standard stream manipulators -*- C++ -*-
++
++// Copyright (C) 1997-2014 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file include/iomanip
++ *  This is a Standard C++ Library header.
++ */
++
++//
++// ISO C++ 14882: 27.6.3  Standard manipulators
++//
++
++#ifndef _GLIBCXX_IOMANIP
++#define _GLIBCXX_IOMANIP 1
++
++#pragma GCC system_header
++
++#include <bits/c++config.h>
++#include <iosfwd>
++#include <bits/ios_base.h>
++
++#if __cplusplus >= 201103L
++#include <locale>
++#endif
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  // [27.6.3] standard manipulators
++  // Also see DR 183.
++
++  struct _Resetiosflags { ios_base::fmtflags _M_mask; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  __mask  A format flags mask.
++   *
++   *  Sent to a stream object, this manipulator resets the specified flags,
++   *  via @e stream.setf(0,__mask).
++  */
++  inline _Resetiosflags 
++  resetiosflags(ios_base::fmtflags __mask)
++  { _Resetiosflags r = { __mask }; return r; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Resetiosflags __f)
++    { 
++      __is.setf(ios_base::fmtflags(0), __f._M_mask); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Resetiosflags __f)
++    { 
++      __os.setf(ios_base::fmtflags(0), __f._M_mask); 
++      return __os; 
++    }
++
++
++  struct _Setiosflags { ios_base::fmtflags _M_mask; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  __mask  A format flags mask.
++   *
++   *  Sent to a stream object, this manipulator sets the format flags
++   *  to @a __mask.
++  */
++  inline _Setiosflags 
++  setiosflags(ios_base::fmtflags __mask)
++  { _Setiosflags s = { __mask }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setiosflags __f)
++    { 
++      __is.setf(__f._M_mask); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setiosflags __f)
++    { 
++      __os.setf(__f._M_mask); 
++      return __os; 
++    }
++
++
++  struct _Setbase { int _M_base; };
++
++  /**
++   *  @brief  Manipulator for @c setf.
++   *  @param  __base  A numeric base.
++   *
++   *  Sent to a stream object, this manipulator changes the
++   *  @c ios_base::basefield flags to @c oct, @c dec, or @c hex when @a base
++   *  is 8, 10, or 16, accordingly, and to 0 if @a __base is any other value.
++  */
++  inline _Setbase 
++  setbase(int __base)
++  { _Setbase s = { __base }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setbase __f)
++    {
++      __is.setf(__f._M_base ==  8 ? ios_base::oct : 
++		__f._M_base == 10 ? ios_base::dec : 
++		__f._M_base == 16 ? ios_base::hex : 
++		ios_base::fmtflags(0), ios_base::basefield);
++      return __is; 
++    }
++  
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setbase __f)
++    {
++      __os.setf(__f._M_base ==  8 ? ios_base::oct : 
++		__f._M_base == 10 ? ios_base::dec : 
++		__f._M_base == 16 ? ios_base::hex : 
++		ios_base::fmtflags(0), ios_base::basefield);
++      return __os; 
++    }
++  
++
++  template<typename _CharT>
++    struct _Setfill { _CharT _M_c; };
++
++  /**
++   *  @brief  Manipulator for @c fill.
++   *  @param  __c  The new fill character.
++   *
++   *  Sent to a stream object, this manipulator calls @c fill(__c) for that
++   *  object.
++  */
++  template<typename _CharT>
++    inline _Setfill<_CharT>
++    setfill(_CharT __c)
++    { _Setfill<_CharT> s = { __c }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setfill<_CharT> __f)
++    { 
++      __is.fill(__f._M_c); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setfill<_CharT> __f)
++    { 
++      __os.fill(__f._M_c); 
++      return __os; 
++    }
++
++
++  struct _Setprecision { int _M_n; };
++
++  /**
++   *  @brief  Manipulator for @c precision.
++   *  @param  __n  The new precision.
++   *
++   *  Sent to a stream object, this manipulator calls @c precision(__n) for
++   *  that object.
++  */
++  inline _Setprecision 
++  setprecision(int __n)
++  { _Setprecision s = { __n }; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setprecision __f)
++    { 
++      __is.precision(__f._M_n); 
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setprecision __f)
++    { 
++      __os.precision(__f._M_n); 
++      return __os; 
++    }
++
++
++  struct _Setw { int _M_n; };
++
++  /**
++   *  @brief  Manipulator for @c width.
++   *  @param  __n  The new width.
++   *
++   *  Sent to a stream object, this manipulator calls @c width(__n) for
++   *  that object.
++  */
++  inline _Setw 
++  setw(int __n)
++  { _Setw s = {__n} ; return s; }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_istream<_CharT, _Traits>& 
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Setw __f)
++    {
++      __is.width(__f._M_n);
++      return __is; 
++    }
++
++  template<typename _CharT, typename _Traits>
++    inline basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Setw __f)
++    {
++      __os.width(__f._M_n);
++      return __os; 
++    }
++
++#if __cplusplus >= 201103L
++  
++  template<typename _MoneyT>
++    struct _Get_money { _MoneyT& _M_mon; bool _M_intl; };
++
++  /**
++   *  @brief  Extended manipulator for extracting money.
++   *  @param  __mon  Either long double or a specialization of @c basic_string.
++   *  @param  __intl A bool indicating whether international format 
++   *                 is to be used.
++   *
++   *  Sent to a stream object, this manipulator extracts @a __mon.
++  */
++  template<typename _MoneyT>
++    inline _Get_money<_MoneyT>
++    get_money(_MoneyT& __mon, bool __intl = false)
++    { _Get_money<_MoneyT> r = { __mon, __intl }; return r; }
++
++  template<typename _CharT, typename _Traits, typename _MoneyT>
++    basic_istream<_CharT, _Traits>&
++    operator>>(basic_istream<_CharT, _Traits>& __is, _Get_money<_MoneyT> __f)
++    {
++      typename basic_istream<_CharT, _Traits>::sentry __cerb(__is, false);
++      if (__cerb)
++	{
++	  ios_base::iostate __err = ios_base::goodbit;
++	  __try
++	    {
++	      typedef istreambuf_iterator<_CharT, _Traits>   _Iter;
++	      typedef money_get<_CharT, _Iter>               _MoneyGet;
++
++	      const _MoneyGet& __mg = use_facet<_MoneyGet>(__is.getloc());
++	      __mg.get(_Iter(__is.rdbuf()), _Iter(), __f._M_intl,
++		       __is, __err, __f._M_mon);
++	    }
++	  __catch(__cxxabiv1::__forced_unwind&)
++	    {
++	      __is._M_setstate(ios_base::badbit);
++	      __throw_exception_again;
++	    }
++	  __catch(...)
++	    { __is._M_setstate(ios_base::badbit); }
++	  if (__err)
++	    __is.setstate(__err);
++	}
++      return __is; 
++    }
++
++
++  template<typename _MoneyT>
++    struct _Put_money { const _MoneyT& _M_mon; bool _M_intl; };
++
++  /**
++   *  @brief  Extended manipulator for inserting money.
++   *  @param  __mon  Either long double or a specialization of @c basic_string.
++   *  @param  __intl A bool indicating whether international format 
++   *                 is to be used.
++   *
++   *  Sent to a stream object, this manipulator inserts @a __mon.
++  */
++  template<typename _MoneyT>
++    inline _Put_money<_MoneyT>
++    put_money(const _MoneyT& __mon, bool __intl = false)
++    { _Put_money<_MoneyT> r = { __mon, __intl }; return r; }
++
++  template<typename _CharT, typename _Traits, typename _MoneyT>
++    basic_ostream<_CharT, _Traits>& 
++    operator<<(basic_ostream<_CharT, _Traits>& __os, _Put_money<_MoneyT> __f)
++    {
++      typename basic_ostream<_CharT, _Traits>::sentry __cerb(__os);
++      if (__cerb)
++	{
++	  ios_base::iostate __err = ios_base::goodbit;
++	  __try
++	    {
++	      typedef ostreambuf_iterator<_CharT, _Traits>   _Iter;
++	      typedef money_put<_CharT, _Iter>               _MoneyPut;
++
++	      const _MoneyPut& __mp = use_facet<_MoneyPut>(__os.getloc());
++	      if (__mp.put(_Iter(__os.rdbuf()), __f._M_intl, __os,
++			   __os.fill(), __f._M_mon).failed())
++		__err |= ios_base::badbit;
++	    }
++	  __catch(__cxxabiv1::__forced_unwind&)
++	    {
++	      __os._M_setstate(ios_base::badbit);
++	      __throw_exception_again;
++	    }
++	  __catch(...)
++	    { __os._M_setstate(ios_base::badbit); }
++	  if (__err)
++	    __os.setstate(__err);
++	}
++      return __os; 
++    }
++
++#if __cplusplus > 201103L
++
++_GLIBCXX_END_NAMESPACE_VERSION
++  namespace __detail {
++  _GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++    /**
++     * @brief Struct for delimited strings.
++     *        The left and right delimiters can be different.
++     */
++    template<typename _String, typename _CharT>
++      struct _Quoted_string
++      {
++	static_assert(is_reference<_String>::value
++		   || is_pointer<_String>::value,
++		      "String type must be pointer or reference");
++
++	_Quoted_string(_String __str, _CharT __del, _CharT __esc)
++	: _M_string(__str), _M_delim{__del}, _M_escape{__esc}
++	{ }
++
++	_Quoted_string&
++	operator=(_Quoted_string&) = delete;
++
++	_String _M_string;
++	_CharT _M_delim;
++	_CharT _M_escape;
++      };
++
++    /**
++     * @brief Inserter for delimited strings.
++     *        The left and right delimiters can be different.
++     */
++    template<typename _CharT, typename _Traits>
++      auto&
++      operator<<(std::basic_ostream<_CharT, _Traits>& __os,
++		 const _Quoted_string<const _CharT*, _CharT>& __str)
++      {
++	__os << __str._M_delim;
++	for (const _CharT* __c = __str._M_string; *__c; ++__c)
++	  {
++	    if (*__c == __str._M_delim || *__c == __str._M_escape)
++	      __os << __str._M_escape;
++	    __os << *__c;
++	  }
++	__os << __str._M_delim;
++
++	return __os;
++      }
++
++    /**
++     * @brief Inserter for delimited strings.
++     *        The left and right delimiters can be different.
++     */
++    template<typename _CharT, typename _Traits, typename _String>
++      auto&
++      operator<<(std::basic_ostream<_CharT, _Traits>& __os,
++		 const _Quoted_string<_String, _CharT>& __str)
++      {
++	__os << __str._M_delim;
++	for (auto& __c : __str._M_string)
++	  {
++	    if (__c == __str._M_delim || __c == __str._M_escape)
++	      __os << __str._M_escape;
++	    __os << __c;
++	  }
++	__os << __str._M_delim;
++
++	return __os;
++      }
++
++    /**
++     * @brief Extractor for delimited strings.
++     *        The left and right delimiters can be different.
++     */
++    template<typename _CharT, typename _Traits, typename _Alloc>
++      auto&
++      operator>>(std::basic_istream<_CharT, _Traits>& __is,
++		 const _Quoted_string<basic_string<_CharT, _Traits, _Alloc>&,
++				      _CharT>& __str)
++      {
++	__str._M_string.clear();
++
++	_CharT __c;
++	__is >> __c;
++	if (!__is.good())
++	  return __is;
++	if (__c != __str._M_delim)
++	  {
++	    __is.unget();
++	    __is >> __str._M_string;
++	    return __is;
++	  }
++	std::ios_base::fmtflags __flags
++	  = __is.flags(__is.flags() & ~std::ios_base::skipws);
++	do
++	  {
++	    __is >> __c;
++	    if (!__is.good())
++	      break;
++	    if (__c == __str._M_escape)
++	      {
++		__is >> __c;
++		if (!__is.good())
++		  break;
++	      }
++	    else if (__c == __str._M_delim)
++	      break;
++	    __str._M_string += __c;
++	  }
++	while (true);
++	__is.setf(__flags);
++
++	return __is;
++      }
++  _GLIBCXX_END_NAMESPACE_VERSION
++  } // namespace __detail
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  /**
++   * @brief Manipulator for quoted strings.
++   * @param __str    String to quote.
++   * @param __delim  Character to quote string with.
++   * @param __escape Escape character to escape itself or quote character.
++   */
++  template<typename _CharT>
++    inline auto
++    quoted(const _CharT* __string,
++	   _CharT __delim = _CharT('"'), _CharT __escape = _CharT('\\'))
++    {
++      return __detail::_Quoted_string<const _CharT*, _CharT>(__string, __delim,
++							     __escape);
++    }
++
++  template<typename _CharT, typename _Traits, typename _Alloc>
++    inline auto
++    quoted(const basic_string<_CharT, _Traits, _Alloc>& __string,
++	   _CharT __delim = _CharT('"'), _CharT __escape = _CharT('\\'))
++    {
++      return __detail::_Quoted_string<
++			const basic_string<_CharT, _Traits, _Alloc>&, _CharT>(
++				__string, __delim, __escape);
++    }
++
++  template<typename _CharT, typename _Traits, typename _Alloc>
++    inline auto
++    quoted(basic_string<_CharT, _Traits, _Alloc>& __string,
++	   _CharT __delim = _CharT('"'), _CharT __escape = _CharT('\\'))
++    {
++      return __detail::_Quoted_string<
++			basic_string<_CharT, _Traits, _Alloc>&, _CharT>(
++				__string, __delim, __escape);
++    }
++
++#endif // __cplusplus > 201103L
++
++#endif // __cplusplus >= 201103L
++
++  // Inhibit implicit instantiations for required instantiations,
++  // which are defined via explicit instantiations elsewhere.  
++  // NB:  This syntax is a GNU extension.
++#if _GLIBCXX_EXTERN_TEMPLATE
++  extern template ostream& operator<<(ostream&, _Setfill<char>);
++  extern template ostream& operator<<(ostream&, _Setiosflags);
++  extern template ostream& operator<<(ostream&, _Resetiosflags);
++  extern template ostream& operator<<(ostream&, _Setbase);
++  extern template ostream& operator<<(ostream&, _Setprecision);
++  extern template ostream& operator<<(ostream&, _Setw);
++  extern template istream& operator>>(istream&, _Setfill<char>);
++  extern template istream& operator>>(istream&, _Setiosflags);
++  extern template istream& operator>>(istream&, _Resetiosflags);
++  extern template istream& operator>>(istream&, _Setbase);
++  extern template istream& operator>>(istream&, _Setprecision);
++  extern template istream& operator>>(istream&, _Setw);
++
++#ifdef _GLIBCXX_USE_WCHAR_T
++  extern template wostream& operator<<(wostream&, _Setfill<wchar_t>);
++  extern template wostream& operator<<(wostream&, _Setiosflags);
++  extern template wostream& operator<<(wostream&, _Resetiosflags);
++  extern template wostream& operator<<(wostream&, _Setbase);
++  extern template wostream& operator<<(wostream&, _Setprecision);
++  extern template wostream& operator<<(wostream&, _Setw);
++  extern template wistream& operator>>(wistream&, _Setfill<wchar_t>);
++  extern template wistream& operator>>(wistream&, _Setiosflags);
++  extern template wistream& operator>>(wistream&, _Resetiosflags);
++  extern template wistream& operator>>(wistream&, _Setbase);
++  extern template wistream& operator>>(wistream&, _Setprecision);
++  extern template wistream& operator>>(wistream&, _Setw);
++#endif
++#endif
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#endif /* _GLIBCXX_IOMANIP */
+diff --git a/GCC_XML/Support/GCC/4.9/mmintrin.h b/GCC_XML/Support/GCC/4.9/mmintrin.h
+new file mode 100644
+index 0000000..826b8fe
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/mmintrin.h
+@@ -0,0 +1,891 @@
++/* Copyright (C) 2002-2014 Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GCC is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Implemented from the specification included in the Intel C++ Compiler
++   User Guide and Reference, version 9.0.  */
++
++#ifndef _MMINTRIN_H_INCLUDED
++#define _MMINTRIN_H_INCLUDED
++
++#ifndef __MMX__
++#pragma GCC push_options
++#pragma GCC target("mmx")
++#define __DISABLE_MMX__
++#endif /* __MMX__ */
++
++/* The Intel API is flexible enough that we must allow aliasing with other
++   vector types, and their scalar components.  */
++typedef int __m64 __attribute__ ((__vector_size__ (8), __may_alias__));
++
++/* Internal data types for implementing the intrinsics.  */
++typedef int __v2si __attribute__ ((__vector_size__ (8)));
++typedef short __v4hi __attribute__ ((__vector_size__ (8)));
++typedef char __v8qi __attribute__ ((__vector_size__ (8)));
++typedef long long __v1di __attribute__ ((__vector_size__ (8)));
++typedef float __v2sf __attribute__ ((__vector_size__ (8)));
++
++/* Empty the multimedia state.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_empty (void)
++{
++  __builtin_ia32_emms ();
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_empty (void)
++{
++  _mm_empty ();
++}
++
++/* Convert I to a __m64 object.  The integer is zero-extended to 64-bits.  */
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_si64 (int __i)
++{
++  return (__m64) __builtin_ia32_vec_init_v2si (__i, 0);
++}
++
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_from_int (int __i)
++{
++  return _mm_cvtsi32_si64 (__i);
++}
++
++#ifdef __x86_64__
++/* Convert I to a __m64 object.  */
++
++/* Intel intrinsic.  */
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_from_int64 (long long __i)
++{
++  return (__m64) __i;
++}
++
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_m64 (long long __i)
++{
++  return (__m64) __i;
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_si64 (long long __i)
++{
++  return (__m64) __i;
++}
++
++extern __inline __m64  __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi64x (long long __i)
++{
++  return (__m64) __i;
++}
++#endif
++
++/* Convert the lower 32 bits of the __m64 object into an integer.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_si32 (__m64 __i)
++{
++  return __builtin_ia32_vec_ext_v2si ((__v2si)__i, 0);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_to_int (__m64 __i)
++{
++  return _mm_cvtsi64_si32 (__i);
++}
++
++#ifdef __x86_64__
++/* Convert the __m64 object to a 64bit integer.  */
++
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_to_int64 (__m64 __i)
++{
++  return (long long)__i;
++}
++
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtm64_si64 (__m64 __i)
++{
++  return (long long)__i;
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_si64x (__m64 __i)
++{
++  return (long long)__i;
++}
++#endif
++
++/* Pack the four 16-bit values from M1 into the lower four 8-bit values of
++   the result, and the four 16-bit values from M2 into the upper four 8-bit
++   values of the result, all with signed saturation.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_packsswb ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_packsswb (__m64 __m1, __m64 __m2)
++{
++  return _mm_packs_pi16 (__m1, __m2);
++}
++
++/* Pack the two 32-bit values from M1 in to the lower two 16-bit values of
++   the result, and the two 32-bit values from M2 into the upper two 16-bit
++   values of the result, all with signed saturation.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_packssdw ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_packssdw (__m64 __m1, __m64 __m2)
++{
++  return _mm_packs_pi32 (__m1, __m2);
++}
++
++/* Pack the four 16-bit values from M1 into the lower four 8-bit values of
++   the result, and the four 16-bit values from M2 into the upper four 8-bit
++   values of the result, all with unsigned saturation.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_packs_pu16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_packuswb ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_packuswb (__m64 __m1, __m64 __m2)
++{
++  return _mm_packs_pu16 (__m1, __m2);
++}
++
++/* Interleave the four 8-bit values from the high half of M1 with the four
++   8-bit values from the high half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckhbw ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckhbw (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpackhi_pi8 (__m1, __m2);
++}
++
++/* Interleave the two 16-bit values from the high half of M1 with the two
++   16-bit values from the high half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckhwd ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckhwd (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpackhi_pi16 (__m1, __m2);
++}
++
++/* Interleave the 32-bit value from the high half of M1 with the 32-bit
++   value from the high half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckhdq ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckhdq (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpackhi_pi32 (__m1, __m2);
++}
++
++/* Interleave the four 8-bit values from the low half of M1 with the four
++   8-bit values from the low half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpcklbw ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpcklbw (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpacklo_pi8 (__m1, __m2);
++}
++
++/* Interleave the two 16-bit values from the low half of M1 with the two
++   16-bit values from the low half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpcklwd ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpcklwd (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpacklo_pi16 (__m1, __m2);
++}
++
++/* Interleave the 32-bit value from the low half of M1 with the 32-bit
++   value from the low half of M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_punpckldq ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_punpckldq (__m64 __m1, __m64 __m2)
++{
++  return _mm_unpacklo_pi32 (__m1, __m2);
++}
++
++/* Add the 8-bit values in M1 to the 8-bit values in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddb (__m64 __m1, __m64 __m2)
++{
++  return _mm_add_pi8 (__m1, __m2);
++}
++
++/* Add the 16-bit values in M1 to the 16-bit values in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddw (__m64 __m1, __m64 __m2)
++{
++  return _mm_add_pi16 (__m1, __m2);
++}
++
++/* Add the 32-bit values in M1 to the 32-bit values in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddd (__m64 __m1, __m64 __m2)
++{
++  return _mm_add_pi32 (__m1, __m2);
++}
++
++/* Add the 64-bit values in M1 to the 64-bit values in M2.  */
++#ifndef __SSE2__
++#pragma GCC push_options
++#pragma GCC target("sse2")
++#define __DISABLE_SSE2__
++#endif /* __SSE2__ */
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_si64 (__m64 __m1, __m64 __m2);
++#ifdef __DISABLE_SSE2__
++#undef __DISABLE_SSE2__
++#pragma GCC pop_options
++#endif /* __DISABLE_SSE2__ */
++
++/* Add the 8-bit values in M1 to the 8-bit values in M2 using signed
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddsb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddsb (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pi8 (__m1, __m2);
++}
++
++/* Add the 16-bit values in M1 to the 16-bit values in M2 using signed
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddsw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddsw (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pi16 (__m1, __m2);
++}
++
++/* Add the 8-bit values in M1 to the 8-bit values in M2 using unsigned
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pu8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddusb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddusb (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pu8 (__m1, __m2);
++}
++
++/* Add the 16-bit values in M1 to the 16-bit values in M2 using unsigned
++   saturated arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_adds_pu16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_paddusw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_paddusw (__m64 __m1, __m64 __m2)
++{
++  return _mm_adds_pu16 (__m1, __m2);
++}
++
++/* Subtract the 8-bit values in M2 from the 8-bit values in M1.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubb (__m64 __m1, __m64 __m2)
++{
++  return _mm_sub_pi8 (__m1, __m2);
++}
++
++/* Subtract the 16-bit values in M2 from the 16-bit values in M1.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubw (__m64 __m1, __m64 __m2)
++{
++  return _mm_sub_pi16 (__m1, __m2);
++}
++
++/* Subtract the 32-bit values in M2 from the 32-bit values in M1.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubd (__m64 __m1, __m64 __m2)
++{
++  return _mm_sub_pi32 (__m1, __m2);
++}
++
++/* Add the 64-bit values in M1 to the 64-bit values in M2.  */
++#ifndef __SSE2__
++#pragma GCC push_options
++#pragma GCC target("sse2")
++#define __DISABLE_SSE2__
++#endif /* __SSE2__ */
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_si64 (__m64 __m1, __m64 __m2);
++#ifdef __DISABLE_SSE2__
++#undef __DISABLE_SSE2__
++#pragma GCC pop_options
++#endif /* __DISABLE_SSE2__ */
++
++/* Subtract the 8-bit values in M2 from the 8-bit values in M1 using signed
++   saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubsb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubsb (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pi8 (__m1, __m2);
++}
++
++/* Subtract the 16-bit values in M2 from the 16-bit values in M1 using
++   signed saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubsw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubsw (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pi16 (__m1, __m2);
++}
++
++/* Subtract the 8-bit values in M2 from the 8-bit values in M1 using
++   unsigned saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pu8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubusb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubusb (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pu8 (__m1, __m2);
++}
++
++/* Subtract the 16-bit values in M2 from the 16-bit values in M1 using
++   unsigned saturating arithmetic.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_subs_pu16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_psubusw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psubusw (__m64 __m1, __m64 __m2)
++{
++  return _mm_subs_pu16 (__m1, __m2);
++}
++
++/* Multiply four 16-bit values in M1 by four 16-bit values in M2 producing
++   four 32-bit intermediate results, which are then summed by pairs to
++   produce two 32-bit results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_madd_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pmaddwd ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmaddwd (__m64 __m1, __m64 __m2)
++{
++  return _mm_madd_pi16 (__m1, __m2);
++}
++
++/* Multiply four signed 16-bit values in M1 by four signed 16-bit values in
++   M2 and produce the high 16 bits of the 32-bit results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pmulhw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmulhw (__m64 __m1, __m64 __m2)
++{
++  return _mm_mulhi_pi16 (__m1, __m2);
++}
++
++/* Multiply four 16-bit values in M1 by four 16-bit values in M2 and produce
++   the low 16 bits of the results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mullo_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pmullw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmullw (__m64 __m1, __m64 __m2)
++{
++  return _mm_mullo_pi16 (__m1, __m2);
++}
++
++/* Shift four 16-bit values in M left by COUNT.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_pi16 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllw (__m64 __m, __m64 __count)
++{
++  return _mm_sll_pi16 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_pi16 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllwi (__m64 __m, int __count)
++{
++  return _mm_slli_pi16 (__m, __count);
++}
++
++/* Shift two 32-bit values in M left by COUNT.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_pi32 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pslld (__m64 __m, __m64 __count)
++{
++  return _mm_sll_pi32 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_pi32 (__m64 __m, int __count)
++{
++  return (__m64) __builtin_ia32_pslldi ((__v2si)__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pslldi (__m64 __m, int __count)
++{
++  return _mm_slli_pi32 (__m, __count);
++}
++
++/* Shift the 64-bit value in M left by COUNT.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sll_si64 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllq (__m64 __m, __m64 __count)
++{
++  return _mm_sll_si64 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_slli_si64 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psllqi (__m64 __m, int __count)
++{
++  return _mm_slli_si64 (__m, __count);
++}
++
++/* Shift four 16-bit values in M right by COUNT; shift in the sign bit.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_pi16 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psraw (__m64 __m, __m64 __count)
++{
++  return _mm_sra_pi16 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_pi16 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrawi (__m64 __m, int __count)
++{
++  return _mm_srai_pi16 (__m, __count);
++}
++
++/* Shift two 32-bit values in M right by COUNT; shift in the sign bit.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sra_pi32 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrad (__m64 __m, __m64 __count)
++{
++  return _mm_sra_pi32 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srai_pi32 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psradi (__m64 __m, int __count)
++{
++  return _mm_srai_pi32 (__m, __count);
++}
++
++/* Shift four 16-bit values in M right by COUNT; shift in zeros.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_pi16 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlw (__m64 __m, __m64 __count)
++{
++  return _mm_srl_pi16 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_pi16 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlwi (__m64 __m, int __count)
++{
++  return _mm_srli_pi16 (__m, __count);
++}
++
++/* Shift two 32-bit values in M right by COUNT; shift in zeros.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_pi32 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrld (__m64 __m, __m64 __count)
++{
++  return _mm_srl_pi32 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_pi32 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrldi (__m64 __m, int __count)
++{
++  return _mm_srli_pi32 (__m, __count);
++}
++
++/* Shift the 64-bit value in M left by COUNT; shift in zeros.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srl_si64 (__m64 __m, __m64 __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlq (__m64 __m, __m64 __count)
++{
++  return _mm_srl_si64 (__m, __count);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_srli_si64 (__m64 __m, int __count);
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psrlqi (__m64 __m, int __count)
++{
++  return _mm_srli_si64 (__m, __count);
++}
++
++/* Bit-wise AND the 64-bit values in M1 and M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_pand (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pand (__m64 __m1, __m64 __m2)
++{
++  return _mm_and_si64 (__m1, __m2);
++}
++
++/* Bit-wise complement the 64-bit value in M1 and bit-wise AND it with the
++   64-bit value in M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_pandn (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pandn (__m64 __m1, __m64 __m2)
++{
++  return _mm_andnot_si64 (__m1, __m2);
++}
++
++/* Bit-wise inclusive OR the 64-bit values in M1 and M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_por (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_por (__m64 __m1, __m64 __m2)
++{
++  return _mm_or_si64 (__m1, __m2);
++}
++
++/* Bit-wise exclusive OR the 64-bit values in M1 and M2.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_si64 (__m64 __m1, __m64 __m2)
++{
++  return __builtin_ia32_pxor (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pxor (__m64 __m1, __m64 __m2)
++{
++  return _mm_xor_si64 (__m1, __m2);
++}
++
++/* Compare eight 8-bit values.  The result of the comparison is 0xFF if the
++   test is true and zero if false.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpeqb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpeqb (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpeq_pi8 (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pi8 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpgtb ((__v8qi)__m1, (__v8qi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpgtb (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpgt_pi8 (__m1, __m2);
++}
++
++/* Compare four 16-bit values.  The result of the comparison is 0xFFFF if
++   the test is true and zero if false.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpeqw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpeqw (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpeq_pi16 (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pi16 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpgtw ((__v4hi)__m1, (__v4hi)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpgtw (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpgt_pi16 (__m1, __m2);
++}
++
++/* Compare two 32-bit values.  The result of the comparison is 0xFFFFFFFF if
++   the test is true and zero if false.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpeqd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpeqd (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpeq_pi32 (__m1, __m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_pi32 (__m64 __m1, __m64 __m2)
++{
++  return (__m64) __builtin_ia32_pcmpgtd ((__v2si)__m1, (__v2si)__m2);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pcmpgtd (__m64 __m1, __m64 __m2)
++{
++  return _mm_cmpgt_pi32 (__m1, __m2);
++}
++
++/* Creates a 64-bit zero.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_si64 (void)
++{
++  return (__m64)0LL;
++}
++
++/* Creates a vector of two 32-bit values; I0 is least significant.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi32 (int __i1, int __i0)
++{
++  return (__m64) __builtin_ia32_vec_init_v2si (__i0, __i1);
++}
++
++/* Creates a vector of four 16-bit values; W0 is least significant.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi16 (short __w3, short __w2, short __w1, short __w0)
++{
++  return (__m64) __builtin_ia32_vec_init_v4hi (__w0, __w1, __w2, __w3);
++}
++
++/* Creates a vector of eight 8-bit values; B0 is least significant.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_pi8 (char __b7, char __b6, char __b5, char __b4,
++	     char __b3, char __b2, char __b1, char __b0)
++{
++  return (__m64) __builtin_ia32_vec_init_v8qi (__b0, __b1, __b2, __b3,
++					       __b4, __b5, __b6, __b7);
++}
++
++/* Similar, but with the arguments in reverse order.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pi32 (int __i0, int __i1)
++{
++  return _mm_set_pi32 (__i1, __i0);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pi16 (short __w0, short __w1, short __w2, short __w3)
++{
++  return _mm_set_pi16 (__w3, __w2, __w1, __w0);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_pi8 (char __b0, char __b1, char __b2, char __b3,
++	      char __b4, char __b5, char __b6, char __b7)
++{
++  return _mm_set_pi8 (__b7, __b6, __b5, __b4, __b3, __b2, __b1, __b0);
++}
++
++/* Creates a vector of two 32-bit values, both elements containing I.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pi32 (int __i)
++{
++  return _mm_set_pi32 (__i, __i);
++}
++
++/* Creates a vector of four 16-bit values, all elements containing W.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pi16 (short __w)
++{
++  return _mm_set_pi16 (__w, __w, __w, __w);
++}
++
++/* Creates a vector of eight 8-bit values, all elements containing B.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_pi8 (char __b)
++{
++  return _mm_set_pi8 (__b, __b, __b, __b, __b, __b, __b, __b);
++}
++#ifdef __DISABLE_MMX__
++#undef __DISABLE_MMX__
++#pragma GCC pop_options
++#endif /* __DISABLE_MMX__ */
++
++#endif /* _MMINTRIN_H_INCLUDED */
+diff --git a/GCC_XML/Support/GCC/4.9/xmmintrin.h b/GCC_XML/Support/GCC/4.9/xmmintrin.h
+new file mode 100644
+index 0000000..4b27753
+--- /dev/null
++++ b/GCC_XML/Support/GCC/4.9/xmmintrin.h
+@@ -0,0 +1,1242 @@
++/* Copyright (C) 2002-2014 Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3, or (at your option)
++   any later version.
++
++   GCC is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Implemented from the specification included in the Intel C++ Compiler
++   User Guide and Reference, version 9.0.  */
++
++#ifndef _XMMINTRIN_H_INCLUDED
++#define _XMMINTRIN_H_INCLUDED
++
++/* We need type definitions from the MMX header file.  */
++#include <mmintrin.h>
++
++/* Get _mm_malloc () and _mm_free ().  */
++#include <mm_malloc.h>
++
++#ifndef __SSE__
++#pragma GCC push_options
++#pragma GCC target("sse")
++#define __DISABLE_SSE__
++#endif /* __SSE__ */
++
++/* The Intel API is flexible enough that we must allow aliasing with other
++   vector types, and their scalar components.  */
++typedef float __m128 __attribute__ ((__vector_size__ (16), __may_alias__));
++
++/* Internal data types for implementing the intrinsics.  */
++typedef float __v4sf __attribute__ ((__vector_size__ (16)));
++
++/* Create a selector for use with the SHUFPS instruction.  */
++#define _MM_SHUFFLE(fp3,fp2,fp1,fp0) \
++ (((fp3) << 6) | ((fp2) << 4) | ((fp1) << 2) | (fp0))
++
++/* Constants for use with _mm_prefetch.  */
++enum _mm_hint
++{
++  _MM_HINT_T0 = 3,
++  _MM_HINT_T1 = 2,
++  _MM_HINT_T2 = 1,
++  _MM_HINT_NTA = 0
++};
++
++/* Bits in the MXCSR.  */
++#define _MM_EXCEPT_MASK       0x003f
++#define _MM_EXCEPT_INVALID    0x0001
++#define _MM_EXCEPT_DENORM     0x0002
++#define _MM_EXCEPT_DIV_ZERO   0x0004
++#define _MM_EXCEPT_OVERFLOW   0x0008
++#define _MM_EXCEPT_UNDERFLOW  0x0010
++#define _MM_EXCEPT_INEXACT    0x0020
++
++#define _MM_MASK_MASK         0x1f80
++#define _MM_MASK_INVALID      0x0080
++#define _MM_MASK_DENORM       0x0100
++#define _MM_MASK_DIV_ZERO     0x0200
++#define _MM_MASK_OVERFLOW     0x0400
++#define _MM_MASK_UNDERFLOW    0x0800
++#define _MM_MASK_INEXACT      0x1000
++
++#define _MM_ROUND_MASK        0x6000
++#define _MM_ROUND_NEAREST     0x0000
++#define _MM_ROUND_DOWN        0x2000
++#define _MM_ROUND_UP          0x4000
++#define _MM_ROUND_TOWARD_ZERO 0x6000
++
++#define _MM_FLUSH_ZERO_MASK   0x8000
++#define _MM_FLUSH_ZERO_ON     0x8000
++#define _MM_FLUSH_ZERO_OFF    0x0000
++
++/* Create a vector of zeros.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setzero_ps (void)
++{
++  return __extension__ (__m128){ 0.0f, 0.0f, 0.0f, 0.0f };
++}
++
++/* Perform the respective operation on the lower SPFP (single-precision
++   floating-point) values of A and B; the upper three SPFP values are
++   passed through from A.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_addss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_subss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_mulss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_divss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_ss (__m128 __A)
++{
++  return (__m128) __builtin_ia32_sqrtss ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rcp_ss (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rcpss ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rsqrt_ss (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rsqrtss ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_minss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_maxss ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Perform the respective operation on the four SPFP values in A and B.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_add_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_addps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sub_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_subps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mul_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_mulps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_div_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_divps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sqrt_ps (__m128 __A)
++{
++  return (__m128) __builtin_ia32_sqrtps ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rcp_ps (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rcpps ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_rsqrt_ps (__m128 __A)
++{
++  return (__m128) __builtin_ia32_rsqrtps ((__v4sf)__A);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_minps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_maxps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Perform logical bit-wise operations on 128-bit values.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_and_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_andps (__A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_andnot_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_andnps (__A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_or_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_orps (__A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_xor_ps (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_xorps (__A, __B);
++}
++
++/* Perform a comparison on the lower SPFP values of A and B.  If the
++   comparison is true, place a mask of all ones in the result, otherwise a
++   mask of zeros.  The upper three SPFP values are passed through from A.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpeqss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpltss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpless ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpltss ((__v4sf) __B,
++								(__v4sf)
++								__A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpless ((__v4sf) __B,
++								(__v4sf)
++								__A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpneqss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnltss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnless ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpnltss ((__v4sf) __B,
++								 (__v4sf)
++								 __A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf) __A,
++					(__v4sf)
++					__builtin_ia32_cmpnless ((__v4sf) __B,
++								 (__v4sf)
++								 __A));
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpordss ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpunordss ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Perform a comparison on the four SPFP values of A and B.  For each
++   element, if the comparison is true, place a mask of all ones in the
++   result, otherwise a mask of zeros.  */
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpeq_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpeqps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmplt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpltps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmple_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpleps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpgt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpgtps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpge_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpgeps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpneq_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpneqps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnlt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnltps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnle_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpnleps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpngt_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpngtps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpnge_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpngeps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpord_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpordps ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cmpunord_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_cmpunordps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Compare the lower SPFP values of A and B and return 1 if true
++   and 0 if false.  */
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comieq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comieq ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comilt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comilt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comile_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comile ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comigt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comigt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comige_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comige ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_comineq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_comineq ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomieq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomieq ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomilt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomilt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomile_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomile ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomigt_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomigt ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomige_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomige ((__v4sf)__A, (__v4sf)__B);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_ucomineq_ss (__m128 __A, __m128 __B)
++{
++  return __builtin_ia32_ucomineq ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Convert the lower SPFP value to a 32-bit integer according to the current
++   rounding mode.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_si32 (__m128 __A)
++{
++  return __builtin_ia32_cvtss2si ((__v4sf) __A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_ss2si (__m128 __A)
++{
++  return _mm_cvtss_si32 (__A);
++}
++
++#ifdef __x86_64__
++/* Convert the lower SPFP value to a 32-bit integer according to the
++   current rounding mode.  */
++
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_si64 (__m128 __A)
++{
++  return __builtin_ia32_cvtss2si64 ((__v4sf) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_si64x (__m128 __A)
++{
++  return __builtin_ia32_cvtss2si64 ((__v4sf) __A);
++}
++#endif
++
++/* Convert the two lower SPFP values to 32-bit integers according to the
++   current rounding mode.  Return the integers in packed form.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pi32 (__m128 __A)
++{
++  return (__m64) __builtin_ia32_cvtps2pi ((__v4sf) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_ps2pi (__m128 __A)
++{
++  return _mm_cvtps_pi32 (__A);
++}
++
++/* Truncate the lower SPFP value to a 32-bit integer.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttss_si32 (__m128 __A)
++{
++  return __builtin_ia32_cvttss2si ((__v4sf) __A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtt_ss2si (__m128 __A)
++{
++  return _mm_cvttss_si32 (__A);
++}
++
++#ifdef __x86_64__
++/* Truncate the lower SPFP value to a 32-bit integer.  */
++
++/* Intel intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttss_si64 (__m128 __A)
++{
++  return __builtin_ia32_cvttss2si64 ((__v4sf) __A);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline long long __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttss_si64x (__m128 __A)
++{
++  return __builtin_ia32_cvttss2si64 ((__v4sf) __A);
++}
++#endif
++
++/* Truncate the two lower SPFP values to 32-bit integers.  Return the
++   integers in packed form.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvttps_pi32 (__m128 __A)
++{
++  return (__m64) __builtin_ia32_cvttps2pi ((__v4sf) __A);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtt_ps2pi (__m128 __A)
++{
++  return _mm_cvttps_pi32 (__A);
++}
++
++/* Convert B to a SPFP value and insert it as element zero in A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi32_ss (__m128 __A, int __B)
++{
++  return (__m128) __builtin_ia32_cvtsi2ss ((__v4sf) __A, __B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_si2ss (__m128 __A, int __B)
++{
++  return _mm_cvtsi32_ss (__A, __B);
++}
++
++#ifdef __x86_64__
++/* Convert B to a SPFP value and insert it as element zero in A.  */
++
++/* Intel intrinsic.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64_ss (__m128 __A, long long __B)
++{
++  return (__m128) __builtin_ia32_cvtsi642ss ((__v4sf) __A, __B);
++}
++
++/* Microsoft intrinsic.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtsi64x_ss (__m128 __A, long long __B)
++{
++  return (__m128) __builtin_ia32_cvtsi642ss ((__v4sf) __A, __B);
++}
++#endif
++
++/* Convert the two 32-bit values in B to SPFP form and insert them
++   as the two lower elements in A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi32_ps (__m128 __A, __m64 __B)
++{
++  return (__m128) __builtin_ia32_cvtpi2ps ((__v4sf) __A, (__v2si)__B);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvt_pi2ps (__m128 __A, __m64 __B)
++{
++  return _mm_cvtpi32_ps (__A, __B);
++}
++
++/* Convert the four signed 16-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi16_ps (__m64 __A)
++{
++  __v4hi __sign;
++  __v2si __hisi, __losi;
++  __v4sf __zero, __ra, __rb;
++
++  /* This comparison against zero gives us a mask that can be used to
++     fill in the missing sign bits in the unpack operations below, so
++     that we get signed values after unpacking.  */
++  __sign = __builtin_ia32_pcmpgtw ((__v4hi)0LL, (__v4hi)__A);
++
++  /* Convert the four words to doublewords.  */
++  __losi = (__v2si) __builtin_ia32_punpcklwd ((__v4hi)__A, __sign);
++  __hisi = (__v2si) __builtin_ia32_punpckhwd ((__v4hi)__A, __sign);
++
++  /* Convert the doublewords to floating point two at a time.  */
++  __zero = (__v4sf) _mm_setzero_ps ();
++  __ra = __builtin_ia32_cvtpi2ps (__zero, __losi);
++  __rb = __builtin_ia32_cvtpi2ps (__ra, __hisi);
++
++  return (__m128) __builtin_ia32_movlhps (__ra, __rb);
++}
++
++/* Convert the four unsigned 16-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpu16_ps (__m64 __A)
++{
++  __v2si __hisi, __losi;
++  __v4sf __zero, __ra, __rb;
++
++  /* Convert the four words to doublewords.  */
++  __losi = (__v2si) __builtin_ia32_punpcklwd ((__v4hi)__A, (__v4hi)0LL);
++  __hisi = (__v2si) __builtin_ia32_punpckhwd ((__v4hi)__A, (__v4hi)0LL);
++
++  /* Convert the doublewords to floating point two at a time.  */
++  __zero = (__v4sf) _mm_setzero_ps ();
++  __ra = __builtin_ia32_cvtpi2ps (__zero, __losi);
++  __rb = __builtin_ia32_cvtpi2ps (__ra, __hisi);
++
++  return (__m128) __builtin_ia32_movlhps (__ra, __rb);
++}
++
++/* Convert the low four signed 8-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi8_ps (__m64 __A)
++{
++  __v8qi __sign;
++
++  /* This comparison against zero gives us a mask that can be used to
++     fill in the missing sign bits in the unpack operations below, so
++     that we get signed values after unpacking.  */
++  __sign = __builtin_ia32_pcmpgtb ((__v8qi)0LL, (__v8qi)__A);
++
++  /* Convert the four low bytes to words.  */
++  __A = (__m64) __builtin_ia32_punpcklbw ((__v8qi)__A, __sign);
++
++  return _mm_cvtpi16_ps(__A);
++}
++
++/* Convert the low four unsigned 8-bit values in A to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpu8_ps(__m64 __A)
++{
++  __A = (__m64) __builtin_ia32_punpcklbw ((__v8qi)__A, (__v8qi)0LL);
++  return _mm_cvtpu16_ps(__A);
++}
++
++/* Convert the four signed 32-bit values in A and B to SPFP form.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtpi32x2_ps(__m64 __A, __m64 __B)
++{
++  __v4sf __zero = (__v4sf) _mm_setzero_ps ();
++  __v4sf __sfa = __builtin_ia32_cvtpi2ps (__zero, (__v2si)__A);
++  __v4sf __sfb = __builtin_ia32_cvtpi2ps (__sfa, (__v2si)__B);
++  return (__m128) __builtin_ia32_movlhps (__sfa, __sfb);
++}
++
++/* Convert the four SPFP values in A to four signed 16-bit integers.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pi16(__m128 __A)
++{
++  __v4sf __hisf = (__v4sf)__A;
++  __v4sf __losf = __builtin_ia32_movhlps (__hisf, __hisf);
++  __v2si __hisi = __builtin_ia32_cvtps2pi (__hisf);
++  __v2si __losi = __builtin_ia32_cvtps2pi (__losf);
++  return (__m64) __builtin_ia32_packssdw (__hisi, __losi);
++}
++
++/* Convert the four SPFP values in A to four signed 8-bit integers.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtps_pi8(__m128 __A)
++{
++  __v4hi __tmp = (__v4hi) _mm_cvtps_pi16 (__A);
++  return (__m64) __builtin_ia32_packsswb (__tmp, (__v4hi)0LL);
++}
++
++/* Selects four specific SPFP values from A and B based on MASK.  */
++#ifdef __OPTIMIZE__
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_ps (__m128 __A, __m128 __B, int const __mask)
++{
++  return (__m128) __builtin_ia32_shufps ((__v4sf)__A, (__v4sf)__B, __mask);
++}
++#else
++#define _mm_shuffle_ps(A, B, MASK)					\
++  ((__m128) __builtin_ia32_shufps ((__v4sf)(__m128)(A),			\
++				   (__v4sf)(__m128)(B), (int)(MASK)))
++#endif
++
++/* Selects and interleaves the upper two SPFP values from A and B.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpackhi_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_unpckhps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Selects and interleaves the lower two SPFP values from A and B.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_unpacklo_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_unpcklps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Sets the upper two SPFP values with 64-bits of data loaded from P;
++   the lower two values are passed through from A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadh_pi (__m128 __A, __m64 const *__P);
++
++/* Stores the upper two SPFP values of A into P.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeh_pi (__m64 *__P, __m128 __A);
++
++/* Moves the upper two values of B into the lower two values of A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movehl_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movhlps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Moves the lower two values of B into the upper two values of A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movelh_ps (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movlhps ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Sets the lower two SPFP values with 64-bits of data loaded from P;
++   the upper two values are passed through from A.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadl_pi (__m128 __A, __m64 const *__P);
++
++/* Stores the lower two SPFP values of A into P.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storel_pi (__m64 *__P, __m128 __A);
++
++/* Creates a 4-bit mask from the most significant bits of the SPFP values.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_ps (__m128 __A)
++{
++  return __builtin_ia32_movmskps ((__v4sf)__A);
++}
++
++/* Return the contents of the control register.  */
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_getcsr (void)
++{
++  return __builtin_ia32_stmxcsr ();
++}
++
++/* Read exception bits from the control register.  */
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_EXCEPTION_STATE (void)
++{
++  return _mm_getcsr() & _MM_EXCEPT_MASK;
++}
++
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_EXCEPTION_MASK (void)
++{
++  return _mm_getcsr() & _MM_MASK_MASK;
++}
++
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_ROUNDING_MODE (void)
++{
++  return _mm_getcsr() & _MM_ROUND_MASK;
++}
++
++extern __inline unsigned int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_GET_FLUSH_ZERO_MODE (void)
++{
++  return _mm_getcsr() & _MM_FLUSH_ZERO_MASK;
++}
++
++/* Set the control register to I.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setcsr (unsigned int __I)
++{
++  __builtin_ia32_ldmxcsr (__I);
++}
++
++/* Set exception bits in the control register.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_EXCEPTION_STATE(unsigned int __mask)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_EXCEPT_MASK) | __mask);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_EXCEPTION_MASK (unsigned int __mask)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_MASK_MASK) | __mask);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_ROUNDING_MODE (unsigned int __mode)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_ROUND_MASK) | __mode);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_MM_SET_FLUSH_ZERO_MODE (unsigned int __mode)
++{
++  _mm_setcsr((_mm_getcsr() & ~_MM_FLUSH_ZERO_MASK) | __mode);
++}
++
++/* Create a vector with element 0 as F and the rest zero.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_ss (float __F)
++{
++  return __extension__ (__m128)(__v4sf){ __F, 0.0f, 0.0f, 0.0f };
++}
++
++/* Create a vector with all four elements equal to F.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set1_ps (float __F)
++{
++  return __extension__ (__m128)(__v4sf){ __F, __F, __F, __F };
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_ps1 (float __F)
++{
++  return _mm_set1_ps (__F);
++}
++
++/* Create a vector with element 0 as *P and the rest zero.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_ss (float const *__P)
++{
++  return _mm_set_ss (*__P);
++}
++
++/* Create a vector with all four elements equal to *P.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load1_ps (float const *__P)
++{
++  return _mm_set1_ps (*__P);
++}
++
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_ps1 (float const *__P)
++{
++  return _mm_load1_ps (__P);
++}
++
++/* Load four SPFP values from P.  The address must be 16-byte aligned.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_load_ps (float const *__P)
++{
++  return (__m128) *(__v4sf *)__P;
++}
++
++/* Load four SPFP values from P.  The address need not be 16-byte aligned.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadu_ps (float const *__P)
++{
++  return (__m128) __builtin_ia32_loadups (__P);
++}
++
++/* Load four SPFP values in reverse order.  The address must be aligned.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_loadr_ps (float const *__P)
++{
++  __v4sf __tmp = *(__v4sf *)__P;
++  return (__m128) __builtin_ia32_shufps (__tmp, __tmp, _MM_SHUFFLE (0,1,2,3));
++}
++
++/* Create the vector [Z Y X W].  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_set_ps (const float __Z, const float __Y, const float __X, const float __W)
++{
++  return __extension__ (__m128)(__v4sf){ __W, __X, __Y, __Z };
++}
++
++/* Create the vector [W X Y Z].  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_setr_ps (float __Z, float __Y, float __X, float __W)
++{
++  return __extension__ (__m128)(__v4sf){ __Z, __Y, __X, __W };
++}
++
++/* Stores the lower SPFP value.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_ss (float *__P, __m128 __A)
++{
++  *__P = __builtin_ia32_vec_ext_v4sf ((__v4sf)__A, 0);
++}
++
++extern __inline float __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_cvtss_f32 (__m128 __A)
++{
++  return __builtin_ia32_vec_ext_v4sf ((__v4sf)__A, 0);
++}
++
++/* Store four SPFP values.  The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_ps (float *__P, __m128 __A)
++{
++  *(__v4sf *)__P = (__v4sf)__A;
++}
++
++/* Store four SPFP values.  The address need not be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storeu_ps (float *__P, __m128 __A)
++{
++  __builtin_ia32_storeups (__P, (__v4sf)__A);
++}
++
++/* Store the lower SPFP value across four words.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store1_ps (float *__P, __m128 __A)
++{
++  __v4sf __va = (__v4sf)__A;
++  __v4sf __tmp = __builtin_ia32_shufps (__va, __va, _MM_SHUFFLE (0,0,0,0));
++  _mm_storeu_ps (__P, __tmp);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_store_ps1 (float *__P, __m128 __A)
++{
++  _mm_store1_ps (__P, __A);
++}
++
++/* Store four SPFP values in reverse order.  The address must be aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_storer_ps (float *__P, __m128 __A)
++{
++  __v4sf __va = (__v4sf)__A;
++  __v4sf __tmp = __builtin_ia32_shufps (__va, __va, _MM_SHUFFLE (0,1,2,3));
++  _mm_store_ps (__P, __tmp);
++}
++
++/* Sets the low SPFP value of A from the low value of B.  */
++extern __inline __m128 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_move_ss (__m128 __A, __m128 __B)
++{
++  return (__m128) __builtin_ia32_movss ((__v4sf)__A, (__v4sf)__B);
++}
++
++/* Extracts one of the four words of A.  The selector N must be immediate.  */
++#ifdef __OPTIMIZE__
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_extract_pi16 (__m64 const __A, int const __N)
++{
++  return __builtin_ia32_vec_ext_v4hi ((__v4hi)__A, __N);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pextrw (__m64 const __A, int const __N)
++{
++  return _mm_extract_pi16 (__A, __N);
++}
++#else
++#define _mm_extract_pi16(A, N)	\
++  ((int) __builtin_ia32_vec_ext_v4hi ((__v4hi)(__m64)(A), (int)(N)))
++
++#define _m_pextrw(A, N) _mm_extract_pi16(A, N)
++#endif
++
++/* Inserts word D into one of four words of A.  The selector N must be
++   immediate.  */
++#ifdef __OPTIMIZE__
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_insert_pi16 (__m64 const __A, int const __D, int const __N)
++{
++  return (__m64) __builtin_ia32_vec_set_v4hi ((__v4hi)__A, __D, __N);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pinsrw (__m64 const __A, int const __D, int const __N)
++{
++  return _mm_insert_pi16 (__A, __D, __N);
++}
++#else
++#define _mm_insert_pi16(A, D, N)				\
++  ((__m64) __builtin_ia32_vec_set_v4hi ((__v4hi)(__m64)(A),	\
++					(int)(D), (int)(N)))
++
++#define _m_pinsrw(A, D, N) _mm_insert_pi16(A, D, N)
++#endif
++
++/* Compute the element-wise maximum of signed 16-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_pi16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pmaxsw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmaxsw (__m64 __A, __m64 __B)
++{
++  return _mm_max_pi16 (__A, __B);
++}
++
++/* Compute the element-wise maximum of unsigned 8-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_max_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pmaxub ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmaxub (__m64 __A, __m64 __B)
++{
++  return _mm_max_pu8 (__A, __B);
++}
++
++/* Compute the element-wise minimum of signed 16-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_pi16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pminsw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pminsw (__m64 __A, __m64 __B)
++{
++  return _mm_min_pi16 (__A, __B);
++}
++
++/* Compute the element-wise minimum of unsigned 8-bit values.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_min_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pminub ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pminub (__m64 __A, __m64 __B)
++{
++  return _mm_min_pu8 (__A, __B);
++}
++
++/* Create an 8-bit mask of the signs of 8-bit values.  */
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_movemask_pi8 (__m64 __A)
++{
++  return __builtin_ia32_pmovmskb ((__v8qi)__A);
++}
++
++extern __inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmovmskb (__m64 __A)
++{
++  return _mm_movemask_pi8 (__A);
++}
++
++/* Multiply four unsigned 16-bit values in A by four unsigned 16-bit values
++   in B and produce the high 16 bits of the 32-bit results.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_mulhi_pu16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pmulhuw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pmulhuw (__m64 __A, __m64 __B)
++{
++  return _mm_mulhi_pu16 (__A, __B);
++}
++
++/* Return a combination of the four 16-bit values in A.  The selector
++   must be an immediate.  */
++#ifdef __OPTIMIZE__
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_shuffle_pi16 (__m64 __A, int const __N)
++{
++  return (__m64) __builtin_ia32_pshufw ((__v4hi)__A, __N);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pshufw (__m64 __A, int const __N)
++{
++  return _mm_shuffle_pi16 (__A, __N);
++}
++#else
++#define _mm_shuffle_pi16(A, N) \
++  ((__m64) __builtin_ia32_pshufw ((__v4hi)(__m64)(A), (int)(N)))
++
++#define _m_pshufw(A, N) _mm_shuffle_pi16 (A, N)
++#endif
++
++/* Conditionally store byte elements of A into P.  The high bit of each
++   byte in the selector N determines whether the corresponding byte from
++   A is stored.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_maskmove_si64 (__m64 __A, __m64 __N, char *__P)
++{
++  __builtin_ia32_maskmovq ((__v8qi)__A, (__v8qi)__N, __P);
++}
++
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_maskmovq (__m64 __A, __m64 __N, char *__P)
++{
++  _mm_maskmove_si64 (__A, __N, __P);
++}
++
++/* Compute the rounded averages of the unsigned 8-bit values in A and B.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pavgb ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pavgb (__m64 __A, __m64 __B)
++{
++  return _mm_avg_pu8 (__A, __B);
++}
++
++/* Compute the rounded averages of the unsigned 16-bit values in A and B.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_avg_pu16 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_pavgw ((__v4hi)__A, (__v4hi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_pavgw (__m64 __A, __m64 __B)
++{
++  return _mm_avg_pu16 (__A, __B);
++}
++
++/* Compute the sum of the absolute differences of the unsigned 8-bit
++   values in A and B.  Return the value in the lower 16-bit word; the
++   upper words are cleared.  */
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sad_pu8 (__m64 __A, __m64 __B)
++{
++  return (__m64) __builtin_ia32_psadbw ((__v8qi)__A, (__v8qi)__B);
++}
++
++extern __inline __m64 __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_m_psadbw (__m64 __A, __m64 __B)
++{
++  return _mm_sad_pu8 (__A, __B);
++}
++
++/* Loads one cache line from address P to a location "closer" to the
++   processor.  The selector I specifies the type of prefetch operation.  */
++#ifdef __OPTIMIZE__
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_prefetch (const void *__P, enum _mm_hint __I)
++{
++  __builtin_prefetch (__P, 0, __I);
++}
++#else
++#define _mm_prefetch(P, I) \
++  __builtin_prefetch ((P), 0, (I))
++#endif
++
++/* Stores the data in A to the address P without polluting the caches.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_pi (__m64 *__P, __m64 __A)
++{
++  __builtin_ia32_movntq ((unsigned long long *)__P, (unsigned long long)__A);
++}
++
++/* Likewise.  The address must be 16-byte aligned.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_stream_ps (float *__P, __m128 __A)
++{
++  __builtin_ia32_movntps (__P, (__v4sf)__A);
++}
++
++/* Guarantees that every preceding store is globally visible before
++   any subsequent store.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_sfence (void)
++{
++  __builtin_ia32_sfence ();
++}
++
++/* The execution of the next instruction is delayed by an implementation
++   specific amount of time.  The instruction does not modify the
++   architectural state.  */
++extern __inline void __attribute__((__gnu_inline__, __always_inline__, __artificial__))
++_mm_pause (void)
++{
++  __asm__ __volatile__ ("rep; nop" : : );
++}
++
++/* Transpose the 4x4 matrix composed of row[0-3].  */
++#define _MM_TRANSPOSE4_PS(row0, row1, row2, row3)			\
++do {									\
++  __v4sf __r0 = (row0), __r1 = (row1), __r2 = (row2), __r3 = (row3);	\
++  __v4sf __t0 = __builtin_ia32_unpcklps (__r0, __r1);			\
++  __v4sf __t1 = __builtin_ia32_unpcklps (__r2, __r3);			\
++  __v4sf __t2 = __builtin_ia32_unpckhps (__r0, __r1);			\
++  __v4sf __t3 = __builtin_ia32_unpckhps (__r2, __r3);			\
++  (row0) = __builtin_ia32_movlhps (__t0, __t1);				\
++  (row1) = __builtin_ia32_movhlps (__t1, __t0);				\
++  (row2) = __builtin_ia32_movlhps (__t2, __t3);				\
++  (row3) = __builtin_ia32_movhlps (__t3, __t2);				\
++} while (0)
++
++/* For backward source compatibility.  */
++# include <emmintrin.h>
++
++#ifdef __DISABLE_SSE__
++#undef __DISABLE_SSE__
++#pragma GCC pop_options
++#endif /* __DISABLE_SSE__ */
++
++#endif /* _XMMINTRIN_H_INCLUDED */
+-- 
+1.7.1
+

--- a/gccxml.spec
+++ b/gccxml.spec
@@ -2,13 +2,15 @@
 
 BuildRequires: cmake
 
-%define commit ab651a2aa866351bdd089a4bf1d57f6a9bec2a66
+%define commit 610ec28d8f67e48ec461d9b9ab83a2d192f5cf2e
 Source: git+https://github.com/gccxml/gccxml.git?obj=master/%{commit}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tar.gz
+Patch0: gccxml-add-gcc49-support
 
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 
 %if %isdarwin
 # Drop no more supported -no-cpp-precomp on Darwin.


### PR DESCRIPTION
Branches IB/CMSSW_7_3_X/stable and IB/CMSSW_7_4_X/gcc481 should be identical.
Because IB/CMSSW_7_4_X/stable has gcc491, the automatic merges brought to IB/CMSSW_7_4_X/gcc481 unwanted gcc changes. 

https://github.com/cms-sw/cmsdist/compare/IB/CMSSW_7_3_X/stable...IB/CMSSW_7_4_X/gcc481
This pull request reverts the difference. 
Notice that in the comparison there are 6 files changed with  with 75 additions and 27,583 deletions.
This pull request modifies those 6 files with 27,583 additions and 75 deletions.

if you compare the nclopezo:revert-unwanted-gcc-changes-74-481 with IB/CMSSW_7_3_X/stable, there are no changes:

https://github.com/nclopezo/cmsdist/compare/cms-sw:IB/CMSSW_7_3_X/stable...nclopezo:revert-unwanted-gcc-changes-74-481
