### PR TITLE
Added path variable for locating the openloops path at runtime

### DIFF
--- a/openloops-toolfile.spec
+++ b/openloops-toolfile.spec
@@ -12,6 +12,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/openloops.xml
 <client>
 <environment name="OPENLOOPS_BASE" default="@TOOL_ROOT@"/>
 <environment name="LIBDIR" default="$OPENLOOPS_BASE/lib"/>
+<runtime name="CMS_OPENLOOPS_PREFIX" value="$OPENLOOPS_BASE" type="path"/>
 </client>
 </tool>
 EOF_TOOLFILE


### PR DESCRIPTION
Add environment path where to look for the openloops proclib directory (Needed for sherpa RelVals)
