### PR TITLE
include cms_oracleocci_abi_hack/include directory

### DIFF
--- a/cms_oracleocci_abi_hack-toolfile.spec
+++ b/cms_oracleocci_abi_hack-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM cms cms_oracleocci_abi_hack-toolfile 1.0
+### RPM cms cms_oracleocci_abi_hack-toolfile 1.1
 Requires: cms_oracleocci_abi_hack
 %prep
 
@@ -7,23 +7,20 @@ Requires: cms_oracleocci_abi_hack
 %install
 
 mkdir -p %i/etc/scram.d
-if ${CMS_ORACLEOCCI_ABI_HACK_ROOT}/bin/is_cxx11_abi ; then
+if [ -e ${CMS_ORACLEOCCI_ABI_HACK_ROOT}/lib ] ; then
+  export CMS_ORACLEOCCI_LIB='<lib name="cms_oracleocci_abi_hack"/>'
+  export CMS_ORACLEOCCI_LIBDIR='<environment name="LIBDIR" value="$ORACLEOCCI_BASE/lib"/>'
+fi
 cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
 <tool name="oracleocci" version="@TOOL_VERSION@">
-  <lib name="cms_oracleocci_abi_hack"/>
+  @CMS_ORACLEOCCI_LIB@
   <use name="oracleocci-official"/>
   <client>
     <environment name="ORACLEOCCI_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" value="$ORACLEOCCI_BASE/lib"/>
+    <environment name="INCLUDE" value="$ORACLEOCCI_BASE/include"/>
+    @CMS_ORACLEOCCI_LIBDIR@
   </client>
 </tool>
 EOF_TOOLFILE
-else
-cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
-<tool name="oracleocci" version="@TOOL_VERSION@">
-  <use name="oracleocci-official"/>
-</tool>
-EOF_TOOLFILE
-fi
 
 ## IMPORT scram-tools-post

--- a/cms_oracleocci_abi_hack.spec
+++ b/cms_oracleocci_abi_hack.spec
@@ -1,5 +1,5 @@
 ### RPM cms cms_oracleocci_abi_hack 20180210
-%define tag 6136662ef5139c381ff82249796a1fed01499dc2
+%define tag 88b2a965305226df1822a14af8fe7174ee5f1614
 Source: git+https://github.com/cms-sw/%{n}.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Requires: oracle
 BuildRequires: gmake

--- a/cms_oracleocci_abi_hack.spec
+++ b/cms_oracleocci_abi_hack.spec
@@ -1,14 +1,8 @@
-### RPM cms cms_oracleocci_abi_hack 20180209
-%define tag 24d917b12c27a024d45859b86cb78699448f2eb4
+### RPM cms cms_oracleocci_abi_hack 20180210
+%define tag 6136662ef5139c381ff82249796a1fed01499dc2
 Source: git+https://github.com/cms-sw/%{n}.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Requires: oracle
 BuildRequires: gmake
-
-%define isdarwin %(case %{cmsos} in (osx*) echo 1 ;; (*) echo 0 ;; esac)
-%define soext so
-%if %isdarwin
-%define soext dylib
-%endif
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -19,7 +13,5 @@ export LIB_DIR=${ORACLE_ROOT}/lib
 make %{makeprocesses}
 
 %install
-mkdir %{i}/lib %{i}/bin
-cp is_cxx11_abi %{i}/bin/
-cp lib%{n}.%{soext} %{i}/lib
-
+[ -d  build/lib ] && cp -r build/lib %{i}/lib
+cp -r build/include %{i}/include


### PR DESCRIPTION
cms_oracleocci_abi_hack now includes occi.h with either contents of 
- https://github.com/cms-sw/cms_oracleocci_abi_hack/blob/master/cms_oracleocci_old_abi.h if we have OLD ABI. This contains inline functions for getOraString and getOraMessage
- https://github.com/cms-sw/cms_oracleocci_abi_hack/blob/master/cms_oracleocci_cxx11_abi.h  if we have new cxx11 ABI. This provide out of line implementation via cms_oracleocci_abi_hack for getOraString and getOraMessage