### PR TITLE
Update the tag of RecoTracker-FinalTrackSelectors

### DIFF
--- a/data-RecoTracker-FinalTrackSelectors.spec
+++ b/data-RecoTracker-FinalTrackSelectors.spec
@@ -1,4 +1,4 @@
-### RPM cms data-RecoTracker-FinalTrackSelectors V01-00-01
+### RPM cms data-RecoTracker-FinalTrackSelectors V01-00-02
 
 %prep
 


### PR DESCRIPTION
Description:
dzPVClosest values were clamped to +-2mm to ensure correct performance with particleGun type tracks.