### PR TITLE
Yoda 1.6.7 and Rivet 2.5.4

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -1,5 +1,6 @@
-### RPM external rivet 2.5.2
-Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
+### RPM external rivet 2.5.4
+## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
+Source: http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/MCGeneratorsTarFiles/Rivet-%{realversion}.tar.bz2
 
 Requires: hepmc fastjet gsl yoda
 BuildRequires: python py2-cython
@@ -7,7 +8,8 @@ BuildRequires: python py2-cython
 Patch0: rivet-1.4.0
 
 %prep
-%setup -n rivet/%{realversion}
+## OLD GENSER: %setup -n rivet/%{realversion}
+%setup -n Rivet-%{realversion}
 %patch0 -p0
 
 # Update config.{guess,sub} to detect aarch64 and ppc64le

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,11 +1,13 @@
-### RPM external yoda 1.6.5
+### RPM external yoda 1.6.7
 
-Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
+## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-%{realversion}-src.tgz
+Source: http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/MCGeneratorsTarFiles/YODA-%{realversion}.tar.gz 
 
 Requires: python root
 BuildRequires: py2-cython
 %prep
-%setup -q -n %{n}/%{realversion}
+## OLD GENSER #%setup -q -n %{n}/%{realversion}
+%setup -q -n YODA-%{realversion}
 
 ./configure --prefix=%i --enable-root
 


### PR DESCRIPTION
Update of external packages Rivet and Yoda. Might need to be also propagated to lower CMSSW versions.