### PR TITLE
Build rules tag updated to V05-05-14

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-13
+%define configtag       V05-05-14
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
New build rules allow to have test without any executable to build e.g. one now can have
```
<test name="MyConfigTest" command="cmsRun myconfig.cfg"/>
```
in Package/test/BuildFile.xml