### PR TITLE
[93X] Update MillePede to version V04-03-08.

### DIFF
--- a/millepede.spec
+++ b/millepede.spec
@@ -1,4 +1,4 @@
-### RPM external millepede V04-03-04
+### RPM external millepede V04-03-08
 
 Source: svn://svnsrv.desy.de/public/MillepedeII/tags/%{realversion}/?scheme=http&module=%{realversion}&output=/%{n}-%{realversion}.tgz
 Requires: zlib


### PR DESCRIPTION
Latest MillePede version contains a few minor bug fixes, more readable error messages and a new optional feature to downscale the errors in the mille binaries. The latter is useful because one can reuse the same binary files and therefore saving a lot of computing ressources for the creation and also for the storage.

[MillePedeII changelog](https://www.wiki.terascale.de/index.php/Millepede_II#Version_V04-03-08_.28new.29)