### PR TITLE
Fix SiteDB LDAP sync on CC7 machines.

### DIFF
--- a/db6.spec
+++ b/db6.spec
@@ -1,0 +1,18 @@
+### RPM external db6 6.0.30
+Source: http://davidlt.web.cern.ch/davidlt/sources/db-%{realversion}.tar.gz
+%define drop_files %{i}/docs
+%define strip_files %{i}/lib
+
+%prep
+%setup -n db-%{realversion}
+
+%build
+mkdir ./obj
+cd ./obj
+../dist/configure --prefix=%{i} --build="%{_build}" --host="%{_host}" \
+                  --disable-java --disable-tcl --disable-static
+make %{makeprocesses}
+
+%install
+cd ./obj
+make install

--- a/openldap.spec
+++ b/openldap.spec
@@ -1,7 +1,7 @@
-### RPM external openldap 2.4.34
+### RPM external openldap 2.4.44
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib
 Source: ftp://ftp.openldap.org/pub/OpenLDAP/%{n}-release/%{n}-%{realversion}.tgz
-Requires: openssl db4
+Requires: openssl db6
 
 %prep
 %setup -q -n %{n}-%{realversion}
@@ -13,7 +13,14 @@ curl -L -k -s -o ./build/config.sub 'http://git.savannah.gnu.org/gitweb/?p=confi
 curl -L -k -s -o ./build/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
 chmod +x ./build/config.{sub,guess}
 
-./configure --prefix=%{i} --without-cyrus-sasl --with-tls --disable-static --disable-slapd --disable-slurpd
+./configure \
+  --prefix=%{i} \
+  --without-cyrus-sasl \
+  --with-tls=openssl \
+  --disable-static \
+  --disable-slapd \
+  CPPFLAGS="-I${OPENSSL_ROOT}/include -I${DB6_ROOT}/include" \
+  LDFLAGS="-L${OPENSSL_ROOT}/lib -L${DB6_ROOT}/lib"
 make depend
 make
 


### PR DESCRIPTION
This patch updates openldap from 2.4.34 to 2.4.44.
It also adds db6 to comp_gcc630 and set it as a requirement for openldap.

These changes are meant to fix the SiteDB's LDAP synchronization problem on CC7 machines.