### PR TITLE
force a rebuild of cmssw full IBs for 73X and 74X

### DIFF
--- a/online.spec
+++ b/online.spec
@@ -7,6 +7,7 @@ Requires: online-tool-conf python
 
 %define patchsrc2       perl -p -i -e ' s!(<classpath.*/test\\+.*>)!!' config/BuildFile.xml
 
+
 ## IMPORT cmssw-partial-build
 ## IMPORT scram-project-build
 ## SUBPACKAGE debug


### PR DESCRIPTION
pkgtools had a bug and it was adding sub-packages in the dependency chain. This only effect builds with debug sub-package ON i.e. 73X and 74X. This is fixed in pkgtools but we need to force full IBs for 73X and 74X
