### PR TITLE
updates to sherpa with openmpi

### DIFF
--- a/openmpi-toolfile.spec
+++ b/openmpi-toolfile.spec
@@ -10,6 +10,7 @@ mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/openmpi.xml
 <tool name="openmpi" version="@TOOL_VERSION@">
 <lib name="mpi"/>
+<lib name="mpi_cxx"/>
 <client>
 <environment name="OPENMPI_BASE" default="@TOOL_ROOT@"/>
 <environment name="LIBDIR" default="$OPENMPI_BASE/lib"/>

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,5 @@
 ### RPM external openmpi 2.1.1
+## INITENV SET OPAL_PREFIX %{i}
 Source: http://www.open-mpi.org/software/ompi/v2.1/downloads/%{n}-%{realversion}.tar.gz 
 Patch1: openmpi-2.1.1-disable-lsf-support
 BuildRequires: autotools
@@ -10,7 +11,7 @@ sed -i -e 's|#!/usr/bin/perl|#!/usr/bin/env perl|' opal/asm/generate-all-asm.pl
 sed -i -e 's|/usr/bin/perl|/usr/bin/env perl|' ./Doxyfile
 sed -i -e 's|/usr/bin/perl|/usr/bin/env perl|' ./orte/Doxyfile
 ./autogen.pl --force
-./configure --prefix=%i --without-lsf --disable-libnuma
+./configure --prefix=%i --without-lsf --disable-libnuma --enable-mpi-cxx
 
 %build
 make %{makeprocesses} 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -42,13 +42,15 @@ esac
             --enable-blackhat=$BLACKHAT_ROOT \
             --enable-pyext \
             --enable-ufo \
-            ${OPENLOOPS_ROOT+--enable-openloops=$OPENLOOPS_ROOT}\
-            --enable-mpi=$OPENMPI_ROOT \
+            ${OPENLOOPS_ROOT+--enable-openloops=$OPENLOOPS_ROOT} \
+            --enable-mpi \
             --with-sqlite3=$SQLITE_ROOT \
-            CXX="g++" \
-            MPICXX="${OPENMPI_ROOT}/bin/mpic++" \
-            CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF -O2 -std=c++0x -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$OPENSSL_ROOT/include -I$OPENMPI_ROOT/include/" \
-            LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib -L$OPENMPI_ROOT/lib/"
+            CC="mpicc" \
+            CXX="mpicxx" \
+            MPICXX="mpicxx" \
+            FC="mpifort" \
+            CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF -O2 -std=c++0x -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$OPENSSL_ROOT/include" \
+            LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib"
 
 make %{makeprocesses}
 


### PR DESCRIPTION
- properly compiles sherpa with openmpi wrapper compilers
- as discussed in yesterdays gen-technical-meeting (28.08.17)