### PR TITLE
Add Google common python package

### DIFF
--- a/py2-googlecommon.spec
+++ b/py2-googlecommon.spec
@@ -1,0 +1,9 @@
+### RPM external py2-googlecommon 0.0.1
+## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
+
+
+%define pip_name google-common
+
+## IMPORT build-with-pip
+
+

--- a/py2-pippkgs_depscipy.spec
+++ b/py2-pippkgs_depscipy.spec
@@ -14,6 +14,7 @@ BuildRequires: py2-rootpy
 %if %isamd64
 BuildRequires: py2-tensorflow
 %endif
+BuildRequires: py2-googlecommon
 BuildRequires: py2-protobuf
 
 BuildRequires: py2-tables
@@ -58,8 +59,10 @@ for pkg in %builddirectpkgreqs ; do
         # https://github.com/jupyter/jupyter_core/issues/55 - now I delete jupyter.py from one of the providers
         #backports is an example directory that can have multiple packages inside
         if [ $f != "backports" ] ; then  
+        if [ $f != "google" ] ; then  
            echo "  Duplicate file found: $f"
            exit 1
+        fi
         fi
 
       fi


### PR DESCRIPTION
This is nothing more than a __Init__.py file that makes protobuf (and eventually other google python products) work without their internal pth file.