### PR TITLE
use icc from /cvmfs/projects.cern.ch

### DIFF
--- a/icc-gcc-toolfile.spec
+++ b/icc-gcc-toolfile.spec
@@ -28,7 +28,6 @@ fi
 export ICC_ROOT=$ICC_SCRAM_ROOT
 export ICC_VERSION=ICC_SCRAM_VERSION
 export GCC_ROOT
-export INTEL_LICENSE_FILE
 
 mkdir -p %i/etc/scram.d
 # Generic template for the toolfiles. 
@@ -38,8 +37,6 @@ mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/intel-license.xml
   <tool name="intel-license" version="@ICC_VERSION@">
     <runtime name="INTEL_LICENSE_FILE" value="28518@AT@lxlicen01.cern.ch,28518@AT@lxlicen02.cern.ch,28518@AT@lxlicen03.cern.ch" type="path" handler="warn"/>
-    <runtime name="INTEL_LICENSE_FILE" value="@INTEL_LICENSE_FILE@" type="path" handler="warn"/>
-    <runtime name="INTEL_LICENSE_FILE" value="/opt/intel/licenses" type="path" handler="warn"/>
   </tool>
 EOF_TOOLFILE
 

--- a/icc-scram.spec
+++ b/icc-scram.spec
@@ -1,10 +1,9 @@
-### RPM cms icc-scram 2017.0.098
-## INITENV SETV INTEL_LICENSE_FILE /afs/cern.ch/sw/IntelSoftware/linux/x86_64/xe2017/beta_license/BETA____B92M-3G387F6M.LIC
+### RPM cms icc-scram 2017.2.174
 ## NOCOMPILER
 Requires: icc-provides
 %prep
 %build
 %install
 cd %i
-ln -s /afs/cern.ch/sw/IntelSoftware/linux/x86_64/xe2017/compilers_and_libraries_%{realversion}/linux installation
-ln -s /afs/cern.ch/sw/IntelSoftware/linux/x86_64/xe2017/compilers_and_libraries_%{realversion}/linux ifort
+ln -s /cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2017/compilers_and_libraries_%{realversion}/linux installation
+ln -s /cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2017/compilers_and_libraries_%{realversion}/linux ifort

--- a/icc.spec
+++ b/icc.spec
@@ -1,4 +1,4 @@
-### RPM external icc composer_xe_2013.2.146
+### RPM external icc 2017.2.174
 ## NOCOMPILER
 Source: none
 Provides: libimf.so()(64bit)
@@ -10,4 +10,5 @@ Provides: libsvml.so()(64bit)
 %build
 %install
 %post
-ln -s /afs/cern.ch/sw/IntelSoftware/linux/x86_64/xe2013/%{realversion} $RPM_INSTALL_PREFIX/%{pkgrel}/installation
+ln -s /cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2017/compilers_and_libraries_%{realversion}/linux $RPM_INSTALL_PREFIX/%{pkgrel}/installation
+

--- a/intel-vtune.spec
+++ b/intel-vtune.spec
@@ -1,4 +1,4 @@
-### RPM external intel-vtune 2017.0.2.478468
+### RPM external intel-vtune 2017.2.0.499904
 ## NOCOMPILER
 
 %prep
@@ -11,7 +11,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/intel-vtune.xml
 <tool name="intel-vtune" version="%{realversion}">
   <info url="https://software.intel.com/en-us/intel-vtune-amplifier-xe"/>
   <client>
-    <environment name="INTEL_VTUNE_BASE" default="/afs/cern.ch/sw/IntelSoftware/linux/x86_64/xe2017/vtune_amplifier_xe_%{realversion}"/>
+    <environment name="INTEL_VTUNE_BASE" default="/cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2017/vtune_amplifier_xe_%{realversion}"/>
     <environment name="BINDIR" default="$INTEL_VTUNE_BASE/bin64"/>
   </client>
   <runtime name="PATH" value="$INTEL_VTUNE_BASE/bin64" type="path"/>


### PR DESCRIPTION
To avoid AFS dependency we now have intel compiler available under /cvmfs/projects.cern.ch