### PR TITLE
update cx_oracle to 5.2.1

### DIFF
--- a/py2-cx-oracle.spec
+++ b/py2-cx-oracle.spec
@@ -1,4 +1,4 @@
-### RPM external py2-cx-oracle 5.1.3
+### RPM external py2-cx-oracle 5.2.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 %define downloadn cx_Oracle
 


### PR DESCRIPTION
No specific reason except to stay up-to-date. Already used for Tier0 production, no problems observed. Is validation during testbed deployment enough or do we need more ?
