### PR TITLE
New version of TTB and dependency fix for DXR

### DIFF
--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -1,7 +1,6 @@
 ### RPM external py2-dxr 1.0
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
-BuildRequires: llvm sqlite
-Requires: python zlib py2-setuptools py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious
+Requires: python zlib py2-setuptools py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious llvm sqlite
 
 %define dxrCommit 6ea764102a
 %define triliteCommit e64a2a1 

--- a/tbb.spec
+++ b/tbb.spec
@@ -1,4 +1,4 @@
-### RPM external tbb 43_20150316oss
+### RPM external tbb 44_20150728oss
 Source: https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/%{n}%{realversion}_src.tgz
 
 %if "%{?cms_cxx:set}" != "set"
@@ -20,7 +20,7 @@ CXX="%cms_cxx" CXXFLAGS="%cms_cxxflags" make %makeprocesses
 install -d %i/lib
 cp -r include %i/include
 case %cmsplatf in 
-  slc*) SONAME=so ;;
   osx*) SONAME=dylib ;;
+  *) SONAME=so ;;
 esac
 find build -name "*.$SONAME*" -exec cp {} %i/lib \; 


### PR DESCRIPTION
Look at the commit messages for more details.

DXR had wrong dependencies, LLVM is not build-time dependency according to RPM headers. This is causing installing `py2-dxr` packages, because LLVM might not be yet installed.

TBB change incl. my bug fix to support Clang + AArch64. This is required as TBB headers end up going to Cling which is Clang-based. In addition to that, use `*.so` extension on all Linux systems not only SLC.
