### PR TITLE
root: build ROOT master branch (soon to be 6.04.00)

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,10 +1,9 @@
-### RPM lcg root 6.02.00
+### RPM lcg root 6.04.00
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 389d8f230ed4c171e3197a914ca20f82878d920f
-%define branch cms/a79eb8a
-%define github_user cms-sw
-Source: git+https://github.com/%github_user/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+%define tag d19d6686be38452b1320d6821e481cfd9ca3ea80
+%define branch master
+Source: git+http://root.cern.ch/git/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %define islinux %(case %{cmsos} in (slc*|fc*) echo 1 ;; (*) echo 0 ;; esac)
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)


### PR DESCRIPTION
Build ROOT 6 master branch for testing 6.04.00 release before it's cooked. Tested locally up to cmssw-tool-conf.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
