### PR TITLE
update vdt to 0.4.0

### DIFF
--- a/vdt.spec
+++ b/vdt.spec
@@ -1,4 +1,4 @@
-### RPM cms vdt 0.3.9
+### RPM cms vdt 0.4.0
 
 Source: https://github.com/dpiparo/%{n}/archive/v%{realversion}.tar.gz 
 


### PR DESCRIPTION
Request by @VinInn
https://github.com/dpiparo/vdt/releases/tag/V0.4.0
- The only change that matters are few additional inline to silence CUDA warning