### PR TITLE
Fix consistently python path relocation and add dependencies to all py3 specs

### DIFF
--- a/py3-certifi.spec
+++ b/py3-certifi.spec
@@ -1,22 +1,22 @@
-### RPM external py3-docutils 0.12
+### RPM external py3-certifi 2017.7.27.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source0: svn://docutils.svn.sourceforge.net/svnroot/docutils/trunk/sandbox/rst2wiki@7467?scheme=https&strategy=export&module=sandbox&output=/rst2wiki.tar.gz
-Source1: http://downloads.sourceforge.net/docutils/docutils-%{realversion}.tar.gz
+Source: https://pypi.python.org/packages/20/d0/3f7a84b0c5b89e94abbd073a5f00c7176089f526edb056686751d5064cbd/certifi-2017.7.27.1.tar.gz
 Requires: python3
+BuildRequires: py3-setuptools
 
 %prep
-%setup -T -b 0 -n sandbox
-%setup -D -T -b 1 -n docutils-%realversion
+%setup -n certifi-%realversion
 
 %build
+export PYTHON3_ROOT
 python3 setup.py build
 
 %install
-python3 setup.py install --prefix=%i
-cp ../sandbox/tools/rst2wiki.py %i/bin/
-cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
-python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
 # replace all instances of #!/path/bin/python into proper format
 for f in `find %i -type f`; do
     if [ -f $f ]; then

--- a/py3-certifi.spec
+++ b/py3-certifi.spec
@@ -17,24 +17,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-chardet.spec
+++ b/py3-chardet.spec
@@ -1,22 +1,20 @@
-### RPM external py3-docutils 0.12
+### RPM external py3-chardet 3.0.4
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source0: svn://docutils.svn.sourceforge.net/svnroot/docutils/trunk/sandbox/rst2wiki@7467?scheme=https&strategy=export&module=sandbox&output=/rst2wiki.tar.gz
-Source1: http://downloads.sourceforge.net/docutils/docutils-%{realversion}.tar.gz
+Source: https://pypi.python.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz
 Requires: python3
+BuildRequires: py3-setuptools
 
 %prep
-%setup -T -b 0 -n sandbox
-%setup -D -T -b 1 -n docutils-%realversion
+%setup -n chardet-%realversion
 
 %build
 python3 setup.py build
 
 %install
-python3 setup.py install --prefix=%i
-cp ../sandbox/tools/rst2wiki.py %i/bin/
-cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
-python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
 # replace all instances of #!/path/bin/python into proper format
 for f in `find %i -type f`; do
     if [ -f $f ]; then

--- a/py3-chardet.spec
+++ b/py3-chardet.spec
@@ -15,24 +15,12 @@ python3 setup.py build
 mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-cherrypy.spec
+++ b/py3-cherrypy.spec
@@ -17,24 +17,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-cherrypy.spec
+++ b/py3-cherrypy.spec
@@ -17,6 +17,24 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
-files=`find %i -name cherryd`
-for f in $files; do perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python}' $f; done
-#for f in %i/bin/cherryd; do perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python}' $f; done
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-cjson.spec
+++ b/py3-cjson.spec
@@ -14,24 +14,12 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-cjson.spec
+++ b/py3-cjson.spec
@@ -14,3 +14,24 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-docutils.spec
+++ b/py3-docutils.spec
@@ -17,24 +17,12 @@ python3 setup.py install --prefix=%i
 cp ../sandbox/tools/rst2wiki.py %i/bin/
 cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
 python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-elementtree.spec
+++ b/py3-elementtree.spec
@@ -12,3 +12,9 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done

--- a/py3-elementtree.spec
+++ b/py3-elementtree.spec
@@ -12,9 +12,9 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+%addDependency

--- a/py3-idna.spec
+++ b/py3-idna.spec
@@ -1,22 +1,22 @@
-### RPM external py3-docutils 0.12
+### RPM external py3-idna 2.6
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source0: svn://docutils.svn.sourceforge.net/svnroot/docutils/trunk/sandbox/rst2wiki@7467?scheme=https&strategy=export&module=sandbox&output=/rst2wiki.tar.gz
-Source1: http://downloads.sourceforge.net/docutils/docutils-%{realversion}.tar.gz
-Requires: python3
+Source: https://pypi.python.org/packages/f4/bd/0467d62790828c23c47fc1dfa1b1f052b24efdf5290f071c7a91d0d82fd3/idna-2.6.tar.gz
+Requires: python3 py3-certifi py3-urllib3
+BuildRequires: py3-setuptools
 
 %prep
