### PR TITLE
Updating Fireworks-Geometry to new tag V07-05-02

### DIFF
--- a/data-Fireworks-Geometry.spec
+++ b/data-Fireworks-Geometry.spec
@@ -1,4 +1,4 @@
-### RPM cms data-Fireworks-Geometry V07-05-01
+### RPM cms data-Fireworks-Geometry V07-05-02
 
 %prep
 


### PR DESCRIPTION
Description of PR on cmsdata is "Set default geometry to 2017 geometry #7",
PR: https://github.com/cms-data/Fireworks-Geometry/pull/7