### PR TITLE
llvm-gcc-toolfile: remove -Wno-psabi and add -ftemplate-depth=512

### DIFF
--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -52,12 +52,14 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags REM_CXXFLAGS="-fipa-pta"/>
     <flags REM_CXXFLAGS="-frounding-math"/>
     <flags REM_CXXFLAGS="-mrecip"/>
+    <flags REM_CXXFLAGS="-Wno-psabi"/>
     <flags CXXFLAGS="-Wno-c99-extensions"/>
     <flags CXXFLAGS="-Wno-c++11-narrowing"/>
     <flags CXXFLAGS="-D__STRICT_ANSI__"/>
     <flags CXXFLAGS="-Wno-unused-private-field"/>
     <flags CXXFLAGS="-Wno-unknown-pragmas"/>
     <flags CXXFLAGS="-Wno-unused-command-line-argument"/>
+    <flags CXXFLAGS="-ftemplate-depth=512"/>
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LLVM_CXXCOMPILER_BASE/lib" type="path"/>
     <runtime name="PATH" value="$LLVM_CXXCOMPILER_BASE/bin" type="path"/>
     <runtime name="COMPILER_RUNTIME_OBJECTS" value="@GCC_ROOT@"/>


### PR DESCRIPTION
`-Wno-psabi` is GCC-only compile flag, remove it on Clang.

The default limit for recursively nested template instantions is 256
in Clang (different compared to GCC). Incrase limit to 512. This is
required for CMSSW packages:
- `ElectroWeakAnalysis/ZMuMu`
- `RecoEgamma/EgammaPhotonAlgos`

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
