### PR TITLE
py2-pygments: fix shebang for pygmentize

### DIFF
--- a/py2-pygments.spec
+++ b/py2-pygments.spec
@@ -12,3 +12,6 @@ python setup.py build
 
 %install
 python setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
+
+sed -ideleteme 's|#!.*/bin/python|#!/usr/bin/env python|' %{i}/bin/pygmentize
+rm -f %{i}/bin/*deleteme


### PR DESCRIPTION
`pygmentize` contains a full path to non-relocated Python. The patch
changes shebang to `#!/usr/bin/env python`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
