### PR TITLE
fix sherpa toofile to remove warning appearing in CMSSW_7_1_.. versions

### DIFF
--- a/sherpa-toolfile.spec
+++ b/sherpa-toolfile.spec
@@ -22,7 +22,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa.xml
 <runtime name="SHERPA_SHARE_PATH" value="$SHERPA_BASE/share/SHERPA-MC" type="path"/>
 <runtime name="SHERPA_INCLUDE_PATH" value="$SHERPA_BASE/include/SHERPA-MC" type="path"/>
 <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-<use name="root_cxxdefaults"/>
 <use name="HepMC"/>
 <use name="lhapdf"/>
 <use name="qd"/>


### PR DESCRIPTION
message:
'****WARNING: Invalid tool root_cxxdefaults. Please fix sherpa file.'
due to modifications for root 6, which is not present in e.g. CMSSW_7_1_23

this does not modify the functionality of sherpa 
