### PR TITLE
upgrade to t0wmadatasvc 0.0.6

### DIFF
--- a/t0wmadatasvc.spec
+++ b/t0wmadatasvc.spec
@@ -1,10 +1,10 @@
-### RPM cms t0wmadatasvc 0.0.3
+### RPM cms t0wmadatasvc 0.0.6
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 1.0.9.pre9
+%define wmcver 1.0.13
 
 Source0: git://github.com/dmwm/WMCore?obj=master/%wmcver&export=wmcore_%n&output=/wmcore_%n.tar.gz
 Source1: git://github.com/dmwm/t0wmadatasvc?obj=master/%realversion&export=%n&output=/%n.tar.gz


### PR DESCRIPTION
Adds a couple new methods and changes the return format of existing methods from string to json.
Needed schema changes are already deployed (they are safe to use with the old code).

Tested in my own personal VM deployment, everything seems to be working. Could wait for the HG1603 deployment (but if you see a chance to include it in HG1602 I also wouldn't mind).
