### PR TITLE
gccxml: add back for ROOT5 builds

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -28,6 +28,7 @@ Requires: expat-toolfile
 Requires: fakesystem
 Requires: fastjet-toolfile
 Requires: gcc-toolfile
+Requires: gccxml-toolfile
 Requires: gdbm-toolfile
 Requires: geant4-toolfile
 Requires: geant4data-toolfile

--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -24,6 +24,7 @@ Requires: fakesystem
 Requires: fftw3-toolfile
 Requires: fwlitedata-toolfile
 Requires: gcc-toolfile
+Requires: gccxml-toolfile
 Requires: gdbm-toolfile
 Requires: gmake-toolfile
 Requires: gsl-toolfile

--- a/gccxml-toolfile.spec
+++ b/gccxml-toolfile.spec
@@ -1,0 +1,19 @@
+### RPM external gccxml-toolfile 1.0
+Requires: gccxml
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gccxml.xml
+<tool name="gccxml" version="@TOOL_VERSION@">
+  <client>
+    <environment name="GCCXML_BASE" default="@TOOL_ROOT@"/>
+  </client>
+  <runtime name="PATH" value="$GCCXML_BASE/bin" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/gccxml.spec
+++ b/gccxml.spec
@@ -1,0 +1,35 @@
+### RPM external gccxml 0.9.0-20140124-0
+
+BuildRequires: cmake
+
+%define commit ab651a2aa866351bdd089a4bf1d57f6a9bec2a66
+Source: git+https://github.com/gccxml/gccxml.git?obj=master/%{commit}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tar.gz
+
+%define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%if %isdarwin
+# Drop no more supported -no-cpp-precomp on Darwin.
+sed -i '' 's/-no-cpp-precomp//g' \
+  GCC/CMakeLists.txt \
+  GCC/configure.in \
+  GCC/configure
+%endif
+
+%build
+mkdir gccxml-build
+cd gccxml-build
+cmake .. \
+   -DCMAKE_INSTALL_PREFIX:PATH=%{i}
+make %makeprocesses
+
+%install
+cd gccxml-build
+make install
+
+%define drop_files %i/share/{man,doc}
+
+%post
+%{relocateConfig}share/gccxml-0.9/gccxml_config


### PR DESCRIPTION
GCCXML is still required for ROOT5 (genreflex). The patch brigs it back.

Brings back old relict from dark ages.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
