### PR TITLE
Reverted fs to 0.5.5a1 to fix xrootdpyfs

### DIFF
--- a/py2-fs.spec
+++ b/py2-fs.spec
@@ -1,9 +1,9 @@
-### RPM external py2-fs 2.0.7
+### RPM external py2-fs 0.5.5a1 
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
-
 
 %define pip_name fs
 
 ## IMPORT build-with-pip
 
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*
 

--- a/py2-xrootdpyfs.spec
+++ b/py2-xrootdpyfs.spec
@@ -1,6 +1,6 @@
 ### RPM external py2-xrootdpyfs 0.1.4
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 
-Requires: xrootd
+Requires: xrootd py2-fs
 
 ## IMPORT build-with-pip


### PR DESCRIPTION
Problem:
'xrootdpyfs' depends on 'fs' versions (>=0.4.0,<2.0), it was not listed as dependency.

Resolution:
'fs' reverted to version 0.5.5a1, listed as 'xrootdpyfs' dependency.