### PR TITLE
Gengetopt: Gengetopt is required to build Herwig7 

### DIFF
--- a/gengetopt-parallelbuild.patch
+++ b/gengetopt-parallelbuild.patch
@@ -1,0 +1,13 @@
+diff -Naur gengetopt-2.22.6/src/Makefile.am Makefile.am 
+--- gengetopt-2.22.6/src/Makefile.am	2012-11-02 13:26:54.000000000 +0000
++++ Makefile.am	2015-06-12 15:15:42.243186580 +0100
+@@ -51,7 +51,7 @@
+ 	@LTLIBOBJS@ \
+ 	skels/libgen.la
+ 
+-LDADD = $(top_builddir)/src/libgengetopt.la
++LDADD = libgengetopt.la
+ 
+ EXTRA_DIST = parser.h argsdef.h gengetopt.h ggos.h gm.h gnugetopt.h \
+ cmdline.c cmdline.h \
+

--- a/gengetopt-toolfile.spec
+++ b/gengetopt-toolfile.spec
@@ -1,0 +1,21 @@
+### RPM external gengetopt-toolfile 1.0
+Requires: gengetopt
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gengetopt.xml
+<tool name="gengetopt" version="@TOOL_VERSION@">
+  <client>
+    <environment name="GENGETOPT_BASE" default="@TOOL_ROOT@"/>
+  </client>
+  <runtime name="PATH" value="$GENGETOPT_BASE/bin" type="path"/>
+  <use name="root_cxxdefaults"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post
+

--- a/gengetopt.spec
+++ b/gengetopt.spec
@@ -4,14 +4,6 @@ Patch0: gengetopt-parallelbuild
 
 BuildRequires: autotools
 
-%if "%{?cms_cxx:set}" != "set"
-%define cms_cxx c++
-%endif
-
-%if "%{?cms_cxxflags:set}" != "set"
-%define cms_cxxflags -O2 -std=c++14
-%endif
-
 %prep
 %setup -q -n gengetopt-%{realversion}
 
@@ -21,20 +13,13 @@ BuildRequires: autotools
 autoreconf -fiv
 
 %build
-CXX="$(which %{cms_cxx}) -fPIC"
-CC="$(which gcc) -fPIC"
-PLATF_CONF_OPTS="--enable-shared --disable-static"
-
 # Only keep bin folder 
-./configure $PLATF_CONF_OPTS \
-            --disable-silent-rules \
-	    --prefix=%{i}\
-            CXX="$CXX" CC="$CC" CXXFLAGS="%{cms_cxxflags}" 
+./configure --disable-silent-rules \
+	    --prefix=%{i}
 
 make %{makeprocesses}
-
-rm -rf %{i}/share
 
 %install
 make install
 
+rm -rf %{i}/share

--- a/gengetopt.spec
+++ b/gengetopt.spec
@@ -28,12 +28,12 @@ PLATF_CONF_OPTS="--enable-shared --disable-static"
 # Only keep bin folder 
 ./configure $PLATF_CONF_OPTS \
             --disable-silent-rules \
-	    --prefix=/tmp \
-            --datarootdir=/tmp \
-            --bindir=%{i} \
+	    --prefix=%{i}\
             CXX="$CXX" CC="$CC" CXXFLAGS="%{cms_cxxflags}" 
 
 make %{makeprocesses}
+
+rm -rf %{i}/share
 
 %install
 make install

--- a/gengetopt.spec
+++ b/gengetopt.spec
@@ -1,0 +1,40 @@
+### RPM external gengetopt 2.22.6
+Source: ftp://ftp.gnu.org/gnu/gengetopt/gengetopt-%{realversion}.tar.gz
+Patch0: gengetopt-parallelbuild
+
+BuildRequires: autotools
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx c++
+%endif
+
+%if "%{?cms_cxxflags:set}" != "set"
+%define cms_cxxflags -O2 -std=c++14
+%endif
+
+%prep
+%setup -q -n gengetopt-%{realversion}
+
+%patch0 -p1 
+
+# Regenerate build scripts
+autoreconf -fiv
+
+%build
+CXX="$(which %{cms_cxx}) -fPIC"
+CC="$(which gcc) -fPIC"
+PLATF_CONF_OPTS="--enable-shared --disable-static"
+
+# Only keep bin folder 
+./configure $PLATF_CONF_OPTS \
+            --disable-silent-rules \
+	    --prefix=/tmp \
+            --datarootdir=/tmp \
+            --bindir=%{i} \
+            CXX="$CXX" CC="$CC" CXXFLAGS="%{cms_cxxflags}" 
+
+make %{makeprocesses}
+
+%install
+make install
+


### PR DESCRIPTION
but it was requested to insert it as a single PR by @davidlt 

I also modified the configure script so that all the unnecessary stuff in the share folder is written to /tmp.
Should I choose another folder?
