### PR TITLE
Set DYNAMIC_ARCH and NUM_THREADS

### DIFF
--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -8,9 +8,9 @@ Source: https://github.com/xianyi/OpenBLAS/archive/v%{realversion}.tar.gz
 
 # PRESCOTT is a generic x86-64 target https://github.com/xianyi/OpenBLAS/issues/685 
 %ifarch x86_64
-make %{makeprocesses} FC=gfortran BINARY=64 TARGET=PENRYN 
+make %{makeprocesses} FC=gfortran BINARY=64 TARGET=PENRYN NUM_THREADS=256 DYNAMIC_ARCH=0
 %else
-make %{makeprocesses} FC=gfortran BINARY=64
+make %{makeprocesses} FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=0
 %endif
 
 %install


### PR DESCRIPTION
Make sure that we don't build multi-libs, instead we have on generic
library. Set NUM_THREADS otherwise it will be set to number of cores on
build machine. Fedora is using 128 as default, but we already have
machines with higher number of threads. Thus let's pick 256.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>