### PR TITLE
Update Davix to 0.6.4

### DIFF
--- a/davix.spec
+++ b/davix.spec
@@ -1,4 +1,4 @@
-### RPM external davix 0.6.3
+### RPM external davix 0.6.4
 
 %define tag %(echo R_%{realversion} | tr . _)
 %define branch master


### PR DESCRIPTION
0.6.4 has a fix for Davix Segfault in libneon when downloading large file with a bad network connection...
