### PR TITLE
Backport XRootD python bindings (partial solution to isue #3359)

### DIFF
--- a/xrootd-toolfile.spec
+++ b/xrootd-toolfile.spec
@@ -18,9 +18,10 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/xrootd.xml
     <environment name="LIBDIR" default="$XROOTD_BASE/lib64"/>
   </client>
   <runtime name="PATH" value="$XROOTD_BASE/bin" type="path"/>
+  <runtime name="PYTHONPATH" value="$XROOTD_BASE/@PYTHON_LIB_SITE_PACKAGES@" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>
 EOF_TOOLFILE
-
+export PYTHON_LIB_SITE_PACKAGES
 ## IMPORT scram-tools-post

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -8,6 +8,7 @@ Source: git+https://github.com/%github_user/xrootd.git?obj=%{branch}/%{tag}&expo
 BuildRequires: cmake
 Requires: zlib
 Requires: openssl
+Requires: python
 
 %prep
 %setup -n %n-%{realversion}
@@ -36,7 +37,9 @@ cmake ../ \
   -DENABLE_KRB5=TRUE \
   -DENABLE_READLINE=FALSE \
   -DENABLE_CRYPTO=TRUE \
-  -DCMAKE_SKIP_RPATH=TRUE
+  -DCMAKE_SKIP_RPATH=TRUE \
+  -DENABLE_PYTHON=TRUE \
+  -DCMAKE_PREFIX_PATH="${PYTHON_ROOT}"
 
 # Use makeprocess macro, it uses compiling_processes defined by
 # build configuration file or build argument


### PR DESCRIPTION
Requested bindings where backported from branch CMSSW_9_4_X .