### PR TITLE
Match tkonlinesw-fake to tkonlinesw

### DIFF
--- a/tkonlinesw-fake-toolfile.spec
+++ b/tkonlinesw-fake-toolfile.spec
@@ -17,6 +17,9 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/tkonlinesw.xml
     <environment name="LIBDIR" value="$TKONLINESW_BASE/lib"/>
     <environment name="INCLUDE" value="$TKONLINESW_BASE/include"/>
   </client>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <flags CXXFLAGS="-DCMS_TK_64BITS"/>
+  <use name="root_cxxdefaults"/>
   <use name="xerces-c"/>
 </tool>
 EOF_TOOLFILE

--- a/tkonlinesw-fake.spec
+++ b/tkonlinesw-fake.spec
@@ -1,6 +1,6 @@
-### RPM external tkonlinesw-fake 4.0.0-1
+### RPM external tkonlinesw-fake 4.1.0-1
 
-Source: http://davidlt.web.cern.ch/davidlt/vault/tkonlinesw-fake-v3.tar.bz2
+Source: http://davidlt.web.cern.ch/davidlt/vault/tkonlinesw-fake-v4.tar.bz2
 %prep
 %setup -n tkonlinesw-fake
 

--- a/tkonlinesw-fake.spec
+++ b/tkonlinesw-fake.spec
@@ -1,6 +1,6 @@
-### RPM external tkonlinesw-fake 2.7.0
+### RPM external tkonlinesw-fake 4.0.0-1
 
-Source: http://davidlt.web.cern.ch/davidlt/vault/tkonlinesw-fake-v2.tar.bz2
+Source: http://davidlt.web.cern.ch/davidlt/vault/tkonlinesw-fake-v3.tar.bz2
 %prep
 %setup -n tkonlinesw-fake
 


### PR DESCRIPTION
Due to migration to Xerces-C we need to update also tkonlinesw-fake to keep POWER8 and AArch64 builds working.