-%setup -T -b 0 -n sandbox
-%setup -D -T -b 1 -n docutils-%realversion
+%setup -n idna-%realversion
 
 %build
+export PYTHON3_ROOT
 python3 setup.py build
 
 %install
-python3 setup.py install --prefix=%i
-cp ../sandbox/tools/rst2wiki.py %i/bin/
-cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
-python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
 # replace all instances of #!/path/bin/python into proper format
 for f in `find %i -type f`; do
     if [ -f $f ]; then

--- a/py3-idna.spec
+++ b/py3-idna.spec
@@ -17,24 +17,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-imagesize.spec
+++ b/py3-imagesize.spec
@@ -1,22 +1,22 @@
-### RPM external py3-docutils 0.12
+### RPM external py3-imagesize 0.7.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source0: svn://docutils.svn.sourceforge.net/svnroot/docutils/trunk/sandbox/rst2wiki@7467?scheme=https&strategy=export&module=sandbox&output=/rst2wiki.tar.gz
-Source1: http://downloads.sourceforge.net/docutils/docutils-%{realversion}.tar.gz
-Requires: python3
+Source: https://pypi.python.org/packages/53/72/6c6f1e787d9cab2cc733cf042f125abec07209a58308831c9f292504e826/imagesize-0.7.1.tar.gz
+Requires: python3 py3-certifi py3-urllib3 py3-idna py3-chardet
+BuildRequires: py3-setuptools
 
 %prep
-%setup -T -b 0 -n sandbox
-%setup -D -T -b 1 -n docutils-%realversion
+%setup -n imagesize-%realversion
 
 %build
+export PYTHON3_ROOT
 python3 setup.py build
 
 %install
-python3 setup.py install --prefix=%i
-cp ../sandbox/tools/rst2wiki.py %i/bin/
-cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
-python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
 # replace all instances of #!/path/bin/python into proper format
 for f in `find %i -type f`; do
     if [ -f $f ]; then

--- a/py3-imagesize.spec
+++ b/py3-imagesize.spec
@@ -17,24 +17,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-jinja.spec
+++ b/py3-jinja.spec
@@ -12,24 +12,12 @@ python3 setup.py build
 
 %install
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-jinja.spec
+++ b/py3-jinja.spec
@@ -12,3 +12,24 @@ python3 setup.py build
 
 %install
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-jsonpath-rw.spec
+++ b/py3-jsonpath-rw.spec
@@ -15,6 +15,24 @@ python3 setup.py build
 python3 setup.py install --skip-build --prefix=%{i} --single-version-externally-managed --record=/dev/null
 
 find %i -name '*.egg-info' -exec rm {} \;
-# get rid of /usr/bin/python
-egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/env python3}'
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
 
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-jsonpath-rw.spec
+++ b/py3-jsonpath-rw.spec
@@ -15,24 +15,12 @@ python3 setup.py build
 python3 setup.py install --skip-build --prefix=%{i} --single-version-externally-managed --record=/dev/null
 
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-lxml.spec
+++ b/py3-lxml.spec
@@ -19,3 +19,24 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-lxml.spec
+++ b/py3-lxml.spec
@@ -19,24 +19,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-nltk.spec
+++ b/py3-nltk.spec
@@ -41,24 +41,12 @@ curl -O https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/corpo
 unzip wordnet.zip
 
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-nltk.spec
+++ b/py3-nltk.spec
@@ -41,8 +41,12 @@ curl -O https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/corpo
 unzip wordnet.zip
 
 find %i -name '*.egg-info' -exec rm {} \;
-# get rid of /usr/bin/python
-egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/env python3}'
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
 mkdir -p %i/etc/profile.d

--- a/py3-numpy.spec
+++ b/py3-numpy.spec
@@ -28,11 +28,14 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
 python3 setup.py build --fcompiler=gnu95
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
-#find %i -name '*.egg-info' -exec rm {} \;
+find %i -name '*.egg-info' -exec rm {} \;
 
-# adjust python path
-f2py3=`find %i -name f2py3`
-perl -p -i -e "s|^#!.*python3|#!/usr/bin/env python3|" $f2py3
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
 mkdir -p %i/etc/profile.d

