### PR TITLE
Update CUDA 9.0.176 external and toolfiles

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external cuda-toolfile 2.0
+### RPM external cuda-toolfile 2.1
 Requires: cuda
 %prep
 
@@ -9,11 +9,12 @@ Requires: cuda
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-stubs.xml
 <tool name="cuda-stubs" version="@TOOL_VERSION@">
-  <info url="https://developer.nvidia.com/cuda-toolkit"/>
+  <info url="https://docs.nvidia.com/cuda/index.html"/>
   <lib name="cuda"/>
   <client>
     <environment name="CUDA_STUBS_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"          default="$CUDA_STUBS_BASE/lib64/stubs"/>
+    <environment name="INCLUDE"         default="$CUDA_STUBS_BASE/include"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
 </tool>
@@ -21,10 +22,10 @@ EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
 <tool name="cuda" version="@TOOL_VERSION@">
-  <info url="https://developer.nvidia.com/cuda-toolkit"/>
+  <info url="https://docs.nvidia.com/cuda/index.html"/>
   <use name="cuda-stubs"/>
   <lib name="cudart"/>
-  <lib name="nppc"/>
+  <lib name="cudadevrt"/>
   <lib name="nvToolsExt"/>
   <client>
     <environment name="CUDA_BASE" default="@TOOL_ROOT@"/>
@@ -33,9 +34,97 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
-  <flags CUDA_CFLAGS="-fPIC"/>
-  <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_61,code=sm_61"/>
+  <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
+  <flags CUDA_FLAGS="-gencode arch=compute_50,code=sm_50"/>
+  <flags CUDA_FLAGS="-gencode arch=compute_61,code=sm_61"/>
+  <flags CUDA_LDFLAGS="-L$(CUDA_BASE)/lib64"/>
   <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cublas.xml
+<tool name="cuda-cublas" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/cublas/index.html"/>
+  <use name="cuda"/>
+  <lib name="cublas"/>
+  <lib name="cublas_device"/>
+  <flags CUDA_LDFLAGS="-lcublas_device"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cufft.xml
+<tool name="cuda-cufft" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/cufft/index.html"/>
+  <use name="cuda"/>
+  <lib name="cufft"/>
+  <lib name="cufftw"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-curand.xml
+<tool name="cuda-curand" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/curand/index.html"/>
+  <use name="cuda"/>
+  <lib name="curand"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cusolver.xml
+<tool name="cuda-cusolver" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/cusolver/index.html"/>
+  <use name="cuda"/>
+  <lib name="cusolver"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cusparse.xml
+<tool name="cuda-cusparse" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/cusparse/index.html"/>
+  <use name="cuda"/>
+  <lib name="cusparse"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-npp.xml
+<tool name="cuda-npp" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/npp/index.html"/>
+  <use name="cuda"/>
+  <lib name="nppial"/>
+  <lib name="nppicc"/>
+  <lib name="nppicom"/>
+  <lib name="nppidei"/>
+  <lib name="nppif"/>
+  <lib name="nppig"/>
+  <lib name="nppim"/>
+  <lib name="nppist"/>
+  <lib name="nppisu"/>
+  <lib name="nppitc"/>
+  <lib name="npps"/>
+  <lib name="nppc"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvgraph.xml
+<tool name="cuda-nvgraph" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/nvgraph/index.html"/>
+  <use name="cuda"/>
+  <lib name="nvgraph"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvml.xml
+<tool name="cuda-nvml" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/deploy/nvml-api/index.html"/>
+  <use name="cuda"/>
+  <lib name="nvidia-ml"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvrtc.xml
+<tool name="cuda-nvrtc" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/nvrtc/index.html"/>
+  <use name="cuda"/>
+  <lib name="nvrtc"/>
 </tool>
 EOF_TOOLFILE
 

--- a/cuda.spec
+++ b/cuda.spec
@@ -20,14 +20,30 @@ mkdir -p %_builddir/tmp
 ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
 ln -sf ../libnsight/nsight %_builddir/bin/nsight
 mkdir -p %{i}/lib64
-cp -ar %_builddir/lib64/libcudadevrt.a %_builddir/lib64/libcudart_static.a %{i}/lib64
-rm -rf %_builddir/lib64/*.a
-rm -rf %_builddir/lib64/libnppi.so* %_builddir/lib64/libcufft.so* %_builddir/lib64/libcurand.so* %_builddir/lib64/libcusparse.so* %_builddir/lib64/libcusolver.so* %_builddir/lib64/libcublas.so* %_builddir/lib64/libnvrtc-builtins.so* %_builddir/lib64/libnvrtc.so* %_builddir/lib64/libnpps.so* %_builddir/lib64/libnvblas.so* %_builddir/lib64/libcufftw.so*
-rm -rf %_builddir/include/sobol_direction_vectors.h %_builddir/include/nppi* %_builddir/include/curand*
-cp -ar %_builddir/bin %{i}
-cp -ar %_builddir/include %{i}
-cp -ar %_builddir/lib64/* %{i}/lib64
-cp -ar %_builddir/nvvm %{i}
-cp -ar %_builddir/jre %{i}
+# package only runtime and device static libraries
+cp -ar %_builddir/lib64/libcudart_static.a %{i}/lib64/
+cp -ar %_builddir/lib64/libcudadevrt.a %{i}/lib64/
+cp -ar %_builddir/lib64/lib*_device.a %{i}/lib64/
+rm -rf %_builddir/lib64/lib*.a
+# do not package dynamic libraries for which we have stubs
+rm -rf %_builddir/lib64/libcublas.so*
+rm -rf %_builddir/lib64/libcufft.so*
+rm -rf %_builddir/lib64/libcufftw.so*
+rm -rf %_builddir/lib64/libcurand.so*
+rm -rf %_builddir/lib64/libcusolver.so*
+rm -rf %_builddir/lib64/libcusparse.so*
+rm -rf %_builddir/lib64/libnpp*.so*
+rm -rf %_builddir/lib64/libnvgraph.so*
+rm -rf %_builddir/lib64/libnvrtc.so*
+rm -rf %_builddir/lib64/libnvrtc-builtins.so*
+# package the other dynamic libraries
+cp -ar %_builddir/lib64/* %{i}/lib64/
 cp -ar %_builddir/libnvvp %{i}
 cp -ar %_builddir/libnsight %{i}
+# package the includes
+rm -rf %_builddir/include/sobol_direction_vectors.h
+cp -ar %_builddir/include %{i}
+# package the binaries and tools
+cp -ar %_builddir/bin %{i}
+cp -ar %_builddir/nvvm %{i}
+cp -ar %_builddir/jre %{i}

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -145,7 +145,7 @@ COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Wstrict-overflow"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fvisibility-inlines-hidden"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50"
-COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Wa,--compress-debug-sections"
+COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Xassembler --compress-debug-sections"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fno-crossjumping"
 
 case %{cmsplatf} in


### PR DESCRIPTION
Update the list of static and dynamic CUDA libraries included in the external
Update build rules for CUDA code:
  - drop CUDA_CFLAGS; instead pass all CXXFLAGS to the host compiler via `nvcc --compiler-flags '...'`
  - use a separate tool for each CUDA library
  - drop the `-lcudadevrt` flag for linking CUDA device code, and hardcode it in the SCRAM rules (see cms-sw/cmssw-config#60)

In GCC, reword '-Wa,...' as '-Xassembler ...' to support CUDA `nvcc --compiler-flags '...'`