### PR TITLE
llvm,llvm-gcc-toolfile,py2-dxr: move to Clang ~3.7.0 RC2

### DIFF
--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -47,7 +47,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags REM_CXXFLAGS="-Werror=format-contains-nul"/>
     <flags REM_CXXFLAGS="-Werror=maybe-uninitialized"/>
     <flags REM_CXXFLAGS="-Werror=unused-but-set-variable"/>
-    <flags REM_CXXFLAGS="-Wno-unused-local-typedefs"/>
     <flags REM_CXXFLAGS="-Werror=return-local-addr"/>
     <flags REM_CXXFLAGS="-fipa-pta"/>
     <flags REM_CXXFLAGS="-frounding-math"/>
@@ -60,7 +59,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags CXXFLAGS="-Wno-unknown-pragmas"/>
     <flags CXXFLAGS="-Wno-unused-command-line-argument"/>
     <flags CXXFLAGS="-ftemplate-depth=512"/>
-    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LLVM_CXXCOMPILER_BASE/lib" type="path"/>
+    <flags CXXFLAGS="-Wno-error=potentially-evaluated-expression"/>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LLVM_CXXCOMPILER_BASE/lib64" type="path"/>
     <runtime name="PATH" value="$LLVM_CXXCOMPILER_BASE/bin" type="path"/>
     <runtime name="COMPILER_RUNTIME_OBJECTS" value="@GCC_ROOT@"/>
   </tool>
@@ -113,7 +113,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm.xml
     <lib name="clang"/>
     <client>
       <environment name="LLVM_BASE" default="@LLVM_ROOT@"/>
-      <environment name="LIBDIR" default="$LLVM_BASE/lib"/>
+      <environment name="LIBDIR" default="$LLVM_BASE/lib64"/>
       <environment name="INCLUDE" default="$LLVM_BASE/include"/>
     </client>
     <flags LDFLAGS="-Wl,-undefined -Wl,suppress"/>
@@ -129,7 +129,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/pyclang.xml
   <client>
     <environment name="PYCLANG_BASE" default="@LLVM_ROOT@"/>
   </client>
-  <runtime name="PYTHONPATH" value="$PYCLANG_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
+  <runtime name="PYTHONPATH" value="$PYCLANG_BASE/lib64/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/llvm.spec
+++ b/llvm.spec
@@ -1,18 +1,22 @@
-### RPM external llvm 3.6
-## INITENV +PATH LD_LIBRARY_PATH %i/lib64
+### RPM external llvm 3.7.0
+## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
+## INITENV +PATH PYTHONPATH %{i}/lib64/python$(echo $PYTHON_VERSION | cut -d. -f 1,2)/site-packages
 
-BuildRequires: python
-Requires: gcc
+BuildRequires: python cmake ninja
+Requires: gcc zlib
 
-%define llvmCommit f04ce0e65747b16e6f321c0fdd38b6e1dc3271a3
-%define llvmBranch cms/f04ce0e
-%define clangCommit 610aefd0e11e2755e5dbb3b920e0a10c8772b718
-%define clangBranch cms/65d8b4c
-%define clangToolsExtraCommit 13f3e9fac71230b24857613d683fa146ef0da7a8
-%define clangToolsExtraBranch cms/13f3e9f
+%define llvmCommit f6573928d7f2d8b80c12d9c73ec2dbb33a472236
+%define llvmBranch cms/f657392
+%define clangCommit 9326c4e5dd194e21502a81e48dee7d27ed644706
+%define clangBranch cms/77eea28
+%define clangToolsExtraCommit 25af2d3ca20da8131f57717d26a10227e9050a4d
+%define clangToolsExtraBranch cms/25af2d3
+%define compilerRtCommit f9ef0f8339ee8831279edbe4901047999365b9b5
+%define compilerRtBranch cms/f9ef0f8
 Source0: git+https://github.com/cms-externals/llvm.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%realversion-%llvmCommit&output=/llvm-%{realversion}-%{llvmCommit}.tgz
 Source1: git+https://github.com/cms-externals/clang.git?obj=%{clangBranch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%realversion-%clangCommit&output=/clang-%{realversion}-%{clangCommit}.tgz
 Source2: git+https://github.com/cms-externals/clang-tools-extra.git?obj=%{clangToolsExtraBranch}/%{clangToolsExtraCommit}&export=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&module=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&output=/clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}.tgz
+Source3: git+https://github.com/cms-externals/compiler-rt.git?obj=%{compilerRtBranch}/%{compilerRtCommit}&export=compiler-rt-%{realversion}-%{compilerRtCommit}&module=compiler-rt-%{realversion}-%{compilerRtCommit}&output=/compiler-rt-%{realversion}-%{compilerrtCommit}.tgz
 
 # Still need forward porting.
 %define keep_archives true
@@ -23,42 +27,45 @@ Source2: git+https://github.com/cms-externals/clang-tools-extra.git?obj=%{clangT
 mv clang-%realversion-%clangCommit clang
 %setup -T -D -a2 -c -n llvm-%{realversion}-%{llvmCommit}/tools/clang/tools
 mv clang-tools-extra-%{realversion}-%{clangToolsExtraCommit} extra
