### PR TITLE
Enable the sherpa interface to MCFM (with inbuild mcfm version)

### DIFF
--- a/sherpa.spec
+++ b/sherpa.spec
@@ -35,9 +35,12 @@ case %cmsplatf in
   ;;
 esac
 
+./AddOns/MCFM/install_mcfm.sh
+
 %build
 ./configure --prefix=%i --enable-analysis --disable-silent-rules \
             --enable-fastjet=$FASTJET_ROOT \
+            --enable-mcfm=$PWD/ \
             --enable-hepmc2=$HEPMC_ROOT \
             --enable-lhapdf=$LHAPDF_ROOT \
             --enable-blackhat=$BLACKHAT_ROOT \


### PR DESCRIPTION
Enabled the sherpa interface to MCFM (previously a patched version of MCFM 6.3 is built which is then used for sherpa)
