### PR TITLE
update pandas version to 0.20.1 for 9_2_X

### DIFF
--- a/py2-pandas.spec
+++ b/py2-pandas.spec
@@ -1,4 +1,4 @@
-### RPM external py2-pandas 0.19.2
+### RPM external py2-pandas 0.20.1
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 
 %define pip_name pandas


### PR DESCRIPTION
I wonder if it is ok to upgrade the pandas version to 0.20.1 from 0.19.2.

In particular, I am interested in [feather](https://blog.rstudio.org/2016/03/29/feather/), which became [available](http://pandas.pydata.org/pandas-docs/version/0.20/io.html#io-feather) from 0.20.



