### PR TITLE
Update py2-chardet.spec

### DIFF
--- a/py2-chardet.spec
+++ b/py2-chardet.spec
@@ -1,7 +1,7 @@
 ### RPM external py2-chardet 3.0.4
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 
-
+%define PipBuildOptions --upgrade
 %define pip_name chardet
 
 ## IMPORT build-with-pip


### PR DESCRIPTION
If chardet is already available then package is build with no contents.
```
+ pip install --user -v --no-deps chardet-3.0.4.tar.gz
Processing ./chardet-3.0.4.tar.gz
  Running setup.py (path:tmp/pip-Li_eTP-build/setup.py) egg_info for package from file://BUILD/slc6_amd64_gcc630/external/py2-chardet/3.0.4-npnolj2/chardet-3.0.4.tar.gz
    Running command python setup.py egg_info
    running egg_info
    creating pip-egg-info/chardet.egg-info
    writing pip-egg-info/chardet.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/chardet.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/chardet.egg-info/dependency_links.txt
    writing entry points to pip-egg-info/chardet.egg-info/entry_points.txt
    writing manifest file 'pip-egg-info/chardet.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found

    reading manifest file 'pip-egg-info/chardet.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    warning: no files found matching 'requirements.txt'
    writing manifest file 'pip-egg-info/chardet.egg-info/SOURCES.txt'
  Source in tmp/pip-Li_eTP-build has version 3.0.4, which satisfies requirement chardet==3.0.4 from file://BUILD/slc6_amd64_gcc630/external/py2-chardet/3.0.4-npnolj2/chardet-3.0.4.tar.gz
  Requirement already satisfied (use --upgrade to upgrade): chardet==3.0.4 from file://BUILD/slc6_amd64_gcc630/external/py2-chardet/3.0.4-npnolj2/chardet-3.0.4.tar.gz in /opt/py2-packages
Cleaning up...
  Removing source in tmp/pip-Li_eTP-build
+ touch BUILD/slc6_amd64_gcc630/external/py2-chardet/3.0.4-npnolj2/files
```
with force --upgrade it build the package fine. For now I am only added --upgrade for py2-chardet but we might want to add it in build-with-pip.file so that all packages can make use of it.
```
  Source in w2/tmp/pip-nqmwRr-build has version 3.0.4, which satisfies requirement chardet==3.0.4 from file:/BUILD/slc6_amd64_gcc630/external/py2-chardet/3.0.4-cms/chardet-3.0.4.tar.gz
Installing collected packages: chardet
  Running setup.py install for chardet: started
    Running command slc6_amd64_gcc630/external/python/2.7.11-fmblme/bin/python -u -c "import setuptools, tokenize;__file__='tmp/pip-nqmwRr-build/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record tmp/pip-ZvPyO3-record/install-record.txt --single-version-externally-managed --compile --user --prefix=
    running install
    running build
    running build_py
    creating build
    creating build/lib
    creating build/lib/chardet
    copying chardet/big5prober.py -> build/lib/chardet
```