### PR TITLE
Fixed decay channels or K0 and antiK0

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 10.02.p02
-%define tag f3271a58f63c955d68aab76c31aeb10e196ff544
+%define tag a7c691a6fb5f3a6669a2929f5d24f8b8671821c4
 %define branch cms/4.%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Back-ported fix to Geant4 10.2p02 for the treatment of K0 and antiK0, which is a part of Geant4 10.3.
The problem was faced in attempt to start simulation production for XeXe run but may affect any workflow.

In G4VDecayChannel the fixes concerns so-called 1 body decay - transformation of K0 into KS or KL.

In G4Decay extended printout for G4Exception is added.