### PR TITLE
Ib/cmssw 8 1 x/stable: Rivet 2.5.2 and Yoda 1.6.4

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -1,4 +1,4 @@
-### RPM external rivet 2.4.0
+### RPM external rivet 2.5.1
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 
 Requires: hepmc boost fastjet gsl yaml-cpp yoda

--- a/rivet.spec
+++ b/rivet.spec
@@ -1,7 +1,8 @@
-### RPM external rivet 2.5.1
+### RPM external rivet 2.5.2
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
+#Source: http://www.hepforge.org/archive/rivet/Rivet-%{realversion}.tar.gz  
 
-Requires: hepmc boost fastjet gsl yaml-cpp yoda
+Requires: hepmc fastjet gsl yoda
 Requires: python cython
 
 Patch0: rivet-1.4.0
@@ -16,6 +17,7 @@ Patch0: rivet-1.4.0
 
 %prep
 %setup -n rivet/%{realversion}
+#%setup -n Rivet-%{realversion}
 %patch0 -p0
 
 ./configure --disable-silent-rules --prefix=%i --with-boost=${BOOST_ROOT} --with-hepmc=$HEPMC_ROOT \

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,4 +1,4 @@
-### RPM external yoda 1.5.5
+### RPM external yoda 1.6.3
 
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
 

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,8 +1,10 @@
-### RPM external yoda 1.6.3
+### RPM external yoda 1.6.4
 
 Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
+#Source: http://www.hepforge.org/archive/yoda/YODA-%{realversion}.tar.gz
 
 Requires: boost python cython
+#Requires: python cython
 
 %if "%{?cms_cxxflags:set}" != "set"
 %define cms_cxxflags -std=c++0x -O2
@@ -10,6 +12,7 @@ Requires: boost python cython
 
 %prep
 %setup -q -n %{n}/%{realversion}
+#%setup -q -n YODA-%{realversion}
 
 ./configure --prefix=%i --with-boost=${BOOST_ROOT} CXX="$(which %cms_cxx)" CXXFLAGS="%cms_cxxflags"
 


### PR DESCRIPTION
Moving to latest Rivet version 2.5.2 (and underlying Yoda 1.6.4)
I could compile the packages and test them in CMSSW_8_1_0_pre10
Also revisited the dependency as some were removed by the authors.
Xavier
