### PR TITLE
drop das-client/etc from PATH. das client wrapper should be picked up…

### DIFF
--- a/das_client-toolfile.spec
+++ b/das_client-toolfile.spec
@@ -11,7 +11,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/das_client.xml
     <environment name="DAS_CLIENT_BASE" default="@TOOL_ROOT@"/>
   </client>
   <runtime name="PATH"       value="$DAS_CLIENT_BASE/bin" type="path"/>
-  <runtime name="PATH"       value="$DAS_CLIENT_BASE/etc" type="path"/>
   <runtime name="PYTHONPATH" value="$DAS_CLIENT_BASE/bin" type="path"/>
   <use name="python"/>
 </tool>


### PR DESCRIPTION
… from the $CMS_PATH/common directory
