### PR TITLE
Update scram-project-build.file

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -63,7 +63,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-23
+%define configtag       V05-05-24
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
use new build rule tag V05-05-24 which contains a bug fix for python/*__init__.py files. Previously there was a chance that two build process can write in the same __init__.py file at same time.