### PR TITLE
Added patch for decay of K0 and antiK0

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 10.02.p02
-%define tag f3271a58f63c955d68aab76c31aeb10e196ff544
+%define tag f9e758d95096c7956792a541549515b3c767d1fb
 %define branch cms/4.%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
This patch for K0 and antiK0 decay should fix XeXE production but not change simulation histories. 