### PR TITLE
patch to sqlalchemy so it can read Oracle timestamps 

### DIFF
--- a/py2-sqlalchemy-0.8.2-fix-sqlite-dialect-timestamp.patch
+++ b/py2-sqlalchemy-0.8.2-fix-sqlite-dialect-timestamp.patch
@@ -1,0 +1,43 @@
+diff --git a/lib/sqlalchemy/processors.py b/lib/sqlalchemy/processors.py
+index 9963ca9..6b50ae8 100644
+--- a/lib/sqlalchemy/processors.py
++++ b/lib/sqlalchemy/processors.py
+@@ -31,8 +31,8 @@ def str_to_datetime_processor_factory(regexp, type_):
+                 m = rmatch(value)
+             except TypeError:
+                 raise ValueError("Couldn't parse %s string '%r' "
+-                                "- value is not a string." %
+-                                (type_.__name__, value))
++                                "- value is not a string, but %s." %
++                                (type_.__name__, value, type(value)))
+             if m is None:
+                 raise ValueError("Couldn't parse %s string: "
+                                 "'%s'" % (type_.__name__, value))
+diff --git a/setup.py b/setup.py
+index 0cdbb40..685c70f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -39,8 +39,8 @@ elif sys.version_info >= (3, 0):
+         cmdclass['build_py'] = build_py
+ 
+ ext_modules = [
+-    Extension('sqlalchemy.cprocessors',
+-           sources=['lib/sqlalchemy/cextension/processors.c']),
++#     Extension('sqlalchemy.cprocessors',
++#           sources=['lib/sqlalchemy/cextension/processors.c']),
+     Extension('sqlalchemy.cresultproxy',
+            sources=['lib/sqlalchemy/cextension/resultproxy.c']),
+     Extension('sqlalchemy.cutils',
+--- a/lib/sqlalchemy/processors.py
++++ b/lib/sqlalchemy/processors.py
+@@ -27,6 +27,10 @@ def str_to_datetime_processor_factory(regexp, type_):
+         if value is None:
+             return None
+         else:
++            # in case we got an oracle timestamp:
++            if type(value) == type(1):
++                return datetime.datetime.fromtimestamp( float(value)/1000000000. ).strftime("%Y-%m-%d %H:%M:%S.%f")
++
+             try:
+                 m = rmatch(value)
+             except TypeError:

--- a/py2-sqlalchemy.spec
+++ b/py2-sqlalchemy.spec
@@ -5,10 +5,12 @@ Source: https://pypi.python.org/packages/source/S/SQLAlchemy/SQLAlchemy-%{realve
 Requires: python 
 
 Patch0: py2-sqlalchemy-0.8.2-add-frontier-dialect
+Patch1: py2-sqlalchemy-0.8.2-fix-sqlite-dialect-timestamp
 
 %prep
 %setup -n SQLAlchemy-%{realversion}
 %patch0 -p1
+%patch1 -p1
 
 %build
 python setup.py build


### PR DESCRIPTION
the c++ tools write timestamps into sqlite files which are formatted like in oracle (nano-seconds since the unix epoch as integers), which are non-standard for sqlite (which expects date-time formatted values). 
This patch allows to read in these time-stamps and converts them to the expected format.
