### PR TITLE
updated bazel to 0.9.0 to avoid build errors due to java 1.8.0.161

### DIFF
--- a/bazel-0.9.0-860af5b.patch
+++ b/bazel-0.9.0-860af5b.patch
@@ -1,0 +1,41 @@
+From 860af5be10b6bad68144d9d2d34173e86b40268c Mon Sep 17 00:00:00 2001
+From: cushon <cushon@google.com>
+Date: Mon, 22 Jan 2018 15:33:46 -0800
+Subject: [PATCH] Consolidate Error Prone resource handling
+
+Fixes bazelbuild/bazel#4483
+
+PiperOrigin-RevId: 182847474
+---
+ .../build/buildjar/javac/plugins/errorprone/ErrorPronePlugin.java     | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorPronePlugin.java b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorPronePlugin.java
+index c573d33a54..3ebc976257 100644
+--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorPronePlugin.java
++++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorPronePlugin.java
+@@ -18,6 +18,7 @@
+ import com.google.common.collect.ImmutableList;
+ import com.google.devtools.build.buildjar.InvalidCommandLineException;
+ import com.google.devtools.build.buildjar.javac.plugins.BlazeJavaCompilerPlugin;
++import com.google.errorprone.BaseErrorProneJavaCompiler;
+ import com.google.errorprone.ErrorProneAnalyzer;
+ import com.google.errorprone.ErrorProneError;
+ import com.google.errorprone.ErrorProneOptions;
+@@ -30,7 +31,6 @@
+ import com.sun.tools.javac.comp.Env;
+ import com.sun.tools.javac.main.JavaCompiler;
+ import com.sun.tools.javac.util.Context;
+-import com.sun.tools.javac.util.JavacMessages;
+ import com.sun.tools.javac.util.Log;
+ import java.util.Arrays;
+ import java.util.List;
+@@ -66,7 +66,7 @@ public ErrorPronePlugin(boolean testOnly, ScannerSupplier scannerSupplier) {
+ 
+   /** Registers our message bundle. */
+   public static void setupMessageBundle(Context context) {
+-    JavacMessages.instance(context).add("com.google.errorprone.errors");
++    BaseErrorProneJavaCompiler.setupMessageBundle(context);
+   }
+ 
+   private static final String COMPILING_TEST_ONLY_CODE_ARG = "-XepCompilingTestOnlyCode";

--- a/bazel-java-vm.patch
+++ b/bazel-java-vm.patch
@@ -1,22 +1,22 @@
 diff --git a/scripts/bootstrap/compile.sh b/scripts/bootstrap/compile.sh
-index dee6ce2..a562b86 100755
+index e817b19..deed3ae 100755
 --- a/scripts/bootstrap/compile.sh
 +++ b/scripts/bootstrap/compile.sh
-@@ -295,7 +295,7 @@ function build_jni() {
- 
-   *)
+@@ -258,7 +258,7 @@ function build_jni() {
+     JNI_FLAGS="-Dio.bazel.EnableJni=1 -Djava.library.path=${output_dir}"
+   else
      # We don't need JNI on other platforms.
 -    JNI_FLAGS="-Dio.bazel.EnableJni=0"
 +    JNI_FLAGS="-Dio.bazel.EnableJni=0 -Xmx512m"
-     ;;
-   esac
+   fi
  }
-@@ -331,7 +331,7 @@ function run_bazel_jar() {
+ 
+@@ -339,7 +339,7 @@ function run_bazel_jar() {
        ${BAZEL_DIR_STARTUP_OPTIONS} \
        ${BAZEL_BOOTSTRAP_STARTUP_OPTIONS:-} \
        $command \
 -      --ignore_unsupported_sandboxing \
-+      --ignore_unsupported_sandboxing --jobs=8 \
++      --ignore_unsupported_sandboxing  --jobs=8 \
        --startup_time=329 --extract_data_time=523 \
        --rc_source=/dev/null --isatty=1 \
-       --ignore_client_env \
+       --build_python_zip \

--- a/bazel.spec
+++ b/bazel.spec
@@ -1,14 +1,16 @@
-### RPM external bazel 0.4.5
+### RPM external bazel 0.9.0
 
-Source: https://github.com/bazelbuild/bazel/releases/download/0.4.5/bazel-0.4.5-dist.zip
+Source: https://github.com/bazelbuild/bazel/releases/download/%{realversion}/bazel-%{realversion}-dist.zip
 BuildRequires: java-env
-Patch1: bazel-0.4.5-java-vm
+Patch1: bazel-java-vm
+Patch2: bazel-0.9.0-860af5b
 %prep
 
 %define __unzip unzip -d bazel-%{realversion}
 
-%setup -q -n bazel-%{realversion}
+%setup -q -n %{n}-%{realversion}
 %patch1 -p1
+%patch2 -p1
 
 %build
 bash ./compile.sh


### PR DESCRIPTION
Bazel failed to build for gcc700 IBs due to update of java 1.8.0.161 on the build machines. It has been reported to bazel https://github.com/bazelbuild/bazel/issues/4483#event-1436272244 .
There is already a fix for this https://github.com/bazelbuild/bazel/commit/860af5be10b6bad68144d9d2d34173e86b40268c which will be part of bazel release 0.10.0 next week.

So this update moved bazel to use release 0.9.0 + the fix.