### PR TITLE
added back the -P%{compiling_processes} option for xargs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -285,7 +285,7 @@ for DIR in $ELF_DIRS $DROP_SYMBOLS_DIRS; do
     if [ $(echo $ELF_BINS | wc -w) -gt 1 ] ; then
       dwz -m .debug/common-symbols.debug -M common-symbols.debug $ELF_BINS
     fi
-    echo "$ELF_BINS" | xargs -t -n1 -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
+    echo "$ELF_BINS" | xargs -t -n1 -P%{compiling_processes} -I% sh -c 'objcopy --compress-debug-sections --only-keep-debug % .debug/%.debug; objcopy --strip-debug --add-gnu-debuglink=.debug/%.debug %'
   fi
   popd
 done


### PR DESCRIPTION
We shall fix cmsBuild to always set compiling_processes to 1 if --jobs|-j <N> option is not set.
