### PR TITLE
Update tkonlinesw fake recipe

### DIFF
--- a/tkonlinesw-fake.spec
+++ b/tkonlinesw-fake.spec
@@ -1,8 +1,10 @@
-### RPM external tkonlinesw-fake 4.1.0-1
+### RPM external tkonlinesw-fake 4.2.0-1_gcc7
 
-Source: http://davidlt.web.cern.ch/davidlt/vault/tkonlinesw-fake-v10.tar.bz2
+%define tag 6bf27b3db8d4c0737b477cc38095fd05d2be3191
+Source: https://github.com/cms-externals/tkonline-fake/archive/%{tag}.tar.gz
+
 %prep
-%setup -n tkonlinesw-fake
+%setup -n tkonline-fake-%{tag}
 
 %build
 # NOP


### PR DESCRIPTION
Fixes the build & link errors in aarch64 IB: https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_aarch64_gcc700/www/wed/10.2-wed-11/CMSSW_10_2_X_2018-04-04-1100
adding the missing signatures & dummy impl. etc. 