### PR TITLE
relocate blackhat config/la files to avoid hardcoded buildpath

### DIFF
--- a/blackhat.spec
+++ b/blackhat.spec
@@ -28,3 +28,8 @@ chmod +x ./config.{sub,guess}
 make %{makeprocesses}
 %install
 make install
+
+%post
+%{relocateConfig}lib/blackhat/lib*.la
+%{relocateConfig}bin/blackhat-config
+%{relocateConfig}bin/dataInstall


### PR DESCRIPTION
Looks like sherpa picks up hard-coded build paths of blackhat and fails
```
libtool: compile:  g++ -Wl,--no-as-needed -DHAVE_CONFIG_H -I. -I../.. -I../../ATOOLS/Org -I../.. -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a13024db34d10b69c878c16413f2aa88/opt/cmssw/slc6_amd64_gcc530/external/blackhat/0.9.9-oenich2/include -g -O2 -fuse-cxa-atexit -O2 -std=c++0x -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/lhapdf/6.1.6-oenich3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/blackhat/0.9.9-oenich2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -MT libSherpaBlackHat_la-BlackHat_Interface.lo -MD -MP -MF .deps/libSherpaBlackHat_la-BlackHat_Interface.Tpo -c BlackHat_Interface.C  -fPIC -DPIC -o .libs/libSherpaBlackHat_la-BlackHat_Interface.o
cc1plus: error: /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a13024db34d10b69c878c16413f2aa88/opt/cmssw/slc6_amd64_gcc530/external/blackhat/0.9.9-oenich2/include: Permission denied
make[3]: *** [libSherpaBlackHat_la-BlackHat_Interface.lo] Error 1
make[3]: Leaving directory `/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/BUILD/slc6_amd64_gcc530/external/sherpa/2.2.1-oenich5/sherpa-2.2.1/AddOns/BlackHat'
```