### PR TITLE
Add a SCRAM toolfile for Intel VTune

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -191,6 +191,7 @@ Requires: tkonlinesw-toolfile
 Requires: py2-cx-oracle-toolfile
 Requires: oracle-toolfile
 Requires: cuda-toolfile
+Requires: intel-vtune
 Requires: openloops-toolfile
 
 %if %isslc
@@ -202,7 +203,7 @@ Requires: oracle-fake-toolfile
 %endif
 %endif
 
-%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler cuda rivet2 opencl opencl-cpp
+%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler cuda rivet2 opencl opencl-cpp intel-vtune
 
 ## IMPORT scramv1-tool-conf
 

--- a/intel-vtune.spec
+++ b/intel-vtune.spec
@@ -1,0 +1,26 @@
+### RPM external intel-vtune 2017.0.2.478468
+## NOCOMPILER
+
+%prep
+
+%build
+
+%install
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/intel-vtune.xml
+<tool name="intel-vtune" version="%{realversion}">
+  <info url="https://software.intel.com/en-us/intel-vtune-amplifier-xe"/>
+  <client>
+    <environment name="INTEL_VTUNE_BASE" default="/afs/cern.ch/sw/IntelSoftware/linux/x86_64/xe2017/vtune_amplifier_xe_%{realversion}"/>
+    <environment name="BINDIR" default="$INTEL_VTUNE_BASE/bin64"/>
+  </client>
+  <runtime name="PATH" value="$INTEL_VTUNE_BASE/bin64" type="path"/>
+  <runtime name="VTUNE_AMPLIFIER_XE_2017_DIR" value="$INTEL_VTUNE_BASE"/>
+</tool>
+EOF_TOOLFILE
+
+%post
+if [ "$CMS_INSTALL_PREFIX" = "" ] ; then CMS_INSTALL_PREFIX=$RPM_INSTALL_PREFIX; export CMS_INSTALL_PREFIX; fi
+%{relocateConfig}etc/scram.d/*.xml
+echo "INTEL_VTUNE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
+echo "set INTEL_VTUNE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh


### PR DESCRIPTION
Add back a tool file for Intel VTune.
It does not export the ittnotify library dependency any more (that lives in the ittnotify tool) and is an optional tool.

The idea is for people to be able to just do
```
scram setup intel-vtune
cmsenv 
```
in order to use it.