### PR TITLE
upgrade t0wmadatasvc to 0.0.3

### DIFF
--- a/t0wmadatasvc.spec
+++ b/t0wmadatasvc.spec
@@ -1,10 +1,10 @@
-### RPM cms t0wmadatasvc 0.0.2
+### RPM cms t0wmadatasvc 0.0.3
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 1.0.0.pre3
+%define wmcver 1.0.9.pre9
 
 Source0: git://github.com/dmwm/WMCore?obj=master/%wmcver&export=wmcore_%n&output=/wmcore_%n.tar.gz
 Source1: git://github.com/dmwm/t0wmadatasvc?obj=master/%realversion&export=%n&output=/%n.tar.gz


### PR DESCRIPTION
Updating the t0wmadatasvc version. The new version contains an expanded schema having more monitoring information. The Oracle databases were already updated as the new schema is backward compatible with both the old insert code and retrieval code.

The new insert and retrieval codes are also independent of each other, so this can just go in whenever and 0.0.3 should then be deployed in the next cmsweb upgrade.

Also updated the WMCore version (no reason really, just to stay up-to-date with the latest version).
