### PR TITLE
fix for timestamp handling in coral frontier and sqlite plugins

### DIFF
--- a/coral-CORAL_2_3_21-fix-timestamp-format-frontier-sqlite.patch
+++ b/coral-CORAL_2_3_21-fix-timestamp-format-frontier-sqlite.patch
@@ -1,0 +1,86 @@
+diff --git a/src/FrontierAccess/src/Statement.cpp b/src/FrontierAccess/src/Statement.cpp
+index 861bf10..e465e4c 100644
+--- a/src/FrontierAccess/src/Statement.cpp
++++ b/src/FrontierAccess/src/Statement.cpp
+@@ -41,66 +41,8 @@ namespace {
+       if( !timestamp )
+         throw coral::Exception( "TimestampParser", "timestamp was zero", "coral::TimestampParser::constructor" );
+ 
+-      char t[31];
+-      // Copy the original timestamp into our buffer
+-      strncpy(t, timestamp, 30);
+-      // Temporary variables
+-      char* pos01 = t;
+-      char* pos02 = 0;
+-      // Parse from 2006-1-12.15.47.0.0
+-
+-      // Get the year
+-      pos02 = strchr( pos01, '-' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the year from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t year = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the month
+-      pos02 = strchr( pos01, '-' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the month from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t month = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the day
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the day from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t day = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the hour
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the hour from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t hour = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the minute
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the minute from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t minute = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the second
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the second from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t second = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the msecond
+-      size_t msecond = atoi(pos01);
+-      // Create a new coral time
+-      m_time = new coral::TimeStamp( year, month, day, hour, minute, second, msecond );
++      // the format supported is: 'YYYY-MM-DD hh:mm:ss'
++      m_time = new coral::TimeStamp( boost::posix_time::time_from_string(std::string(timestamp)));
+     }
+ 
+     ~TimestampParser()
+diff --git a/src/SQLiteAccess/src/SQLiteStatement.cpp b/src/SQLiteAccess/src/SQLiteStatement.cpp
+index 6afb78c..71dfdbb 100644
+--- a/src/SQLiteAccess/src/SQLiteStatement.cpp
++++ b/src/SQLiteAccess/src/SQLiteStatement.cpp
+@@ -26,7 +26,7 @@
+ namespace coral {
+   namespace SQLiteAccess {
+     std::string toSimpleString( const boost::posix_time::ptime& time ){
+-      boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%Y-%m-%d %H:%M:%f");
++      boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%Y-%m-%d %H:%M:%S%F");
+       std::ostringstream os;
+       os.imbue(std::locale(os.getloc(), facet));
+       os << time;

--- a/coral.spec
+++ b/coral.spec
@@ -7,6 +7,7 @@ Patch4: coral-CORAL_2_3_20-remove-lost-dependencies
 Patch5: coral-CORAL_2_3_21-move-to-libuuid
 Patch6: coral-CORAL_2_3_21-forever-ttl
 Patch7: coral-CORAL_2_3_21-fix-timestamp-format-sqlite
+Patch8: coral-CORAL_2_3_21-fix-timestamp-format-frontier-sqlite
 
 %define isarmv7 %(case %{cmsplatf} in (*armv7*) echo 1 ;; (*) echo 0 ;; esac)
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
@@ -28,12 +29,13 @@ Patch7: coral-CORAL_2_3_21-fix-timestamp-format-sqlite
 %define patchsrc7       %patch4 -p0
 %define patchsrc9	%patch6 -p0
 %define patchsrc8	%patch7 -p1
+%define patchsrc9	%patch8 -p1
 
 
 # Drop Oracle interface on ARM machines. 
 # Oracle does not provide Instant Client for ARMv7/v8.
 %if %isarmv7
-%define patchsrc8       rm -rf ./src/OracleAccess
+%define patchsrc10       rm -rf ./src/OracleAccess
 %endif
 
 %define source1 cvs://:pserver:anonymous@%{n}.cvs.cern.ch/cvs/%{n}?passwd=Ah<Z&force=1&tag=-r%{cvstag}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz


### PR DESCRIPTION
This PR contains:
- a fix for the timestamp format in insert/update with SQLite coral plugin
- a fix for the timestamp format in selecting with Frontier coral plugin
