### PR TITLE
updates RecoBTag-SecondaryVertex spec to use latest tag

### DIFF
--- a/data-RecoBTag-SecondaryVertex.spec
+++ b/data-RecoBTag-SecondaryVertex.spec
@@ -1,4 +1,4 @@
-### RPM cms data-RecoBTag-SecondaryVertex V02-00-01
+### RPM cms data-RecoBTag-SecondaryVertex V02-00-02
 
 %prep
 


### PR DESCRIPTION
https://github.com/cms-sw/cmsdist/issues/2440
