### PR TITLE
Revert "Enable support for 'concepts' in GCC 6 and later"

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -140,8 +140,7 @@ EOF_TOOLFILE
 # optimizations as they become available in gcc.
 COMPILER_CXXFLAGS=
 
-COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++17 -ftree-vectorize"
-COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fconcepts"
+COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -std=c++1z -ftree-vectorize"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Wstrict-overflow"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fvisibility-inlines-hidden"

--- a/icc-gcc-toolfile.spec
+++ b/icc-gcc-toolfile.spec
@@ -50,7 +50,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/icc-cxxcompiler.xml
     </client>
     <flags REM_CXXFLAGS="-felide-constructors"/>
     <flags REM_CXXFLAGS="-ftree-vectorize"/>
-    <flags REM_CXXFLAGS="-fconcepts"/>
     <flags REM_CXXFLAGS="-Wstrict-overflow"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-Wno-non-template-friend"/>

--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -54,7 +54,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags REM_CXXFLAGS="-Wno-psabi"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-fno-aggressive-loop-optimizations"/>
-    <flags REM_CXXFLAGS="-fconcepts"/>
     <flags CXXFLAGS="-Wno-c99-extensions"/>
     <flags CXXFLAGS="-Wno-c++11-narrowing"/>
     <flags CXXFLAGS="-D__STRICT_ANSI__"/>


### PR DESCRIPTION
Reverts cms-sw/cmsdist#3638
This broke the IB 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_10_0_X_2017-12-18-1100/CondFormats/CastorObjects