### PR TITLE
cleanup for fwlite build

### DIFF
--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -8,10 +8,6 @@
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
 %define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
 
-Provides: libboost_regex-gcc-mt.so 
-Provides: libboost_signals-gcc-mt.so 
-Provides: libboost_thread-gcc-mt.so
-
 Requires: tbb-toolfile
 Requires: boost-toolfile
 Requires: bz2lib-toolfile
@@ -46,6 +42,7 @@ Requires: xz-toolfile
 Requires: zlib-toolfile
 Requires: libxml2-toolfile
 Requires: llvm-gcc-toolfile
+Requires: vdt-toolfile
 
 %if %isamd64
 %if %islinux

--- a/fwlite.spec
+++ b/fwlite.spec
@@ -1,4 +1,4 @@
-### RPM cms fwlite CMSSW_7_1_0_pre1_FWLITE
+### RPM cms fwlite CMSSW_7_5_7_FWLITE
 
 Requires: fwlite-tool-conf python
 
@@ -10,7 +10,7 @@ Requires: fwlite-tool-conf python
 %define patchsrc perl -p -i -e ' s|(<classpath.*test\\+test.*>)||;' config/BuildFile.xml*
 
 #patch to build fwlite release; this should be fixed in cmssw
-%define patchsrc2 sed -i -e 's|^#include "Geometry/GEMGeometry/|//#include "Geometry/GEMGeometry/|' src/Fireworks/Muons/plugins/FWGEMDigiProxyBuilder.cc
+%define patchsrc2 rm -f src/CommonTools/Utils/src/TMVAEvaluator.cc src/CommonTools/Utils/plugins/GBRForestWriter.cc
 
 # depends on MessageService, which pulls in service dependencies
 %define patchsrc3 rm -f src/FWCore/MessageLogger/python/MessageLogger_cfi.py
@@ -19,4 +19,3 @@ Requires: fwlite-tool-conf python
 
 ## IMPORT cmssw-partial-build
 ## IMPORT scram-project-build
-

--- a/fwlite_build_set.file
+++ b/fwlite_build_set.file
@@ -83,7 +83,6 @@ FWCore/ParameterSet
 FWCore/PluginManager
 FWCore/PythonParameterSet
 FWCore/PythonUtilities
-FWCore/RootAutoLibraryLoader
 FWCore/ServiceRegistry
 FWCore/Utilities
 FWCore/Version
@@ -121,8 +120,8 @@ Utilities/General
 Utilities/ReleaseScripts
 Geometry/CommonDetUnit
 SimDataFormats/JetMatching/interface/JetFlavourInfo.h
-Geometry/CommonTopologies/interface/Topology.h
-DataFormats/TrackerCommon/interface/TrackerTopology.h
 Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h
 Geometry/TrackerGeometryBuilder/interface/GeomDetLess.h
-RecoLocalCalo/HcalRecAlgos/interface/HcalCaloFlagLabels.h
+DataFormats/TrackerCommon
+Geometry/CommonTopologies
+Geometry/GEMGeometry


### PR DESCRIPTION
- clean up fwlite buildset
- added new vdt dependency
- patch/delete CommonTools/Utils/src files which brings in unneeded dependencies
  Automatically ported from IB/CMSSW_7_5_X/stable #2013 (original by @smuzaffar).
