### PR TITLE
patch to coral to read (and write) sqlite formatted timestamps 

### DIFF
--- a/coral-CORAL_2_3_21-fix-timestamp-format-sqlite.patch
+++ b/coral-CORAL_2_3_21-fix-timestamp-format-sqlite.patch
@@ -1,0 +1,76 @@
+diff --git a/src/SQLiteAccess/src/SQLiteStatement.cpp b/src/SQLiteAccess/src/SQLiteStatement.cpp
+index 5038806..71dfdbb 100644
+--- a/src/SQLiteAccess/src/SQLiteStatement.cpp
++++ b/src/SQLiteAccess/src/SQLiteStatement.cpp
+@@ -23,6 +23,30 @@
+ #include "SQLiteStatement.h"
+ #include "StatementStatistics.h"
+ 
++namespace coral {
++  namespace SQLiteAccess {
++    std::string toSimpleString( const boost::posix_time::ptime& time ){
++      boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%Y-%m-%d %H:%M:%f");
++      std::ostringstream os;
++      os.imbue(std::locale(os.getloc(), facet));
++      os << time;
++      return os.str();
++    }
++
++    bool isInteger( const char* str ){
++      std::string s(str);
++      size_t sz = s.size();
++      bool isNumber = sz>0;
++      size_t i = 0;
++      while( isNumber && i<sz ){
++	isNumber = isdigit(s[i]);
++	i++;
++      }  
++      return isNumber;
++    }
++  }
++}
++
+ using namespace coral::SQLiteAccess;
+ 
+ SQLiteStatement::SQLiteStatement( boost::shared_ptr<const SessionProperties> properties ) :
+@@ -185,15 +209,15 @@ SQLiteStatement::bind( const coral::AttributeList& inputData )
+       }
+       else if(st(attributeType)==SQLT_DATE )
+       {
+-        coral::TimeStamp::ValueType value=coral::TimeStamp((*iAttribute).data<coral::Date>().time()).total_nanoseconds();
+-        rs=sqlite3_bind_int64(m_stmt,idx,(long long int)value);
+-        log<<coral::Debug<<"(DATE) "<<value<<" ";
++	std::string val=toSimpleString( (*iAttribute).data<coral::Date>().time() );
++        rs=sqlite3_bind_text(m_stmt,idx,val.c_str(),val.length(),SQLITE_TRANSIENT);
++        log<<coral::Debug<<"(DATE) "<<val<<" ";
+       }
+       else if(st(attributeType)==SQLT_TIMESTAMP)
+       {
+-        coral::TimeStamp::ValueType value=(*iAttribute).data<coral::TimeStamp>().total_nanoseconds();
+-        rs=sqlite3_bind_int64(m_stmt,idx,(long long int)value);
+-        log<<coral::Debug<<"(TIME) "<<value<<" ";
++	std::string val=toSimpleString( (*iAttribute).data<coral::TimeStamp>().time() );
++        rs=sqlite3_bind_text(m_stmt,idx,val.c_str(),val.length(),SQLITE_TRANSIENT);
++        log<<coral::Debug<<"(TIME) "<<val<<" ";
+       }
+     }
+     m_properties->mutex()->unlock();
+@@ -446,10 +470,16 @@ SQLiteStatement::defineOutput( coral::AttributeList& outputData )
+       {
+         //lock the sqlite3 methods
+         m_properties->mutex()->lock();
+-        long long int result = sqlite3_column_int64(m_stmt,idx);
++	const char* result = (const char*)sqlite3_column_text(m_stmt,idx);
+         m_properties->mutex()->unlock();
+ 
+-        coral::TimeStamp t(result);
++	coral::TimeStamp t;
++        if(isInteger( result ) ){
++          long long int tm = boost::lexical_cast<long long int>(std::string(result) );
++	  t = coral::TimeStamp( tm );
++	} else {
++	  t = coral::TimeStamp( boost::posix_time::time_from_string(std::string(result)));
++	}
+         if( st(attributeType)==SQLT_DATE ) {
+           iAttribute->data<coral::Date>()=coral::Date(t.time());
+         }else{

--- a/coral.spec
+++ b/coral.spec
@@ -6,6 +6,7 @@ Patch3: coral-CORAL_2_3_20-hide-strict-aliasing
 Patch4: coral-CORAL_2_3_20-remove-lost-dependencies
 Patch5: coral-CORAL_2_3_21-move-to-libuuid
 Patch6: coral-CORAL_2_3_21-forever-ttl
+Patch7: coral-CORAL_2_3_21-fix-timestamp-format-sqlite
 
 %define isarmv7 %(case %{cmsplatf} in (*armv7*) echo 1 ;; (*) echo 0 ;; esac)
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
@@ -26,6 +27,8 @@ Patch6: coral-CORAL_2_3_21-forever-ttl
 %define patchsrc6       %patch3 -p0
 %define patchsrc7       %patch4 -p0
 %define patchsrc9	%patch6 -p0
+%define patchsrc8	%patch7 -p1
+
 
 # Drop Oracle interface on ARM machines. 
 # Oracle does not provide Instant Client for ARMv7/v8.

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -285,7 +285,7 @@ for DIR in $ELF_DIRS $DROP_SYMBOLS_DIRS; do
     if [ $(echo $ELF_BINS | wc -w) -gt 1 ] ; then
       dwz -m .debug/common-symbols.debug -M common-symbols.debug $ELF_BINS
     fi
-    echo "$ELF_BINS" | xargs -t -n1 -P%{compiling_processes} -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
+    echo "$ELF_BINS" | xargs -t -n1 -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
   popd
 done


### PR DESCRIPTION
With this patch, coral will write "sqlite-formatted" ("datetime") timestamps into sqlite files for conddb V2, such that sqlite can read them w/o changes (we still need the patch from PR #1500 so that the V2 tools can read files created with older versions of the V2 tools, though older versions of the V2 tools will not be able to read the new files). 
Reading/writing from/to Oracle is not changed. 

The change in the scram-project-build.file was needed in order to build the project; the build w/o that change was failing with "invalid number for -P option" (using the "minimal" cmsBuild command), so it may be possible to "ignore" that. 
