### PR TITLE
Python 2.7.11

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 32.0
+### RPM cms cmssw-tool-conf 33.0
 ## NOCOMPILER
 # With cmsBuild, change the above version only when a new
 # tool is added
@@ -155,6 +155,7 @@ Requires: py2-pyparsing-toolfile
 Requires: py2-requests-toolfile
 Requires: giflib-toolfile
 Requires: utm-toolfile
+Requires: libffi-toolfile
 
 # Only for Linux platform.
 %if %islinux

--- a/graphviz.spec
+++ b/graphviz.spec
@@ -1,6 +1,6 @@
 ### RPM external graphviz 2.38.0
 Source: http://www.graphviz.org/pub/%{n}/ARCHIVE/%{n}-%{realversion}.tar.gz  
-Requires: expat zlib libjpeg-turbo libpng
+Requires: expat zlib libjpg libpng
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -22,8 +22,8 @@ esac
   --with-zlibdir=$ZLIB_ROOT/lib \
   --with-pngincludedir=$LIBPNG_ROOT/include \
   --with-pnglibdir=$LIBPNG_ROOT/lib \
-  --with-jpegincludedir=$LIBJPEG_TURBO_ROOT/include \
-  --with-jpeglibdir=$LIBJPEG_TURBO_ROOT/lib \
+  --with-jpegincludedir=$LIBJPG_ROOT/include \
+  --with-jpeglibdir=$LIBJPG_ROOT/lib \
   --without-x \
   --without-tclsh \
   --without-tcl \

--- a/graphviz.spec
+++ b/graphviz.spec
@@ -1,14 +1,13 @@
-### RPM external graphviz 2.16.1
+### RPM external graphviz 2.38.0
 Source: http://www.graphviz.org/pub/%{n}/ARCHIVE/%{n}-%{realversion}.tar.gz  
-Requires: expat zlib libjpg libpng 
+Requires: expat zlib libjpeg-turbo libpng
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
-which gcc
 case %cmsplatf in
-    slc*)
+    slc*|fc*)
         ADDITIONAL_OPTIONS="--with-freetype2=no --disable-shared --enable-static --disable-ltdl"
     ;;
     osx*)
@@ -16,14 +15,15 @@ case %cmsplatf in
     ;;
 esac
 ./configure \
+  --disable-silent-rules \
   --with-expatlibdir=$EXPAT_ROOT/lib \
   --with-expatincludedir=$EXPAT_ROOT/include \
   --with-zincludedir=$ZLIB_ROOT/include \
   --with-zlibdir=$ZLIB_ROOT/lib \
   --with-pngincludedir=$LIBPNG_ROOT/include \
   --with-pnglibdir=$LIBPNG_ROOT/lib \
-  --with-jpegincludedir=$LIBJPG_ROOT/include \
-  --with-jpeglibdir=$LIBJPG_ROOT/lib \
+  --with-jpegincludedir=$LIBJPEG_TURBO_ROOT/include \
+  --with-jpeglibdir=$LIBJPEG_TURBO_ROOT/lib \
   --without-x \
   --without-tclsh \
   --without-tcl \
@@ -37,6 +37,7 @@ esac
   --without-pangocairo \
   --without-fontconfig \
   --without-gdk-pixbuf \
+  --with-libgd=no \
   --disable-sharp \
   --disable-guile \
   --disable-java \
@@ -45,32 +46,23 @@ esac
   --disable-perl \
   --disable-php \
   --disable-python \
+  --with-qt=no \
   --prefix=%{i} \
   $ADDITIONAL_OPTIONS
 
-# Probably the configure should just be remade on Darwin, but it builds
-# as-is with this small cleanup
-#perl -p -i -e "s|-lexpat||g;s|-ljpeg||g" configure
-# make %makeprocesses
-make 
+make %{makeprocesses}
 
 %install
 make install
 %define drop_files %{i}/share
-# We remove pkg-config files for two reasons:
-# * it's actually not required (macosx does not even have it).
-# * rpm 4.8 adds a dependency on the system /usr/bin/pkg-config 
-#   on linux.
-# In the case at some point we build a package that can be build
-# only via pkg-config we have to think on how to ship our own
-# version.
-rm -rf %i/lib/pkgconfig
+
+rm -rf %{i}/lib/pkgconfig
 
 # To match configure options above
