### PR TITLE
create only toolfile per py2 package for pip packages insteaded in pippkgs

### DIFF
--- a/py2-pippkgs-toolfile.spec
+++ b/py2-pippkgs-toolfile.spec
@@ -18,6 +18,14 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pippkgs.xml
 </tool>
 EOF_TOOLFILE
 
+for pkg in $(grep '^[%]define  *builddirectpkgreqs  *external/' %{cmsroot}/SPECS/external/py2-pippkgs/$PY2_PIPPKGS_VERSION/spec | sed 's|.* builddirectpkgreqs *||' | tr ' ' '\n' | grep '/py2-')  ; do
+  pk_name=$(echo $pkg | cut -d/ -f2)
+  pk_ver=$(echo $pkg | cut -d/ -f3)
+  echo "<tool name=\"$pk_name\" version=\"$pk_ver\">" > %{i}/etc/scram.d/$pk_name.xml
+  echo "  <use name=\"py2-pippkgs\"/>" >> %{i}/etc/scram.d/$pk_name.xml
+  echo "</tool>" >> %{i}/etc/scram.d/$pk_name.xml
+done
+
 export PYTHON_LIB_SITE_PACKAGES
 
 ## IMPORT scram-tools-post


### PR DESCRIPTION
@davidlange6 , this PR creates one toolfile per py2-package which is deployed in py2-pippkgs tool. This will allow us to run 
```
scram tool list | grep py2-
 py2-pippkgs          3.0-cms2  
 py2-dablooms         0.9.1-oenich2
 py2-pysqlite         2.8.1-oenich2
 py2-h5py             2.6.0-oenich2
 py2-pippkgs_depscipy 2.0-ogepgl
 py2-pygithub         1.23.0-oenich2
 py2-pyyaml           3.11-oenich2
 py2-root_numpy       4.6.0-oenich
 py2-appdirs          1.4.0     
 py2-argparse         1.4.0     
 py2-backports_abc    0.5       
```
to see which py2- packages are part of a release and what are their versions. We can then also use 
```<use name="py2-package-name"/>```
instead of 
```<use name="py2-pippkgs"/>```