### PR TITLE
update build rules tag to V05-05-19

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-18
+%define configtag       V05-05-19
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
New tag contains fixes for
  - llvm-ccdb rule to use full file name in compile_commands.json to avoid clang-tidy crashes
  - Bug fix: make sure that python symlinks are generated when ```scram build <packag-name>``` type commands are run