### PR TITLE
cmsos.file: add a proper shebang

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,5 +1,5 @@
 ### RPM cms cms-common 1.0
-## REVISION 1122
+## REVISION 1123
 ## NOCOMPILER
 
 %if "%{?cmsroot:set}" != "set"

--- a/cmsos.file
+++ b/cmsos.file
@@ -1,4 +1,4 @@
-### FILE cmsos
+#!/bin/sh
 
 cmsos()
 {


### PR DESCRIPTION
It looks there are some magic involved in ./common/cmsos execution.
Under QEMU user-mode emulation it fails as it attempts executing
the file directly and file does not contain a proper shebang.

```
-sh-4.3$ type -a cmsos
cmsos is /mnt/build/davidlt/proot/cmsinst/common/cmsos
cmsos is /mnt/build/davidlt/proot/cmsinst/bin/cmsos
cmsos is /cvmfs/cms.cern.ch/common/cmsos
cmsos is /cvmfs/cms.cern.ch/bin/cmsos
cmsos is /cvmfs/cms.cern.ch/common/cmsos
cmsos is /cvmfs/cms.cern.ch/bin/cmsos

-sh-4.3$ head -n3 $(which cmsos)
### FILE cmsos

cmsos()

-sh-4.3$ cmsos
Error while loading /mnt/build/davidlt/proot/cmsinst/common/cmsos: Exec format error
```

If shebang is missing parent shell most likely uses itself as interpreter,
thus the ./common/cmsos will fail on C Shells (e.g., tcsh).

```
$ /cvmfs/cms.cern.ch/common/cmsos
Badly placed ()'s.
```

Add a proper sheband to avoid mystery.

Signed-off-by: David Abdurachmanov david.abdurachmanov@gmail.com
