### PR TITLE
set env CMSSW_FULL_RELEASE_BASE for full release used in a patch release

### DIFF
--- a/cmssw-toolfile.spec
+++ b/cmssw-toolfile.spec
@@ -21,6 +21,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cmssw.xml
   <runtime name="PYTHONPATH" value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHONPATH" value="$LIBDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="CMSSW_FULL_RELEASE_BASE" value="$CMSSW_BASE"/>
   <use name="root_cxxdefaults"/>
 </tool>
 EOF_TOOLFILE


### PR DESCRIPTION
backported from devel IBs