### PR TITLE
Change python to unicode ucs4

### DIFF
--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -29,7 +29,7 @@ if [ `cat files.list | wc -l` == "1" ] ; then
    echo ${PIPFILE}
    export PYTHONUSERBASE=%i
    pip list
-   pip install --user %{PipBuildOptions} $PIPFILE
+   pip install --user -v %{PipBuildOptions} $PIPFILE
 else
    echo "Sorry I don't know how to handle no/multiple install files yet"
    cat %{_sourcedir}/files.txt

--- a/py2-pippkgs.spec
+++ b/py2-pippkgs.spec
@@ -76,6 +76,7 @@ BuildRequires: py2-pbr
 BuildRequires: py2-mpmath
 BuildRequires: py2-sympy
 BuildRequires: py2-tqdm
+BuildRequires: py2-funcsigs
 
 %prep
 

--- a/python.spec
+++ b/python.spec
@@ -79,7 +79,7 @@ sed -ibak "s|LIBFFI_INCLUDEDIR=.*|LIBFFI_INCLUDEDIR=\"${LIBFFI_ROOT}/include\"|g
   --prefix=%{i} \
   --enable-shared \
   --with-system-ffi \
-  --with-system-expat \
+  --with-system-expat --enable-unicode=ucs4 \
   $additionalConfigureOptions
 
 # Modify pyconfig.h to match macros from GLIBC features.h on Linux machines.


### PR DESCRIPTION
avoids the need for building tensor flow from source.  From what I read, this is the "typical" way of building python, but it is different from the default on SLC6/centos7. Basic tests (building cmssw, running relvals, python interactively) all look ok to me.

Would like to try in devel for now (even if that means I will ask for a slc7 version of devel....)