### PR TITLE
add forgotten funcsigs python package

### DIFF
--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -29,7 +29,7 @@ if [ `cat files.list | wc -l` == "1" ] ; then
    echo ${PIPFILE}
    export PYTHONUSERBASE=%i
    pip list
-   pip install --user %{PipBuildOptions} $PIPFILE
+   pip install --user -v %{PipBuildOptions} $PIPFILE
 else
    echo "Sorry I don't know how to handle no/multiple install files yet"
    cat %{_sourcedir}/files.txt

--- a/py2-pippkgs.spec
+++ b/py2-pippkgs.spec
@@ -76,6 +76,7 @@ BuildRequires: py2-pbr
 BuildRequires: py2-mpmath
 BuildRequires: py2-sympy
 BuildRequires: py2-tqdm
+BuildRequires: py2-funcsigs
 
 %prep
 


### PR DESCRIPTION
the spec is already there and in use, but only as build requires.