### PR TITLE
updated latest scram and build rules

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_7_pre1
+### RPM lcg SCRAMV1 V2_2_7_pre6
 ## NOCOMPILER
 
 BuildRequires: gmake

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: file
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-40
+%define configtag       V05-05-74
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
get latest scrama nd build rules in 92X. This should fix the wrong python directory path https://github.com/cms-sw/cmsdist/pull/3599