### PR TITLE
Increase PHEDEX-datasvc to 2.3.21 and PHEDEX-web to 4.2.13

### DIFF
--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-datasvc 2.3.19
+### RPM cms PHEDEX-datasvc 2.3.21
 ## INITENV +PATH PERL5LIB %i/perl_lib
 
 %define downloadn %(echo %n | cut -f1 -d-)

--- a/PHEDEX-web.spec
+++ b/PHEDEX-web.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-web 4.2.10
+### RPM cms PHEDEX-web 4.2.13
 ## INITENV +PATH PERL5LIB %i/perl_lib
 
 %define downloadn %(echo %n | cut -f1 -d-)


### PR DESCRIPTION
completing the support in PhEDEX Web&DataSvc for T1 Disk moves, as requested by CompOps - see the following issues:

https://github.com/dmwm/PHEDEX/issues/978
https://github.com/dmwm/PHEDEX/issues/958

These changes have been extensively tested since the beginning of 2015 on a development instance by Meric & Tony.