-case %cmsplatf in
-    slc*)
-        ln -s dot_static %i/bin/dot
+case %{cmsplatf} in
+    slc*|fc*)
+        ln -s dot_static %{i}/bin/dot
     ;;
 esac
 # Drop static libraries.
-rm -rf %i/lib/*.{l,}a
+rm -rf %{i}/lib/*.{l,}a

--- a/libffi-3.2.1-fix-include-path.patch
+++ b/libffi-3.2.1-fix-include-path.patch
@@ -1,0 +1,37 @@
+diff --git a/include/Makefile.am b/include/Makefile.am
+index fd28024..8090684 100644
+--- a/include/Makefile.am
++++ b/include/Makefile.am
+@@ -5,5 +5,5 @@ AUTOMAKE_OPTIONS=foreign
+ DISTCLEANFILES=ffitarget.h
+ EXTRA_DIST=ffi.h.in ffi_common.h
+ 
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)/
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+diff --git a/include/Makefile.in b/include/Makefile.in
+index 9d747e8..b1c939e 100644
+--- a/include/Makefile.in
++++ b/include/Makefile.in
+@@ -314,7 +314,7 @@ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = foreign
+ DISTCLEANFILES = ffitarget.h
+ EXTRA_DIST = ffi.h.in ffi_common.h
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)/
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+ all: all-am
+ 
+diff --git a/libffi.pc.in b/libffi.pc.in
+index edf6fde..6fad83b 100644
+--- a/libffi.pc.in
++++ b/libffi.pc.in
+@@ -2,7 +2,7 @@ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ toolexeclibdir=@toolexeclibdir@
+-includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includedir=@includedir@
+ 
+ Name: @PACKAGE_NAME@
+ Description: Library supporting Foreign Function Interfaces

--- a/libffi-toolfile.spec
+++ b/libffi-toolfile.spec
@@ -1,0 +1,21 @@
+### RPM external libffi-toolfile 1.0
+Requires: libffi
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/libffi.xml
+<tool name="libffi" version="@TOOL_VERSION@">
+  <lib name="ffi"/>
+  <client>
+    <environment name="LIBFFI_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$LIBFFI_BASE/lib64"/>
+    <environment name="INCLUDE" default="$LIBFFI_BASE/include"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/libffi.spec
+++ b/libffi.spec
@@ -1,0 +1,25 @@
+### RPM external libffi 3.2.1
+Source: ftp://sourceware.org/pub/%{n}/%{n}-%{realversion}.tar.gz
+
+Patch0: libffi-3.2.1-fix-include-path
+
+%prep
+%setup -n %{n}-%{realversion}
+%patch0 -p1
+
+%build
+./configure \
+  --prefix=%{i} \
+  --enable-portable-binary \
+  --disable-dependency-tracking \
+  --disable-static
+
+make %{makeprocesses}
+
+%install
+make %{makeprocesses} install
+
+rm -rf %{i}/lib
+rm -rf %{i}/lib64/*.la
+
+%define drop_files %{i}/share

--- a/libffi.spec
+++ b/libffi.spec
@@ -1,4 +1,6 @@
 ### RPM external libffi 3.2.1
+## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
+
 Source: ftp://sourceware.org/pub/%{n}/%{n}-%{realversion}.tar.gz
 
 Patch0: libffi-3.2.1-fix-include-path

--- a/openssl-1.0.2d-disable-install-openssldir.patch
+++ b/openssl-1.0.2d-disable-install-openssldir.patch
@@ -1,0 +1,38 @@
+diff --git a/apps/Makefile b/apps/Makefile
+index cafe554..547fc41 100644
+--- a/apps/Makefile
++++ b/apps/Makefile
+@@ -109,16 +109,6 @@ install:
+ 	 chmod 755 $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new; \
+ 	 mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i ); \
+ 	 done;
+-	@set -e; for i in $(SCRIPTS); \
+-	do  \
+-	(echo installing $$i; \
+-	 cp $$i $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	 chmod 755 $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	 mv -f $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i ); \
+-	 done
+-	@cp openssl.cnf $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf.new; \
+-	chmod 644 $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf.new; \
+-	mv -f  $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf.new $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf
+ 
+ tags:
+ 	ctags $(SRC)
+diff --git a/tools/Makefile b/tools/Makefile
+index c1a2f6b..6e7c104 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -26,12 +26,6 @@ install:
+ 	chmod 755 $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new; \
+ 	mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i ); \
+ 	done;
+-	@for i in $(MISC_APPS) ; \
+-	do  \
+-	(cp $$i $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	chmod 755 $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	mv -f $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i ); \
+-	done;
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl Makefile >> $(TOP)/MINFO

--- a/openssl-1.0.2d-pr3979.patch
+++ b/openssl-1.0.2d-pr3979.patch
@@ -1,0 +1,44 @@
+diff --git a/crypto/x509v3/v3_purp.c b/crypto/x509v3/v3_purp.c
+index 36b0d87..845be67 100644
+--- a/crypto/x509v3/v3_purp.c
++++ b/crypto/x509v3/v3_purp.c
+@@ -380,6 +380,14 @@ static void setup_crldp(X509 *x)
+         setup_dp(x, sk_DIST_POINT_value(x->crldp, i));
+ }
+ 
++#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
++#define ku_reject(x, usage) \
++        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
++#define xku_reject(x, usage) \
++        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
++#define ns_reject(x, usage) \
++        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
++
+ static void x509v3_cache_extensions(X509 *x)
+ {
+     BASIC_CONSTRAINTS *bs;
+@@ -499,7 +507,8 @@ static void x509v3_cache_extensions(X509 *x)
+     if (!X509_NAME_cmp(X509_get_subject_name(x), X509_get_issuer_name(x))) {
+         x->ex_flags |= EXFLAG_SI;
+         /* If SKID matches AKID also indicate self signed */
+-        if (X509_check_akid(x, x->akid) == X509_V_OK)
++        if (X509_check_akid(x, x->akid) == X509_V_OK &&
++            !ku_reject(x, KU_KEY_CERT_SIGN))
+             x->ex_flags |= EXFLAG_SS;
+     }
+     x->altname = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
+@@ -538,14 +547,6 @@ static void x509v3_cache_extensions(X509 *x)
+  * 4 basicConstraints absent but keyUsage present and keyCertSign asserted.
+  */
+ 
+-#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
+-#define ku_reject(x, usage) \
+-        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
+-#define xku_reject(x, usage) \
+-        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
+-#define ns_reject(x, usage) \
+-        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
+-
+ static int check_ca(const X509 *x)
+ {
+     /* keyUsage if present should allow cert signing */

--- a/openssl.spec
+++ b/openssl.spec
@@ -1,88 +1,73 @@
-### RPM external openssl 0.9.8e__1.0.1
-%define slc_version 0.9.8e
-%define generic_version 1.0.1
-Source0: http://www.openssl.org/source/%{n}-%{generic_version}.tar.gz
-Source1: http://cmsrep.cern.ch/cmssw/openssl-sources/%{n}-fips-%{slc_version}-usa.tar.bz2
-Patch0: openssl-0.9.8e-rh-0.9.8e-12.el5_4.6
-Patch1: openssl-x86-64-gcc420
-Patch2: openssl-1.0.1-disable-install_docs
+### RPM external openssl 1.0.1e_1.0.2d
+%define generic_version 1.0.2d
+%define slc6_version 1.0.1e
+Source0: http://davidlt.web.cern.ch/davidlt/vault/openssl-1.0.2d-5675d07a144aa1a6c85f488a95aeea7854e86059.tar.bz2
+Source1: http://davidlt.web.cern.ch/davidlt/vault/openssl-1.0.1e-42.el6.src.tar.bz2
 
-%define ismac %(case %{cmsplatf} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
-%define isfc %(case %{cmsplatf} in (fc*) echo 1 ;; (*) echo 0 ;; esac)
-%define isslc %(case %{cmsplatf} in (slc*) echo 1 ;; (*) echo 0 ;; esac)
+%define isslc6 %(case %{cmsplatf} in (slc6*) echo 1 ;; (*) echo 0 ;; esac)
 
 %prep
-%if %ismac
-%setup -b 0 -n %{n}-%{generic_version}
-%patch2 -p1
+%if %isslc6
+%setup -b 1 -n openssl-%{slc6_version}
+%else
+%setup -b 0 -n openssl-%{generic_version}
 %endif
-%if %isfc
-%setup -b 0 -n %{n}-%{generic_version}
-%patch2 -p1
-%endif
-%if %isslc
-%setup -b 1 -n %{n}-fips-%{slc_version}
-%patch0 -p1
-%patch1 -p1
-%endif
+
+# Disable documenation
+sed -ibak 's/install: all install_docs install_sw/install: all install_sw/g' Makefile.org Makefile
 
 %build
-# Looks like rpmbuild passes its own sets of flags via the
-# RPM_OPT_FLAGS environment variable and those flags include
-# -m64 (probably since rpmbuild processor detection is not
-# fooled by linux32). A quick fix is to just set the variable
-# to "" but we should probably understand how rpm determines
-# those flags and use them for our own good.
-RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
-               -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
-               -fstack-protector --param=ssp-buffer-size=4"
 
 case "%{cmsplatf}" in
-  *armv7*)
-    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic-armv7-a"
+  slc6_amd64_*)
+    RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
+                   -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
+                   -fstack-protector --param=ssp-buffer-size=4 -mtune=generic"
     ;;
