### PR TITLE
disable atlas usage in py2-numpy

### DIFF
--- a/py2-numpy.spec
+++ b/py2-numpy.spec
@@ -16,6 +16,7 @@ esac
 export LAPACK_ROOT
 export LAPACK=$LAPACK_ROOT/lib/liblapack.$SONAME
 export BLAS=$LAPACK_ROOT/lib/libblas.$SONAME
+export ATLAS=None
 mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 
 python setup.py build --fcompiler=gnu95


### PR DESCRIPTION
if atlas package is installed on system then py2-numpy picks it up from system but as we do not seed atlas in our bootstrap so it is an issue.
If we need atlas package then we should add it in our externals.