### PR TITLE
Added a new Geant4  patch to DEVEL

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 10.02.p02
-%define tag c46e78c2aa06b8c61b102bdfbf937713b623b72b
+%define tag f6e73d3b63947d45839445eae2dddd57445ec227
 %define branch cms/4.%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz
@@ -40,6 +40,7 @@ cmake ../%{n}.%{realversion} \
   -DGEANT4_BUILD_CXXSTD:STRING="c++11" \
   -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic" \
   -DGEANT4_ENABLE_TESTING=OFF \
+  -GEANT4_BUILD_VERBOSE_CODE=OFF \
   -DBUILD_SHARED_LIBS=ON \
   -DXERCESC_ROOT_DIR:PATH="${XERCES_C_ROOT}" \
   -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT" \


### PR DESCRIPTION
Added a new Geant4 10.2 CMS-private patch to FTF-model configuration. This patch is now only for the DEVEL branch.

This include disabled Geant4 verbosity which should provide non-negligble speed-up of the production. 
