### PR TITLE
Use pth file instead of most python path components

### DIFF
--- a/cvs2git-toolfile.spec
+++ b/cvs2git-toolfile.spec
@@ -9,7 +9,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cvs2git.xml
   <client>
     <environment name="CVS2GIT_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$CVS2GIT_BASE/lib" type="path"/>
   <runtime name="PATH" value="$CVS2GIT_BASE/bin" type="path"/>
 </tool>
 EOF_TOOLFILE

--- a/das_client-toolfile.spec
+++ b/das_client-toolfile.spec
@@ -11,7 +11,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/das_client.xml
     <environment name="DAS_CLIENT_BASE" default="@TOOL_ROOT@"/>
   </client>
   <runtime name="PATH"       value="$DAS_CLIENT_BASE/bin" type="path"/>
-  <runtime name="PYTHON27PATH" value="$DAS_CLIENT_BASE/bin" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/frontier_client-toolfile.spec
+++ b/frontier_client-toolfile.spec
@@ -21,7 +21,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/frontier_client.xml
   <use name="zlib"/>
   <use name="openssl"/>
   <use name="expat"/>
-  <runtime name="PYTHON27PATH" value="$FRONTIER_CLIENT_BASE/python/lib" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/gosam-toolfile.spec
+++ b/gosam-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gosam.xml
     <environment name="GOSAM_BASE" default="@TOOL_ROOT@"/>
     <environment name="BINDIR" default="$GOSAM_BASE/bin"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$GOSAM_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <runtime name="PATH" default="$BINDIR" type="path"/>
 </tool>
 EOF_TOOLFILE

--- a/lhapdf-toolfile.spec
+++ b/lhapdf-toolfile.spec
@@ -17,7 +17,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/lhapdf.xml
   </client>
   <use name="yaml-cpp"/>
   <runtime name="LHAPDF_DATA_PATH" value="$LHAPDF_BASE/share/LHAPDF"/>
-  <runtime name="PYTHON27PATH" value="$LHAPDF_BASE/@PYTHON_LIB_SITE_PACKAGES@" type="path"/>
   <runtime name="PATH" value="$LHAPDF_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -142,7 +142,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/pyclang.xml
   <client>
     <environment name="PYCLANG_BASE" default="@LLVM_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PYCLANG_BASE/lib64/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/photospline-toolfile.spec
+++ b/photospline-toolfile.spec
@@ -15,7 +15,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/photospline.xml
     <environment name="PHOTOSPLINE_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PHOTOSPLINE_BASE/lib"/>
     <environment name="INCLUDE" default="$PHOTOSPLINE_BASE/include"/>
-    <runtime name="PYTHON27PATH" value="$PHOTOSPLINE_BASE/lib/python2.7/site-packages" type="path"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/professor-toolfile.spec
+++ b/professor-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/professor.xml
 <environment name="PROFESSOR_BASE" default="@TOOL_ROOT@"/>
 </client>
 <runtime name="PATH" value="$PROFESSOR_BASE/bin" type="path"/>
-<runtime name="PYTHON27PATH" value="$PROFESSOR_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
 </tool>
 EOF_TOOLFILE
 

--- a/professor2-toolfile.spec
+++ b/professor2-toolfile.spec
@@ -19,7 +19,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/professor2.xml
 <use name="yoda"/>
 <use name="eigen"/>
 <runtime name="PATH" value="$PROFESSOR2_BASE/bin" type="path"/>
-<runtime name="PYTHON27PATH" value="$PROFESSOR2_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
 </tool>
 EOF_TOOLFILE
 

--- a/py2-PyYAML-toolfile.spec
+++ b/py2-PyYAML-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-PyYAML.xml
   <client>
     <environment name="PY2_PYYAML" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PY2_PYYAML/lib"/>
-    <runtime name="PYTHON27PATH" value="$PY2_PYYAML/lib/python@PYTHONV@/site-packages" type="path"/>
   </client>
 </tool>
 EOF_TOOLFILE

--- a/py2-cx-oracle-toolfile.spec
+++ b/py2-cx-oracle-toolfile.spec
@@ -12,7 +12,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/py2-cx-oracle.xml
   <client>
     <environment name="PY2_CX_ORACLE_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PY2_CX_ORACLE_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
   <use name="oracle"/>
 </tool>

