### PR TITLE
New data external for CalibCalorimetry-HcalAlgos

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -29,6 +29,7 @@ Requires: data-GeneratorInterface-EvtGenInterface
 Requires: data-MagneticField-Interpolation
 Requires: data-RecoBTag-SoftLepton
 Requires: data-Calibration-Tools
+Requires: data-CalibCalorimetry-HcalAlgos
 
 %if %isnotonline
 # extra data dependencies for standard builds

--- a/data-CalibCalorimetry-HcalAlgos.spec
+++ b/data-CalibCalorimetry-HcalAlgos.spec
@@ -1,0 +1,5 @@
+### RPM cms CalibCalorimetry-HcalAlgos V01-00-00
+
+%prep
+
+## IMPORT data-build-github


### PR DESCRIPTION
The new repository is [here](https://github.com/cms-data/CalibCalorimetry-HcalAlgos)
And the first tag is [V01-00-00](https://github.com/cms-data/CalibCalorimetry-HcalAlgos/tree/V01-00-00)
