### PR TITLE
Update llvm.spec to build 5.0.0

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -1,27 +1,28 @@
-### RPM external llvm 4.0.1
+### RPM external llvm 5.0.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHONPATH %{i}/lib64/python$(echo $PYTHON_VERSION | cut -d. -f 1,2)/site-packages
 
 BuildRequires: python cmake ninja
 Requires: gcc zlib
 
-%define llvmCommit c8fccc53ed66d505898f8850bcc690c977a7c9a7
-%define llvmBranch release_40
-%define clangCommit a4ff1c73147875d7f2356f4f664fcbe920db225f
-%define clangBranch cms/3c8961b
-%define clangToolsExtraCommit e44e2e4b73bf0a70fc1163da3cfaf6347e65bb65
-%define clangToolsExtraBranch release_40
-%define compilerRtCommit 76ab2e5c9b2a2e3d638e217cc21622f9be54f633
-%define compilerRtBranch release_40
-%define openmpCommit e62ab1ab8242fb70b31f627d78a1ca489b49ce01
-%define openmpBranch release_40
-%define iwyuCommit c6c4520c0b0a0ad2ba22218ef2aa3f0b81ecbc6f
-%define iwyuBranch clang_4.0
-%define lldCommit 4439e42e1a3dcc6bf15fdb00114e4fc598b9d614
-%define lldBranch release_40
-Source0: git+https://github.com/llvm-mirror/llvm.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%realversion-%llvmCommit&output=/llvm-%{realversion}-%{llvmCommit}.tgz
-Source1: git+https://github.com/cms-externals/clang.git?obj=%{clangBranch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%realversion-%clangCommit&output=/clang-%{realversion}-%{clangCommit}.tgz
-Source2: git+https://github.com/cms-externals/clang-tools-extra.git?obj=%{clangToolsExtraBranch}/%{clangToolsExtraCommit}&export=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&module=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&output=/clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}.tgz
+%define llvmCommit 657c31173ea30090583e40c7a9204561d9c2d8c4
+%define llvmBranch release_50
+%define clangCommit 01b3b66e5b8d3a88167c08975cf26ffe53fb0f5d
+%define clangBranch cms/release_50/7e8743f
+%define clangToolsExtraCommit 58cffec4d74b21c1097de4298e637a31c637851a
+%define clangToolsExtraBranch release_50
+%define compilerRtCommit 4b38c4038a4f2b8e2d02b5f5d7877fa79d940009
+%define compilerRtBranch release_50
+%define openmpCommit 6999fe680ad14c87c7fe96ddc3986f86ab15215d
+%define openmpBranch release_50
+%define iwyuCommit bcc3f0a58eb01d002ddc715cb9b466e2e0a4c833
+%define iwyuBranch master
+%define lldCommit e2974bce18137935bde80dd34acb255cf6c68db0
+%define lldBranch release_50
+
+Source0: git+https://github.com/llvm-mirror/llvm.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz
+Source1: git+https://github.com/cms-externals/clang.git?obj=%{clangBranch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%{realversion}-%{clangCommit&output}=/clang-%{realversion}-%{clangCommit}.tgz
+Source2: git+https://github.com/llvm-mirror/clang-tools-extra.git?obj=%{clangToolsExtraBranch}/%{clangToolsExtraCommit}&export=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&module=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&output=/clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}.tgz
 Source3: git+https://github.com/llvm-mirror/compiler-rt.git?obj=%{compilerRtBranch}/%{compilerRtCommit}&export=compiler-rt-%{realversion}-%{compilerRtCommit}&module=compiler-rt-%{realversion}-%{compilerRtCommit}&output=/compiler-rt-%{realversion}-%{compilerRtCommit}.tgz
 Source4: git+https://github.com/llvm-mirror/openmp.git?obj=%{openmpBranch}/%{openmpCommit}&export=openmp-%{realversion}-%{openmpCommit}&module=openmp-%{realversion}-%{openmpCommit}&output=/openmp-%{realversion}-%{openmpCommit}.tgz
 Source5: git+https://github.com/include-what-you-use/include-what-you-use.git?obj=%{iwyuBranch}/%{iwyuCommit}&export=iwyu-%{realversion}-%{iwyuCommit}&module=iwyu-%{realversion}-%{iwyuCommit}&output=/iwyu-%{realversion}-%{iwyuCommit}.tgz
@@ -30,9 +31,9 @@ Source6: git+https://github.com/llvm-mirror/lld.git?obj=%{lldBranch}/%{lldCommit
 %define keep_archives true
 
 %prep
