### PR TITLE
run dwz if we have multiple binary files

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -299,7 +299,7 @@ for DIR in $ELF_DIRS $DROP_SYMBOLS_DIRS; do
   # ELF binaries
   ELF_BINS=$(file * | grep ELF | cut -d':' -f1)
   if [ ! -z "$ELF_BINS" ]; then
-    if [ `echo $ELF_BINS | wc -w` -gt 1 ] ; then
+    if [ $(echo $ELF_BINS | wc -w) -gt 1 ] ; then
       dwz -m .debug/common-symbols.debug -M common-symbols.debug $ELF_BINS
     fi
     echo "$ELF_BINS" | xargs -t -n1 -P%{compiling_processes} -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -299,7 +299,9 @@ for DIR in $ELF_DIRS $DROP_SYMBOLS_DIRS; do
   # ELF binaries
   ELF_BINS=$(file * | grep ELF | cut -d':' -f1)
   if [ ! -z "$ELF_BINS" ]; then
-    dwz -m .debug/common-symbols.debug -M common-symbols.debug $ELF_BINS
+    if [ `echo $ELF_BINS | wc -w` -gt 1 ] ; then
+      dwz -m .debug/common-symbols.debug -M common-symbols.debug $ELF_BINS
+    fi
     echo "$ELF_BINS" | xargs -t -n1 -P%{compiling_processes} -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
   popd


### PR DESCRIPTION
this should fix the building of patch releases where (some times) there are exactly one binary/shared library