--- a/py3-numpy.spec
+++ b/py3-numpy.spec
@@ -31,23 +31,10 @@ PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --p
 find %i -name '*.egg-info' -exec rm {} \;
 
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pycurl.spec
+++ b/py3-pycurl.spec
@@ -18,5 +18,27 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
 # Remove documentation.
 %define drop_files %i/share
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pycurl.spec
+++ b/py3-pycurl.spec
@@ -18,27 +18,14 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
-# replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
-
 # Remove documentation.
 %define drop_files %i/share
 
+# replace all instances of #!/path/bin/python into proper format
+%py3PathRelocation
+
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pygments.spec
+++ b/py3-pygments.spec
@@ -12,4 +12,25 @@ python3 setup.py build
 
 %install
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
-for f in %i/bin/pygmentize; do perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python}' $f; done
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh
+

--- a/py3-pygments.spec
+++ b/py3-pygments.spec
@@ -12,24 +12,12 @@ python3 setup.py build
 
 %install
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pymongo.spec
+++ b/py3-pymongo.spec
@@ -15,3 +15,25 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pymongo.spec
+++ b/py3-pymongo.spec
@@ -15,25 +15,12 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
-# replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
 
+# replace all instances of #!/path/bin/python into proper format
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pyrex.spec
+++ b/py3-pyrex.spec
@@ -16,4 +16,24 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
-for f in %i/bin/pyrexc; do perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python}' $f; done
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pyrex.spec
+++ b/py3-pyrex.spec
@@ -16,24 +16,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pystemmer.spec
+++ b/py3-pystemmer.spec
@@ -17,24 +17,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pystemmer.spec
+++ b/py3-pystemmer.spec
@@ -17,3 +17,24 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pytz.spec
+++ b/py3-pytz.spec
@@ -15,3 +15,24 @@ python3 setup.py build
 mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-pytz.spec
+++ b/py3-pytz.spec
@@ -15,24 +15,12 @@ python3 setup.py build
 mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-requests.spec
+++ b/py3-requests.spec
@@ -17,24 +17,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-requests.spec
+++ b/py3-requests.spec
@@ -1,22 +1,22 @@
-### RPM external py3-docutils 0.12
+### RPM external py3-requests 2.18.4
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source0: svn://docutils.svn.sourceforge.net/svnroot/docutils/trunk/sandbox/rst2wiki@7467?scheme=https&strategy=export&module=sandbox&output=/rst2wiki.tar.gz
-Source1: http://downloads.sourceforge.net/docutils/docutils-%{realversion}.tar.gz
-Requires: python3
+Source: https://pypi.python.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz
+Requires: python3 py3-certifi py3-urllib3 py3-idna py3-chardet
+BuildRequires: py3-setuptools
 
 %prep
-%setup -T -b 0 -n sandbox
-%setup -D -T -b 1 -n docutils-%realversion
+%setup -n requests-%realversion
 
 %build
+export PYTHON3_ROOT
 python3 setup.py build
 
 %install
-python3 setup.py install --prefix=%i
-cp ../sandbox/tools/rst2wiki.py %i/bin/
-cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
-python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
 # replace all instances of #!/path/bin/python into proper format
 for f in `find %i -type f`; do
     if [ -f $f ]; then

--- a/py3-scons.spec
+++ b/py3-scons.spec
@@ -11,6 +11,26 @@ python3 setup.py build
 
 %install
 python3 setup.py install --prefix=%i
-egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/env python}'
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
 %define drop_files %i/man
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-scons.spec
+++ b/py3-scons.spec
@@ -12,25 +12,13 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
-# replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
 %define drop_files %i/man
 
