### PR TITLE
Update SCRAMV1.spec

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_6_pre8
+### RPM lcg SCRAMV1 V2_2_6
 ## NOCOMPILER
 
 BuildRequires: gmake


### PR DESCRIPTION
For accounting purpose, scram now also includes releasetop information when accesses cmssdt.cern.ch/releases.map