### PR TITLE
PHEDEX agents bundle pre-release 4.2.0pre5

### DIFF
--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-admin 4.2.0pre4
+### RPM cms PHEDEX-admin 4.2.0pre5
 # Dummy line to force a rebuild
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-micro 4.2.0pre4
+### RPM cms PHEDEX-micro 4.2.0pre5
 ## INITENV +PATH PATH %i/Utilities:%i/Toolkit/DropBox:%i/Toolkit/Request
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX 4.2.0pre4
+### RPM cms PHEDEX 4.2.0pre5
 ## INITENV +PATH PATH %i/Utilities
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)


### PR DESCRIPTION
Minor pre-release of PhEDEx agents, includes fix for #1021 . 
primarily for exercising the release procedure and also to check if the new rpm is automatically picked up by cvmfs update scripts. 
