### PR TITLE
Move the RecoEgamma-PhotonIdentification tag from 04 to 05

### DIFF
--- a/data-RecoEgamma-PhotonIdentification.spec
+++ b/data-RecoEgamma-PhotonIdentification.spec
@@ -1,4 +1,4 @@
-### RPM cms data-RecoEgamma-PhotonIdentification V01-00-04
+### RPM cms data-RecoEgamma-PhotonIdentification V01-00-05
 
 %prep
 


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/3668