-  *)
-    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic"
+  *_aarch64_*|fc*)
+    RPM_OPT_FLAGS="$RPM_OPT_FLAGS -Wa,--noexecstack -DPURIFY"
+    ;;
+esac
+
+case "%{cmsplatf}" in
+  osx*)         target=darwin64-x86_64-cc ;;
+  *_aarch64_*)  target=linux-aarch64 ;;
+  *_ppc64le_*)  target=linux-ppc64le ;;
+  *_amd64_*)    target=linux-x86_64 ;;
+  *)            target=linux-generic64 ;;
+esac
+
+case "%{cmsplatf}" in
+  osx*)
+    cfg_args="-DOPENSSL_USE_NEW_FUNCTIONS"
+    ;;
+    *)
+    cfg_args="--with-krb5-flavor=MIT --with-krb5-dir=/usr enable-krb5 no-zlib --openssldir=%{_sysconfdir}/pki/tls fips no-ec2m no-gost no-srp"
     ;;
 esac
 
 export RPM_OPT_FLAGS
 
-case "%{cmsplatf}" in
-  osx*)
-    export KERNEL_BITS=64 # used by config to decide 64-bit build
-    cfg_args="-DOPENSSL_USE_NEW_FUNCTIONS"
-    ;;
-  fc*)
-    cfg_args="--with-krb5-flavor=MIT enable-krb5"
-    ;;
-  *)
-    cfg_args="--with-krb5-flavor=MIT enable-krb5 fipscanisterbuild"
-    ;;
-esac
-
-./config --prefix=%{i} ${cfg_args} enable-seed enable-tlsext enable-rfc3779 no-asm \
-                       no-idea no-mdc2 no-rc5 no-ec no-ecdh no-ecdsa shared
+perl ./Configure ${target} ${cfg_args} enable-seed enable-tlsext enable-rfc3779 no-asm \
+                 no-idea no-mdc2 no-rc5 shared --prefix=%{i}
 
 case "%{cmsplatf}" in
