### PR TITLE
Resolve issue with PycURL not matching SSL backend

### DIFF
--- a/curl.spec
+++ b/curl.spec
@@ -1,4 +1,4 @@
-### RPM external curl 7.46.0
+### RPM external curl 7.47.1
 Source: http://curl.haxx.se/download/%{n}-%{realversion}.tar.gz
 Requires: openssl
 Requires: zlib

--- a/curl.spec
+++ b/curl.spec
@@ -12,8 +12,11 @@ case %{cmsplatf} in
   *) KERBEROS_ROOT=/usr ;;
 esac
 
+unset MAGIC
+
 ./configure \
   --prefix=%{i} \
+  --disable-silent-rules \
   --disable-static \
   --without-libidn \
   --disable-ldap \

--- a/py2-pycurl.spec
+++ b/py2-pycurl.spec
@@ -7,9 +7,9 @@ Requires: python curl openssl
 %setup -n pycurl-%{realversion}
 
 %build
-python setup.py --with-openssl build
+python setup.py --with-openssl --openssl-dir=${OPENSSL_ROOT} build
 
 %install
-python setup.py --with-openssl install --prefix=%{i}
+python setup.py --with-openssl --openssl-dir=${OPENSSL_ROOT} install --prefix=%{i}
 find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -rf
 rm -rf %{i}/share

--- a/py2-pycurl.spec
+++ b/py2-pycurl.spec
@@ -1,16 +1,15 @@
-### RPM external py2-pycurl 7.19.3.1
-## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
-Source: http://pycurl.sourceforge.net/download/pycurl-%realversion.tar.gz
-Requires: python curl
+### RPM external py2-pycurl 7.43.0
+## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
+Source: https://dl.bintray.com/pycurl/pycurl/pycurl-%{realversion}.tar.gz
+Requires: python curl openssl
 
 %prep
-%setup -n pycurl-%realversion
+%setup -n pycurl-%{realversion}
 
 %build
-python setup.py build
+python setup.py --with-openssl build
 
 %install
-python setup.py install --prefix=%i
-find %i -name '*.egg-info' -exec rm {} \;
-# Remove documentation.
-%define drop_files %i/share
+python setup.py --with-openssl install --prefix=%{i}
+find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -rf
+rm -rf %{i}/share


### PR DESCRIPTION
The following changes are from CMSSW_8_1_X to resolve:

```
    import pycurl
ImportError: pycurl: libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (none/other)
```

More details are available in the commit messages. We have noticed that CRAB3 still uses mixed binaries and triggering this issue.
