### PR TITLE
CRAB3 3.3.15 first release candidate

### DIFF
--- a/crabclient.spec
+++ b/crabclient.spec
@@ -1,11 +1,11 @@
-### RPM cms crabclient 3.3.14
+### RPM cms crabclient 3.3.15.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-%define wmcver 1.0.3.pre1
+%define wmcver 1.0.5.pre5
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define crabserver 3.3.14.rc1
+%define crabserver 3.3.15.rc1
 
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,11 +1,11 @@
-### RPM cms crabserver 3.3.14.rc4
+### RPM cms crabserver 3.3.15.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 1.0.1
+%define wmcver 1.0.5.pre5
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz

--- a/crabtaskworker-setup.patch
+++ b/crabtaskworker-setup.patch
@@ -1,13 +1,85 @@
-diff --git a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
-index 8249eea..2a3fa14 100755
---- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
-+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
-@@ -601,7 +601,7 @@ class SetupCMSSWPset(ScriptInterface):
-         self.handleSeeding()
+diff --git a/src/python/WMCore/Services/DBS/DBS3Reader.py b/src/python/WMCore/Services/DBS/DBS3Reader.py
+index 6900101..42b5404 100644
+--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
++++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
+@@ -26,7 +26,7 @@ def remapDBS3Keys(data, stringify = False, **others):
+                    'logical_file_name' : 'LogicalFileName',
+                    'adler32': 'Adler32', 'check_sum': 'Checksum', 'md5': 'Md5',
+                    'block_name': 'BlockName','run_num': 'RunNumber', 'lumi_section_num': 'LumiSectionNumber'}
+-    
++
+     mapping.update(others)
+     format = lambda x: str(x) if stringify and type(x) == unicode else x
+     for name, newname in mapping.iteritems():
+@@ -82,7 +82,7 @@ class DBS3Reader:
+             item['LumiSectionNumber'] = lumisItem['lumi_section_num']
+             lumiDict[lumisItem['logical_file_name']].append(item)
+         return lumiDict
+-    
++
+     def listPrimaryDatasets(self, match = '*'):
+         """
+         _listPrimaryDatasets_
+@@ -216,13 +216,13 @@ class DBS3Reader:
  
-         # make sure default parametersets for perf reports are installed
--        self.handlePerformanceSettings()
-+#        self.handlePerformanceSettings()
+         """
+         return [ x['logical_file_name'] for x in self.dbs.listFiles(dataset = datasetPath)]
+-        
++
  
-         # check for event numbers in the producers
-         self.handleProducersNumberOfEvents()
+     def listDatasetFileDetails(self, datasetPath, getParents=False):
+         """
+         TODO: This is completely wrong need to be redone. or be removed - getting dataset altogether
+-        might be to costly 
+-        
++        might be to costly
++
+         _listDatasetFileDetails_
+ 
+         Get list of lumis, events, and parents for each file in a dataset
+@@ -231,8 +231,8 @@ class DBS3Reader:
+               'BlockName': '/HighPileUp/Run2011A-v1/RAW#dd6e0796-cbcc-11e0-80a9-003048caaace',
+               'Lumis': {173658: [8, 12, 9, 14, 19, 109, 105]},
+               'Parents': [],
+-              'Checksum': '22218315', 
+-              'Adler32': 'a41a1446', 
++              'Checksum': '22218315',
++              'Adler32': 'a41a1446',
+               'Md5': 'NOTSET',
+               'FileSize': 286021145
+             }
+@@ -242,7 +242,7 @@ class DBS3Reader:
+         blocks = set() #the set of blocks of the dataset
+         #Iterate over the files and prepare the set of blocks and a dict where the keys are the files
+         files = {}
+-        for f in fileDetails:        
++        for f in fileDetails:
+             blocks.add(f['block_name'])
+             files[f['logical_file_name']] = remapDBS3Keys(f, stringify = True)
+             files[f['logical_file_name']]['Lumis'] = {}
+@@ -255,7 +255,8 @@ class DBS3Reader:
+             if getParents:
+                 parents = self.dbs.listFileParents(block_name=blockName)
+                 for p in parents:
+-                    files[p['logical_file_name']]['Parents'].extend(p['parent_logical_file_name'])
++                    if p['logical_file_name'] in files: #invalid files are not there
++                        files[p['logical_file_name']]['Parents'].extend(p['parent_logical_file_name'])
+             #get the lumis
+             file_lumis = self.dbs.listFileLumis(block_name=blockName, validFileOnly = 1)
+             for f in file_lumis:
+@@ -504,12 +505,12 @@ class DBS3Reader:
+                     if lumis:
+                         dbsFile["LumiList"] = self._getLumiList(parentLFN)[parentLFN]
+                     parentList.append(dbsFile)
+-                        
++
+             parentsByLFN[f['logical_file_name']] = parentList
+-            
++
+         for fileInfo in fileDetails:
+             fileInfo["ParentList"] = parentsByLFN[fileInfo['logical_file_name']]
+-             
++
+         return fileDetails
+ 
+     def lfnsInBlock(self, fileBlockName):

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,10 +1,10 @@
-### RPM cms crabtaskworker 3.3.14.rc4
+### RPM cms crabtaskworker 3.3.15.rc1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 1.0.3.pre1
+%define wmcver 1.0.5.pre5
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz


### PR DESCRIPTION
So, April is a "major" release where we introduce new features. That said, the number of changes in the REST are not so relevant, and I don't expect to find any major issue (I will regret saying this..):
- return the `DagmanHoldReason` to the client
- do not consider jobs in 'cooloff' during resubmit
- add a new API (`updateschedd`) to allow binding schedd on the TW
- changes for the `dryrun` features (new DB column and SQL queries to support it)
- Use cached external configuration when git is down
- Check that only CRAB3 operators can delete filemetadata
- Other 'random' refactorings and bugfixes

Complete list: https://github.com/dmwm/CRABServer/commits/master/src/python/CRABInterface
