### PR TITLE
added new tool cms_oracleocci_abi_hack

### DIFF
--- a/cms_oracleocci_abi_hack-toolfile.spec
+++ b/cms_oracleocci_abi_hack-toolfile.spec
@@ -1,0 +1,29 @@
+### RPM cms cms_oracleocci_abi_hack-toolfile 1.0
+Requires: cms_oracleocci_abi_hack
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+if ${CMS_ORACLEOCCI_ABI_HACK_ROOT}/bin/is_cxx11_abi ; then
+cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
+<tool name="oracleocci" version="@TOOL_VERSION@">
+  <lib name="cms_oracleocci_abi_hack"/>
+  <use name="oracleocci-official"/>
+  <client>
+    <environment name="ORACLEOCCI_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" value="$ORACLEOCCI_BASE/lib"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+else
+cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
+<tool name="oracleocci" version="@TOOL_VERSION@">
+  <use name="oracleocci-official"/>
+</tool>
+EOF_TOOLFILE
+fi
+
+## IMPORT scram-tools-post

--- a/cms_oracleocci_abi_hack.spec
+++ b/cms_oracleocci_abi_hack.spec
@@ -1,0 +1,25 @@
+### RPM cms cms_oracleocci_abi_hack 20180209
+%define tag 24d917b12c27a024d45859b86cb78699448f2eb4
+Source: git+https://github.com/cms-sw/%{n}.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Requires: oracle
+BuildRequires: gmake
+
+%define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
+%define soext so
+%if %isdarwin
+%define soext dylib
+%endif
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+export INCLUDE_DIR=${ORACLE_ROOT}/include
+export LIB_DIR=${ORACLE_ROOT}/lib
+make %{makeprocesses}
+
+%install
+mkdir %{i}/lib %{i}/bin
+cp is_cxx11_abi %{i}/bin/
+cp lib%{n}.%{soext} %{i}/lib
+

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -174,6 +174,7 @@ Requires: dmtcp-toolfile
 Requires: tkonlinesw-toolfile
 Requires: py2-cx-oracle-toolfile
 Requires: oracle-toolfile
+Requires: cms_oracleocci_abi_hack-toolfile
 Requires: cuda-toolfile
 Requires: cuda-api-wrappers-toolfile
 Requires: intel-vtune

--- a/oracle-toolfile.spec
+++ b/oracle-toolfile.spec
@@ -27,8 +27,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/oracle.xml
 </tool>
 EOF_TOOLFILE
 
-cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
-<tool name="oracleocci" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci-official.xml
+<tool name="oracleocci-official" version="@TOOL_VERSION@">
   <lib name="occi"/>
   <use name="oracle"/>
 </tool>


### PR DESCRIPTION
This tool provide libcms_oracleocci_abi_hack.so which provide implementation of following for old CXX ABI ( gcc4-compatible ) 
- std::length()
- oracle::occi::Statement::getString(int n)
- oracle::occi::ResultSet::getString(int n)

This is done as oracleocci is build with old C++ ABI which CMSSW wants to move to new CXX11 ABI