### PR TITLE
Update py2-rootpy.spec

### DIFF
--- a/py2-rootpy.spec
+++ b/py2-rootpy.spec
@@ -1,4 +1,4 @@
-### RPM external py2-rootpy 0.9.0
+### RPM external py2-rootpy 0.9.1
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 
 


### PR DESCRIPTION
new version contains the fix https://github.com/rootpy/rootpy/commit/ef99f63d13a665afad3384ba67888f4b5fad4668 which is needed with root 6.10 releases