### PR TITLE
updated config tag which fixes the unit test prefix command

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -48,7 +48,7 @@ Requires: SCRAMV1
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-04-09
+%define configtag       V05-04-10
 %endif
 
 %if "%{?useCmsTC:set}" != "set"


### PR DESCRIPTION
(cherry picked from commit cc5d39599528b3a8e4e0e3a439ea682e6b0dcf49)
