### PR TITLE
Python via pip in cmsdist

### DIFF
--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -9,7 +9,7 @@ BuildRequires: py2-pip
 %build
 
 pip list
-pip install -t %{i}/$PYTHON_LIB_SITE_PACKAGES  %{my_name}==%{realversion}
+pip install --no-deps -t %{i}/$PYTHON_LIB_SITE_PACKAGES  %{my_name}==%{realversion}
 #see how many things got installed
 if [ `ls -d %{i}/$PYTHON_LIB_SITE_PACKAGES/*info | wc -l` == "1" ] ; then
    echo "Pip installed just what you asked for"

--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -1,20 +1,20 @@
 %define my_name %(echo %n | cut -f2 -d-)
 Source: none
 
+Requires: python
 BuildRequires: py2-pip
 
 %prep
 
 %build
 
-%define pythonVersion %(python -V |& cut -f2 -d' ' | cut -f1-2 -d.)
-
-pip install -v -v -v -t %{i}/lib/python%{pythonVersion}/site-packages  %{my_name}==%{realversion}
+pip list
+pip install -t %{i}/$PYTHON_LIB_SITE_PACKAGES  %{my_name}==%{realversion}
 #see how many things got installed
-if [ `ls -d %{i}/lib/python%{pythonVersion}/site-packages/*info | wc -l` == "1" ] ; then
+if [ `ls -d %{i}/$PYTHON_LIB_SITE_PACKAGES/*info | wc -l` == "1" ] ; then
    echo "Pip installed just what you asked for"
 else
