### PR TITLE
Update IB/CMSSW_10_0_X/root612 root.spec to tip of root v6-12 patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,8 +1,8 @@
 ### RPM lcg root 6.12.05
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 3ac13e5ca998a8b9e67a8a3e6df638bfce4438c4
-%define branch cms/v6-12-00-patches/a188173
+%define tag 16ec111aa65ee055769c69212464cb58860e2cec
+%define branch cms/v6-12-00-patches/c86ba6e
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 


### PR DESCRIPTION
Update root spec on CMS root-6-12 branch - v6-12 patches to latest commit