### PR TITLE
add patch to fix pythia8 matching for events with top quarks (53x)

### DIFF
--- a/pythia8-205-fix-matching.patch
+++ b/pythia8-205-fix-matching.patch
@@ -1,0 +1,49 @@
+--- ../pythia8205/include/Pythia8Plugins/JetMatching.h	2015-01-23 21:22:34.000000001 +0100
++++ pythia8205/include/Pythia8Plugins/JetMatching.h	2015-02-05 01:45:28.000000001 +0100
+@@ -1365,46 +1365,6 @@
+         continue;
+       }
+     }
+-
+-    // Get the index of this particle in original event
+-    int idx = workEventJet[i].daughter1();
+-
+-    // Start with particle idx, and afterwards track mothers
+-    while (true) {
+-
+-      // Light jets
+-      if (iType == 0) {
+-
+-        // Do not include if originates from heavy jet or 'other'
+-        if (typeSet[1].find(idx) != typeSet[1].end() ||
+-            typeSet[2].find(idx) != typeSet[2].end()) {
+-          workEventJet[i].statusNeg();
+-          break;
+-        }
+-
+-        // Made it to start of event record so done
+-        if (idx == 0) break;
+-        // Otherwise next mother and continue
+-        idx = event[idx].mother1();
+-
+-      // Heavy jets
+-      } else if (iType == 1) {
+-
+-        // Only include if originates from heavy jet
+-        if (typeSet[1].find(idx) != typeSet[1].end()) break;
+-
+-        // Made it to start of event record with no heavy jet mother,
+-        // so DO NOT include particle
+-        if (idx == 0) {
+-          workEventJet[i].statusNeg();
+-          break;
+-        }
+-
+-        // Otherwise next mother and continue
+-        idx = event[idx].mother1();
+-
+-      } // if (iType)
+-    } // while (true)
+   } // for (i)
+ }
+ 

--- a/pythia8.spec
+++ b/pythia8.spec
@@ -5,6 +5,7 @@ Requires: hepmc lhapdf
 Source: http://home.thep.lu.se/~torbjorn/pythia8/%{n}%{realversion}.tgz
 
 Patch0: pythia8-205-fix-gcc-options
+Patch1: pythia8-205-fix-matching
 
 %if "%{?cms_cxxflags:set}" != "set"
 %define cms_cxxflags -std=c++0x
@@ -13,6 +14,7 @@ Patch0: pythia8-205-fix-gcc-options
 %prep
 %setup -q -n %{n}%{realversion}
 %patch0 -p2
+%patch1 -p2
  
 export USRCXXFLAGS="%cms_cxxflags"
 export HEPMCLOCATION=${HEPMC_ROOT}  


### PR DESCRIPTION
Fixes remaining problem with LO ttbar samples in gen validation
