### PR TITLE
Fix geant4 relocation and cleanup of ccache toolfile

### DIFF
--- a/ccache-gcc-toolfile.spec
+++ b/ccache-gcc-toolfile.spec
@@ -1,41 +1,17 @@
-### RPM cms ccache-gcc-toolfile 1.0
+### RPM external ccache-gcc-toolfile 1.0
 Requires: ccache
 
-%if "%(echo %cmsos | grep osx >/dev/null && echo true)" == "true"
-Requires: gfortran-macosx
-%endif
-Source: none
-
 %prep
+
 %build
+
 %install
-mkdir -p %i/etc/scram.d
-
-# Determine the GCC_ROOT if "use system compiler is used.  We still need this
-# because we need to pick up libstdc++ from the gcc installation since clang
-# does not ship its own and because clang does not provide a fortran compiler.
-if [ "X$GCC_ROOT" = X ]
-then
-    GCC_PATH=`which gcc` || exit 1
-    GCC_VERSION=`gcc -dumpversion` || exit 1
-    GCC_ROOT=`echo $GCC_PATH | sed -e 's|/bin/gcc||'`
-    G77_ROOT=$GFORTRAN_MACOSX_ROOT
-else
-    G77_ROOT=$GCC_ROOT
-fi
-export CCACHE_GCC_TOOLFILE_ROOT
-export CCACHE_GCC_TOOLFILE_VERSION
-export GCC_ROOT
 export CCACHE_ROOT
-export G77_ROOT
+export CCACHE_VERSION
 
 mkdir -p %i/etc/scram.d
-# Generic template for the toolfiles. 
-# *** USE @VARIABLE@ plus associated environment variable to customize. ***
-# DO NOT DUPLICATE the toolfile template.
-
 cat << \EOF_TOOLFILE >%i/etc/scram.d/ccache-cxxcompiler.xml
-  <tool name="ccache-cxxcompiler" version="@CCACHE_GCC_TOOLFILE_VERSION@" type="compiler">
+  <tool name="ccache-cxxcompiler" version="@CCACHE_VERSION@" type="compiler">
     <use name="gcc-cxxcompiler"/>
     <client>
       <environment name="CXX" value="@CCACHE_ROOT@/bin/c++"/>
@@ -45,7 +21,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/ccache-cxxcompiler.xml
 EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE >%i/etc/scram.d/ccache-ccompiler.xml
-  <tool name="ccache-ccompiler" version="@CCACHE_GCC_TOOLFILE_VERSION@" type="compiler">
+  <tool name="ccache-ccompiler" version="@CCACHE_VERSION@" type="compiler">
     <use name="gcc-ccompiler"/>
     <client>
       <environment name="CC" value="@CCACHE_ROOT@/bin/gcc"/>
@@ -54,7 +30,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/ccache-ccompiler.xml
 EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE >%i/etc/scram.d/ccache-f77compiler.xml
-  <tool name="ccache-f77compiler" version="@CCACHE_GCC_TOOLFILE_VERSION@" type="compiler">
+  <tool name="ccache-f77compiler" version="@CCACHE_VERSION@" type="compiler">
     <use name="gcc-f77compiler"/>
     <client>
       <environment name="FC" default="@CCACHE_ROOT@/bin/gfortran"/>
@@ -62,16 +38,4 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/ccache-f77compiler.xml
   </tool>
 EOF_TOOLFILE
 
-# NON-empty defaults
-# First of all handle OS specific options.
-OS_RUNTIME_LDPATH_NAME="LD_LIBRARY_PATH"
-case %cmsplatf in
-  osx* ) OS_RUNTIME_LDPATH_NAME="DYLD_LIBRARY_PATH" ;;
-esac
-export OS_RUNTIME_LDPATH_NAME
-
-# General substitutions
-export AT="@"
-perl -p -i -e 's|\@([^@]*)\@|$ENV{$1}|g' %i/etc/scram.d/*.xml
-%post
-%{relocateConfig}etc/scram.d/*.xml
+## IMPORT scram-tools-post

--- a/geant4.spec
+++ b/geant4.spec
@@ -64,3 +64,8 @@ find . -name "*.o" -delete
 
 %post
 %{relocateConfig}lib/Geant4-*/Geant4Config.cmake
+%{relocateConfig}bin/geant4-config
+%{relocateConfig}bin/geant4.*
+%{relocateConfig}share/Geant4-*/geant4-*
+%{relocateConfig}share/Geant4-*/geant4make/geant4make.*
+%{relocateConfig}lib/Geant4-*/Geant4LibraryDepends.cmake

--- a/geant4data.spec
+++ b/geant4data.spec
@@ -1,4 +1,4 @@
-### RPM external geant4data 1.0
+### RPM external geant4data 2.0
 ## NOCOMPILER
 
 Requires: geant4-G4NDL
@@ -17,3 +17,5 @@ Requires: geant4-G4ENSDFSTATE
 if [ "X$CMS_INSTALL_PREFIX" = "X" ] ; then CMS_INSTALL_PREFIX=$RPM_INSTALL_PREFIX; export CMS_INSTALL_PREFIX; fi
 echo "GEANT4DATA_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
 echo "set GEANT4DATA_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
+echo "GEANT4DATA_VERSION='%v'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
+echo "set GEANT4DATA_VERSION='%v'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh


### PR DESCRIPTION
Some config file in geant4 distribution contains the build path which causes geant4-parfulcms to fail [a].
This PR fixes 
- the relocation of geant4 files 
- ccache-toolfile cleanup and fix for version
- set geant4-data version

[a]
```
make[2]: *** No rule to make target `/build/cmsbld/auto-builds/CMSSW_9_3_0_pre2-slc6_amd64_gcc630/build/CMSSW_9_3_0_pre2-build/slc6_amd64_gcc630/external/xerces-c/3.1.3/lib/libxerces-c.so', needed by `ParFullCMS'.  Stop.
make[2]: Leaving directory `/tmp/muzaffar/w2/BUILD/slc6_amd64_gcc630/external/geant4-parfullcms/2014.01.27-cms/ParFullCMS/build-ParFullCMS'
```