### PR TITLE
add -Wno-unknown-warning-option for clang compiler

### DIFF
--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -60,6 +60,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags CXXFLAGS="-Wno-unused-private-field"/>
     <flags CXXFLAGS="-Wno-unknown-pragmas"/>
     <flags CXXFLAGS="-Wno-unused-command-line-argument"/>
+    <flags CXXFLAGS="-Wno-unknown-warning-option"/>
     <flags CXXFLAGS="-ftemplate-depth=512"/>
     <flags CXXFLAGS="-Wno-error=potentially-evaluated-expression"/>
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LLVM_CXXCOMPILER_BASE/lib64" type="path"/>


### PR DESCRIPTION
In Clang IBs we see warnings like these
```
  HLTrigger/Timer/src/ProcessCallGraph.cc:13:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
```
`-Wno-unknown-warning-option` flag is added for llvm-cxxcompiler to avoid such warnings.

https://github.com/cms-sw/cmssw/pull/22567 can be dropped in favor of this PR