### PR TITLE
gdb: bump to 7.9.1

### DIFF
--- a/gdb-disable-makeinfo.patch
+++ b/gdb-disable-makeinfo.patch
@@ -1,0 +1,44 @@
+diff --git a/configure b/configure
+index 64d287d..ae1d2b8 100755
+--- a/configure
++++ b/configure
+@@ -8038,21 +8038,26 @@ fi
+ done
+ test -n "$MAKEINFO" || MAKEINFO="$MISSING makeinfo"
+ 
+-case " $build_configdirs " in
+-  *" texinfo "*) MAKEINFO='$$r/$(BUILD_SUBDIR)/texinfo/makeinfo/makeinfo' ;;
+-  *)
++if test "${MAKEINFO}" = "true"; then
++  # Disable makeinfo if requested
++  MAKEINFO=true
++else
++  case " $build_configdirs " in
++    *" texinfo "*) MAKEINFO='$$r/$(BUILD_SUBDIR)/texinfo/makeinfo/makeinfo' ;;
++    *)
+ 
+-    # For an installed makeinfo, we require it to be from texinfo 4.7 or
+-    # higher, else we use the "missing" dummy.
+-    if ${MAKEINFO} --version \
+-       | egrep 'texinfo[^0-9]*(4\.([7-9]|[1-9][0-9])|[5-9]|[1-9][0-9])' >/dev/null 2>&1; then
+-      :
+-    else
+-      MAKEINFO="$MISSING makeinfo"
+-    fi
+-    ;;
++      # For an installed makeinfo, we require it to be from texinfo 4.7 or
++      # higher, else we use the "missing" dummy.
++      if ${MAKEINFO} --version \
++         | egrep 'texinfo[^0-9]*(4\.([7-9]|[1-9][0-9])|[5-9]|[1-9][0-9])' >/dev/null 2>&1; then
++        :
++      else
++        MAKEINFO="$MISSING makeinfo"
++      fi
++      ;;
+ 
+-esac
++  esac
++fi
+ 
+ # FIXME: expect and dejagnu may become build tools?
+ 

--- a/gdb.spec
+++ b/gdb.spec
@@ -1,12 +1,13 @@
-### RPM external gdb 7.8.1
+### RPM external gdb 7.9.1
 Source: http://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
 Patch0: gdb-7.6-fix-pythonhome
+Patch1: gdb-disable-makeinfo
 Requires: python ncurses zlib xz expat
 
 %prep
 %setup -n %n-%realversion
 %patch0 -p1
-
+%patch1 -p1
 
 %build
 export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
@@ -20,7 +21,8 @@ export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
             --with-lzma=yes \
             --with-liblzma-prefix=${XZ_ROOT} \
             LDFLAGS="-L${PYTHON_ROOT}/lib -L${NCURSES_ROOT}/lib -L${ZLIB_ROOT}/lib -L${EXPAT_ROOT}/lib -L${XZ_ROOT}/lib" \
-            CFLAGS="-Wno-error=strict-aliasing -I${PYTHON_ROOT}/include -I${NCURSES_ROOT}/include -I${ZLIB_ROOT}/include -I${EXPAT_ROOT}/include -I${XZ_ROOT}/include"
+            CFLAGS="-Wno-error=strict-aliasing -I${PYTHON_ROOT}/include -I${NCURSES_ROOT}/include -I${ZLIB_ROOT}/include -I${EXPAT_ROOT}/include -I${XZ_ROOT}/include" \
+            MAKEINFO=true
 make %makeprocesses
 
 %install


### PR DESCRIPTION
Older version of GDB contains bug which heavily slows down GDB
if LLVM symbols are involved. 7.9.1 provides huge speedup debugging
CMSSW (which incl. ROOT6 + LLVM).

An extra patch is required for `configure` to disable `makeinfo` if
such does not exist on the system. The patch brings `configure` to
it's documented behavior. There are BZ items for `MAKEINFO=true` not
working as advertised.

`configure` is patched instead of `configure.ac` because for
regeneration a very specific version of `autoconf` would be required,
which is too old on the system and too new in `autotools` package.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
