### PR TITLE
[94X] Add GeneralBrokenLines as external library.

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 38.0
+### RPM cms cmssw-tool-conf 39.0
 ## NOCOMPILER
 # With cmsBuild, change the above version only when a new
 # tool is added
@@ -32,6 +32,7 @@ Requires: evtgen-toolfile
 Requires: expat-toolfile
 Requires: fakesystem
 Requires: fastjet-toolfile
+Requires: gbl-toolfile
 Requires: gcc-toolfile
 Requires: gdbm-toolfile
 Requires: geant4-toolfile

--- a/gbl-toolfile.spec
+++ b/gbl-toolfile.spec
@@ -1,0 +1,24 @@
+### RPM external gbl-toolfile 1.0
+Requires: gbl
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gbl.xml
+<tool name="gbl" version="@TOOL_VERSION@">
+  <info url="https://www.wiki.terascale.de/index.php/GeneralBrokenLines"/>
+  <lib name="GBL"/>
+  <client>
+    <environment name="GBL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$GBL_BASE/lib"/>
+    <environment name="INCLUDE" default="$GBL_BASE/include"/>
+  </client>
+  <use name="eigen"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post
+

--- a/gbl.spec
+++ b/gbl.spec
@@ -1,0 +1,29 @@
+### RPM external gbl V02-01-03
+
+Source: svn://svnsrv.desy.de/public/GeneralBrokenLines/tags/%{realversion}/cpp/?scheme=http&module=%{realversion}&output=/%{n}-%{realversion}.tgz
+
+BuildRequires: cmake
+Requires: eigen
+
+%prep
+%setup -q -n %{realversion}
+
+%build
+rm -rf build
+mkdir build
+cd build
+
+cmake .. \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DEIGEN3_INCLUDE_DIR=${EIGEN_ROOT}/include/eigen3 \
+  -DSUPPORT_ROOT=False
+
+make %{makeprocesses}
+
+%install
+cd build
+make install
+
+%post
+%{relocateConfig}GBLConfig.cmake


### PR DESCRIPTION
GeneralBrokenLines (GBL) is already used in CMSSW but was integrated some time ago by copying the files directly into CMSSW.
Using it as external would ensure that code updates by the maintainers can be included much easier.