### PR TITLE
Update PhysicsTools-NanoAOD  to tag V01-00-01

### DIFF
--- a/data-PhysicsTools-NanoAOD.spec
+++ b/data-PhysicsTools-NanoAOD.spec
@@ -1,4 +1,4 @@
-### RPM cms data-PhysicsTools-NanoAOD V01-00-00
+### RPM cms data-PhysicsTools-NanoAOD V01-00-01
 
 %prep
 


### PR DESCRIPTION
backport of #3873

Description: https://github.com/cms-data/PhysicsTools-NanoAOD/pull/2