### PR TITLE
updated scram and cmssw-config tag

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_7_pre6
+### RPM lcg SCRAMV1 V2_2_7_pre7
 ## NOCOMPILER
 
 BuildRequires: gmake

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -63,7 +63,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-75
+%define configtag       V05-05-76
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- new scram: which make sure any special env variables (e.g. LD_PRELOAD) are not set if scram runtime env is not set.
- cmssw-config: Allow to override default library name via `<export><lib name="myname"/></export>` section. This helps if you have packages with depth more than 2 for example one can have src/SubSystem/Package/Package/src and would like to give special name to this public library.