### PR TITLE
gmp-static: set --host and --build to for a generic build

### DIFF
--- a/gmp-static.spec
+++ b/gmp-static.spec
@@ -23,6 +23,8 @@ BuildRequires: autotools
 %build
 ./configure \
   --prefix=%{i} \
+  --build=%{_build} \
+  --host=%{_host} \
   --disable-shared \
   --enable-static \
   --enable-cxx \


### PR DESCRIPTION
GMP package automatically detects CPU on the build system and optimizes
the whole build for that particular architecture.

This caused crashes (illegal instruction) in a number of workflows due
to usage of CGAL (links to GMP).

```
5  __gmpq_set_d () [Illegal instruction -- vmovq (AVX)]
6  CGAL::Cartesian_converter..
7  CGAL::Sign CGAL::Filtered_predicate..
8  CGAL::Triangulation_2..
9  CGAL::Triangulation_2..
10 CGAL::Delaunay_triangulation_2..
11 CGAL::VoronoiDiagram_2::Internal::Delaunay_triangulation_nearest_site_2..
12 CGAL::Voronoi_diagram_2..
13 VoronoiAlgorithm::voronoi_area_incident() [CMSSW]
```

This happened because `gmp-static` was built on AVX-capable machine.

NOTE: GMP supports `--enable-fat` for building fat binaries.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
