### PR TITLE
updated to use patched pythia8 from cms-external/pythia8 (93X)

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,12 +1,13 @@
 ### RPM external pythia8 230
+%define tag 47af87f3d9b0986b61bf0a1a1ca21cd69689754f
+%define branch cms/%{realversion}
+%define github_user cms-externals
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 Requires: hepmc lhapdf
 
-Source: http://home.thep.lu.se/~torbjorn/pythia8/%{n}%{realversion}.tgz
-
-
 %prep
-%setup -q -n %{n}%{realversion}
+%setup -q -n %{n}-%{realversion}
 
 ./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-lhapdf6=${LHAPDF_ROOT}
 


### PR DESCRIPTION
backport of #3831

needed for Phase 2 production