### PR TITLE
new scram version to send release, arch and scram version info to cmssdt

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_6_pre7
+### RPM lcg SCRAMV1 V2_2_6_pre8
 ## NOCOMPILER
 
 BuildRequires: gmake


### PR DESCRIPTION
For accounting purpose, we include release name, arch and scram version when we make a call to wget releases.map
