### PR TITLE
root,roofit: remove CMS specific patch

### DIFF
--- a/roofit.spec
+++ b/roofit.spec
@@ -1,7 +1,7 @@
 ### RPM lcg roofit 6.02.00
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag f92afa9e9a268d9ba92c8d346f8678e3488b4813
+%define tag dbb15f91ef4d06cca1a317f421722f1120857b66
 %define branch cms/0fa9d45
 %define github_user cms-sw
 Source: git+https://github.com/%github_user/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/root.spec
+++ b/root.spec
@@ -1,7 +1,7 @@
 ### RPM lcg root 6.02.00
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag f92afa9e9a268d9ba92c8d346f8678e3488b4813
+%define tag dbb15f91ef4d06cca1a317f421722f1120857b66
 %define branch cms/0fa9d45
 %define github_user cms-sw
 Source: git+https://github.com/%github_user/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
The patch removes CMS specific patch, but keeps ROOT at the same
commit.

Moves to cms-sw/root@dbb15f91ef4d06cca1a317f421722f1120857b66.
