### PR TITLE
updated git/openssl/curl

### DIFF
--- a/curl.spec
+++ b/curl.spec
@@ -1,52 +1,54 @@
-### RPM external curl 7.28.0
-Source: http://curl.haxx.se/download/%n-%realversion.tar.gz
-Provides: libcurl.so.3()(64bit) 
+### RPM external curl 7.58.0
+Source: http://curl.haxx.se/download/%{n}-%{realversion}.tar.gz
 Requires: openssl
 Requires: zlib
-   
+
 %prep
-%setup -n %n-%{realversion}
+%setup -n %{n}-%{realversion}
 
 %build
-export OPENSSL_ROOT
-export ZLIB_ROOT
-case %cmsplatf in
-  slc6*) KERBEROS_ROOT=/usr ;;
-  slc5*) KERBEROS_ROOT=/usr/kerberos ;;
+case %{cmsplatf} in
   osx*) KERBEROS_ROOT=/usr/heimdal ;;
+  *) KERBEROS_ROOT=/usr ;;
 esac
-./configure --prefix=%i --disable-static --without-libidn --disable-ldap --with-ssl=${OPENSSL_ROOT} --with-zlib=${ZLIB_ROOT} --with-gssapi=$KERBEROS_ROOT
-# This should change link from "-lz" to "-lrt -lz", needed by gold linker
-# This is a fairly ugly way to do it, however.
-perl -p -i -e "s!\(LIBS\)!(LIBCURL_LIBS)!" src/Makefile
-make %makeprocesses
+
+./configure \
+  --prefix=%{i} \
+  --disable-silent-rules \
+  --disable-static \
+  --without-libidn \
+  --disable-ldap \
+  --with-zlib=${ZLIB_ROOT} \
+  --with-ssl=${OPENSSL_ROOT} \
+  --without-nss \
+  --without-libssh2 \
+  --with-gssapi=${KERBEROS_ROOT}
+
+make %{makeprocesses}
 
 %install
 make install
-case %cmsos in 
+case %{cmsos} in 
   osx*) SONAME=dylib ;;
   *) SONAME=so ;;
 esac
 
-ln -s libcurl.$SONAME %i/lib/libcurl.$SONAME.3
 # Trick to get our version of curl pick up our version of its associated shared
 # library (which is different from the one coming from the system!).
-case %cmsos in
-  osx*)
-install_name_tool -id %i/lib/libcurl-cms.dylib -change %i/lib/libcurl.4.dylib %i/lib/libcurl-cms.dylib  %i/lib/libcurl.4.dylib
-install_name_tool -change %i/lib/libcurl.4.dylib %i/lib/libcurl-cms.dylib %i/bin/curl
-ln -s libcurl.4.dylib %i/lib/libcurl-cms.dylib
-  ;;
-esac
+%ifos darwin
+install_name_tool -id %{i}/lib/libcurl-cms.dylib -change %{i}/lib/libcurl.4.dylib %{i}/lib/libcurl-cms.dylib  %{i}/lib/libcurl.4.dylib
+install_name_tool -change %{i}/lib/libcurl.4.dylib %{i}/lib/libcurl-cms.dylib %{i}/bin/curl
+ln -s libcurl.4.dylib %{i}/lib/libcurl-cms.dylib
+%endif
 
 # Remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
 # which we neither need nor use at this time.
-rm -rf %i/lib/pkgconfig
+rm -rf %{i}/lib/pkgconfig
 
 # Strip libraries, we are not going to debug them.
-%define strip_files %i/lib
+%define strip_files %{i}/lib
 # Read documentation online.
-%define drop_files %i/share
+%define drop_files %{i}/share
 
 %post
 %{relocateConfig}bin/curl-config

