### PR TITLE
First release candidate for CRAB 3.3.13

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,11 +1,11 @@
-### RPM cms crabclient 3.3.12.patch1
+### RPM cms crabclient 3.3.13.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define wmcver 1.0.3.pre1
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define crabserver 3.3.12.rc1
+%define crabserver 3.3.13.rc1
 
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,4 +1,4 @@
-### RPM cms crabserver 3.3.12.rc7
+### RPM cms crabserver 3.3.13.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,4 +1,4 @@
-### RPM cms crabtaskworker 3.3.12.rc7
+### RPM cms crabtaskworker 3.3.13.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
As usual posting a summary of the changes concerning just the REST interface here:
- Return information to spot when publication is disabled
- Report: reutrn the input file lfns to correctly count read files
- Refactoring: added a ServerUtilities with the checkOutLFN function (to be shared with the client)
- Refactoring: remove transformation parameter from the task database
- Changed getoutput and getlog to align with new local stageout policy
- Do not use merge but insert/update in filemetadata upload
- Validate the publication dataset name and the primary dataset name
- Add the possibility to specify the collector
- Add parameter for Hook WMCore event aware lumi splitting
