### PR TITLE
Updated Pede external to V04-03-04.

### DIFF
--- a/millepede.spec
+++ b/millepede.spec
@@ -1,4 +1,4 @@
-### RPM external millepede V04-03-03 
+### RPM external millepede V04-03-04
 
 Source: svn://svnsrv.desy.de/public/MillepedeII/tags/%{realversion}/?scheme=http&module=%{realversion}&output=/%{n}-%{realversion}.tgz
 Requires: zlib


### PR DESCRIPTION
 Summary of changes: fixed uninitialized variable
- when used with option 'monitorresiduals' pede crashed when
   compiled with gcc530
- although no crash has been observed with older compilers the fix
   should be applied also there
- build was successful
