### PR TITLE
config tag updated; generate llvm-ccdb for cmssw projects

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -63,7 +63,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-19
+%define configtag       V05-05-20
 %endif
 
 %if "%{?cvssrc:set}" != "set"
@@ -195,6 +195,7 @@ export SCRAM_NOSYMCHECK=true
 %scramcmd b --verbose -f %{prebuildtarget} </dev/null
 %endif
 
+case %n in (cmssw|cmssw-patch) %scramcmd b -f -k %{makeprocesses} llvm-ccdb </dev/null || true ;; esac
 %scramcmd b --verbose -f %{compileOptions} %{extraOptions} %{makeprocesses} %{buildtarget} </dev/null || { touch ../build-errors && %scramcmd b -f outputlog && [ "%{?ignore_compile_errors:set}" == "set" ]; }
 
 %if "%{?additionalBuildTarget0:set}" == "set"


### PR DESCRIPTION
New cmssw-config tag V05-05-20 avoids picking up makefile fragments for deleted packages from release,