### PR TITLE
First release candidate of CRAB3 3.3.12

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,4 +1,4 @@
-### RPM cms crabclient 3.3.12.rc1
+### RPM cms crabclient 3.3.12.rc3
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,4 +1,4 @@
-### RPM cms crabtaskworker 3.3.12.rc1
+### RPM cms crabtaskworker 3.3.12.rc3
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
As usual reporting only changes in the REST:

Report input number of events analyzed by terminal jobs. Input files from the jobreport are also uploaded into the filemetadata
Add an API to ge thet webdir and refactor some variable names.
Add outtmplfn parameter to filemetadata and improve getFiles accordingly.
Add use parent option to the REST interface.
Record output datasets in the task table and not in the filemetadata anymore.
outLFN must start with /store/user/username/ or /store/group/groupname etc.
