### PR TITLE
update html5lib to be consistent with jupyter stack requirements

### DIFF
--- a/py2-html5lib.spec
+++ b/py2-html5lib.spec
@@ -1,7 +1,5 @@
-### RPM external py2-html5lib 0.9999999
+### RPM external py2-html5lib 0.999999999
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
-
-#bleach can not currently use anything newer than 0.9999999 (7 9s)
 
 %define pip_name html5lib
 Requires: py2-ordereddict py2-six py2-packaging py2-setuptools py2-webencodings py2-pyparsing py2-appdirs 


### PR DESCRIPTION
backport html5lib change to 92x as the jupyter changes are there as well