### PR TITLE
updated scram and config tags

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_7_pre7
+### RPM lcg SCRAMV1 V2_2_7_pre8
 ## NOCOMPILER
 
 BuildRequires: gmake

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -63,7 +63,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-76
+%define configtag       V05-05-77
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- SCRAM: Added new filters to use used in BuildFiles
  - ifrelease
  - ifscram
  - ifconfig
  - ifcompiler
  - ifproject
  - ifcxx11_abi
e.g
   - `<ifreleaase match="CMSSW_10_.*">....</ifrelease>`
   - `<ifcompiler value="gcc">....</ifrelease>`

- BuildRules: Allow to serenv and source script for unit tests
   - `<flags SETENV="LD_PRELOAD=blabla"/>`
   - `<flags SETENV_SCRIPT="set-env-script.sh"/>`