### PR TITLE
added java-env dependency for tensorflow

### DIFF
--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -8,7 +8,7 @@
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}-%{tag}.tgz
 
 BuildRequires: bazel eigen protobuf gcc
-BuildRequires: py2-setuptools
+BuildRequires: py2-setuptools java-env
 Requires: py2-numpy python py2-wheel
 
 %prep


### PR DESCRIPTION
Without this we get build errors like
```
11:57:23 * The action "build-external+tensorflow-sources+1.6.0" was not completed successfully because Failed to build tensorflow-sources. Log file in /build/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/slc7_aarch64_gcc700/external/tensorflow-sources/1.6.0/log. Final lines of the log file:
11:57:23 + rm -rf ../build
11:57:23 + ./configure
11:57:23 Couldn't find java at '/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.131-3.b12.el7_3.aarch64/bin/java'.
11:57:23 Traceback (most recent call last):
11:57:23 File "configure.py", line 1459, in <module>
11:57:23 main()
```