### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient-binary.spec
+++ b/dasgoclient-binary.spec
@@ -1,11 +1,11 @@
-### RPM cms dasgoclient-binary v01.00.06
+### RPM cms dasgoclient-binary v01.00.08
 Source0: git+https://github.com/dmwm/dasgoclient?obj=master/%{realversion}&export=dasgoclient&output=/dasgoclient.tar.gz
 Source1: git+https://github.com/dmwm/cmsauth?obj=master/e9fca92e3335252a5f71d8e6d09c64012f7d3c0c&export=github.com/dmwm/cmsauth&output=/cmsauth.tar.gz
 Source2: git+https://github.com/vkuznet/x509proxy?obj=master/b4622388b3a347c8df75b6e944e9d2a580acee60&export=github.com/vkuznet/x509proxy&output=/x509proxy.tar.gz
 Source3: git+https://github.com/buger/jsonparser?obj=master/6bd16707875b997f7a60327f888a28a3d28cf8c2&export=github.com/buger/jsonparser&output=/jsonparser.tar.gz
 Source4: git+https://github.com/go-mgo/mgo?obj=v2/3f83fa5005286a7fe593b055f0d7771a7dce4655&export=gopkg.in/mgo.v2&output=/mgo.v2.tar.gz
 Source5: git+https://github.com/pkg/profile?obj=master/3a8809bd8a80f8ecfe4ee1b34b3f37194968617c&export=github.com/pkg/profile&output=/profile.tar.gz
-Source6: git+https://github.com/dmwm/das2go?obj=master/ee759b3782ba64d503f1347d934f38418c5ba43f&export=github.com/dmwm/das2go&output=/das2go.tar.gz
+Source6: git+https://github.com/dmwm/das2go?obj=master/3650f6c1c83664ebd7441b36200afd27e12b5c6c&export=github.com/dmwm/das2go&output=/das2go.tar.gz
 %prep
 
 %setup -n dasgoclient

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,6 +1,6 @@
-### RPM cms dasgoclient v01.00.06
+### RPM cms dasgoclient v01.00.08
 ## NOCOMPILER
-%define dasgoclient_arch     slc6_amd64_gcc530
+%define dasgoclient_arch     slc6_amd64_gcc630
 %define dasgoclient_pkg      cms+%{n}-binary+%{realversion}
 %define dasgoclient_rpm      %{dasgoclient_pkg}-1-1.%{dasgoclient_arch}.rpm
 Source0: https://cern.ch/valya/dasgoclient/%{dasgoclient_rpm}


### PR DESCRIPTION
Replacement of #3386 

It is new build on slc6_amd64_gcc630 (instead of slc6_amd64_gcc530).

dasgoclient-binary is uploaded to eos area:
/eos/user/v/valya/www/dasgoclient/cms+dasgoclient-binary+v01.00.08-1-1.slc6_amd64_gcc630.rpm