### PR TITLE
Enable llvmlite version that works with llvm5

### DIFF
--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -9,8 +9,11 @@
 %if "%{?PipBuildOptions:set}" != "set"
 %define PipBuildOptions --no-deps
 %endif
+%if "%{?source0:set}" != "set"
+%define source0 pip://%{pip_name}/%{realversion}?pip_options=%{PipDownloadOptions}&output=/source.tar.gz
+%endif
 
-Source: pip://%{pip_name}/%{realversion}?pip_options=%{PipDownloadOptions}&output=/source.tar.gz
+Source: %source0
 
 Requires: python
 BuildRequires: py2-pip
@@ -20,7 +23,12 @@ BuildRequires: py2-pip
 %build
 mkdir -p %{i}
 
+%if "%{?source_file:set}" != "set"
 tar xfz %{_sourcedir}/source.tar.gz
+%else
+cp %{_sourcedir}/source.tar.gz %{source_file}
+echo %{source_file} > files.list
+%endif
 
 %{?PipPreBuild:%PipPreBuild}
 

--- a/py2-llvmlite.spec
+++ b/py2-llvmlite.spec
@@ -1,13 +1,15 @@
-### RPM external py2-llvmlite 0.18.0
+### RPM external py2-llvmlite 0.20.0
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 #Patch0: py2-llvmlite_lib6
 
 %define pip_name llvmlite
+
 Requires: py2-enum34 
 Requires: llvm
 BuildRequires: py2-wheel
-
 %define PipPreBuild export LLVM_CONFIG=${LLVM_ROOT}/bin/llvm-config 
+%define source_file llvmlite-%{realversion}.tar.gz
+%define source0     git+https://github.com/numba/llvmlite?obj=master/772b6099e43017d58793bbed6b3ca5bb1dbdca32&export=llvmlite-%{realversion}&output=/source.tar.gz
 
 ## IMPORT build-with-pip
 

--- a/py2-numba.spec
+++ b/py2-numba.spec
@@ -1,9 +1,11 @@
-### RPM external py2-numba 0.33.0
+### RPM external py2-numba 0.35.0
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 
 
 %define pip_name numba
 Requires: py2-funcsigs py2-enum34 py2-six py2-singledispatch py2-llvmlite py2-numpy 
+%define source_file numba-%{realversion}.tar.gz
+%define source0 git+https://github.com/numba/numba?obj=master/9ed665ea67ce293b94c641aab0387fc846588b38&export=numba-%{realversion}&output=/source.tar.gz
 
 ## IMPORT build-with-pip
 

--- a/py2-numpy.spec
+++ b/py2-numpy.spec
@@ -45,3 +45,7 @@ PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
 OSARCH=$(uname -m)
 [ -d  %{i}/${PYTHON_LIB_SITE_PACKAGES}/numpy-%{realversion}-py${PYTHONV}-linux-$OSARCH.egg/numpy/core ] || exit 1
 ln -s   ../${PYTHON_LIB_SITE_PACKAGES}/numpy-%{realversion}-py${PYTHONV}-linux-$OSARCH.egg/numpy/core %{i}/c-api/core
+%post
+%{relocateConfig}lib/python*/site-packages/numpy-*.egg/numpy/__config__.py
+%{relocateConfig}lib/python*/site-packages/numpy-*.egg/numpy/distutils/__config__.py
+%{relocateConfig}lib/python*/site-packages/numpy-*.egg/numpy/distutils/site.cfg

--- a/py2-pippkgs_depscipy.spec
+++ b/py2-pippkgs_depscipy.spec
@@ -26,8 +26,8 @@ BuildRequires: py2-bottleneck
 BuildRequires: py2-downhill 
 BuildRequires: py2-theanets
 BuildRequires: py2-xgboost
-#BuildRequires: py2-llvmlite
-#BuildRequires: py2-numba
+BuildRequires: py2-llvmlite
+BuildRequires: py2-numba
 BuildRequires: py2-hep_ml
 BuildRequires: py2-rep
 BuildRequires: py2-uncertainties


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/3593 and https://github.com/cms-sw/cmsdist/pull/3597 to gcc630next 