### PR TITLE
Python migration towards pth instead of PATHs

### DIFF
--- a/py2-numpy.spec
+++ b/py2-numpy.spec
@@ -3,7 +3,9 @@
 ## INITENV SET PY2_NUMPY_REAL_VERSION %{realversion}
 
 Source: https://github.com/numpy/numpy/releases/download/v%{realversion}/numpy-%{realversion}.tar.gz
-Requires: python py2-setuptools zlib OpenBLAS
+Requires: python  zlib OpenBLAS
+#py2-setuptools
+BuildRequires: py2-pip
 
 %define pythonver %(echo %{allpkgreqs} | tr ' ' '\\n' | grep ^external/python/ | cut -d/ -f3 | cut -d. -f 1,2)
 %define numpyArch %(uname -m)
@@ -32,27 +34,27 @@ library_dirs = $OPENBLAS_ROOT/lib
 [atlas]
 atlas_libs = openblas
 atlas_dirs = $OPENBLAS_ROOT/lib
+[build]
+fcompiler=gnu95
 EOF
 
 mkdir -p %i/${PYTHON_LIB_SITE_PACKAGES}
 
-python setup.py build  %{makeprocesses} --fcompiler=gnu95
-PYTHON27PATH=%i/${PYTHON_LIB_SITE_PACKAGES}:$PYTHON27PATH python setup.py install --prefix=%i
-sed -ideleteme 's|#!.*/bin/python|#!/usr/bin/env python|' \
-  %{i}/bin/f2py \
-  %{i}/lib/python*/site-packages/numpy-*/EGG-INFO/scripts/f2py \
-  %{i}/lib/python*/site-packages/numpy-*/numpy/core/tests/test_arrayprint.py \
-  %{i}/lib/python*/site-packages/numpy-*/numpy/distutils/from_template.py \
-  %{i}/lib/python*/site-packages/numpy-*/numpy/distutils/conv_template.py
+export PYTHONUSERBASE=%i
+pip install . --user 
 
-  
-find %{i} -name '*deleteme' -delete
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*
+
+#afaik, this functionality is not needed - but keep it for now.
 mkdir %{i}/c-api
 PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
 OSARCH=$(uname -m)
-[ -d  %{i}/${PYTHON_LIB_SITE_PACKAGES}/numpy-%{realversion}-py${PYTHONV}-linux-$OSARCH.egg/numpy/core ] || exit 1
-ln -s   ../${PYTHON_LIB_SITE_PACKAGES}/numpy-%{realversion}-py${PYTHONV}-linux-$OSARCH.egg/numpy/core %{i}/c-api/core
+[ -d  %{i}/${PYTHON_LIB_SITE_PACKAGES}/numpy/core ] || exit 1
+ln -s   ../${PYTHON_LIB_SITE_PACKAGES}/numpy/core %{i}/c-api/core
+
+
 %post
-%{relocateConfig}lib/python*/site-packages/numpy-*.egg/numpy/__config__.py
-%{relocateConfig}lib/python*/site-packages/numpy-*.egg/numpy/distutils/__config__.py
-%{relocateConfig}lib/python*/site-packages/numpy-*.egg/numpy/distutils/site.cfg
+%{relocateConfig}lib/python*/site-packages/numpy/__config__.py
+%{relocateConfig}lib/python*/site-packages/numpy/distutils/__config__.py
+%{relocateConfig}lib/python*/site-packages/numpy/distutils/site.cfg
+

--- a/py2-sqlalchemy.spec
+++ b/py2-sqlalchemy.spec
@@ -2,11 +2,7 @@
 ## INITENV +PATH PYTHON27PATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
 Source: https://pypi.python.org/packages/ca/ca/c2436fdb7bb75d772d9fa17ba60c4cfded6284eed053a7274b2beb96596a/SQLAlchemy-%{realversion}.tar.gz
