### PR TITLE
Update scram-project-build.file

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -63,7 +63,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-25
+%define configtag       V05-05-26
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Build rules tag V05-05-26 added. New build rules are avilable now
- scram build style-check
   * To run clang-tidy
- scram build style-apply
   * To apply the clang-tidy checks
- scram build style
   * to run and apply clang-tidy checks
- scram build format
   * To run clang-format