### PR TITLE
change HepPDT ParticleTable internal from a map to a tbb::concurrent_unordered_map

### DIFF
--- a/heppdt-3.03.00-concurrency.patch
+++ b/heppdt-3.03.00-concurrency.patch
@@ -1,0 +1,80 @@
+diff -x Makefile -x '*.Po' -ur a/include/HepPDT/ParticleDataTable.hh b/include/HepPDT/ParticleDataTable.hh
+--- a/include/HepPDT/ParticleDataTable.hh	2008-10-14 12:36:40.000000000 -0400
++++ b/include/HepPDT/ParticleDataTable.hh	2016-01-28 14:05:21.407152947 -0500
+@@ -10,6 +10,7 @@
+ #include <iostream>
+ #include <string>
+ #include <map>
++#include "tbb/concurrent_unordered_map.h"
+ 
+ #include "HepPDT/ParticleID.hh"
+ #include "HepPDT/ParticleData.hh"
+@@ -44,11 +45,19 @@
+ class ParticleDataTable  {
+   
+ public:
++  struct PIDhash {
++    PIDhash() {}
++    size_t operator()(const ParticleID& p) const
++    {
++      return tbb::tbb_hasher(p.pid());
++    }
++  };
++
+   typedef  ParticleData                     CPD;
+ 
+   typedef  std::map<ParticleID,TempParticleData>  TempMap;
+-  typedef  std::map<ParticleID,ParticleData,ParticleDataTableComparison> PDTMap;
+-  typedef  std::map<std::string,ParticleID>       PDTNameMap;
++  typedef  tbb::concurrent_unordered_map<ParticleID,ParticleData,PIDhash> PDTMap;
++  typedef  tbb::concurrent_unordered_map<std::string,ParticleID>       PDTNameMap;
+ 
+   typedef PDTMap::const_iterator                  const_iterator;
+   typedef PDTNameMap::const_iterator              const_iteratorByName;
+diff -x Makefile -x '*.Po' -ur a/include/HepPDT/ProcessUnknownID.hh b/include/HepPDT/ProcessUnknownID.hh
+--- a/include/HepPDT/ProcessUnknownID.hh	2007-09-04 14:39:16.000000000 -0400
++++ b/include/HepPDT/ProcessUnknownID.hh	2016-01-28 11:38:11.058292139 -0500
+@@ -33,12 +33,12 @@
+   ParticleData  * callProcessUnknownID( ParticleID, const ParticleDataTable & );
+ 
+ protected:
+-  ProcessUnknownID( ) : alreadyHere(false) {}
++  ProcessUnknownID( ) {}
+   virtual ~ProcessUnknownID( ) {}
+ 
+ private: 
+ 
+-  bool alreadyHere;
++  static thread_local bool alreadyHere;
+ 
+   virtual ParticleData  * processUnknownID( ParticleID, 
+                                             const ParticleDataTable & ) = 0;
+diff -x Makefile -x '*.Po' -ur a/src/HepPDT/ProcessUnknownID.cc b/src/HepPDT/ProcessUnknownID.cc
+--- a/src/HepPDT/ProcessUnknownID.cc	2007-08-28 13:39:43.000000000 -0400
++++ b/src/HepPDT/ProcessUnknownID.cc	2016-01-28 11:45:18.165788033 -0500
+@@ -9,14 +9,23 @@
+ 
+ namespace HepPDT {
+ 
++thread_local bool ProcessUnknownID::alreadyHere = false;
++
++class sentry {
++public:
++  sentry(bool& b) : b_(b) { b_ = true; }
++  ~sentry() { b_ = false; }
++private:
++  bool& b_;
++};
++
+ ParticleData * ProcessUnknownID::callProcessUnknownID
+               ( ParticleID key, const ParticleDataTable & pdt ) 
+ { 
+     ParticleData * pd = 0;
+     if( !alreadyHere ) {
+-       alreadyHere = true;
++       sentry s(alreadyHere);
+        pd = processUnknownID( key, pdt );
+-       alreadyHere = false;
+     } 
+     return pd;
+ }

--- a/heppdt.spec
+++ b/heppdt.spec
@@ -2,22 +2,26 @@
 Source: http://lcgapp.cern.ch/project/simu/HepPDT/download/HepPDT-%{realversion}.tar.gz
 Patch1: heppdt-2.03.00-nobanner
 Patch2: heppdt-3.03.00-silence-debug-output 
+Patch3: heppdt-3.03.00-concurrency
 %define keep_archives yes
+
+Requires: tbb
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx g++
 %endif
 
 %if "%{?cms_cxxflags:set}" != "set"
-%define cms_cxxflags -O2 -std=c++0x
+%define cms_cxxflags -O2 -std=c++14
 %endif
 
 %prep
 %setup -q -n HepPDT-%{realversion}
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 
-CXX="%cms_cxx" CXXFLAGS="%cms_cxxflags" ./configure  --prefix=%{i} 
+CXX="%cms_cxx" CXXFLAGS="%cms_cxxflags" CPPFLAGS="-I$TBB_ROOT/include" LDFLAGS="-L$TBB_ROOT/lib -ltbb" ./configure  --prefix=%{i} 
 
 %build
 make 


### PR DESCRIPTION
The HepPDT::ParticleDataTable class with HeavyIonUnknownID() as the handler for processing unknown particle IDs is not thread safe, as it can update an internal stl::map when the ParticleDataTable::particle() method is called with the ID of an ion not already present in the table.  This has been seen to cause infinite loops (and helgrind errors) with the multi-threaded MixingModule, as the SimTracker/SiStripDigitizer makes calls that can result in unsafe updates that corrupt the map.  This patch replaces the HepPDT::ParticleDataTable internal maps with tbb::concurrent_unordered_map, adding a dependency on tbb.  Since this changes the internal maps from an ordered type to an unordered type, and HepPDT::ParticleDataTable exposes iterators over its internal maps, this does result in an observable change in behavior (which, unfortunately breaks most of the HepPDT tests).  A search for PDTMap::const_iterator in CMSSW finds three places where this interface is called, none of which appear to depend on map ordering, but it is always possible that some ordering dependency has been missed.

This patch has been tested with the full matrix.  Detailed one-to-one and validation tests on one workflow found no differences (other than the same uninitialized values found in the MixingModule testing) but further IB testing is needed.