--- a/py2-dablooms-toolfile.spec
+++ b/py2-dablooms-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-dablooms.xml
   <client>
     <environment name="PY2_DABLOOMS" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PY2_DABLOOMS/lib"/>
-    <runtime name="PYTHON27PATH" value="$PY2_DABLOOMS/lib/python@PYTHONV@/site-packages" type="path"/>
   </client>
 </tool>
 EOF_TOOLFILE

--- a/py2-dxr-toolfile.spec
+++ b/py2-dxr-toolfile.spec
@@ -14,7 +14,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-dxr.xml
     <environment name="PY2_DXR_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PY2_DXR_BASE/lib"/>
   </client>
-    <runtime name="PYTHON27PATH" value="$PY2_DXR_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
     <runtime name="PATH" value="$PY2_DXR_BASE/bin" type="path"/>
     <use name="python"/>
     <use name="sqlite"/>

--- a/py2-lint-toolfile.spec
+++ b/py2-lint-toolfile.spec
@@ -14,7 +14,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/py2-lint.xml
     <environment name="PY2_LINT_BASE" default="@TOOL_ROOT@"/>
   </client>
   <runtime name="PATH" value="$PY2_LINT_BASE/bin" type="path"/>
-  <runtime name="PYTHON27PATH" value="$PY2_LINT_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/py2-matplotlib-toolfile.spec
+++ b/py2-matplotlib-toolfile.spec
@@ -12,7 +12,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/py2-matplotlib.xml
   <client>
     <environment name="PY2_MATPLOTLIB_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PY2_MATPLOTLIB_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
   <use name="zlib"/>
   <use name="libpng"/>

--- a/py2-numpy-toolfile.spec
+++ b/py2-numpy-toolfile.spec
@@ -14,7 +14,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/py2-numpy.xml
     <environment name="PY2_NUMPY_BASE" default="@TOOL_ROOT@"/>
   </client>
   <runtime name="PATH" value="$PY2_NUMPY_BASE/bin" type="path"/>
-  <runtime name="PYTHON27PATH" value="$PY2_NUMPY_BASE/lib/python@PYTHONV@/site-packages/" type="path"/>
   <use name="python"/>
   <use name="zlib"/>
   <use name="lapack"/>

--- a/py2-pip-toolfile.spec
+++ b/py2-pip-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pip.xml
   <client>
     <environment name="PY2_PIP" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PY2_PIP/lib"/>
-    <runtime name="PYTHON27PATH" value="$PY2_PIP/lib/python@PYTHONV@/site-packages" type="path"/>
     <runtime name="PATH" value="$PY2_PIP/bin" type="path"/>
   </client>
 </tool>

--- a/py2-pippkgs-toolfile.spec
+++ b/py2-pippkgs-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pippkgs.xml
   <client>
     <environment name="PY2_PIPPKGS" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PY2_PIPPKGS/@PYTHON_LIB_SITE_PACKAGES@" type="path"/>
   <runtime name="PATH" value="$PY2_PIPPKGS/bin" type="path"/>
 </tool>
 EOF_TOOLFILE

--- a/py2-pippkgs_depscipy-toolfile.spec
+++ b/py2-pippkgs_depscipy-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pippkgs_depscipy.xml
   <client>
     <environment name="PY2_PIPPKGS_DEPSCIPY" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PY2_PIPPKGS_DEPSCIPY/@PYTHON_LIB_SITE_PACKAGES@" type="path"/>
   <runtime name="PATH" value="$PY2_PIPPKGS_DEPSCIPY/bin" type="path"/>
 </tool>
 EOF_TOOLFILE

--- a/py2-pygithub-toolfile.spec
+++ b/py2-pygithub-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pygithub.xml
   <client>
     <environment name="PY2_PYGITHUB" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PY2_PYGITHUB/lib"/>
-    <runtime name="PYTHON27PATH" value="$PY2_PYGITHUB/lib/python@PYTHONV@/site-packages" type="path"/>
   </client>
 </tool>
 EOF_TOOLFILE

--- a/py2-setuptools-toolfile.spec
+++ b/py2-setuptools-toolfile.spec
@@ -12,7 +12,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/py2-setuptools.xml
   <client>
     <environment name="PY2_SETUPTOOLS_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PY2_SETUPTOOLS_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/py2-six-toolfile.spec
+++ b/py2-six-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-six.xml
   <client>
     <environment name="PY2_SIX" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PY2_SIX/lib"/>