+# replace all instances of #!/path/bin/python into proper format
+%py3PathRelocation
+
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-setuptools.spec
+++ b/py3-setuptools.spec
@@ -14,4 +14,24 @@ python3 setup.py build
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
 rm -f %i/$PYTHON_LIB_SITE_PACKAGES/setuptools/*.exe
-for f in %i/bin/easy_install*; do perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python}' $f; done
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-setuptools.spec
+++ b/py3-setuptools.spec
@@ -14,24 +14,12 @@ python3 setup.py build
 python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
 rm -f %i/$PYTHON_LIB_SITE_PACKAGES/setuptools/*.exe
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-six.spec
+++ b/py3-six.spec
@@ -14,6 +14,24 @@ python3 setup.py build
 mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --skip-build --prefix=%{i}
-# get rid of /usr/bin/python
-egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/env python3}'
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
 
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-six.spec
+++ b/py3-six.spec
@@ -14,24 +14,12 @@ python3 setup.py build
 mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --skip-build --prefix=%{i}
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-sphinx.spec
+++ b/py3-sphinx.spec
@@ -38,24 +38,12 @@ for d in ../Sphinx-* ../sphinx_rtd_theme-* ../alabaster-* ../babel-* ../snowball
     python3 setup.py install --prefix=%i
   fi
 done
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-sphinx.spec
+++ b/py3-sphinx.spec
@@ -12,7 +12,7 @@ Source1: http://github.com/snide/sphinx_rtd_theme/archive/%sphinx_rtd_theme_vers
 Source2: http://github.com/bitprophet/alabaster/archive/%alabaster_version.tar.gz
 Source3: http://github.com/python-babel/babel/archive/%babel_version.tar.gz
 Source4: http://pypi.python.org/packages/source/s/snowballstemmer/snowballstemmer-%snowballstemmer_version.tar.gz
-Requires: python3 py3-docutils py3-jinja py3-pygments py3-setuptools py3-six py3-pytz
+Requires: python3 py3-docutils py3-jinja py3-pygments py3-setuptools py3-six py3-pytz py3-requests py3-imagesize
 
 %prep
 %setup -T -b 0 -n Sphinx-%realversion
@@ -38,5 +38,24 @@ for d in ../Sphinx-* ../sphinx_rtd_theme-* ../alabaster-* ../babel-* ../snowball
     python3 setup.py install --prefix=%i
   fi
 done
-for f in %i/bin/sphinx-*; do perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python}' $f; done
-for f in %i/bin/py*; do perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python}' $f; done
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-sphinxcontrib-websupport.spec
+++ b/py3-sphinxcontrib-websupport.spec
@@ -22,24 +22,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-sphinxcontrib-websupport.spec
+++ b/py3-sphinxcontrib-websupport.spec
@@ -1,22 +1,27 @@
-### RPM external py3-docutils 0.12
+### RPM external py3-sphinxcontrib-websupport 1.0.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source0: svn://docutils.svn.sourceforge.net/svnroot/docutils/trunk/sandbox/rst2wiki@7467?scheme=https&strategy=export&module=sandbox&output=/rst2wiki.tar.gz
-Source1: http://downloads.sourceforge.net/docutils/docutils-%{realversion}.tar.gz
-Requires: python3
+Source: https://pypi.python.org/packages/c5/6b/f0630436b931ad4f8331a9399ca18a7d447f0fcc0c7178fb56b1aee68d01/sphinxcontrib-websupport-1.0.1.tar.gz
+Requires: python3 py3-sphinx
+BuildRequires: py3-setuptools
 
 %prep
-%setup -T -b 0 -n sandbox
-%setup -D -T -b 1 -n docutils-%realversion
+%setup -n sphinxcontrib-websupport-%realversion
 
 %build
+export PY3_SPHINX_ROOT
+pver=`python3 -V | awk '{print $2}' | cut -d . -f 1,2`
+export PYTHONPATH=$PY3_SPHINX_ROOT/lib/python$pver/site-packages:$PYTHONPATH
 python3 setup.py build
 
 %install
-python3 setup.py install --prefix=%i
-cp ../sandbox/tools/rst2wiki.py %i/bin/
-cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
-python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+export PY3_SPHINX_ROOT
+pver=`python3 -V | awk '{print $2}' | cut -d . -f 1,2`
+export PYTHONPATH=$PY3_SPHINX_ROOT/lib/python$pver/site-packages:$PYTHONPATH
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
 # replace all instances of #!/path/bin/python into proper format
 for f in `find %i -type f`; do
     if [ -f $f ]; then

--- a/py3-urllib3.spec
+++ b/py3-urllib3.spec
@@ -1,22 +1,22 @@
-### RPM external py3-docutils 0.12
+### RPM external py3-urllib3 1.22
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source0: svn://docutils.svn.sourceforge.net/svnroot/docutils/trunk/sandbox/rst2wiki@7467?scheme=https&strategy=export&module=sandbox&output=/rst2wiki.tar.gz
-Source1: http://downloads.sourceforge.net/docutils/docutils-%{realversion}.tar.gz
+Source: https://pypi.python.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz
 Requires: python3
+BuildRequires: py3-setuptools
 
 %prep
-%setup -T -b 0 -n sandbox
-%setup -D -T -b 1 -n docutils-%realversion
+%setup -n urllib3-%realversion
 
 %build
+export PYTHON3_ROOT
 python3 setup.py build
 
 %install
-python3 setup.py install --prefix=%i
-cp ../sandbox/tools/rst2wiki.py %i/bin/
-cp ../sandbox/docutils/writers/wiki.py %i/$PYTHON_LIB_SITE_PACKAGES/docutils/writers/
-python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
 # replace all instances of #!/path/bin/python into proper format
 for f in `find %i -type f`; do
     if [ -f $f ]; then

--- a/py3-urllib3.spec
+++ b/py3-urllib3.spec
@@ -17,24 +17,12 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-whoosh.spec
+++ b/py3-whoosh.spec
@@ -15,24 +15,12 @@ python3 setup.py build
 %install
 python3 setup.py install -O1 --skip-build --prefix=%{i} --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-whoosh.spec
+++ b/py3-whoosh.spec
@@ -15,6 +15,24 @@ python3 setup.py build
 %install
 python3 setup.py install -O1 --skip-build --prefix=%{i} --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
-# get rid of /usr/bin/python
-egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/env python3}'
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
 
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-yajl.spec
+++ b/py3-yajl.spec
@@ -22,24 +22,12 @@ PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 # --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-yajl.spec
+++ b/py3-yajl.spec
@@ -22,3 +22,24 @@ PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python3 setup.py install --prefix=%i
 # --single-version-externally-managed --record=/dev/null
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-yaml.spec
+++ b/py3-yaml.spec
@@ -22,24 +22,12 @@ python3 setup.py build
 %install
 python3 setup.py --with-libyaml install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+
 # replace all instances of #!/path/bin/python into proper format
-for f in `find %i -type f`; do
-    if [ -f $f ]; then
-        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
-    fi
-done
+%py3PathRelocation
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-mkdir -p %i/etc/profile.d
-: > %i/etc/profile.d/dependencies-setup.sh
-: > %i/etc/profile.d/dependencies-setup.csh
-for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
-  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
-  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
-  fi
-done
+%addDependency
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/py3-yaml.spec
+++ b/py3-yaml.spec
@@ -22,3 +22,24 @@ python3 setup.py build
 %install
 python3 setup.py --with-libyaml install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
+# replace all instances of #!/path/bin/python into proper format
+for f in `find %i -type f`; do
+    if [ -f $f ]; then
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f
+    fi
+done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -234,20 +234,20 @@
 
 # Define a macro for adding dependencies
 %define addDependency \
-mkdir -p %i/etc/profile.d \
-: > %i/etc/profile.d/dependencies-setup.sh \
-: > %i/etc/profile.d/dependencies-setup.csh \
+mkdir -p %{pkginstroot}/etc/profile.d \
+: > %{pkginstroot}/etc/profile.d/dependencies-setup.sh \
+: > %{pkginstroot}/etc/profile.d/dependencies-setup.csh \
 for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do \
   root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root \
   if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then \
-    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh \
-    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh \
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %{pkginstroot}/etc/profile.d/dependencies-setup.sh \
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %{pkginstroot}/etc/profile.d/dependencies-setup.csh \
   fi \
 done
 
 # Define a macro for fixing python3 path relocation
 %define py3PathRelocation \
-for f in `find %i -type f`; do \
+for f in `find %{pkginstroot} -type f`; do \
     if [ -f $f ]; then \
         perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f \
     fi \

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -231,3 +231,24 @@
 %else
 %define strip strip
 %endif
+
+# Define a macro for adding dependencies
+%define addDependency \
+mkdir -p %i/etc/profile.d \
+: > %i/etc/profile.d/dependencies-setup.sh \
+: > %i/etc/profile.d/dependencies-setup.csh \
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do \
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root \
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then \
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh \
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh \
+  fi \
+done
+
+# Define a macro for fixing python3 path relocation
+%define py3PathRelocation \
+for f in `find %i -type f`; do \
+    if [ -f $f ]; then \
+        perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f \
+    fi \
+done


### PR DESCRIPTION
I found one common problem in all py3 specs, the python path relocation issues. I adjusted all py3 spec to have consistent fix as well as added missing dependency look-up.

In addition, I've added 

       py3-certifi.spec
       py3-chardet.spec
       py3-idna.spec
       py3-imagesize.spec
       py3-requests.spec
       py3-sphinxcontrib-websupport.spec
       py3-urllib3.spec

specs which are required now by py3-spinx.spec which was split into multiple sub-packages in python3 land.