### PR TITLE
DQMGUI 9.1.2

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.1.1
+### RPM cms dqmgui 9.1.2
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
Solve a problem while rendering histograms with many nans that was causing the server to crash.
The user will receive a completely black plot, instead.