### PR TITLE
Create prefix directories before calling pip

### DIFF
--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -18,6 +18,7 @@ BuildRequires: py2-pip
 %prep
 
 %build
+mkdir -p %{i}
 
 tar xfz %{_sourcedir}/source.tar.gz
 


### PR DESCRIPTION
`create_home_path` from `lib/python2.7/distutils/command/install.py` is
responsible for creating prefix (part of installation) directory. By default
it's created with 0700 permission, instead of default umask 0755. According to
Python documention mode while creating directories can be ignored on some
systems thus one should always use os.chmod to set correct permission afterwards.

If prefix directories are created with 0700 we will get conflicts from RPM
while trying to install pip based packages.

We use `mkdir -p %{i}` to create prefix directory with correct umask to get 0755
permissions.

Signed-off-by: David Abdurachmanov <david.abdurachmanov@gmail.com>