### PR TITLE
cleaned up patches for timestamp handling in coral

### DIFF
--- a/coral-CORAL_2_3_21-fix-timestamp-frontier.patch
+++ b/coral-CORAL_2_3_21-fix-timestamp-frontier.patch
@@ -1,0 +1,90 @@
+diff --git a/src/FrontierAccess/src/Statement.cpp b/src/FrontierAccess/src/Statement.cpp
+index 861bf10..1e1e110 100644
+--- a/src/FrontierAccess/src/Statement.cpp
++++ b/src/FrontierAccess/src/Statement.cpp
+@@ -41,66 +41,8 @@ namespace {
+       if( !timestamp )
+         throw coral::Exception( "TimestampParser", "timestamp was zero", "coral::TimestampParser::constructor" );
+ 
+-      char t[31];
+-      // Copy the original timestamp into our buffer
+-      strncpy(t, timestamp, 30);
+-      // Temporary variables
+-      char* pos01 = t;
+-      char* pos02 = 0;
+-      // Parse from 2006-1-12.15.47.0.0
+-
+-      // Get the year
+-      pos02 = strchr( pos01, '-' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the year from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t year = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the month
+-      pos02 = strchr( pos01, '-' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the month from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t month = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the day
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the day from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t day = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the hour
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the hour from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t hour = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the minute
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the minute from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t minute = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the second
+-      pos02 = strchr( pos01, '.' );
+-      if( !pos02 )
+-        throw coral::Exception( "TimestampParser", "error in parsing the second from timestamp [" + std::string(timestamp) + "]", "coral::TimestampParser::constructor" );
+-
+-      *pos02 = 0;
+-      size_t second = atoi(pos01);
+-      pos01 = pos02 + 1;
+-      // Get the msecond
+-      size_t msecond = atoi(pos01);
+-      // Create a new coral time
+-      m_time = new coral::TimeStamp( year, month, day, hour, minute, second, msecond );
++      // the format supported is: 'YYYY-MM-DD hh:mm:ss'
++      m_time = new coral::TimeStamp( boost::posix_time::time_from_string(std::string(timestamp)));
+     }
+ 
+     ~TimestampParser()
+@@ -212,12 +154,11 @@ namespace coral
+         }
+         else if( colType == typeid(coral::TimeStamp) )
+         {
+-          std::stringstream os;
++          std::ostringstream os;
+           const coral::TimeStamp& tsVal = iColumn->data<coral::TimeStamp>();
+-          os << "'"
+-             << tsVal.year() << "-" << tsVal.month()  << "-" << tsVal.day() << " "
+-             << tsVal.hour() << ":" << tsVal.minute() << ":" << tsVal.second()
+-             << "." << tsVal.nanosecond() << "'";
++	  boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%Y-%m-%d %H:%M:%S%F");
++	  os.imbue(std::locale(os.getloc(), facet));
++	  os << "TO_TIMESTAMP('"<<tsVal.time()<<"','YYYY-MM-DD HH24:MI:SS.FF')";
+           nipp.bindVariable( iColumn->specification().name(), os.str(), m_sqlStatement );
+         }
+         else if( colType == typeid(bool) )

--- a/coral-CORAL_2_3_21-fix-timestamp-sqlite.patch
+++ b/coral-CORAL_2_3_21-fix-timestamp-sqlite.patch
@@ -1,0 +1,76 @@
+diff --git a/src/SQLiteAccess/src/SQLiteStatement.cpp b/src/SQLiteAccess/src/SQLiteStatement.cpp
+index 5038806..6afb78c 100644
+--- a/src/SQLiteAccess/src/SQLiteStatement.cpp
++++ b/src/SQLiteAccess/src/SQLiteStatement.cpp
+@@ -23,6 +23,30 @@
+ #include "SQLiteStatement.h"
+ #include "StatementStatistics.h"
+ 
++namespace coral {
++  namespace SQLiteAccess {
++    std::string toSimpleString( const boost::posix_time::ptime& time ){
++      boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%Y-%m-%d %H:%M:%S%F");
++      std::ostringstream os;
++      os.imbue(std::locale(os.getloc(), facet));
++      os << time;
++      return os.str();
++    }
++
++    bool isInteger( const char* str ){
++      std::string s(str);
++      size_t sz = s.size();
++      bool isNumber = sz>0;
++      size_t i = 0;
++      while( isNumber && i<sz ){
++	isNumber = isdigit(s[i]);
++	i++;
++      }  
++      return isNumber;
++    }
++  }
++}
++
+ using namespace coral::SQLiteAccess;
+ 
+ SQLiteStatement::SQLiteStatement( boost::shared_ptr<const SessionProperties> properties ) :
+@@ -185,15 +209,15 @@ SQLiteStatement::bind( const coral::AttributeList& inputData )
+       }
+       else if(st(attributeType)==SQLT_DATE )
+       {
+-        coral::TimeStamp::ValueType value=coral::TimeStamp((*iAttribute).data<coral::Date>().time()).total_nanoseconds();
+-        rs=sqlite3_bind_int64(m_stmt,idx,(long long int)value);
+-        log<<coral::Debug<<"(DATE) "<<value<<" ";
++	std::string val=toSimpleString( (*iAttribute).data<coral::Date>().time() );
++        rs=sqlite3_bind_text(m_stmt,idx,val.c_str(),val.length(),SQLITE_TRANSIENT);
++        log<<coral::Debug<<"(DATE) "<<val<<" ";
+       }
+       else if(st(attributeType)==SQLT_TIMESTAMP)
+       {
+-        coral::TimeStamp::ValueType value=(*iAttribute).data<coral::TimeStamp>().total_nanoseconds();
+-        rs=sqlite3_bind_int64(m_stmt,idx,(long long int)value);
+-        log<<coral::Debug<<"(TIME) "<<value<<" ";
++	std::string val=toSimpleString( (*iAttribute).data<coral::TimeStamp>().time() );
++        rs=sqlite3_bind_text(m_stmt,idx,val.c_str(),val.length(),SQLITE_TRANSIENT);
++        log<<coral::Debug<<"(TIME) "<<val<<" ";
+       }
+     }
+     m_properties->mutex()->unlock();
+@@ -446,10 +470,16 @@ SQLiteStatement::defineOutput( coral::AttributeList& outputData )
+       {
+         //lock the sqlite3 methods
+         m_properties->mutex()->lock();
+-        long long int result = sqlite3_column_int64(m_stmt,idx);
++	const char* result = (const char*)sqlite3_column_text(m_stmt,idx);
+         m_properties->mutex()->unlock();
+ 
+-        coral::TimeStamp t(result);
++	coral::TimeStamp t;
++        if(isInteger( result ) ){
++          long long int tm = boost::lexical_cast<long long int>(std::string(result) );
++	  t = coral::TimeStamp( tm );
++	} else {
++	  t = coral::TimeStamp( boost::posix_time::time_from_string(std::string(result)));
++	}
+         if( st(attributeType)==SQLT_DATE ) {
+           iAttribute->data<coral::Date>()=coral::Date(t.time());
+         }else{

--- a/coral.spec
+++ b/coral.spec
@@ -6,8 +6,8 @@ Patch3: coral-CORAL_2_3_20-hide-strict-aliasing
 Patch4: coral-CORAL_2_3_20-remove-lost-dependencies
 Patch5: coral-CORAL_2_3_21-move-to-libuuid
 Patch6: coral-CORAL_2_3_21-forever-ttl
-Patch7: coral-CORAL_2_3_21-fix-timestamp-format-sqlite
-Patch8: coral-CORAL_2_3_21-fix-timestamp-format-frontier-sqlite
+Patch7: coral-CORAL_2_3_21-fix-timestamp-sqlite
+Patch8: coral-CORAL_2_3_21-fix-timestamp-frontier
 
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
 


### PR DESCRIPTION
This PR cleans up the last patches for coral. The fixes in the Timestamp usage for Frontier and SQLite have been split in two patches. The fix for frontier has been completed for the where clauses.
