### PR TITLE
Update ROOT6, CMake and SQLite

### DIFF
--- a/cgal-4.2-cmake-string-replace.patch
+++ b/cgal-4.2-cmake-string-replace.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 6caf13a..48f010a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -116,7 +116,7 @@ foreach(package ${CGAL_CONFIGURED_PACKAGES})
+   file(GLOB CONFIGURED_LIBS_IN_PACKAGE ${package}/src/CGAL_*/CMakeLists.txt)
+   foreach (libconfigfile ${CONFIGURED_LIBS_IN_PACKAGE})
+     string(REPLACE "${package}/src/" "" libconfigfile ${libconfigfile})
+-    string(REPLACE "//CMakeLists.txt" "" CGAL_CONFIGURED_LIBRARY_NAME ${libconfigfile})
++    string(REPLACE "/CMakeLists.txt" "" CGAL_CONFIGURED_LIBRARY_NAME ${libconfigfile})
+     if (NOT ${CGAL_CONFIGURED_LIBRARY_NAME} STREQUAL "CGAL")
+ 
+      message(STATUS "Sources for CGAL component library '${CGAL_CONFIGURED_LIBRARY_NAME}' detected")

--- a/cgal.spec
+++ b/cgal.spec
@@ -1,6 +1,7 @@
 ### RPM external cgal 4.2
 
 Source: https://gforge.inria.fr/frs/download.php/32360/%{n}-%{realversion}.tar.bz2
+Patch0: cgal-4.2-cmake-string-replace
 
 BuildRequires: cmake
 Requires: gmp-static mpfr-static
@@ -19,6 +20,7 @@ Requires: boost zlib
 
 %prep
 %setup -n CGAL-%{realversion}
+%patch0 -p1
 
 %build
 

--- a/cmake.spec
+++ b/cmake.spec
@@ -1,13 +1,7 @@
-### RPM external cmake 3.2.3
+### RPM external cmake 3.3.0
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
-%define online %(case %cmsplatf in (*onl_*_*) echo true;; (*) echo false;; esac)
-Requires: bz2lib curl expat
-
-#We are using system zlib for the online builds:
-%if "%online" != "true"
-Requires: zlib
-%endif
+Requires: bz2lib curl expat zlib
 
 %prep
 %setup -n cmake-%realversion

--- a/libxslt.spec
+++ b/libxslt.spec
@@ -11,7 +11,12 @@ BuildRequires: autotools
 %setup -n %{n}-%{realversion}
 
 %build
-./autogen.sh --prefix=%{i} --with-libxml-prefix=$LIBXML2_ROOT --with-libxml-include-prefix=$LIBXML2_ROOT/include  --with-libxml-libs-prefix=$LIBXML2_ROOT/lib
+./autogen.sh \
+  --prefix=%{i} \
+  --with-libxml-prefix=$LIBXML2_ROOT \
+  --with-libxml-include-prefix=$LIBXML2_ROOT/include \
+  --with-libxml-libs-prefix=$LIBXML2_ROOT/lib \
+  --without-crypto
 make
 
 %install

--- a/root.spec
+++ b/root.spec
@@ -1,8 +1,8 @@
-### RPM lcg root 6.04.01
+### RPM lcg root 6.04.03
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag dc284fb4360bd3104444d61103a0fb7a58d427c5
-%define branch cms/0cf8001
+%define tag 5a1bc9d04955af056f49f758fe2f3a96c0b65d52
+%define branch cms/e590c47
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 

--- a/sqlite.spec
+++ b/sqlite.spec
@@ -1,8 +1,8 @@
-### RPM external sqlite 3.7.17
-Source: http://www.sqlite.org/2013/sqlite-autoconf-3071700.tar.gz
+### RPM external sqlite 3.8.11.1
+Source: https://www.sqlite.org/2015/sqlite-autoconf-3081101.tar.gz
 
 %prep
-%setup -n sqlite-autoconf-3071700
+%setup -n sqlite-autoconf-3081101
 
 %build
 ./configure --build="%{_build}" --host="%{_host}" --prefix=%{i} \


### PR DESCRIPTION
Update CMake to 3.3.0 and SQLite to 3.8.11.1. Recent SQLite version should provide significant performance improvements (at least in official micro-benchmarks). Update ROOT6 commit, last time it was updated a month ago. Also we have to disable crypto for libxslt otherwise it gets auto-enabled if available on the system, but it's not part of our bootstrap.

Build tested.
