### PR TITLE
updated build rules to fix the generation of python init files for deleted packages

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -63,7 +63,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-73
+%define configtag       V05-05-74
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
fixes the bug reported : https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1558.html