### PR TITLE
updated scramand config tag

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_6_pre2
+### RPM lcg SCRAMV1 V2_2_6_pre3
 ## NOCOMPILER
 
 BuildRequires: gmake

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -58,7 +58,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-03-28
+%define configtag       V05-03-30
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
- SCRAM v2_2_6_pre3: which uses system copy to avoid extra stats on filesystem
- config tag V05-03-30:
  - support for lib/<arch>/.poisonededmplugin https://github.com/cms-sw/cmssw/pull/6220
  - support for .rootmap 
