### PR TITLE
Updated PHEDEX-lifecycle.spec:

### DIFF
--- a/PHEDEX-lifecycle.spec
+++ b/PHEDEX-lifecycle.spec
@@ -1,19 +1,11 @@
-### RPM cms PHEDEX-lifecycle 1.2.1
-# Dummy line to force a rebuild
+### RPM cms PHEDEX-lifecycle 1.3.0
 ## INITENV +PATH PERL5LIB %i/perl_lib
-## INITENV +PATH PERL5LIB %i/T0/perl_lib
+## INITENV +PATH PERL5LIB %i/Testbed/T0FeedTest/Perl_libs
 %define downloadn %(echo %n | cut -f1 -d-)
 %define downloadp %(echo %n | cut -f2 -d- | tr '[a-z]' '[A-Z]')
 %define downloadt %(echo %realversion | tr '.' '_')
 %define setupdir  %{downloadn}-%{downloadp}_%{downloadt}
 Source: https://github.com/dmwm/PHEDEX/archive/%{downloadp}_%{downloadt}.tar.gz
-
-#%define gittag 58f3eed1c98b8edaae10f6befe9d0343c0abc38b
-#Source0: git://github.com/dmwm/PHEDEX?obj=PHEDEX-LifeCycle/%gittag&export=%n&output=/%n.tar.gz
-
-# TODO Need to get this from somewhere else...
-%define cvsserver cvs://:pserver:anonymous@cmssw.cvs.cern.ch:/local/reps/CMSSW?passwd=AA_:yZZ3e
-Source1: %cvsserver&strategy=export&module=T0&export=T0&&tag=-rPHEDEX_LIFECYCLE_1_0_0&output=/T0.tar.gz
 
 Requires: p5-poe p5-poe-component-child p5-clone p5-time-hires p5-text-glob
 Requires: p5-compress-zlib p5-log-log4perl p5-json-xs p5-xml-parser p5-monalisa-apmon
@@ -27,32 +19,23 @@ Requires: oracle oracle-env p5-dbi p5-dbd-oracle
 # add PHEDEX to fix perl dependency problem
 Requires: PHEDEX
 
-#Provides: perl(XML::LibXML)
 Provides: perl(XML::Twig)
 Provides: perl(T0::FileWatcher)
 Provides: perl(T0::Logger::Sender)
 Provides: perl(T0::Util)
 
-# Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
-# This is so it gets into our dependencies-setup.sh
-#Requires:  expat
-
 %prep
 %setup -n %{setupdir}
-tar zxf %_sourcedir/T0.tar.gz
-rm Testbed/AutomatedTesting/check_API.pl
 
 %build
 %install
-mkdir -p %i/etc/{env,profile}.d %i/bin
-tar -cf - * | (cd %i && tar -xf -)
-cp -p Testbed/LifeCycle/Lifecycle.pl %i/bin
-cp -p Testbed/LifeCycle/CheckProxy.pl %i/bin
-cp -p Testbed/LifeCycle/fake-delete.pl %i/bin
-cp -p Testbed/LifeCycle/fake-validate.pl %i/bin
-cp -p Testbed/FakeFTS.pl %i/bin
+# Install only what belongs to the lifecycle:
+tar -c perl_lib/PHEDEX/Testbed | tar -x -C %i 
+tar -c Testbed/{Integration,LifeCycle} | tar -x -C %i
+tar -c -C Testbed/T0FeedTest/Perl_libs T0/{Logger,Util.pm,FileWatcher.pm} | tar -x -C %i/perl_lib
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/{env,profile}.d
 : > %i/etc/profile.d/dependencies-setup.sh
 : > %i/etc/profile.d/dependencies-setup.csh
 #echo export LIFECYCLE=%instroot/Testbed/LifeCycle >> %i/etc/profile.d/dependencies-setup.sh


### PR DESCRIPTION
 - 1.3.0 release integrating all developments done in the last few years
 - adjusted directory structure and PERL5LIB paths accordig to changes
 - use explicit list of code included in this distribution
 - drop bin/ directory which is no longer used