### PR TITLE
Get and build numba from sources (fixes broken tests)

### DIFF
--- a/py2-numba.spec
+++ b/py2-numba.spec
@@ -1,9 +1,11 @@
-### RPM external py2-numba 0.33.0
+### RPM external py2-numba 0.35.0
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define pip_name numba
 Requires: py2-funcsigs py2-enum34 py2-six py2-singledispatch py2-llvmlite py2-numpy 
+%define source_file numba-%{realversion}.tar.gz
+%define source0 git+https://github.com/numba/numba?obj=master/9ed665ea67ce293b94c641aab0387fc846588b38&export=numba-%{realversion}&output=/source.tar.gz
 
 ## IMPORT build-with-pip
 


### PR DESCRIPTION
Fix for this failure https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-3593/24658/unitTests.log 
and bringing numba back for gcc7 (hopefully, eventually)