+%setup -T -D -a3 -c -n llvm-%{realversion}-%{llvmCommit}/projects
+mv compiler-rt-%{realversion}-%{compilerRtCommit} compiler-rt
 %setup -T -D -n llvm-%realversion-%llvmCommit
 
 %build
+rm -rf %{_builddir}/build
+mkdir -p %{_builddir}/build
+cd %{_builddir}/build
 
-CONF_OPTS=
-case "%{cmsplatf}" in
-  slc*|fc*)
-    CONF_OPTS="${CONF_OPTS} --with-binutils-include=${GCC_ROOT}/include"
-    ;;
-esac
+cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit} \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DLLVM_LIBDIR_SUFFIX:STRING=64 \
+  -DBUILD_SHARED_LIBS:BOOL=ON \
+  -DLLVM_ENABLE_EH:BOOL=ON \
+  -DLLVM_ENABLE_PIC:BOOL=ON \
+  -DLLVM_ENABLE_RTTI:BOOL=ON \
+  -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64" \
+  -DCMAKE_REQUIRED_INCLUDES="${ZLIB_ROOT}/include" \
+  -DCMAKE_PREFIX_PATH="${ZLIB_ROOT}"
 
-mkdir objs ; cd objs
-../configure --prefix=%i --enable-optimized ${CONF_OPTS} \
-             --disable-terminfo --enable-bindings=none \
-             CC="gcc" CXX="g++" CPP="gcc -E" CXXCPP="g++ -E"
-make %makeprocesses
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 
 %install
-cd objs
-make install
+cd ../build
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
 
-BINDINGS_PATH=%i/lib/python$(echo $PYTHON_VERSION | cut -d. -f 1,2)/site-packages
+BINDINGS_PATH=%{i}/lib64/python$(echo $PYTHON_VERSION | cut -d. -f 1,2)/site-packages
 mkdir -p $BINDINGS_PATH
-cp -r ../tools/clang/bindings/python/clang $BINDINGS_PATH
+cp -r %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/bindings/python/clang $BINDINGS_PATH
 
-rm -f ../tools/clang/tools/scan-build/set-xcode*
-find ../tools/clang/tools/scan-build -exec install {} %i/bin \;
-find ../tools/clang/tools/scan-view -type f -exec install {} %i/bin \;
+rm -f %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/tools/scan-build/set-xcode*
+find %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/tools/scan-build -exec install {} %{i}/bin \;
+find %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/tools/scan-view -type f -exec install {} %{i}/bin \;
 # Remove compiled AppleScript scripts, otherwise install_name_tool from
 # DEFAULT_INSTALL_POSTAMBLE will fail. These are non-object files.
 # TODO: Improve DEFAULT_INSTALL_POSTAMBLE for OS X.
-rm  %i/bin/FileRadar.scpt %i/bin/GetRadarVersion.scpt
-# Fix up a perl path
-perl -p -i -e 's|^#!.*perl(.*)|#!/usr/bin/env perl$1|' %i/bin/llvm-config
+rm -f %{i}/bin/FileRadar.scpt %{i}/bin/GetRadarVersion.scpt
 
 %post
-%{relocateConfig}include/llvm/Config/config.h
 %{relocateConfig}include/llvm/Config/llvm-config.h
-%{relocateConfig}include/clang/Config/config.h

--- a/py2-dxr-clang37.patch
+++ b/py2-dxr-clang37.patch
@@ -1,0 +1,13 @@
+diff --git a/dxr/plugins/clang/dxr-index.cpp b/dxr/plugins/clang/dxr-index.cpp
+index e7cf597..460d373 100644
+--- a/dxr/plugins/clang/dxr-index.cpp
++++ b/dxr/plugins/clang/dxr-index.cpp
+@@ -128,7 +128,7 @@ private:
+   std::ostream *out;
+   std::map<std::string, FileInfo *> relmap;
+   LangOptions &features;
+-  DiagnosticConsumer *inner;
++  std::unique_ptr<clang::DiagnosticConsumer> inner;
+ 
+   FileInfo *getFileInfo(const std::string &filename) {
+     std::map<std::string, FileInfo *>::iterator it;

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -15,6 +15,7 @@ Patch0: py2-dxr
 Patch1: trilite
 Patch2: py2-dxr-fix-clang-linker-flags
 Patch3: py2-dxr-clang36
+Patch4: py2-dxr-clang37
 %define keep_archives true
 
 %prep
@@ -26,6 +27,7 @@ cd ..
 %patch0 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 mv trilite-%triliteCommit/* trilite
 %setup -T -D -n dxr-%dxrCommit
 


### PR DESCRIPTION
The following updates LLVM/CLang/Clang Tools to ~3.7.0 RC2 version.
Note, this also brings Compiler RT and should allow building ASan,
UBSan, TSan, etc. builds directly with Clang.

Removes `-Wno-unused-local-typedefs` flag as most of the warnings are
not useful (e.g., from boost).

Adds `-Wno-error=potentially-evaluated-expression` flag to downgrade
error to warning. We most likely do not care about side effects in
`sizeof()` and `typeid()`.

Change library direction from `lib` to `lib64`.

This change depends on changes in _cmssw-config_ and _cmssw_
repositories.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
