### PR TITLE
fix utm build for gcc630/700 where looks like boost is messing up with std namespace

### DIFF
--- a/utm-0.6.4-boost-and-transform-fix.patch
+++ b/utm-0.6.4-boost-and-transform-fix.patch
@@ -1,0 +1,82 @@
+diff --git a/tmEventSetup/tmEventSetup.cc b/tmEventSetup/tmEventSetup.cc
+index 3910a28..a1ce3f9 100644
+--- a/tmEventSetup/tmEventSetup.cc
++++ b/tmEventSetup/tmEventSetup.cc
+@@ -4,15 +4,41 @@
+ #include "tmEventSetup/esTriggerMenuHandle.hh"
+ #include "tmEventSetup/tmEventSetup.hh"
+ 
+-// boost
+-#include <boost/lexical_cast.hpp>
+-
+ // stl
+ #include <algorithm>
+ #include <cmath>
+ 
+ namespace tmeventsetup
+ {
++void
++applySin(std::vector<double>& array, const size_t n)
++{
++  const size_t offset = std::min(n, array.size());
++  std::transform(array.begin(), array.begin() + offset, array.begin(), ::sin);
++}
++
++
++void
++applyCos(std::vector<double>& array, const size_t n)
++{
++  const size_t offset = std::min(n, array.size());
++  std::transform(array.begin(), array.begin() + offset, array.begin(), ::cos);
++}
++
++
++void
++applyCosh(std::vector<double>& array, const size_t n)
++{
++  const size_t offset = std::min(n, array.size());
++  std::transform(array.begin(), array.begin() + offset, array.begin(), ::cosh);
++}
++} //end of namespace tmeventsetup
++
++// boost
++#include <boost/lexical_cast.hpp>
++
++namespace tmeventsetup
++{
+ 
+ // TODO: better to define with tmGrammar?
+ const std::string GRAMMAR_VERSION = "0.6";
+@@ -529,30 +555,6 @@ getDeltaVector(std::vector<double>& array,
+   return n;
+ }
+ 
+-
+-void
+-applySin(std::vector<double>& array, const size_t n)
+-{
+-  const size_t offset = std::min(n, array.size());
+-  std::transform(array.begin(), array.begin() + offset, array.begin(), ::sin);
+-}
+-
+-
+-void
+-applyCos(std::vector<double>& array, const size_t n)
+-{
+-  const size_t offset = std::min(n, array.size());
+-  std::transform(array.begin(), array.begin() + offset, array.begin(), ::cos);
+-}
+-
+-
+-void
+-applyCosh(std::vector<double>& array, const size_t n)
+-{
+-  const size_t offset = std::min(n, array.size());
+-  std::transform(array.begin(), array.begin() + offset, array.begin(), ::cosh);
+-}
+-
+ } // namespace tmeventsetup
+ 
+-/* eof */
+\ No newline at end of file
++/* eof */

--- a/utm.spec
+++ b/utm.spec
@@ -3,9 +3,11 @@ Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}
 BuildRequires: gmake
 Requires: xerces-c
 Requires: boost
+Patch0: utm-0.6.4-boost-and-transform-fix
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 export XERCES_C_BASE=${XERCES_C_ROOT}


### PR DESCRIPTION
This is just a workaround to avoid the utm build error for gcc630 and gcc700. A proper fix should go in utm.