-Requires: python py2-setuptools
-
-#%define pythonver %(echo %{allpkgreqs} | tr ' ' '\\n' | grep ^external/python/ | cut -d/ -f3 | cut -d. -f 1,2)
-#%define pyArch %(uname -m)
-
+Requires: python py2-pip
 
 Patch0: py2-sqlalchemy-1.1.4-add-frontier-dialect
 Patch1: py2-sqlalchemy-1.1.4-fix-sqlite-dialect-timestamp
@@ -17,9 +13,11 @@ Patch1: py2-sqlalchemy-1.1.4-fix-sqlite-dialect-timestamp
 %patch1 -p1
 
 %build
-python setup.py build
 
 %install
-mkdir -p %{i}/${PYTHON_LIB_SITE_PACKAGES}
-PYTHON27PATH=%{i}/${PYTHON_LIB_SITE_PACKAGES}:${PYTHON27PATH} python setup.py install --skip-build --prefix=%{i}
+export PYTHONUSERBASE=%i
+pip install . --user 
+
+
+
 

--- a/py2-tensorflow.spec
+++ b/py2-tensorflow.spec
@@ -5,6 +5,7 @@
 Source: none
 
 BuildRequires: tensorflow-sources
+BuildRequires: py2-setuptools
 Requires: python
 BuildRequires: py2-pip 
 Requires: py2-funcsigs py2-protobuf py2-pbr py2-six py2-packaging py2-appdirs py2-setuptools py2-pyparsing py2-numpy py2-mock py2-werkzeug

--- a/python3.spec
+++ b/python3.spec
@@ -1,8 +1,8 @@
 ### RPM external python3 3.6.4
 ## INITENV +PATH PATH %{i}/bin
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib
-## INITENV SETV PYTHON_LIB_SITE_PACKAGES lib/python%{pythonv}/site-packages
-## INITENV SETV PYTHONHASHSEED random
+## INITENV SETV PYTHON3_LIB_SITE_PACKAGES lib/python%{pythonv}/site-packages
+## INITENV SETV PYTHON3HASHSEED random
 # OS X patches and build fudging stolen from fink
 %define pythonv %(echo %realversion | cut -d. -f 1,2)
 %define python_major %(echo %realversion | cut -d. -f 1)

--- a/scramv1-tool-conf.file
+++ b/scramv1-tool-conf.file
@@ -95,5 +95,16 @@ if [ -e $SCRAMV1_ROOT/bin/chktool ] ; then
   rm -f %i/errors.log
 fi
 
+
+py27List=`echo ${PYTHON27PATH} | tr ':' '\n'`
+
+mkdir -p %{i}/${PYTHON_LIB_SITE_PACKAGES}
+touch %{i}/${PYTHON_LIB_SITE_PACKAGES}/tool-deps.pth
+for pkg in ${py27List} ; do
+   echo "adding $pkg"
+   echo "$pkg" >> %{i}/${PYTHON_LIB_SITE_PACKAGES}/tool-deps.pth
+done
+
+
 %post
 %{relocateCmsFiles} $(find $RPM_INSTALL_PREFIX/%{pkgrel}/tools -type f)

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -7,6 +7,7 @@
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}-%{tag}.tgz
 
 BuildRequires: bazel eigen protobuf gcc
+BuildRequires: py2-setuptools
 Requires: py2-numpy python py2-wheel
 
 %prep


### PR DESCRIPTION
Created a pth file with all cmssw python dependencies to reduce use of python envvars.

This required to stop using eggs, affecting only numpy and sqlalchemy builds. I changed those to use pip to build from source, making things a bit more consistent with the rest. 

setting PYTHON27PATH ....cmssw-tool-conf/<version>/lib/python2.7/site-packages  is now sufficient for all of the py2* tools (hooray). However, I did not yet enable that functionality. This would be the next step (purely a change of tool files, where a bunch of lines would be removed and one line added to the cmssw tool file)

The tensorflow changes were due to a missing setup tools dependency that they were previously  picking up from py2-numpy.