### PR TITLE
Enable support for 'concepts' in GCC 6 and later

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -140,7 +140,7 @@ EOF_TOOLFILE
 # optimizations as they become available in gcc.
 COMPILER_CXXFLAGS=
 
-COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++1z -ftree-vectorize"
+COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++17 -ftree-vectorize"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Wstrict-overflow"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fvisibility-inlines-hidden"

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -141,6 +141,7 @@ EOF_TOOLFILE
 COMPILER_CXXFLAGS=
 
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++17 -ftree-vectorize"
+COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fconcepts"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Wstrict-overflow"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fvisibility-inlines-hidden"

--- a/icc-gcc-toolfile.spec
+++ b/icc-gcc-toolfile.spec
@@ -50,6 +50,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/icc-cxxcompiler.xml
     </client>
     <flags REM_CXXFLAGS="-felide-constructors"/>
     <flags REM_CXXFLAGS="-ftree-vectorize"/>
+    <flags REM_CXXFLAGS="-fconcepts"/>
     <flags REM_CXXFLAGS="-Wstrict-overflow"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-Wno-non-template-friend"/>

--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -54,6 +54,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags REM_CXXFLAGS="-Wno-psabi"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-fno-aggressive-loop-optimizations"/>
+    <flags REM_CXXFLAGS="-fconcepts"/>
     <flags CXXFLAGS="-Wno-c99-extensions"/>
     <flags CXXFLAGS="-Wno-c++11-narrowing"/>
     <flags CXXFLAGS="-D__STRICT_ANSI__"/>


### PR DESCRIPTION
GCC 6.x and higher supports 'concepts' as defined in the Concepts TS ["C++ Extensions for concepts", ISO Technical Specification ISO/IEC TS 19217:2015](https://www.iso.org/standard/64031.html).
With GCC 6.x, the `-fconepts` option enables support for concepts and defines `__cpp_concepts` to `201500`.
With GCC 7.x, the `-fconepts` option enables support for concepts and defines `__cpp_concepts` to `201509`, as dictated by the TS.

LLVM/clang and Intel ICC do not support 'concepts' yet.