### PR TITLE
Add py2-jsonpickle packages

### DIFF
--- a/py2-jsonpickle.spec
+++ b/py2-jsonpickle.spec
@@ -1,0 +1,7 @@
+### RPM external py2-jsonpickle 0.9.4
+## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
+
+%define pip_name jsonpickle
+
+## IMPORT build-with-pip
+

--- a/py2-pippkgs.spec
+++ b/py2-pippkgs.spec
@@ -81,6 +81,7 @@ BuildRequires: py2-nose
 BuildRequires: py2-pkgconfig
 BuildRequires: py2-pysqlite
 BuildRequires: py2-click
+BuildRequires: py2-jsonpickle
 
 %prep
 


### PR DESCRIPTION
This packages allows to dump Python objects in JSON format which is much
more human readable than standard pickle format.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>