### PR TITLE
CUDA 9.0.176 for 9.2.x

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -10,6 +10,7 @@ mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
 <tool name="cuda" version="@TOOL_VERSION@">
   <info url="https://developer.nvidia.com/cuda-toolkit"/>
+  <lib name="cuda"/>
   <lib name="cudart"/>
   <lib name="nppc"/>
   <lib name="nvToolsExt"/>
@@ -18,6 +19,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="NVCC"      default="$CUDA_BASE/bin/nvcc"/>
     <environment name="BINDIR"    default="$CUDA_BASE/bin"/>
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
+    <environment name="LIBDIR"    default="$CUDA_BASE/lib64/stubs"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
   <flags CUDA_CFLAGS="-fPIC"/>

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -21,7 +21,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
   <flags CUDA_CFLAGS="-fPIC"/>
-  <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
+  <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_61,code=sm_61"/>
   <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>
 </tool>
 EOF_TOOLFILE

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -10,6 +10,7 @@ mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-stubs.xml
 <tool name="cuda-stubs" version="@TOOL_VERSION@">
   <info url="https://developer.nvidia.com/cuda-toolkit"/>
+  <lib name="cuda"/>
   <client>
     <environment name="CUDA_STUBS_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"          default="$CUDA_STUBS_BASE/lib64/stubs"/>
@@ -22,7 +23,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
 <tool name="cuda" version="@TOOL_VERSION@">
   <info url="https://developer.nvidia.com/cuda-toolkit"/>
   <use name="cuda-stubs"/>
-  <lib name="cuda"/>
   <lib name="cudart"/>
   <lib name="nppc"/>
   <lib name="nvToolsExt"/>

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external cuda-toolfile 1.0
+### RPM external cuda-toolfile 2.0
 Requires: cuda
 %prep
 
@@ -7,9 +7,21 @@ Requires: cuda
 %install
 
 mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-stubs.xml
+<tool name="cuda-stubs" version="@TOOL_VERSION@">
+  <info url="https://developer.nvidia.com/cuda-toolkit"/>
+  <client>
+    <environment name="CUDA_STUBS_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"          default="$CUDA_STUBS_BASE/lib64/stubs"/>
+  </client>
+  <flags SKIP_TOOL_SYMLINKS="1"/>
+</tool>
+EOF_TOOLFILE
+
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
 <tool name="cuda" version="@TOOL_VERSION@">
   <info url="https://developer.nvidia.com/cuda-toolkit"/>
+  <use name="cuda-stubs"/>
   <lib name="cuda"/>
   <lib name="cudart"/>
   <lib name="nppc"/>
@@ -19,7 +31,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="NVCC"      default="$CUDA_BASE/bin/nvcc"/>
     <environment name="BINDIR"    default="$CUDA_BASE/bin"/>
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
-    <environment name="LIBDIR"    default="$CUDA_BASE/lib64/stubs"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
   <flags CUDA_CFLAGS="-fPIC"/>
@@ -29,4 +40,3 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
 EOF_TOOLFILE
 
 ## IMPORT scram-tools-post
-

--- a/cuda.spec
+++ b/cuda.spec
@@ -12,11 +12,11 @@ AutoReqProv: no
 cp %{SOURCE0} %_builddir
 mkdir -p %_builddir/tmp
 /bin/sh %_builddir/%{n}_%{realversion}_%{driversversion}_linux-run --silent --tmpdir %_builddir/tmp --extract %_builddir
+# extracts:
+# %_builddir/NVIDIA-Linux-x86_64-384.81.run
+# %_builddir/cuda-linux.9.0.176-22781540.run
+# %_builddir/cuda-samples.9.0.176-22781540-linux.run
 /bin/sh %_builddir/%{n}-linux.%{realversion}-*.run -noprompt -nosymlink -tmpdir %_builddir/tmp -prefix %_builddir
-/bin/sh %_builddir/NVIDIA-Linux-x86_64-%{driversversion}.run --accept-license --extract-only --target %_builddir/drivers
-cp %_builddir/drivers/libcuda.so.* %_builddir/drivers/libnvidia-fatbinaryloader.so.* %_builddir/lib64
-ln -sf `basename %_builddir/lib64/libcuda.so.*` %_builddir/lib64/libcuda.so.1
-ln -sf libcuda.so.1 %_builddir/lib64/libcuda.so
 ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
 ln -sf ../libnsight/nsight %_builddir/bin/nsight
 mkdir -p %{i}/lib64

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,6 +1,7 @@
 ### RPM external cuda 8.0.61
+%define driversversion 375.26
 
-Source: https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/%{n}_%{realversion}_375.26_linux-run
+Source: https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/%{n}_%{realversion}_%{driversversion}_linux-run
 AutoReqProv: no
 
 %prep
