### PR TITLE
enable new CXX11 ABI for 10.1.X; drop -fno-crossjumping flag

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -149,7 +149,6 @@ COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Werror=array-bounds -Werror=format-contai
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fvisibility-inlines-hidden"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50"
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Xassembler --compress-debug-sections"
-COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fno-crossjumping"
 
 case %{cmsplatf} in
    *_amd64_*)

--- a/gcc.spec
+++ b/gcc.spec
@@ -289,7 +289,7 @@ export LD_LIBRARY_PATH=%{i}/lib64:%{i}/lib:$LD_LIBRARY_PATH
              --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object \
              --enable-plugin --with-linker-hash-style=gnu --enable-linker-build-id \
              $CONF_GCC_OS_SPEC $CONF_GCC_WITH_LTO --with-gmp=%{i} --with-mpfr=%{i} --enable-bootstrap \
-             --with-mpc=%{i} --with-isl=%{i} --with-default-libstdcxx-abi=gcc4-compatible --enable-checking=release \
+             --with-mpc=%{i} --with-isl=%{i} --enable-checking=release \
              --build=%{_build} --host=%{_host} --enable-libstdcxx-time=rt $CONF_GCC_ARCH_SPEC \
              --enable-shared --disable-libgcj CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" \
              CFLAGS="-I%{i}/tmp/sw/include" CXXFLAGS="-I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/tmp/sw/lib"


### PR DESCRIPTION
- Enable CXX11 ABI for 10.1.X gcc630 IBs
- Dropped the -fno-crossjumping flag which was a short term solution to avoid PPC64LE issues ( https://github.com/cms-sw/cmsdist/commit/1ce112c75ebe9fd31bb2f4d8b058a6ced775f537 )