### PR TITLE
add patch for memory leak to 7_5_X

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 10.00.p03
-%define tag 86c476e297a2f1e3461929714240b0c6709012e3
+%define tag 7edf9e74c7c714aefc9ba4da919b1dde1466a593
 %define branch cms/4.%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Switch to use the same Geant4 as in 7_6_X. @degano, please, correct me if this is done in a wrong way.
