### PR TITLE
updated fastjet to 3.3.3 and fastjet-contrib to 1.032

### DIFF
--- a/fastjet-contrib.spec
+++ b/fastjet-contrib.spec
@@ -1,6 +1,6 @@
-### RPM external fastjet-contrib 1.026
-%define tag 63154ae21b8f40acfb4ee163ac720c39e260aabe
-%define branch cms/v%realversion
+### RPM external fastjet-contrib 1.032
+%define tag 6000f18568bd2f03fb6bbb89cedf0baeed5344ad
+%define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&foo=1&output=/%{n}-%{realversion}.tgz
 Requires: fastjet

--- a/fastjet.spec
+++ b/fastjet.spec
@@ -1,5 +1,5 @@
 ### RPM external fastjet 3.3.0
-%define tag 2db2b530b753af3ab39c91f2551e6a90597e1c13
+%define tag 26e1f4828f4622742062f1465ae8de9986f96f86
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/fastjet.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz

--- a/fastjet.spec
+++ b/fastjet.spec
@@ -1,5 +1,5 @@
-### RPM external fastjet 3.1.0
-%define tag 5e4e8ed7a6ebcca0467add9d1a22d2f7cf6cdbd3
+### RPM external fastjet 3.3.0
+%define tag 2db2b530b753af3ab39c91f2551e6a90597e1c13
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/fastjet.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
This integrates the following requests in 10.1.X DEVEL IBs. Once it is validated in there then we will backport it to normal 10.1.X IBs.
- https://github.com/cms-sw/cmsdist/issues/3725
- https://github.com/cms-sw/cmsdist/issues/3731