### PR TITLE
davix-toolfile: use include/davix for INCLUDE

### DIFF
--- a/davix-toolfile.spec
+++ b/davix-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external davix-toolfile 1.0
+### RPM external davix-toolfile 1.1
 Requires: davix
 
 %prep
@@ -12,7 +12,7 @@ cat << \EOF_TOOLFILE > %i/etc/scram.d/davix.xml
     <client>
       <environment name="DAVIX_BASE" default="@TOOL_ROOT@"/>
       <environment name="LIBDIR" default="$DAVIX_BASE/lib64"/>
-      <environment name="INCLUDE" default="$DAVIX_BASE/include"/>
+      <environment name="INCLUDE" default="$DAVIX_BASE/include/davix"/>
     </client>
     <runtime name="PATH" value="$DAVIX_BASE/bin" type="path"/>
     <use name="boost_system"/>


### PR DESCRIPTION
All the headers are in 'davix' directory:

```
[..]
davix/0.6.0-giojec/include/davix/auth
davix/0.6.0-giojec/include/davix/auth/davixauth.hpp
davix/0.6.0-giojec/include/davix/auth/davixx509cred.hpp
davix/0.6.0-giojec/include/davix/davix.hpp
davix/0.6.0-giojec/include/davix/davixcontext.hpp
davix/0.6.0-giojec/include/davix/davix_file_types.hpp
[..]
```

The code like

```
#include <davix/davix.hpp>
```

will be broken, because Davix does not use 'davix/' in includes.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
