### PR TITLE
Update data-L1Trigger-L1TCalorimeter.spec

### DIFF
--- a/data-L1Trigger-L1TCalorimeter.spec
+++ b/data-L1Trigger-L1TCalorimeter.spec
@@ -1,4 +1,4 @@
-### RPM cms data-L1Trigger-L1TCalorimeter V01-00-21
+### RPM cms data-L1Trigger-L1TCalorimeter V01-00-22
 
 %prep
 


### PR DESCRIPTION
As requested https://github.com/cms-data/L1Trigger-L1TCalorimeter/pull/21
- Two LUTs to 93x.
- They reflect recent Calo conditions used at P5.
- Needed for upcoming PR.