### PR TITLE
Updated spacemon-client: 1.0.1 release, drop dependency on gcc.

### DIFF
--- a/spacemon-client.spec
+++ b/spacemon-client.spec
@@ -1,4 +1,5 @@
-### RPM cms spacemon-client 1.0.1-pre5
+### RPM cms spacemon-client 1.0.1
+## NOCOMPILER
 ## INITENV +PATH PERL5LIB %i
 ## INITENV +PATH PATH %i/DMWMMON/SpaceMon/Utilities
 


### PR DESCRIPTION
Please merge. 
Tested on slc6_amd64_gcc493 with new cmspkg tool.  