-    <runtime name="PYTHON27PATH" value="$PY2_SIX/lib/python@PYTHONV@/site-packages" type="path"/>
   </client>
 </tool>
 EOF_TOOLFILE

--- a/py2-sqlalchemy-toolfile.spec
+++ b/py2-sqlalchemy-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-sqlalchemy.xml
   <client>
     <environment name="PY2_SQLALCHEMY_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PY2_SQLALCHEMY_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/pyminuit2-toolfile.spec
+++ b/pyminuit2-toolfile.spec
@@ -12,7 +12,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/pyminuit2.xml
 <client>
 <environment name="PYMINUIT2_BASE" default="@TOOL_ROOT@"/>
 </client>
-<runtime name="PYTHON27PATH" value="$PYMINUIT2_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
 </tool>
 EOF_TOOLFILE
 

--- a/pyqt-toolfile.spec
+++ b/pyqt-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/pyqt.xml
   <client>
     <environment name="PYQT_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$PYQT_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
   <use name="qt"/>
   <use name="sip"/>

--- a/rivet-toolfile.spec
+++ b/rivet-toolfile.spec
@@ -16,7 +16,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/rivet.xml
 <environment name="INCLUDE" default="$RIVET_BASE/include"/>
 </client>
 <runtime name="PATH" value="$RIVET_BASE/bin" type="path"/>
-<runtime name="PYTHON27PATH" value="$RIVET_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
 <runtime name="RIVET_ANALYSIS_PATH" value="$RIVET_BASE/lib" type="path"/>
 <runtime name="PDFPATH" default="$RIVET_BASE/share" type="path"/>
 <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/root-toolfile.spec
+++ b/root-toolfile.spec
@@ -27,7 +27,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/root_interface.xml
     <environment name="LIBDIR"                  default="$ROOT_INTERFACE_BASE/lib"/>
   </client>
   <runtime name="PATH"                          value="$ROOT_INTERFACE_BASE/bin" type="path"/>
-  <runtime name="PYTHON27PATH"                    value="$ROOT_INTERFACE_BASE/lib" type="path"/>
   <runtime name="ROOTSYS"                       value="$ROOT_INTERFACE_BASE/"/>
   <runtime name="ROOT_TTREECACHE_SIZE"          value="0"/>
   <runtime name="ROOT_TTREECACHE_PREFILL"       value="0"/>

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-05-83
+%define configtag       V05-05-84
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/sherpa-toolfile.spec
+++ b/sherpa-toolfile.spec
@@ -26,7 +26,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sherpa.xml
   <runtime name="SHERPA_SHARE_PATH" value="$SHERPA_BASE/share/SHERPA-MC" type="path"/>
   <runtime name="SHERPA_INCLUDE_PATH" value="$SHERPA_BASE/include/SHERPA-MC" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PYTHON27PATH" value="$SHERPA_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <runtime name="SHERPA_LIBRARY_PATH" value="$SHERPA_BASE/lib/SHERPA-MC" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="HepMC"/>

--- a/sip-toolfile.spec
+++ b/sip-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/sip.xml
   <client>
     <environment name="SIP_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PYTHON27PATH" value="$SIP_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE

--- a/xrootd-toolfile.spec
+++ b/xrootd-toolfile.spec
@@ -18,7 +18,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/xrootd.xml
     <environment name="LIBDIR" default="$XROOTD_BASE/lib64"/>
   </client>
   <runtime name="PATH" value="$XROOTD_BASE/bin" type="path"/>
-  <runtime name="PYTHON27PATH" value="$XROOTD_BASE/@PYTHON_LIB_SITE_PACKAGES@" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/yoda-toolfile.spec
+++ b/yoda-toolfile.spec
@@ -16,7 +16,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/yoda.xml
     <environment name="INCLUDE" default="$YODA_BASE/include"/>
   </client>
   <use name="root_cxxdefaults"/>
-  <runtime name="PYTHON27PATH" value="$YODA_BASE/lib/python@PYTHONV@/site-packages" type="path"/>
   <runtime name="PATH"       value="$YODA_BASE/bin" type="path"/>
 </tool>
 EOF_TOOLFILE


### PR DESCRIPTION
Not really tested outside of the bot as I'm not sure how  - changes are all "simple" removal of PYTHONPATHS from tool files and then the addition of one to pick up the pth.