--- a/git-2.16.2-runtime.patch
+++ b/git-2.16.2-runtime.patch
@@ -1,0 +1,32 @@
+diff --git a/exec_cmd.c b/exec_cmd.c
+index ce192a2..2414b2b 100644
+--- a/exec_cmd.c
++++ b/exec_cmd.c
+@@ -7,19 +7,21 @@
+ static const char *argv_exec_path;
+ 
+ #ifdef RUNTIME_PREFIX
+-static const char *argv0_path;
++static const char *argv0_path = NULL;
+ 
+ static const char *system_prefix(void)
+ {
+-	static const char *prefix;
++	static const char *prefix = NULL;
+ 
+ 	assert(argv0_path);
+ 	assert(is_absolute_path(argv0_path));
+ 
+-	if (!prefix &&
+-	    !(prefix = strip_path_suffix(argv0_path, GIT_EXEC_PATH)) &&
+-	    !(prefix = strip_path_suffix(argv0_path, BINDIR)) &&
+-	    !(prefix = strip_path_suffix(argv0_path, "git"))) {
++	if (!argv0_path ||
++	    !is_absolute_path(argv0_path) ||
++	    (!prefix &&
++	     !(prefix = strip_path_suffix(argv0_path, GIT_EXEC_PATH)) &&
++	     !(prefix = strip_path_suffix(argv0_path, BINDIR)) &&
++	     !(prefix = strip_path_suffix(argv0_path, "git")))) {
+ 		prefix = PREFIX;
+ 		trace_printf("RUNTIME_PREFIX requested, "
+ 				"but prefix computation failed.  "

--- a/openssl-1.0.2d-disable-install-openssldir.patch
+++ b/openssl-1.0.2d-disable-install-openssldir.patch
@@ -1,0 +1,38 @@
+diff --git a/apps/Makefile b/apps/Makefile
+index cafe554..547fc41 100644
+--- a/apps/Makefile
++++ b/apps/Makefile
+@@ -109,16 +109,6 @@ install:
+ 	 chmod 755 $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new; \
+ 	 mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i ); \
+ 	 done;
+-	@set -e; for i in $(SCRIPTS); \
+-	do  \
+-	(echo installing $$i; \
+-	 cp $$i $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	 chmod 755 $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	 mv -f $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i ); \
+-	 done
+-	@cp openssl.cnf $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf.new; \
+-	chmod 644 $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf.new; \
+-	mv -f  $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf.new $(INSTALL_PREFIX)$(OPENSSLDIR)/openssl.cnf
+ 
+ tags:
+ 	ctags $(SRC)
+diff --git a/tools/Makefile b/tools/Makefile
+index c1a2f6b..6e7c104 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -26,12 +26,6 @@ install:
+ 	chmod 755 $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new; \
+ 	mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i.new $(INSTALL_PREFIX)$(INSTALLTOP)/bin/$$i ); \
+ 	done;
+-	@for i in $(MISC_APPS) ; \
+-	do  \
+-	(cp $$i $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	chmod 755 $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new; \
+-	mv -f $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i.new $(INSTALL_PREFIX)$(OPENSSLDIR)/misc/$$i ); \
+-	done;
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl Makefile >> $(TOP)/MINFO

--- a/openssl-1.0.2d-pr3979.patch
+++ b/openssl-1.0.2d-pr3979.patch
@@ -1,0 +1,44 @@
+diff --git a/crypto/x509v3/v3_purp.c b/crypto/x509v3/v3_purp.c
+index 36b0d87..845be67 100644
+--- a/crypto/x509v3/v3_purp.c
++++ b/crypto/x509v3/v3_purp.c
+@@ -380,6 +380,14 @@ static void setup_crldp(X509 *x)
+         setup_dp(x, sk_DIST_POINT_value(x->crldp, i));
+ }
+ 
++#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
++#define ku_reject(x, usage) \
++        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
++#define xku_reject(x, usage) \
++        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
++#define ns_reject(x, usage) \
++        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
++
+ static void x509v3_cache_extensions(X509 *x)
+ {
+     BASIC_CONSTRAINTS *bs;
+@@ -499,7 +507,8 @@ static void x509v3_cache_extensions(X509 *x)
+     if (!X509_NAME_cmp(X509_get_subject_name(x), X509_get_issuer_name(x))) {
+         x->ex_flags |= EXFLAG_SI;
+         /* If SKID matches AKID also indicate self signed */
+-        if (X509_check_akid(x, x->akid) == X509_V_OK)
++        if (X509_check_akid(x, x->akid) == X509_V_OK &&
++            !ku_reject(x, KU_KEY_CERT_SIGN))
+             x->ex_flags |= EXFLAG_SS;
+     }
+     x->altname = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
+@@ -538,14 +547,6 @@ static void x509v3_cache_extensions(X509 *x)
+  * 4 basicConstraints absent but keyUsage present and keyCertSign asserted.
+  */
+ 
+-#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
+-#define ku_reject(x, usage) \
+-        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
+-#define xku_reject(x, usage) \
+-        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
+-#define ns_reject(x, usage) \
+-        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
+-
+ static int check_ca(const X509 *x)
+ {
+     /* keyUsage if present should allow cert signing */

--- a/openssl.spec
+++ b/openssl.spec
@@ -1,9 +1,26 @@
-### RPM external openssl 1.1.0g
-%define openssl_tag %(echo %{realversion} | tr '.' '_')
-Source0: https://github.com/%{n}/%{n}/archive/OpenSSL_%{openssl_tag}.tar.gz
+### RPM external openssl 1.0.2d
+Source0: http://davidlt.web.cern.ch/davidlt/vault/openssl-1.0.2d-5675d07a144aa1a6c85f488a95aeea7854e86059.tar.bz2
+
+# https://rt.openssl.org/Ticket/Display.html?id=3979&user=guest&pass=guest
+Patch0: openssl-1.0.2d-pr3979
+# We want to pick CA certificates from /etc/pki/tls (openssldir), but we
+# cannot install to a standard system location
+Patch1: openssl-1.0.2d-disable-install-openssldir
 
 %prep
-%setup -b 0 -n openssl-OpenSSL_%{openssl_tag}
+%setup -b 0 -n openssl-%{realversion}
+%patch0 -p1
+%patch1 -p1
+
+# Disable documenation
+sed -ibak 's/install: all install_docs install_sw/install: all install_sw/g' Makefile.org Makefile
+
+case "%{cmsplatf}" in
+  slc6*)
+    # https://sourceware.org/glibc/wiki/Tips_and_Tricks/secure_getenv
+    grep -H -R 'secure_getenv(' * | cut -d':' -f1 | sort -u | xargs -t -n 1 sed -ibak 's;secure_getenv;__secure_getenv;g'
+    ;;
+esac
 
 %build
 
@@ -32,17 +49,14 @@ case "%{cmsplatf}" in
     cfg_args="-DOPENSSL_USE_NEW_FUNCTIONS"
     ;;
     *)
-    cfg_args="no-zlib --openssldir=/etc/pki/tls fips no-ec2m no-gost no-srp"
+    cfg_args="--with-krb5-flavor=MIT --with-krb5-dir=/usr enable-krb5 no-zlib --openssldir=/etc/pki/tls fips no-ec2m no-gost no-srp"
     ;;
 esac
 
 export RPM_OPT_FLAGS
 
-perl ./Configure ${target} ${cfg_args} enable-seed enable-rfc3779 no-asm \
+perl ./Configure ${target} ${cfg_args} enable-seed enable-tlsext enable-rfc3779 no-asm \
                  no-idea no-mdc2 no-rc5 shared --prefix=%{i}
-
-# Disable documenation
-sed -ibak 's/^install:  *install_sw  *.*/install: install_sw/' Makefile
 
 case "%{cmsplatf}" in
   *_aarch64_*|fc*|osx*)
