### PR TITLE
create scram toolfile for individual py2-pippkgs_depscipy packages

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -142,7 +142,6 @@ Requires: eigen-toolfile
 Requires: gdb-toolfile
 Requires: file-toolfile
 Requires: libxslt-toolfile
-Requires: py2-six-toolfile
 Requires: giflib-toolfile
 Requires: freetype-toolfile
 Requires: utm-toolfile
@@ -151,7 +150,6 @@ Requires: CSCTrackFinderEmulation-toolfile
 Requires: tinyxml-toolfile
 Requires: scons-toolfile
 Requires: md5-toolfile
-Requires: py2-setuptools-toolfile
 Requires: madgraph5amcatnlo-toolfile
 Requires: histogrammar-toolfile
 Requires: py2-pippkgs-toolfile

--- a/py2-pippkgs_depscipy-toolfile.spec
+++ b/py2-pippkgs_depscipy-toolfile.spec
@@ -18,6 +18,14 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pippkgs_depscipy.xml
 </tool>
 EOF_TOOLFILE
 
+for pkg in $(grep '^[%]define  *builddirectpkgreqs  *external/' %{cmsroot}/SPECS/external/py2-pippkgs_depscipy/$PY2_PIPPKGS_DEPSCIPY_VERSION/spec | sed 's|.* builddirectpkgreqs *||' | tr ' ' '\n' | grep '/py2-')  ; do
+  pk_name=$(echo $pkg | cut -d/ -f2)
+  pk_ver=$(echo $pkg | cut -d/ -f3)
+  echo "<tool name=\"$pk_name\" version=\"$pk_ver\">" > %{i}/etc/scram.d/$pk_name.xml
+  echo "  <use name=\"py2-pippkgs_depscipy\"/>" >> %{i}/etc/scram.d/$pk_name.xml
+  echo "</tool>" >> %{i}/etc/scram.d/$pk_name.xml
+done
+
 export PYTHON_LIB_SITE_PACKAGES
 
 ## IMPORT scram-tools-post


### PR DESCRIPTION
 - generate individual toolfiles for pippkgs_depscipy.
 - cleanup  cmssw-tool-conf drop py2-six-toolfile and py2-setuptools-toolfile which are part of py2-pippkgs