### PR TITLE
fastjet 1.020 specs (same as 76X version in #1953)

### DIFF
--- a/fastjet-contrib.spec
+++ b/fastjet-contrib.spec
@@ -1,5 +1,5 @@
-### RPM external fastjet-contrib 1.014
-%define tag f873eacf1e3c46bcf5213db9f86386dc599ab34c
+### RPM external fastjet-contrib 1.020
+%define tag d53aaa4eae502d51154a362d262af2155ed17f38
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&foo=1&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
reused the same topic branch from 76X to make this PR for fastjet 1.020
The tag matches the head of https://github.com/cms-externals/fastjet-contrib/tree/cms/v1.020