@@ -51,9 +65,22 @@ case "%{cmsplatf}" in
 esac
 
 make all
-make install
 
 %install
+case "%{cmsplatf}" in
+  slc*_amd64_*)
+    RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
+                   -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
+                   -fstack-protector --param=ssp-buffer-size=4 -mtune=generic"
+    ;;
+  *_aarch64_*|fc*)
+    RPM_OPT_FLAGS="$RPM_OPT_FLAGS -Wa,--noexecstack -DPURIFY"
+    ;;
+esac
+
+export RPM_OPT_FLAGS
+
+make install
 
 rm -rf %{i}/lib/pkgconfig
 # We remove archive libraries because otherwise we need to propagate everywhere

--- a/openssl.spec
+++ b/openssl.spec
@@ -1,59 +1,69 @@
-### RPM external openssl 0.9.8e__1.0.1
-%define linver 0.9.8e
-%define osxver 1.0.1
-Source0: http://www.openssl.org/source/openssl-%osxver.tar.gz
-Source1: http://cmsrep.cern.ch/cmssw/openssl-sources/%n-fips-%linver-usa.tar.bz2
-Patch0: openssl-0.9.8e-rh-0.9.8e-12.el5_4.6
-Patch1: openssl-x86-64-gcc420
+### RPM external openssl 1.1.0g
+%define openssl_tag %(echo %{realversion} | tr '.' '_')
+Source0: https://github.com/%{n}/%{n}/archive/OpenSSL_%{openssl_tag}.tar.gz
 
 %prep
