### PR TITLE
Herwig7: Changed include directive in toolfile

### DIFF
--- a/herwigpp-toolfile.spec
+++ b/herwigpp-toolfile.spec
@@ -12,7 +12,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/herwigpp.xml
   <client>
     <environment name="HERWIGPP_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$HERWIGPP_BASE/lib/Herwig"/>
-    <environment name="INCLUDE" default="$HERWIGPP_BASE/include/Herwig"/>
+    <environment name="INCLUDE" default="$HERWIGPP_BASE/include"/>
     <environment name="BINDIR" default="$HERWIGPP_BASE/bin"/>
   </client>
   <runtime name="HERWIGPATH" value="$HERWIGPP_BASE/share/Herwig"/>

--- a/thepeg-toolfile.spec
+++ b/thepeg-toolfile.spec
@@ -14,7 +14,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/thepeg.xml
   <client>
     <environment name="THEPEG_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$THEPEG_BASE/lib/ThePEG"/>
-    <environment name="INCLUDE" default="$THEPEG_BASE/include/ThePEG"/>
+    <environment name="INCLUDE" default="$THEPEG_BASE/include"/>
   </client>
   <runtime name="THEPEGPATH" value="$THEPEG_BASE/share/ThePEG"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>


### PR DESCRIPTION
I just adjusted the include directive in the toolfile of ThePEG and Herwig7, so that I can make a PR for the upcoming Herwig7 interface soon.

Since this PR does not break anything, testing is not required IMHO. You can just merge this PR.