### PR TITLE
various fixes for debug builds

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_6_pre2
+### RPM lcg SCRAMV1 V2_2_6_pre3
 ## NOCOMPILER
 
 BuildRequires: gmake

--- a/cms-git-tools.spec
+++ b/cms-git-tools.spec
@@ -1,9 +1,9 @@
-### RPM cms cms-git-tools 141118.0
+### RPM cms cms-git-tools 150119.0
 ## NOCOMPILER
 
 # ***Do not change minor number of the above version.***
 
-%define commit 63f4f334830259953080b8600f1af15f85881450
+%define commit bfba63d2b083f7e041c71839d885b31a9dfe8fcb
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when they are dependencies.

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -67,7 +67,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-04-00
+%define configtag       V05-04-02
 %endif
 
 %if "%{?useCmsTC:set}" != "set"
@@ -282,14 +282,17 @@ rm -fR %{srctree} tmp
 # Handle debug symbols. We always have a debug subpackage for debug symbols so
 # no point in complicating the standard builds with this.
 %if "%{?subpackageDebug:set}" == "set"
+touch %i/.SCRAM/%cmsplatf/subpackage-debug
 if [ "%{n}" == "coral" ]; then
   ELF_DIRS="%i/%cmsplatf/lib %i/%cmsplatf/tests/bin"
+  DROP_SYMBOLS_DIRS=""
 else
   ELF_DIRS="%i/lib/%cmsplatf %i/biglib/%cmsplatf %i/bin/%cmsplatf %i/test/%cmsplatf"
+  DROP_SYMBOLS_DIRS="%i/objs/%cmsplatf"
 fi
 
 # optimise the debug symbols, compress them, and split them into separate file
-for DIR in $ELF_DIRS; do
+for DIR in $ELF_DIRS $DROP_SYMBOLS_DIRS; do
   pushd $DIR
   mkdir -p .debug
   # ELF binaries
@@ -299,6 +302,10 @@ for DIR in $ELF_DIRS; do
     echo "$ELF_BINS" | xargs -t -n1 -P%{compiling_processes} -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
   popd
+done
+
+for DIR in $DROP_SYMBOLS_DIRS; do
+  rm -rf $DIR/.debug
 done
 
 # split the debug symbols out of the main binaries, into separate files

--- a/scramv1-build.file
+++ b/scramv1-build.file
@@ -18,7 +18,7 @@
 # FIXME: produce requirements from "scram tool info"?
 # FIXME: automatic sub-packages for "doc" etc?
 # FIXME: post-install stuff for modules etc?
-
+ 
 Requires: SCRAMV1
 %define initenv		%initenv_direct
 %define scram_xml   .xml


### PR DESCRIPTION
- new scram version
- new config tag: 
  - fixes for python empty directory
  - CMSSW_SEARCH_PATH fix for patch release build
  - new precompiler header rules
  - debug symbols for big objs cleaned up
- cms-git-tools: fix -f <file> option
