### PR TITLE
Update LLVM/Clang to pre-3.6

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -1,14 +1,15 @@
-### RPM external llvm 3.5
+### RPM external llvm 3.6
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 BuildRequires: python
 Requires: gcc
 
-%define llvmCommit f55c17bc339
-%define clangCommit 656aa83af0b
-%define branch cms/v%realversion
-Source0: git+https://github.com/cms-externals/llvm.git?obj=%{branch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%realversion-%llvmCommit&output=/llvm-%{realversion}-%{llvmCommit}.tgz
-Source1: git+https://github.com/cms-externals/clang.git?obj=%{branch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%realversion-%clangCommit&output=/clang-%{realversion}-%{clangCommit}.tgz
+%define llvmCommit f04ce0e65747b16e6f321c0fdd38b6e1dc3271a3
+%define llvmBranch cms/f04ce0e
+%define clangCommit ff59fc3b222f373bdd5bbebfad41ee6f2d950b43
+%define clangBranch cms/65d8b4c
+Source0: git+https://github.com/cms-externals/llvm.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%realversion-%llvmCommit&output=/llvm-%{realversion}-%{llvmCommit}.tgz
+Source1: git+https://github.com/cms-externals/clang.git?obj=%{clangBranch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%realversion-%clangCommit&output=/clang-%{realversion}-%{clangCommit}.tgz
 
 # Still need forward porting.
 %define keep_archives true

--- a/py2-dxr-clang36.patch
+++ b/py2-dxr-clang36.patch
@@ -1,0 +1,24 @@
+diff --git a/dxr/plugins/clang/dxr-index.cpp b/dxr/plugins/clang/dxr-index.cpp
+index 7692809..e7cf597 100644
+--- a/dxr/plugins/clang/dxr-index.cpp
++++ b/dxr/plugins/clang/dxr-index.cpp
+@@ -158,7 +158,7 @@ public:
+       m_currentFunction(NULL) {
+     inner = ci.getDiagnostics().takeClient();
+     ci.getDiagnostics().setClient(this, false);
+-    ci.getPreprocessor().addPPCallbacks(new PreprocThunk(this));
++    ci.getPreprocessor().addPPCallbacks(llvm::make_unique<PreprocThunk>(this));
+   }
+ 
+   virtual DiagnosticConsumer *clone(DiagnosticsEngine &Diags) const {
+@@ -1150,8 +1150,8 @@ void PreprocThunk::InclusionDirective(  // same in 3.2 and 3.3
+ 
+ class DXRIndexAction : public PluginASTAction {
+ protected:
+-  ASTConsumer *CreateASTConsumer(CompilerInstance &CI, llvm::StringRef f) {
+-    return new IndexConsumer(CI);
++  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI, llvm::StringRef f) {
++    return llvm::make_unique<IndexConsumer>(CI);
+   }
+ 
+   bool ParseArgs(const CompilerInstance &CI,

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -14,6 +14,7 @@ Source2: https://re2.googlecode.com/files/re2-%re2Version.tgz
 Patch0: py2-dxr
 Patch1: trilite
 Patch2: py2-dxr-fix-clang-linker-flags
+Patch3: py2-dxr-clang36
 %define keep_archives true
 
 %prep
@@ -24,6 +25,7 @@ Patch2: py2-dxr-fix-clang-linker-flags
 cd ..
 %patch0 -p1
 %patch2 -p1
+%patch3 -p1
 mv trilite-%triliteCommit/* trilite
 %setup -T -D -n dxr-%dxrCommit
 


### PR DESCRIPTION
Updates LLVM and Clang to pre-3.6, which adds additional features used in CMSSW. In addition to that resolves some asserts in Clang while compiling CMSSW. Same PR (#1220) was merged into DEVEL IBs ~2 months ago. Plain CMSSW now fully compiles and links with Clang.

We will probably again update Clang soonish as 3.6 RC1 is now released, but not tested with CMSSW.

@ktf @davidlange6
