### PR TITLE
fix memory leak in wmstats

### DIFF
--- a/reqmon.spec
+++ b/reqmon.spec
@@ -1,4 +1,4 @@
-### RPM cms reqmon 1.0.9.pre9
+### RPM cms reqmon 1.0.9_cmsweb.patch1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
 Source0: git://github.com/dmwm/WMCore?obj=master/%realversion&export=%n&output=/%n.tar.gz


### PR DESCRIPTION
It seems previous code gets the request data for each cherry thread (when the called is made) in worst case instead of getting the data from server side cache (one per node). Not completely sure how much this will reduce the memory usage since whether current status hits the worst case.  (In best scenario, it will just get the data from the server side cache (one per node). Please deploy this in testbed for further test.  Sorry for all the trouble.