-%setup -T -b0 -n llvm-%realversion-%llvmCommit
-%setup -T -D -a1 -c -n llvm-%realversion-%llvmCommit/tools
-mv clang-%realversion-%clangCommit clang
+%setup -T -b0 -n llvm-%{realversion}-%{llvmCommit}
+%setup -T -D -a1 -c -n llvm-%{realversion}-%{llvmCommit}/tools
+mv clang-%{realversion}-%{clangCommit} clang
 %setup -T -D -a6 -c -n llvm-%{realversion}-%{llvmCommit}/tools
 mv lld-%{realversion}-%{lldCommit} lld
 %setup -T -D -a2 -c -n llvm-%{realversion}-%{llvmCommit}/tools/clang/tools
@@ -43,7 +44,7 @@ mv iwyu-%{realversion}-%{iwyuCommit} include-what-you-use
 mv compiler-rt-%{realversion}-%{compilerRtCommit} compiler-rt
 %setup -T -D -a4 -c -n llvm-%{realversion}-%{llvmCommit}/projects
 mv openmp-%{realversion}-%{openmpCommit} openmp
-%setup -T -D -n llvm-%realversion-%llvmCommit
+%setup -T -D -n llvm-%{realversion}-%{llvmCommit}
 
 # include-what-you-see is not LLVM project, we have to
 # add it explicitly.

--- a/llvm.spec
+++ b/llvm.spec
@@ -7,7 +7,7 @@ Requires: gcc zlib
 
 %define llvmCommit 657c31173ea30090583e40c7a9204561d9c2d8c4
 %define llvmBranch release_50
-%define clangCommit 01b3b66e5b8d3a88167c08975cf26ffe53fb0f5d
+%define clangCommit 2e74b10d74e0d6320bcf7e2efb98016d0a8d3bf3
 %define clangBranch cms/release_50/7e8743f
 %define clangToolsExtraCommit 58cffec4d74b21c1097de4298e637a31c637851a
 %define clangToolsExtraBranch release_50

--- a/llvm.spec
+++ b/llvm.spec
@@ -21,7 +21,7 @@ Requires: gcc zlib
 %define lldBranch release_50
 
 Source0: git+https://github.com/llvm-mirror/llvm.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz
-Source1: git+https://github.com/cms-externals/clang.git?obj=%{clangBranch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%{realversion}-%{clangCommit&output}=/clang-%{realversion}-%{clangCommit}.tgz
+Source1: git+https://github.com/cms-externals/clang.git?obj=%{clangBranch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%{realversion}-%{clangCommit}&output=/clang-%{realversion}-%{clangCommit}.tgz
 Source2: git+https://github.com/llvm-mirror/clang-tools-extra.git?obj=%{clangToolsExtraBranch}/%{clangToolsExtraCommit}&export=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&module=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&output=/clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}.tgz
 Source3: git+https://github.com/llvm-mirror/compiler-rt.git?obj=%{compilerRtBranch}/%{compilerRtCommit}&export=compiler-rt-%{realversion}-%{compilerRtCommit}&module=compiler-rt-%{realversion}-%{compilerRtCommit}&output=/compiler-rt-%{realversion}-%{compilerRtCommit}.tgz
 Source4: git+https://github.com/llvm-mirror/openmp.git?obj=%{openmpBranch}/%{openmpCommit}&export=openmp-%{realversion}-%{openmpCommit}&module=openmp-%{realversion}-%{openmpCommit}&output=/openmp-%{realversion}-%{openmpCommit}.tgz

--- a/py2-pippkgs_depscipy.spec
+++ b/py2-pippkgs_depscipy.spec
@@ -26,8 +26,8 @@ BuildRequires: py2-bottleneck
 BuildRequires: py2-downhill 
 BuildRequires: py2-theanets
 BuildRequires: py2-xgboost
-BuildRequires: py2-llvmlite
-BuildRequires: py2-numba
+#BuildRequires: py2-llvmlite
+#BuildRequires: py2-numba
 BuildRequires: py2-hep_ml
 BuildRequires: py2-rep
 BuildRequires: py2-uncertainties


### PR DESCRIPTION
updated LLVM to 5.0.0 for DEVEL IBs.
- disabled py2-numba and py2-llvmlite as there is no these are not yet ready for llvm 5.0 . Once we have llvmlite available based on llvm 5.0 then we can include it in normal IBs.