### PR TITLE
New minor version of fasthadd, 2.1, and move llvm sqlite from BuildRequires and Requires for py2-dxr

### DIFF
--- a/fasthadd.spec
+++ b/fasthadd.spec
@@ -1,8 +1,8 @@
-### RPM external fasthadd 2.0
+### RPM external fasthadd 2.1
 
 #Change the commit hash every time a new version is needed.
-#Commit mapped to merge of PR 10280
-%define commit 8db96f30b22860033087994689f4ec3bb024a268
+#Commit mapped to CMSSW_8_0_0_pre6
+%define commit 38304a4dbdfc1a5e7cc860afbb1c31dd09a9ff1e
 Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Components/bin/fastHadd.cc
 Source1: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Core/src/ROOTFilePB.proto
 Requires: protobuf root

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -1,7 +1,6 @@
 ### RPM external py2-dxr 1.0
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
-BuildRequires: llvm sqlite
-Requires: python zlib py2-setuptools py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious py2-pysqlite
+Requires: python zlib py2-setuptools py2-futures py2-jinja py2-markupsafe py2-ordereddict py2-parsimonious py2-pysqlite llvm sqlite
 %define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
 %define dxrCommit 6ea764102a
 %define triliteCommit e64a2a1 


### PR DESCRIPTION
Define new minor version of `fasthadd`, namely 2.1:
- the new minor version 2.1 is defined so that it is explicitly built on top of the new `ROOT 6.0.6`, featuring changes in the histogram serialisation;
- the code base has been moved to the latest 80X pre-release, but no changes in the source file is done.

No changes in performance observed or expected.
The new version is required for ease the deployment in the online environment.
@deguio @vanbesien @dmitrijus this is something you might want to watch as well.

Local test failed, but it seems unrelated with this change: `fasthadd` RPM was built:

```
....
Starting to process package external+fasthadd+2.1
Checking if fasthadd is cached.
Package external+fasthadd+2.1 not found in repository. Queuing for build.
Dependencies for external+fasthadd+2.1: ['install-external+gcc+4.9.3', 'install-lcg+root+6.06.00-cms2', 'install-external+protobuf+2.4.1', 'fetch-external+fasthadd+2.1']
....
Fetching sources for fasthadd
Done fetching https://raw.githubusercontent.com/cms-sw/cmssw/38304a4dbdfc1a5e7cc860afbb1c31dd09a9ff1e/DQMServices/Components/bin/fastHadd.cc
Done fetching https://raw.githubusercontent.com/cms-sw/cmssw/38304a4dbdfc1a5e7cc860afbb1c31dd09a9ff1e/DQMServices/Core/src/ROOTFilePB.proto
....
Creating directory /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/BUILD/slc6_amd64_gcc493/external/fasthadd/2.1 if not existing.
Building fasthadd. Log can be found in /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/BUILD/slc6_amd64_gcc493/external/fasthadd/2.1/log.
TMPDIR=/build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/tmp  rpmbuild  --buildroot /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/tmp/BUILDROOT/e98e7322aec04cd4ef8cd98649921a6f -ba --define '_topdir /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a' --define "compiling_processes 24"  --define "cmscompilerv  493" --define "cmsos slc6_amd64" /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/SPECS/external/fasthadd/2.1/spec >/build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/BUILD/slc6_amd64_gcc493/external/fasthadd/2.1/log 2>&1
Build successful.
Trying to install the rpm package external+fasthadd+2.1 just built.
Done
....
* The action "build-cms+cmssw-tool-conf+32.0-cms2" was not completed successfully because The following dependencies could not complete:
install-external+py2-dxr-toolfile+1.0-ikhhed
* The action "final-job" was not completed successfully because The following dependencies could not complete:
build-cms+cmssw-tool-conf+32.0-cms2
install-cms+cmssw-tool-conf+32.0-cms2
install-external+py2-dxr-toolfile+1.0-ikhhed
* The action "install-external+py2-dxr-toolfile+1.0-ikhhed" was not completed successfully because Traceback (most recent call last):
File "/build/diguida/ext/CMSSW_8_0_X/20160215_1421/PKGTOOLS/scheduler.py", line 199, in doSerial
result = commandSpec[0](*commandSpec[1:])
File "PKGTOOLS/cmsBuild", line 2782, in installApt
RpmInstallFailed: Failed to install package py2-dxr-toolfile. Reason:
Reading Package Lists...
Building Dependency Tree...
The following extra packages will be installed:
external+py2-dxr+1.0-ikhhed
The following NEW packages will be installed:
external+py2-dxr+1.0-ikhhed external+py2-dxr-toolfile+1.0-ikhhed
0 upgraded, 2 newly installed, 0 removed and 0 not upgraded.
Need to get 0B/868kB of archives.
After unpacking 2596kB of additional disk space will be used.
Executing RPM (/build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/slc6_amd64_gcc493/external/apt/0.5.16/bin/rpm-wrapper -Uvh -r /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a --force --prefix /build/diguida
/ext/CMSSW_8_0_X/20160215_1421/a --ignoreos --ignorearch --force --prefix /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a --ignoreos --ignorearch --oldpackage)...
error: Failed dependencies:
#looks like something wrong with LLVM/clang, I do not list the .so files here
E: Sub-process /build/diguida/ext/CMSSW_8_0_X/20160215_1421/a/slc6_amd64_gcc493/external/apt/0.5.16/bin/rpm-wrapper returned an error code (2)

* The action "install-cms+cmssw-tool-conf+32.0-cms2" was not completed successfully because The following dependencies could not complete:
build-cms+cmssw-tool-conf+32.0-cms2
```

This was traced to be an issue with `py2-dxr` `spec` file. LLVM and SQLite are run-time dependencies. In addition to that this causes installation failures. APT-RPM fails if LLVM and SQLite is not installed before DXR. This is fixed in `IB/CMSSW_8_0_X/gcc530` branch by https://github.com/cms-sw/cmsdist/commit/1ac4cd1f418f385cbe07e32f63ee29b7b53db3c9. This is cherry-picked here.

Local tests are now ok, indeed.
