### PR TITLE
builds pycurl with openssl option, fix import pycurl with proper backend

### DIFF
--- a/py2-pycurl.spec
+++ b/py2-pycurl.spec
@@ -2,8 +2,9 @@
 ## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
 
 
+%define PipBuildOptions --global-option="--with-openssl" --global-option="--openssl-dir=${OPENSSL_ROOT}" 
 %define pip_name pycurl
-Requires: curl
+Requires: curl openssl
 
 ## IMPORT build-with-pip
 


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/issues/17483