### PR TITLE
Update davix.spec

### DIFF
--- a/davix.spec
+++ b/davix.spec
@@ -1,4 +1,4 @@
-### RPM external davix 0.6.0
+### RPM external davix 0.6.3
 
 %define tag %(echo R_%{realversion} | tr . _)
 %define branch master


### PR DESCRIPTION
Until 0.6.2 version davix is allocating multi-range buffers on the stack. If chunk size is bigger than the stack size, it segfaults.
Starting from 0.6.2 this was fixed to allocate on the heap. Upgrading to the newest version 0.6.3