-  fc*|osx*)
+  *_aarch64_*|fc*|osx*)
     make depend
     ;;
 esac
 
-make
+make all
 
 %install
-RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
-               -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
-               -fstack-protector --param=ssp-buffer-size=4"
-
 case "%{cmsplatf}" in
-  *armv7*)
-    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic-armv7-a"
+  slc*_amd64_*)
+    RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
+                   -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
+                   -fstack-protector --param=ssp-buffer-size=4 -mtune=generic"
     ;;
-  *)
-    RPM_OPT_FLAGS="${RPM_OPT_FLAGS} -mtune=generic"
+  *_aarch64_*|fc*)
+    RPM_OPT_FLAGS="$RPM_OPT_FLAGS -Wa,--noexecstack -DPURIFY"
     ;;
 esac
 
@@ -95,10 +80,10 @@ rm -rf %{i}/lib/pkgconfig
 # their dependency on kerberos.
 rm -rf %{i}/lib/*.a
 
-# MacOSX is case insensitive and the man page structure has case sensitive logic
-case %cmsplatf in
-  osx* ) 
-    rm -rf %{i}/ssl/man
-    ;;
-esac
-perl -p -i -e "s|^#!.*perl|#!/usr/bin/env perl|" %{i}/ssl/misc/CA.pl %{i}/ssl/misc/der_chop %{i}/bin/c_rehash
+sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/env perl;' \
+  %{i}/bin/c_rehash
+find %{i} -name '*deleteme' -type f -print0 | xargs -0 rm -f
+
+%post
+%{relocateConfig}bin/c_rehash
+%{relocateConfig}include/openssl/opensslconf.h

--- a/python.spec
+++ b/python.spec
@@ -63,7 +63,7 @@ echo $dirs
 LDFLAGS=""
 CPPFLAGS=""
 for d in $dirs; do
-  LDFLAGS="$LDFLAGS -L$d/lib"
+  LDFLAGS="$LDFLAGS -L$d/lib -L$d/lib64"
 done
 for d in $dirs $READLINE_ROOT $NCURSES_ROOT; do
   CPPFLAGS="$CPPFLAGS -I$d/include"

--- a/python.spec
+++ b/python.spec
@@ -101,7 +101,10 @@ esac
 # Triggers an error if -Werror=format is used with GNU GCC 4.8.0+.
 sed -ibak "s/\(#define HAVE_ATTRIBUTE_FORMAT_PARSETUPLE .*\)/\/* \1 *\//g" pyconfig.h
 
-make %makeprocesses
+# Python does not support parallel builds because of bug:
+# https://bugs.python.org/issue22359
+# Note, the problem is solved upstream (3.5)
+make
 
 %install
 # We need to export it because setup.py now uses it to determine the actual

--- a/python.spec
+++ b/python.spec
@@ -6,7 +6,7 @@
 # OS X patches and build fudging stolen from fink
 %{expand:%%define python_major_version %(echo %realversion | cut -d. -f1,2)}
 
-Requires: expat bz2lib db6 gdbm openssl libffi
+Requires: expat bz2lib db4 gdbm openssl libffi
 Requires: zlib sqlite readline ncurses 
 
 # FIXME: readline, crypt 
@@ -49,11 +49,11 @@ done
 
 mkdir -p %{i}/{include,lib,bin}
 
-dirs="${EXPAT_ROOT} ${BZ2LIB_ROOT} ${DB6_ROOT} ${GDBM_ROOT} ${OPENSSL_ROOT} ${LIBFFI_ROOT} ${ZLIB_ROOT} ${SQLITE_ROOT} ${READLINE_ROOT} ${NCURSES_ROOT}"
+dirs="${EXPAT_ROOT} ${BZ2LIB_ROOT} ${DB4_ROOT} ${GDBM_ROOT} ${OPENSSL_ROOT} ${LIBFFI_ROOT} ${ZLIB_ROOT} ${SQLITE_ROOT} ${READLINE_ROOT} ${NCURSES_ROOT}"
 
 # We need to export it because setup.py now uses it to determine the actual
 # location of DB4, this was needed to avoid having it picked up from the system.
-export DB6_ROOT
+export DB4_ROOT
 export LIBFFI_ROOT
 export READLINE_ROOT
 export NCURSES_ROOT
@@ -125,7 +125,7 @@ make
 %install
 # We need to export it because setup.py now uses it to determine the actual
 # location of DB4, this was needed to avoid having it picked up from the system.
-export DB6_ROOT
+export DB4_ROOT
 export LIBFFI_ROOT
 export READLINE_ROOT
 export NCURSES_ROOT


### PR DESCRIPTION
Moving CMSSW to the latest and greatest version of Python 2.7.11. Note, that starting 2.7.9 version SSL host verification is enabled by default thus machines must have CERN CA bundles installed (i.e. CERN-CA-certs).
