### PR TITLE
Update scram-project-build.file

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -63,7 +63,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-42
+%define configtag       V05-05-50
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
new build rules V05-05-50 which contains update cuba rules (use of device link step)