### PR TITLE
Initial import of debug related files.

### DIFF
--- a/dwz.spec
+++ b/dwz.spec
@@ -1,0 +1,16 @@
+### RPM external dwz 0.11
+
+%define dwz_branch master
+%define dwz_commit dwz-0.11
+
+Source: git://sourceware.org/git/dwz.git?obj=%{dwz_branch}/%{dwz_commit}&export=dwz-%{dwz_commit}&output=/dwz-%{dwz_commit}.tgz
+
+%prep
+%setup -T -b 0 -n dwz-%{dwz_commit}
+
+%build
+make %{makeprocesses}
+
+%install
+mkdir -p %{i}/bin
+cp dwz %{i}/bin

--- a/file-toolfile.spec
+++ b/file-toolfile.spec
@@ -1,0 +1,19 @@
+### RPM external file-toolfile 1.0
+Requires: file
+
+%prep
+%build
+%install
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE > %{i}/etc/scram.d/file.xml
+  <tool name="file" version="@TOOL_VERSION@">
+    <lib name="magic"/>
+    <client>
+      <environment name="FILE_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$FILE_BASE/lib"/>
+      <environment name="INCLUDE" default="$FILE_BASE/include"/>
+    </client>
+    <runtime name="PATH" value="$FILE_BASE/bin" type="path"/>
+  </tool>
+EOF_TOOLFILE
+## IMPORT scram-tools-post

--- a/subpackage-debug.file
+++ b/subpackage-debug.file
@@ -13,26 +13,10 @@ Separate debug symbol files for %{pkgcategory}+%{pkgname}+%{pkgversion}.
 %post -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion}
 # nothing to do
 
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-if [ -e $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz ] ; then
-  tar xzf $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz -C $RPM_INSTALL_PREFIX/%pkgrel/
-  rm -fR  $RPM_INSTALL_PREFIX/%pkgrel/debug.tar.gz
-fi
-%endif
-
 %preun -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion}
-# FIXME - work around the 2GB limit in RPM 4.4.2
-%if "%{?subpackageDebug:set}" == "set"
-if [ -e $RPM_INSTALL_PREFIX/%pkgrel ] ; then
-  rm -fR $(find $RPM_INSTALL_PREFIX/%pkgrel/ -type d -name .debug)
-fi
-%endif
+# nothing to do
 
 %if "%{?subpackageDebug:set}" == "set"
-%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} 
-# FIXME - work around the 2GB limit in RPM 4.4.2
-#%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} -f %_builddir/files.debug
-%{pkginstroot}/debug.tar.gz
+%files -n %{pkgcategory}+%{pkgname}-debug+%{pkgversion} -f %_builddir/files.debug
 %defattr(-, root, root)
 %endif


### PR DESCRIPTION
These files are needed for the debug builds. Since they are not used right now, there is no harm in importing them in base builds to simplify the back port of the rest.
