### PR TITLE
update autotools

### DIFF
--- a/autotools.spec
+++ b/autotools.spec
@@ -78,6 +78,7 @@ pushd %_builddir/gettext-%{gettext_version}
               --disable-dependency-tracking \
               --disable-silent-rules \
               --with-included-glib \
+              --with-included-libunistring \
               --with-included-libcroco
   make %makeprocesses && make install
 popd


### PR DESCRIPTION
Force gettext to build with internal libunistring instead of system one (if available).