### PR TITLE
tbb: bump to 44_20151115oss; enable Clang C++11 features on Linux

### DIFF
--- a/tbb-cpp11-rvalue-ref-present.patch
+++ b/tbb-cpp11-rvalue-ref-present.patch
@@ -1,0 +1,17 @@
+diff --git a/include/tbb/tbb_config.h b/include/tbb/tbb_config.h
+index 58937e6..c416e15 100644
+--- a/include/tbb/tbb_config.h
++++ b/include/tbb/tbb_config.h
+@@ -160,7 +160,11 @@
+ /** on OS X* the only way to get C++11 is to use clang. For library features (e.g. exception_ptr) libc++ is also
+  *  required. So there is no need to check GCC version for clang**/
+     #define __TBB_CPP11_VARIADIC_TEMPLATES_PRESENT    (__has_feature(__cxx_variadic_templates__))
+-    #define __TBB_CPP11_RVALUE_REF_PRESENT            (__has_feature(__cxx_rvalue_references__) && (__TBB_GCC_VERSION >= 40300 || _LIBCPP_VERSION))
++    #if (__APPLE__)
++	#define __TBB_CPP11_RVALUE_REF_PRESENT        (__has_feature(__cxx_rvalue_references__) && _LIBCPP_VERSION)
++    #else
++	#define __TBB_CPP11_RVALUE_REF_PRESENT        (__has_feature(__cxx_rvalue_references__))
++    #endif
+ /** TODO: extend exception_ptr related conditions to cover libstdc++ **/
+     #define __TBB_EXCEPTION_PTR_PRESENT               (__cplusplus >= 201103L && _LIBCPP_VERSION)
+     #define __TBB_STATIC_ASSERT_PRESENT               __has_feature(__cxx_static_assert__)

--- a/tbb.spec
+++ b/tbb.spec
@@ -1,5 +1,7 @@
-### RPM external tbb 44_20150728oss
+### RPM external tbb 44_20151115oss
 Source: https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/%{n}%{realversion}_src.tgz
+
+Patch0: tbb-cpp11-rvalue-ref-present
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
@@ -11,6 +13,7 @@ Source: https://www.threadingbuildingblocks.org/sites/default/files/software_rel
 
 %prep
 %setup -n tbb%{realversion}
+%patch0 -p1
 
 %build
 


### PR DESCRIPTION
Currently we cannot use use C++11 features provided by Clang on Linux
with TBB because of GCC version check as Clang always reports GCC 4.2.1
compability version. In addition to that we should not require libc++ on
Linux. On Linux distributions Clang is mostly used with GNU libstdc++
for binary compatibility.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
