### PR TITLE
Update PHEDEX-datasvc.spec for a new release 2.3.24 .

### DIFF
--- a/PHEDEX-datasvc.spec
+++ b/PHEDEX-datasvc.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-datasvc 2.3.23
+### RPM cms PHEDEX-datasvc 2.3.24
 ## INITENV +PATH PERL5LIB %i/perl_lib
 
 %define downloadn %(echo %n | cut -f1 -d-)


### PR DESCRIPTION
Changes in PHEDEX data service 2.3.24:

BlockTestFiles  API:  
 - fix inconsistent required parameters, see https://github.com/dmwm/PHEDEX/issues/1081

TransferHistory API: 
    - explain the try_ values and the limitations of their use, see details in https://github.com/dmwm/PHEDEX/issues/1087