### PR TITLE
xrootd: fix version ("unknown" -> "v4.0.4")

### DIFF
--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,7 +1,7 @@
 ### RPM external xrootd 4.0.4
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 %define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
-%define tag 333bc986604f0e127ffd705be2abb491a1b443b7
+%define tag bce4ade9ded4f5bc6be5646dccf5b9f2c16448c7
 %define branch cms/v4.0.4
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/xrootd.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
The bug was found while compiling ROOT6 with CMake. We were missing
VERSION_INFO file with correct content and due to this XrdVersion.hh
was generated with a wrong version information.

More: https://github.com/cms-externals/xrootd/pull/5

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
