### PR TITLE
root: bump root version

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,7 +1,7 @@
 ### RPM lcg root 6.02.00
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 389d8f230ed4c171e3197a914ca20f82878d920f
+%define tag 444352723bba74e5b35162891d3904f06c7f6290
 %define branch cms/a79eb8a
 %define github_user cms-sw
 Source: git+https://github.com/%github_user/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
The following update includes two fixes for user-after-free bugs in
TCling and TClass.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
