### PR TITLE
Adding autotools dependency

### DIFF
--- a/protobuf.spec
+++ b/protobuf.spec
@@ -1,7 +1,7 @@
 ### RPM external protobuf 3.4.0
 Source: https://github.com/google/protobuf/archive/v%{realversion}.tar.gz
 Requires: zlib
-
+BuildRequires: autotools
 #
 # When changing the version of protobuf, remember to regenerate protobuf objects in CMSSW
 # current recipe for this is:
@@ -9,8 +9,6 @@ Requires: zlib
 # git cms-addpkg DQMServices/Core
 # cd $CMSSW_BASE/src
 # protoc --cpp_out=. DQMServices/Core/src/ROOTFilePB.proto
-
-BuildRequires: autotools
 
 %prep
 %setup -n %{n}-%{realversion}

--- a/protobuf.spec
+++ b/protobuf.spec
@@ -10,6 +10,8 @@ Requires: zlib
 # cd $CMSSW_BASE/src
 # protoc --cpp_out=. DQMServices/Core/src/ROOTFilePB.proto
 
+BuildRequires: autotools
+
 %prep
 %setup -n %{n}-%{realversion}
 


### PR DESCRIPTION
Adding autotools dependency for protobuf as it was failing when not accidentally available on the machine