### PR TITLE
Update CUDA compilation flags

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -37,7 +37,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
   <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
   <flags CUDA_FLAGS="-gencode arch=compute_50,code=sm_50"/>
   <flags CUDA_FLAGS="-gencode arch=compute_61,code=sm_61"/>
-  <flags CUDA_FLAGS="-O2 -std=c++14"/>
+  <flags CUDA_FLAGS="-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda"/>
   <flags CUDA_LDFLAGS="-dlink"/>
   <flags CUDA_LDFLAGS="-shared"/>
   <flags CUDA_LDFLAGS="-L$(CUDA_BASE)/lib64"/>


### PR DESCRIPTION
Update the default CUDA flags to include `-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda`