### PR TITLE
To avoid latency disable uniq sorting by default and made it optional

### DIFF
--- a/dasgoclient-binary.spec
+++ b/dasgoclient-binary.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient-binary v00.00.05
+### RPM cms dasgoclient-binary v00.00.06
 Source0: git+https://github.com/vkuznet/dasgoclient?obj=master/%{realversion}&export=dasgoclient&output=/dasgoclient.tar.gz
 Source1: git+https://github.com/vkuznet/cmsauth?obj=master/e9fca92e3335252a5f71d8e6d09c64012f7d3c0c&export=github.com/vkuznet/cmsauth&output=/cmsauth.tar.gz
 Source2: git+https://github.com/vkuznet/x509proxy?obj=master/b4622388b3a347c8df75b6e944e9d2a580acee60&export=github.com/vkuznet/x509proxy&output=/x509proxy.tar.gz

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v00.00.05
+### RPM cms dasgoclient v00.00.06
 ## NOCOMPILER
 %define dasgoclient_arch     slc6_amd64_gcc530
 %define dasgoclient_pkg      cms+%{n}-binary+%{realversion}


### PR DESCRIPTION
I found that recent change to use unique results may significantly hurt performance for large queries, such as `file dataset=/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW` which returns 125K+ LFNs. Sorting of such list will take a minute and not really necessary. While for other DAS queries, such as site for given dataset, it is required since users want to see final set of sites, while results shows all possible replicas. As compromise I made unique flag and made it optional. By default sorting/uniq is disabled to provide ability to look-up results as fast as possible.