### PR TITLE
Update SCRAMV1.spec

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_7_pre2
+### RPM lcg SCRAMV1 V2_2_7_pre3
 ## NOCOMPILER
 
 BuildRequires: gmake


### PR DESCRIPTION
new bug fix scram tag V2_2_7_pre3: 'scram build help' command is fixed to show build-rules help when it is run from within a scram-base project otherwise show scram help.