### PR TITLE
boost: resolve broken merge

### DIFF
--- a/boost-1.51.0-define-BOOST_SP_USE_SPINLOCK.patch
+++ b/boost-1.51.0-define-BOOST_SP_USE_SPINLOCK.patch
@@ -1,0 +1,11 @@
+diff --git a/boost/config/user.hpp b/boost/config/user.hpp
+index 5a4a9d4..8c7f353 100644
+--- a/boost/config/user.hpp
++++ b/boost/config/user.hpp
+@@ -121,4 +121,5 @@
+ // #define BOOST_WHATEVER_NO_LIB
+  
+ 
+-
++// Do not use inline assembly for atomic operations
++#define BOOST_SP_USE_SPINLOCK

--- a/boost.spec
+++ b/boost.spec
@@ -7,12 +7,14 @@ Source: http://switch.dl.sourceforge.net/project/%{n}/%{n}/%{v}/%{n}%{boostver}.
 %define cms_cxxflags -std=c++0x -O2
 %endif
 
-Requires: python bz2lib zlib
-Patch0: boost-1.57.0-BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS
-Patch1: boost-add-missing-header-serialization
-Patch2: boost-disable-int128-makecint
-Patch3: boost-unused-variable-silence
-Patch4: boost-1.57.0-define-BOOST_SP_USE_SPINLOCK
+Requires: python bz2lib
+%if "%online" != "true"
+Requires: zlib
+%endif
+Patch0: boost-1.47.0-fix-strict-overflow
+Patch1: boost-1.47.0-fix-unused
+Patch2: boost-1.49.0-explicit_stored_group
+Patch3: boost-1.51.0-define-BOOST_SP_USE_SPINLOCK
 
 %prep
 %setup -n %{n}%{boostver}
@@ -20,7 +22,6 @@ Patch4: boost-1.57.0-define-BOOST_SP_USE_SPINLOCK
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
-%patch4 -p1
 
 perl -p -i -e 's/-no-cpp-precomp//' tools/build/v2/tools/darwin.jam \
                                     tools/build/v2/tools/darwin.py


### PR DESCRIPTION
`-x ours` did not merge everything. We had a file missing and half merged `boost.spec`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
