### PR TITLE
Critical fixes for crabserver 3.3.12 version

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,9 +1,9 @@
-### RPM cms crabclient 3.3.12
+### RPM cms crabclient 3.3.12.patch1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-%define wmcver 1.0.1
+%define wmcver 1.0.3.pre1
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
 %define crabserver 3.3.12.rc1
 


### PR DESCRIPTION
Make outtmplfn in RESTFileMetadata optional and give it a default value
Fix getFiles as it required DirectStageout
Add hcxrootd activity to the allowed ones
