### PR TITLE
Get llvmlite from source & bring numba back

### DIFF
--- a/py2-llvmlite.spec
+++ b/py2-llvmlite.spec
@@ -1,4 +1,4 @@
-### RPM external py2-llvmlite 0.22.0
+### RPM external py2-llvmlite 0.23.0
 ## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 #Patch0: py2-llvmlite_lib6
 
@@ -8,6 +8,8 @@ Requires: llvm
 BuildRequires: py2-wheel
 
 %define PipPreBuild export LLVM_CONFIG=${LLVM_ROOT}/bin/llvm-config 
+%define source_file llvmlite-%{realversion}.tar.gz
+%define source0     git+https://github.com/numba/llvmlite?obj=master/9ae78b184965f76d32b2120c25216cabe23bb3c4&export=llvmlite-%{realversion}&output=/source.tar.gz
 
 ## IMPORT build-with-pip
 

--- a/py2-pippkgs_depscipy.spec
+++ b/py2-pippkgs_depscipy.spec
@@ -25,8 +25,8 @@ BuildRequires: py2-bottleneck
 BuildRequires: py2-downhill 
 BuildRequires: py2-theanets
 BuildRequires: py2-xgboost
-#BuildRequires: py2-llvmlite
-#BuildRequires: py2-numba
+BuildRequires: py2-llvmlite
+BuildRequires: py2-numba
 BuildRequires: py2-hep_ml
 BuildRequires: py2-rep
 BuildRequires: py2-uncertainties


### PR DESCRIPTION
This gets numba 23 from source as it's not yet available as pip package and brings back llvmlite and numba for DEVEL IBs 