### PR TITLE
bison: add dependency on autotools (m4)

### DIFF
--- a/bison.spec
+++ b/bison.spec
@@ -2,6 +2,7 @@
 Source: http://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
 
 BuildRequires: autotools
+Requires: autotools
 
 %define drop_files %{i}/share/{man,locale,info}
 


### PR DESCRIPTION
Bison needs m4 and build-time and run-time. Our m4 is part of autotools
package. Otherwise we will fail compiling doxygen:

    bison: m4 subprocess failed

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>
(cherry picked from commit 4fae994415679bb1e660a1534cd21b7131c8503e)