### PR TITLE
Update to Rivet 2.4.0 in 76X 

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -1,4 +1,4 @@
-### RPM external rivet 2.3.0
+### RPM external rivet 2.4.0
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 
 Requires: hepmc boost fastjet gsl yaml-cpp yoda

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,4 +1,4 @@
-### RPM external yoda 1.4.0
+### RPM external yoda 1.5.5
 
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
 


### PR DESCRIPTION
Update to latest Rivet version: 2.4.0 (and to Yoda 1.5.5 dependency)
