### PR TITLE
root: incl. ROOT-7245 bugfix

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,7 +1,7 @@
 ### RPM lcg root 6.02.00
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 34f53cca          
+%define tag 72e54456c5a89d38698a7f91a2f5ccf965d8af93
 %define branch cms/a79eb8a
 %define github_user cms-sw
 Source: git+https://github.com/%github_user/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
This fixes a problem seen by CMS when using TH1::Copy on histograms read
from a TTree.

https://sft.its.cern.ch/jira/browse/ROOT-7245

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
