### PR TITLE
relocate py2-sympy/bin/isympy to not have full python path

### DIFF
--- a/py2-sympy.spec
+++ b/py2-sympy.spec
@@ -1,7 +1,7 @@
 ### RPM external py2-sympy 1.0
 ## INITENV +PATH PYTHONPATH %{i}/$PYTHON_LIB_SITE_PACKAGES
 
-
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/isympy
 %define pip_name sympy
 Requires: py2-mpmath 
 


### PR DESCRIPTION
Looks like rpm IB/CMSSW_9_0_X/gcc530 does not catch this which rpm used in gcc6X does