@@ -10,7 +11,7 @@ AutoReqProv: no
 %install
 cp %{SOURCE0} %_builddir
 mkdir -p %_builddir/tmp
-/bin/sh %_builddir/%{n}_%{realversion}_375.26_linux-run --silent --tmpdir %_builddir/tmp --extract %_builddir
+/bin/sh %_builddir/%{n}_%{realversion}_%{driversversion}_linux-run --silent --tmpdir %_builddir/tmp --extract %_builddir
 /bin/sh %_builddir/%{n}-linux64-rel-%{realversion}-*.run -noprompt -nosymlink -tmpdir %_builddir/tmp -prefix %_builddir
 /bin/sh %_builddir/NVIDIA-Linux-x86_64-*.run --accept-license --extract-only --target %_builddir/drivers
 cp %_builddir/drivers/libcuda.so.* %_builddir/drivers/libnvidia-fatbinaryloader.so.* %_builddir/lib64

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,7 +1,7 @@
-### RPM external cuda 8.0.61
-%define driversversion 375.26
+### RPM external cuda 9.0.103
+%define driversversion 384.59
 
-Source: https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/%{n}_%{realversion}_%{driversversion}_linux-run
+Source: https://developer.nvidia.com/compute/cuda/9.0/rc/local_installers/%{n}_%{realversion}_%{driversversion}_linux-run
 AutoReqProv: no
 
 %prep
@@ -12,8 +12,8 @@ AutoReqProv: no
 cp %{SOURCE0} %_builddir
 mkdir -p %_builddir/tmp
 /bin/sh %_builddir/%{n}_%{realversion}_%{driversversion}_linux-run --silent --tmpdir %_builddir/tmp --extract %_builddir
-/bin/sh %_builddir/%{n}-linux64-rel-%{realversion}-*.run -noprompt -nosymlink -tmpdir %_builddir/tmp -prefix %_builddir
-/bin/sh %_builddir/NVIDIA-Linux-x86_64-*.run --accept-license --extract-only --target %_builddir/drivers
+/bin/sh %_builddir/%{n}-linux.%{realversion}-*.run -noprompt -nosymlink -tmpdir %_builddir/tmp -prefix %_builddir
+/bin/sh %_builddir/NVIDIA-Linux-x86_64-%{driversversion}.run --accept-license --extract-only --target %_builddir/drivers
 cp %_builddir/drivers/libcuda.so.* %_builddir/drivers/libnvidia-fatbinaryloader.so.* %_builddir/lib64
 ln -sf `basename %_builddir/lib64/libcuda.so.*` %_builddir/lib64/libcuda.so.1
 ln -sf libcuda.so.1 %_builddir/lib64/libcuda.so

--- a/cuda.spec
+++ b/cuda.spec
@@ -20,7 +20,7 @@ ln -sf libcuda.so.1 %_builddir/lib64/libcuda.so
 ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
 ln -sf ../libnsight/nsight %_builddir/bin/nsight
 mkdir -p %{i}/lib64
-cp -ar %_builddir/lib64/libcudadevrt.a %{i}/lib64
+cp -ar %_builddir/lib64/libcudadevrt.a %_builddir/lib64/libcudart_static.a %{i}/lib64
 rm -rf %_builddir/lib64/*.a
 rm -rf %_builddir/lib64/libnppi.so* %_builddir/lib64/libcufft.so* %_builddir/lib64/libcurand.so* %_builddir/lib64/libcusparse.so* %_builddir/lib64/libcusolver.so* %_builddir/lib64/libcublas.so* %_builddir/lib64/libnvrtc-builtins.so* %_builddir/lib64/libnvrtc.so* %_builddir/lib64/libnpps.so* %_builddir/lib64/libnvblas.so* %_builddir/lib64/libcufftw.so*
 rm -rf %_builddir/include/sobol_direction_vectors.h %_builddir/include/nppi* %_builddir/include/curand*

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,7 +1,7 @@
-### RPM external cuda 9.0.103
-%define driversversion 384.59
+### RPM external cuda 9.0.176
+%define driversversion 384.81
 
-Source: https://developer.nvidia.com/compute/cuda/9.0/rc/local_installers/%{n}_%{realversion}_%{driversversion}_linux-run
+Source: https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/%{n}_%{realversion}_%{driversversion}_linux-run
 AutoReqProv: no
 
 %prep


### PR DESCRIPTION
Update CUDA to version 9.0.176.

Include `libcudart_static.a` in the external.

No longer include `libcuda.so.*` and `libnvidia-fatbinaryloader.so.*` in the external; instead, rely on the libraries installed on the system, since they would anyway need to match the version of the installed (kernel) driver.

To make them available at link time, we add `libcuda.so` to the libraries, and add `lib64/stubs` to the linker library path.