### PR TITLE
Upgrade pythia8 to 226

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,8 +1,8 @@
-### RPM external pythia8 212
+### RPM external pythia8 226
 
 Requires: hepmc lhapdf
 
-%define tag 2c5a4f204767dfd62849eb01c9b70b4ff16311a9
+%define tag 1dfa81bc0b3efa66793deb50b63eaf85d42e4dd2
 %define branch cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
Use cms-externals/pythia8 repo for sources: this replaces https://github.com/cms-sw/cmsdist/pull/3004
It should go with cms-sw/cmssw#18567