-%ifos darwin
-%setup -b 0 -n %n-%osxver
-%else
-%setup -b 1 -n %n-fips-%linver
-%patch0 -p1
-%patch1 -p1
-%endif
+%setup -b 0 -n openssl-OpenSSL_%{openssl_tag}
 
 %build
-# Looks like rpmbuild passes its own sets of flags via the
-# RPM_OPT_FLAGS environment variable and those flags include
-# -m64 (probably since rpmbuild processor detection is not
-# fooled by linux32). A quick fix is to just set the variable
-# to "" but we should probably understand how rpm determines
-# those flags and use them for our own good.
-export RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -mtune=generic"
 
-cfg_opts="no-idea no-mdc2 no-rc5 no-ec no-ecdh no-ecdsa shared fipscanisterbuild"
-
-case %cmsplatf in
-  osx*)
-    export KERNEL_BITS=64 # used by config to decide 64-bit build
-    cfg_args="-DOPENSSL_USE_NEW_FUNCTIONS"
-   ;;
-  *)
-    cfg_args="--with-krb5-flavor=MIT enable-krb5 fipscanisterbuild"
-   ;;
+case "%{cmsplatf}" in
+  slc6_amd64_*)
+    RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing \
+                   -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
+                   -fstack-protector --param=ssp-buffer-size=4 -mtune=generic"
+    ;;
+  *_aarch64_*|fc*)
+    RPM_OPT_FLAGS="$RPM_OPT_FLAGS -Wa,--noexecstack -DPURIFY"
+    ;;
 esac
 
-./config --prefix=%i $cfg_args enable-seed enable-tlsext enable-rfc3779 no-asm \
-                     no-idea no-mdc2 no-rc5 no-ec no-ecdh no-ecdsa shared
+case "%{cmsplatf}" in
+  osx*)         target=darwin64-x86_64-cc ;;
+  *_aarch64_*)  target=linux-aarch64 ;;
+  *_ppc64le_*)  target=linux-ppc64le ;;
+  *_ppc64_*)    target=linux-ppc64 ;;
+  *_amd64_*)    target=linux-x86_64 ;;
+  *)            target=linux-generic64 ;;
+esac
 
-make
-%install
-export RPM_OPT_FLAGS="-O2 -fPIC -g -pipe -Wall -Wa,--noexecstack -fno-strict-aliasing -Wp,-DOPENSSL_USE_NEW_FUNCTIONS -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -mtune=generic"
+case "%{cmsplatf}" in
+  osx*)
+    cfg_args="-DOPENSSL_USE_NEW_FUNCTIONS"
+    ;;
+    *)
+    cfg_args="no-zlib --openssldir=/etc/pki/tls fips no-ec2m no-gost no-srp"
+    ;;
+esac
 
+export RPM_OPT_FLAGS
+
+perl ./Configure ${target} ${cfg_args} enable-seed enable-rfc3779 no-asm \
+                 no-idea no-mdc2 no-rc5 shared --prefix=%{i}
+
+# Disable documenation
+sed -ibak 's/^install:  *install_sw  *.*/install: install_sw/' Makefile
+
+case "%{cmsplatf}" in
+  *_aarch64_*|fc*|osx*)
+    make depend
+    ;;
+esac
+
+make all
 make install
+
+%install
 
 rm -rf %{i}/lib/pkgconfig
 # We remove archive libraries because otherwise we need to propagate everywhere
 # their dependency on kerberos.
 rm -rf %{i}/lib/*.a
 
-# MacOSX is case insensitive and the man page structure has case sensitive logic
-case %cmsplatf in
-  osx* ) 
-    rm -rf %{i}/ssl/man
-    ;;
-esac
-perl -p -i -e "s|^#!.*perl|#!/usr/bin/env perl|" %{i}/ssl/misc/CA.pl %{i}/ssl/misc/der_chop %{i}/bin/c_rehash
+sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/env perl;' \
+  %{i}/bin/c_rehash
+find %{i} -name '*deleteme' -type f -print0 | xargs -0 rm -f
+
+%post
+%{relocateConfig}bin/c_rehash
+%{relocateConfig}include/openssl/opensslconf.h


### PR DESCRIPTION
github dropped spport for weak cryptographic standards removal notice : https://githubengineering.com/crypto-removal-notice/

This PR updates OpenSSL 1.0.2d, curl 7.58 and git 2.16.2