### PR TITLE
included cms patches for geant4 10.04

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 10.04
-%define tag b15f6fadadf568e951bbb04c7d55ed4765dfe533
+%define tag 7788cfbecfee824344bd3761cb32efe2bdc53046
 %define branch cms/4.%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
These patches were part of 10.02.p02 branch but were not picked up for 10.04. This is the cause of failures on clang IBs.
- Do not use __has_feature(c_atomic) in C++ to detect std::atomic support : https://github.com/cms-externals/geant4/commit/7788cfbecfee824344bd3761cb32efe2bdc53046
- Do not use __has_feature(c_atomic) in C++11/C++14/C++1z: https://github.com/cms-externals/geant4/commit/f5a27d9b0a47f2a40fc27db06a3851685005bf72