### PR TITLE
update cmssw-config(build rules) tag to V05-05-25

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-24
+%define configtag       V05-05-25
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
backport of #3116

new tag generates python/package/__init__.py for all the packages (even if there is no src/package/python directory). This fixes the issue we have seen due to PR https://github.com/cms-sw/cmssw/pull/19360 where RecoLocalTracker/Phase2ITPixelClusterizer/python was deleted and we only noticed the problem when full release was built.

New build rules also create python/package/__init__.py for deleted packages