### PR TITLE
update clhep to 2.4.0.0 with cms patches

### DIFF
--- a/clhep.spec
+++ b/clhep.spec
@@ -1,6 +1,6 @@
-### RPM external clhep 2.3.4.2
+### RPM external clhep 2.4.0.0
 
-%define tag 03bdb22fe139303b43ca834a641f451f8e79bbcf
+%define tag 4b23da33f4607fde6f47c864871972558aa75c39
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
we had missed the follow cms patch that is why geant4 was failing
- https://github.com/cms-externals/clhep/commit/637e542df5446b01f6e1e419a47a2aa0e656e6f3
- https://github.com/cms-externals/clhep/commit/ecd1cd007aaf11500b44afac4fd7b0ba7015d1ce
- https://github.com/cms-externals/clhep/commit/28bf45d8c55dfa74444ebe200e40dd010dea1c44
- https://github.com/cms-externals/clhep/commit/03bdb22fe139303b43ca834a641f451f8e79bbcf