### PR TITLE
new scram tag V2_2_7_pre2

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_7_pre1
+### RPM lcg SCRAMV1 V2_2_7_pre2
 ## NOCOMPILER
 
 BuildRequires: gmake


### PR DESCRIPTION
New scram allows to setup scram-based project env without changing directory to the project area e.g. 
```
eval `scram runtime -sh /full/path/to/release/directory`
```