### PR TITLE
zlib: experimental changes (SSE4.2, PCLMUL, AVX2)

### DIFF
--- a/zlib-build.file
+++ b/zlib-build.file
@@ -1,0 +1,32 @@
+#Build ZLIB
+
+%prep
+%setup -n zlib-%{realversion}
+
+%build
+%if "%{cmscompiler}" == "icc"
+%define cfgopts CC="icc -fPIC"
+%else
+%define cfgopts %{nil}
+%endif
+
+case %{cmsplatf} in
+   *_amd64_*|*_mic_*)
+     CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1 -msse3" \
+     ./configure --prefix=%{i}
+     ;;
+   *_armv7hl_*|*_aarch64_*|*_ppc64le_*)
+     CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1" \
+     ./configure --prefix=%{i}
+     ;;
+   *)
+     %{cfgopts} ./configure --prefix=%{i}
+     ;;
+esac
+
+make %{makeprocesses}
+
+# Strip libraries, we are not going to debug them.
+%define strip_files %{i}/lib
+# Look up documentation online.
+%define drop_files %{i}/share

--- a/zlib-build.file
+++ b/zlib-build.file
@@ -4,11 +4,6 @@
 %setup -n zlib-%{realversion}
 
 %build
-%if "%{cmscompiler}" == "icc"
-%define cfgopts CC="icc -fPIC"
-%else
-%define cfgopts %{nil}
-%endif
 
 case %{cmsplatf} in
    *_amd64_*|*_mic_*)
@@ -20,7 +15,7 @@ case %{cmsplatf} in
      ./configure --prefix=%{i}
      ;;
    *)
-     %{cfgopts} ./configure --prefix=%{i}
+     ./configure --prefix=%{i}
      ;;
 esac
 

--- a/zlib-non-x86_64.spec
+++ b/zlib-non-x86_64.spec
@@ -1,0 +1,4 @@
+### RPM external zlib-non-x86_64 1.2.8
+Source: http://zlib.net/zlib-%{realversion}.tar.gz
+
+## IMPORT zlib-build

--- a/zlib-x86_64.spec
+++ b/zlib-x86_64.spec
@@ -1,0 +1,7 @@
+### RPM external zlib-x86_64 1.2.8
+%define git_repo cms-externals
+%define git_branch cms/v1.2.8
+%define git_commit 822f7f5a8c57802faf8bbfe16266be02eff8c2e2
+Source0: git://github.com/%{git_repo}/zlib.git?obj=%{git_branch}/%{git_commit}&export=zlib-%{realversion}&output=/zlib-%{realversion}.tgz
+
+## IMPORT zlib-build

--- a/zlib.spec
+++ b/zlib.spec
@@ -1,5 +1,5 @@
 ### RPM external zlib 1.0
-%if "%{_arch}" == "x86_64"
+%ifarch x86_64
 Requires: zlib-x86_64
 %define ZLIB_PKG ZLIB_X86_64
 %else

--- a/zlib.spec
+++ b/zlib.spec
@@ -1,33 +1,16 @@
-### RPM external zlib 1.2.8
-Source: http://zlib.net/%{n}-%{realversion}.tar.gz
-
-%prep
-%setup -n %{n}-%{realversion}
-
-%build
-%if "%{cmscompiler}" == "icc"
-%define cfgopts CC="icc -fPIC"
+### RPM external zlib 1.0
+%if "%{_arch}" == "x86_64"
+Requires: zlib-x86_64
+%define ZLIB_PKG ZLIB_X86_64
 %else
-%define cfgopts %{nil}
+Requires: zlib-non-x86_64
+%define ZLIB_PKG ZLIB_NON_X86_64
 %endif
 
-case %{cmsplatf} in
-   *_amd64_*|*_mic_*)
-     CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1 -msse3" \
-     ./configure --prefix=%{i}
-     ;;
-   *_armv7hl_*|*_aarch64_*|*_ppc64le_*)
-     CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1" \
-     ./configure --prefix=%{i}
-     ;;
-   *)
-     %{cfgopts} ./configure --prefix=%{i}
-     ;;
-esac
+%prep
+%build
+%install
+%post
+cp ${RPM_INSTALL_PREFIX}/%{cmsplatf}/$(echo %{directpkgreqs} | tr ' ' '\n' | grep /zlib-)/etc/profile.d/init.* ${RPM_INSTALL_PREFIX}/%{pkgrel}/etc/profile.d
+sed -i -e 's|%{ZLIB_PKG}_|ZLIB_|' ${RPM_INSTALL_PREFIX}/%{pkgrel}/etc/profile.d/init.*
 
-make %{makeprocesses}
-
-# Strip libraries, we are not going to debug them.
-%define strip_files %{i}/lib
-# Look up documentation online.
-%define drop_files %{i}/share


### PR DESCRIPTION
This is identical to #2795 but zlib package now either depends on zlib-x86_64 or zlib-non-x86_64.

The following is a mix of Cloudfare + Brian + orignal zlib. Some
internal functions are implemented with SSE4.2, PCLMUL and AVX2.
Those are picked at load time. This still builds on "generic" machine.