### PR TITLE
tbb: update to 44_20150728oss

### DIFF
--- a/tbb.spec
+++ b/tbb.spec
@@ -1,4 +1,4 @@
-### RPM external tbb 43_20150316oss
+### RPM external tbb 44_20150728oss
 Source: https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/%{n}%{realversion}_src.tgz
 
 %if "%{?cms_cxx:set}" != "set"
@@ -20,7 +20,7 @@ CXX="%cms_cxx" CXXFLAGS="%cms_cxxflags" make %makeprocesses
 install -d %i/lib
 cp -r include %i/include
 case %cmsplatf in 
-  slc*) SONAME=so ;;
   osx*) SONAME=dylib ;;
+  *) SONAME=so ;;
 esac
 find build -name "*.$SONAME*" -exec cp {} %i/lib \; 


### PR DESCRIPTION
The following includes support for AArch64 + Clang. TTB does not have
hand written assembly for atomic support. Clang provides `__sync_*`
builtins like GCC, thus we can fallback to builtin atomics on Clang.

This is needed, because TBB headers end up going through ROOT6 Cling
run-time (Clang-based).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
