### PR TITLE
Update Keras to 2.1.2

### DIFF
--- a/py2-Keras.spec
+++ b/py2-Keras.spec
@@ -1,13 +1,8 @@
-### RPM external py2-Keras 2.0.5
+### RPM external py2-Keras 2.1.2
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
-
 
 %define pip_name Keras
 Requires: py2-PyYAML py2-six py2-scipy py2-Theano py2-numpy
 ## IMPORT build-with-pip
 
-
-%define PipPostBuild \
-   perl -p -i -e "s|# Default backend: TensorFlow.|# Default backend: Theano.|" %{i}/lib/python2.7/site-packages/keras/backend/__init__.py; \
-   perl -p -i -e "s|_BACKEND = 'tensorflow'|_BACKEND = 'theano'|" %{i}/lib/python2.7/site-packages/keras/backend/__init__.py
 


### PR DESCRIPTION
backport of #3625

Update keras and leave the default backend untouched (tensorflow instead of theano)