### PR TITLE
clnag version fix (4.0.0-mlhled2 to 3.8.0)

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -1,4 +1,4 @@
-### RPM external llvm 4.0.0
+### RPM external llvm 3.8.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHONPATH %{i}/lib64/python$(echo $PYTHON_VERSION | cut -d. -f 1,2)/site-packages
 


### PR DESCRIPTION
clang version was 4.0.0 in the specs wrt the real version being 3.8.0 (Mentioned by Andrea Bocci). This commit provides the fix to avoid ambiguity.