### PR TITLE
das_client.py symlink in CMS_PATH/share/overrides/bin

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_6_pre5
+### RPM lcg SCRAMV1 V2_2_6_pre6
 ## NOCOMPILER
 
 BuildRequires: gmake
@@ -88,6 +88,7 @@ VERSION_REGEXP="%{SCRAM_REL_MAJOR}_"   ; VERSION_FILE=default-scram/%{SCRAM_REL_
 if [ `cat $RPM_INSTALL_PREFIX/share/etc/default-scramv1-version` == '%v' ] ; then
   cp -f $RPM_INSTALL_PREFIX/%{pkgrel}/docs/man/man1/scram.1 ${RPM_INSTALL_PREFIX}/share/man/man1/scram.1
 fi
+
 #FIMEME: Remove it when cmsBuild has a fix
 #For some strange reason we need something after the last statement
 #otherwise RPM does not run it. rpm -q --scripts also confirm that above

--- a/das_client.spec
+++ b/das_client.spec
@@ -60,3 +60,8 @@ if [ "`ls ${RPM_INSTALL_PREFIX}/*/%{pkgcategory}/%{pkgname}/v*/etc/profile.d/ini
   /bin/cp -f ${RPM_INSTALL_PREFIX}/%{pkgrel}/etc/das_client $RPM_INSTALL_PREFIX/common/das_client.tmp
   mv $RPM_INSTALL_PREFIX/common/das_client.tmp $RPM_INSTALL_PREFIX/common/das_client
 fi
+
+#Create overrides/bin directory (newly supported by SCRAM)
+#and make sure that das_client.py script points to das_cleint wrapper
+mkdir -p $RPM_INSTALL_PREFIX/share/overrides/bin
+[ -e $RPM_INSTALL_PREFIX/share/overrides/bin/das_client.py ] || ln -sf ../../../common/das_client $RPM_INSTALL_PREFIX/share/overrides/bin/das_client.py


### PR DESCRIPTION
- New scram tag which adds CMS_PATH/share/overrides/bin (if exists) as first directory in PATH 
- das_client now creates CMS_PATH/share/overrides/bin/das_client.py symlink pointing to common/das_client wrapper

this is needed in order to get the old releases, which have old das_client in them and they call das_client.py instead on das_client wrapper, working
