### PR TITLE
CRAB3 3.3.14.rc1 version

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,11 +1,11 @@
-### RPM cms crabclient 3.3.13.patch1
+### RPM cms crabclient 3.3.14.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define wmcver 1.0.3.pre1
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define crabserver 3.3.13.rc1
+%define crabserver 3.3.14.rc1
 
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,4 +1,4 @@
-### RPM cms crabserver 3.3.13.rc2
+### RPM cms crabserver 3.3.14.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,4 +1,4 @@
-### RPM cms crabtaskworker 3.3.13.rc2
+### RPM cms crabtaskworker 3.3.14.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
The main changes worth mentioning is that schedd names are put in the DB (will be used for the late binding), and that the state of the jobs will be reported when the tasks are QUEUED and have been resubmitted
