### PR TITLE
PhEDEx agents 4.2.2 and p5-crypt-ssleay dependency

### DIFF
--- a/PHEDEX-admin.spec
+++ b/PHEDEX-admin.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-admin 4.2.1
+### RPM cms PHEDEX-admin 4.2.2
 # Dummy line to force a rebuild
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
@@ -15,6 +15,7 @@ Requires: p5-dbd-oracle p5-xml-parser p5-poe p5-poe-component-child
 Requires: p5-log-log4perl p5-log-dispatch p5-log-dispatch-filerotate
 Requires: p5-params-validate p5-monalisa-apmon
 Requires: p5-clone p5-json-xs p5-mail-rfc822-address
+Requires: p5-crypt-ssleay
 # Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
 # This is so it gets into our dependencies-setup.sh
 Requires: expat

--- a/PHEDEX-micro.spec
+++ b/PHEDEX-micro.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX-micro 4.2.1
+### RPM cms PHEDEX-micro 4.2.2
 ## INITENV +PATH PATH %i/Utilities:%i/Toolkit/DropBox:%i/Toolkit/Request
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
@@ -17,6 +17,7 @@ Requires: p5-time-hires p5-text-glob p5-compress-zlib p5-dbi
 Requires: p5-dbd-oracle p5-xml-parser p5-poe p5-poe-component-child
 Requires: p5-log-log4perl p5-log-dispatch p5-log-dispatch-filerotate
 Requires: p5-params-validate p5-monalisa-apmon p5-json-xs
+Requires: p5-crypt-ssleay
 # Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
 # This is so it gets into our dependencies-setup.sh
 Requires: expat

--- a/PHEDEX.spec
+++ b/PHEDEX.spec
@@ -1,4 +1,4 @@
-### RPM cms PHEDEX 4.2.1
+### RPM cms PHEDEX 4.2.2
 ## INITENV +PATH PATH %i/Utilities
 ## INITENV +PATH PERL5LIB %i/perl_lib
 %define downloadn %(echo %n | cut -f1 -d-)
@@ -17,6 +17,7 @@ Requires: p5-time-hires p5-text-glob p5-compress-zlib p5-dbi
 Requires: p5-dbd-oracle p5-xml-parser p5-monalisa-apmon p5-poe
 Requires: p5-poe-component-child p5-log-log4perl p5-log-dispatch
 Requires: p5-log-dispatch-filerotate p5-params-validate p5-json-xs
+Requires: p5-crypt-ssleay
 # Actually, it is p5-xml-parser that requires this, but it doesn't configure itself correctly
 # This is so it gets into our dependencies-setup.sh
 Requires: expat


### PR DESCRIPTION
PHEDEX 4_2_2 agents release 
Includes improvements to the central FileRouter agent needed a.s.a.p. 
and other new features outlined in the release note:
https://github.com/dmwm/PHEDEX/releases/tag/PHEDEX_4_2_2