-   ls -d %{i}/lib/python%{pythonVersion}/site-packages/*info
+   ls -d %{i}/$PYTHON_LIB_SITE_PACKAGES/*info
    echo "Pip installed dependencies. Please install them separately first"
    exit 1
 fi

--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -1,0 +1,26 @@
+%define my_name %(echo %n | cut -f2 -d-)
+Source: none
+
+BuildRequires: py2-pip
+
+%prep
+
+%build
+
+pip install -v -v -v --root %{i} %{my_name}==%{realversion}
+#see how many things got installed
+if [ `ls -d %{i}/$PYTHON_ROOT/lib/python*/site-packages/*info | wc -l` == "1" ] ; then
+   echo "Pip installed just what you asked for"
+else
+   ls -d %{i}/$PYTHON_ROOT/lib/python*/site-packages/*info
+   echo "Pip installed dependencies. Please install them separately first"
+   exit 1
+fi
+ 
+
+%install
+cd %i
+mv %{i}/$PYTHON_ROOT/lib . 
+rm -rf %{i}/build
+
+

--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -10,12 +10,14 @@ BuildRequires: py2-pip
 
 tar xfz %{_sourcedir}/source.tar.gz
 
+%{?PipPreBuild:%PipPreBuild}
+
 if [ `cat files.list | wc -l` == "1" ] ; then
    export PIPFILE=`cat files.list`
    echo ${PIPFILE}
    export PYTHONUSERBASE=%i
    pip list
-   pip install --no-deps --user  $PIPFILE
+   pip install --no-deps --user %{?PipBuildOptions:%PipBuildOptions} $PIPFILE
 #   pip install --no-deps --user  %{my_name}==%{realversion}
 else
    echo "Sorry I don't know how to handle no/multiple install files yet"
@@ -24,5 +26,7 @@ else
 fi
 
 %install
+
+%{?PipPostBuild:%PipPostBuild}
 
 

--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -7,20 +7,19 @@ BuildRequires: py2-pip
 
 %build
 
-pip install -v -v -v --root %{i} %{my_name}==%{realversion}
+%define pythonVersion %(python -V |& cut -f2 -d' ' | cut -f1-2 -d.)
+
+pip install -v -v -v -t %{i}/lib/python%{pythonVersion}/site-packages  %{my_name}==%{realversion}
 #see how many things got installed
-if [ `ls -d %{i}/$PYTHON_ROOT/lib/python*/site-packages/*info | wc -l` == "1" ] ; then
+if [ `ls -d %{i}/lib/python%{pythonVersion}/site-packages/*info | wc -l` == "1" ] ; then
    echo "Pip installed just what you asked for"
 else
-   ls -d %{i}/$PYTHON_ROOT/lib/python*/site-packages/*info
+   ls -d %{i}/lib/python%{pythonVersion}/site-packages/*info
    echo "Pip installed dependencies. Please install them separately first"
    exit 1
 fi
  
 
 %install
-cd %i
-mv %{i}/$PYTHON_ROOT/lib . 
-rm -rf %{i}/build
 
 

--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -1,5 +1,5 @@
 %define my_name %(echo %n | cut -f2 -d-)
-Source: none
+Source: pip://%{my_name}/%{realversion}/source.tar.gz
 
 Requires: python
 BuildRequires: py2-pip
@@ -8,17 +8,20 @@ BuildRequires: py2-pip
 
 %build
 
-pip list
-pip install --no-deps -t %{i}/$PYTHON_LIB_SITE_PACKAGES  %{my_name}==%{realversion}
-#see how many things got installed
-if [ `ls -d %{i}/$PYTHON_LIB_SITE_PACKAGES/*info | wc -l` == "1" ] ; then
-   echo "Pip installed just what you asked for"
+tar xfz %{_sourcedir}/source.tar.gz
+
+if [ `cat files.list | wc -l` == "1" ] ; then
+   export PIPFILE=`cat files.list`
+   echo ${PIPFILE}
+   export PYTHONUSERBASE=%i
+   pip list
+   pip install --no-deps --user  $PIPFILE
+#   pip install --no-deps --user  %{my_name}==%{realversion}
 else
-   ls -d %{i}/$PYTHON_LIB_SITE_PACKAGES/*info
-   echo "Pip installed dependencies. Please install them separately first"
+   echo "Sorry I don't know how to handle no/multiple install files yet"
+   cat %{_sourcedir}/files.txt
    exit 1
 fi
- 
 
 %install
 

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -170,6 +170,9 @@ Requires: scons-toolfile
 Requires: md5-toolfile
 Requires: py2-setuptools-toolfile
 Requires: madgraph5amcatnlo-toolfile
+Requires: histogrammar-toolfile
+Requires: py2-rootpy-toolfile
+Requires: py2-notebook
 
 # Only for Linux platform.
 %if %islinux
@@ -188,7 +191,6 @@ Requires: py2-cx-oracle-toolfile
 Requires: oracle-toolfile
 Requires: cuda-toolfile
 Requires: openloops-toolfile
-Requires: histogrammar-toolfile
 
 %if %isslc
 Requires: glibc-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -172,7 +172,7 @@ Requires: py2-setuptools-toolfile
 Requires: madgraph5amcatnlo-toolfile
 Requires: histogrammar-toolfile
 Requires: py2-rootpy-toolfile
-Requires: py2-notebook
+#still a work in progress Requires: py2-notebook
 
 # Only for Linux platform.
 %if %islinux

--- a/histogrammar.spec
+++ b/histogrammar.spec
@@ -1,13 +1,15 @@
-### RPM external histogrammar 1.0.3
+### RPM external histogrammar 1.0.5
 ## INITENV +PATH PYTHONPATH %i/$PYTHON_LIB_SITE_PACKAGES
-Source: https://pypi.python.org/packages/68/d5/a3b095f9513643832f8b767a1c1739c78751753e880317cbbe3488d69323/histogrammar-%{realversion}.tar.gz
+
+
+Source: https://github.com/histogrammar/histogrammar-python/archive/%{realversion}.tar.gz
 Requires: python
 Requires: py2-numpy
 Requires: py2-pandas
 Requires: root
 
 %prep
-%setup -n histogrammar-%{realversion}
+%setup -n histogrammar-python-%{realversion}
 
 %build
 %install

--- a/py2-configparser.spec
+++ b/py2-configparser.spec
@@ -1,0 +1,5 @@
+### RPM external py2-configparser 3.5.0
+## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
+
+Requires: python 
+## IMPORT build-with-pip

--- a/py2-configparser.spec
+++ b/py2-configparser.spec
@@ -1,5 +1,4 @@
 ### RPM external py2-configparser 3.5.0
 ## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
 
-Requires: python 
 ## IMPORT build-with-pip

--- a/py2-entrypoints.spec
+++ b/py2-entrypoints.spec
@@ -1,0 +1,5 @@
+### RPM external py2-entrypoints 0.2.2
+## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
+
+Requires: python py2-configparser
+## IMPORT build-with-pip

--- a/py2-entrypoints.spec
+++ b/py2-entrypoints.spec
@@ -1,5 +1,5 @@
 ### RPM external py2-entrypoints 0.2.2
 ## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
 
-Requires: python py2-configparser
+Requires: py2-configparser
 ## IMPORT build-with-pip

--- a/py2-pip.spec
+++ b/py2-pip.spec
@@ -1,10 +1,12 @@
 ### RPM external py2-pip 9.0.1
+## INITENV +PATH PATH %{i}/bin
+## INITENV +PATH LD_LIBRARY_PATH %{i}/lib
 ## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
 %define my_name %(echo %n | cut -f2 -d-)
 Source: https://github.com/pypa/pip/archive/%{realversion}.tar.gz
-Requires: python 
-BuildRequires: py2-setuptools
-
+Requires: python py2-setuptools 
+#BuildRequires: 
+  
 %prep
 %setup -n %{my_name}-%{realversion}
 
@@ -13,6 +15,5 @@ python setup.py build
 
 %install
 python setup.py install --single-version-externally-managed --record=/dev/null  --prefix=%{i}
-find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -rf
 perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*
 

--- a/py2-pip.spec
+++ b/py2-pip.spec
@@ -1,0 +1,17 @@
+### RPM external py2-pip 9.0.1
+## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
+%define my_name %(echo %n | cut -f2 -d-)
+Source: https://github.com/pypa/pip/archive/%{realversion}.tar.gz
+Requires: python 
+BuildRequires: py2-setuptools
+
+%prep
+%setup -n %{my_name}-%{realversion}
+
+%build
+python setup.py build
+
+%install
+python setup.py install --single-version-externally-managed --record=/dev/null  --prefix=%{i}
+find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -rf
+

--- a/py2-pip.spec
+++ b/py2-pip.spec
@@ -14,4 +14,5 @@ python setup.py build
 %install
 python setup.py install --single-version-externally-managed --record=/dev/null  --prefix=%{i}
 find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -rf
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*
 

--- a/py2-rootpy-toolfile.spec
+++ b/py2-rootpy-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external py2-rootpy-toolfile 1.0
+Requires: py2-rootpy
+%prep
+
+%build
+
+%install
+
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-root_numpy.xml
+<tool name="py2-rootpy" version="@TOOL_VERSION@">
+  <info url="https://github.com/rootpy/rootpy"/>
+  <client>
+    <environment name="PY2_ROOTPY" default="@TOOL_ROOT@"/>
+    <runtime name="PYTHONPATH" value="$PY2_ROOTPY/lib/python@PYTHONV@/site-packages" type="path"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/py2-rootpy.spec
+++ b/py2-rootpy.spec
@@ -1,18 +1,10 @@
 ### RPM external py2-rootpy 0.8.0
 ## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
-%define my_name %(echo %n | cut -f2 -d-)
-Source: https://github.com/rootpy/%my_name/archive/%{realversion}.tar.gz
+
+
+%define PipPostBuild \
+   perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/rootpy %{i}/bin/roosh %{i}/bin/root2hdf5
 
 Requires: python root py2-matplotlib root
-BuildRequires: py2-setuptools
+## IMPORT build-with-pip
 
-%prep
-%setup -n %{my_name}-%{realversion}
-
-%build
-python setup.py build
-
-%install
-python setup.py install --single-version-externally-managed --record=/dev/null  --prefix=%{i}
-find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -rf
-perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/rootpy %{i}/bin/roosh %{i}/bin/root2hdf5

--- a/py2-rootpy.spec
+++ b/py2-rootpy.spec
@@ -1,0 +1,18 @@
+### RPM external py2-rootpy 0.8.0
+## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
+%define my_name %(echo %n | cut -f2 -d-)
+Source: https://github.com/rootpy/%my_name/archive/%{realversion}.tar.gz
+
+Requires: python root py2-matplotlib root
+BuildRequires: py2-setuptools
+
+%prep
+%setup -n %{my_name}-%{realversion}
+
+%build
+python setup.py build
+
+%install
+python setup.py install --single-version-externally-managed --record=/dev/null  --prefix=%{i}
+find %{i}/${PYTHON_LIB_SITE_PACKAGES} -name '*.egg-info' -print0 | xargs -0 rm -rf
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/rootpy %{i}/bin/roosh %{i}/bin/root2hdf5


### PR DESCRIPTION
Introduce the ability to build python packages from pip. More testing is certainly needed, however current implementation checks for any dependencies being installed by pip and fails in the case that there are (so still a one to one mapping of python package to spec file). 

Two examples are added (py2-configparser and py2-entrypoints) that confirm that dependencies are handled correctly (both are part of the stack of dependencies that jupiter depends on).

The main outstanding issue is to retain the source somehow..

Otherwise, I add rootpy (which I will eventually change to install via pip...)