### PR TITLE
Revert "update pythia8 to version 235"

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,11 +1,13 @@
-### RPM external pythia8 235
-
-Source: http://home.thep.lu.se/~torbjorn/pythia8/%{n}%{realversion}.tgz
+### RPM external pythia8 230
+%define tag 3a07a17386fcbc5dd451c1900d96551430d84790
+%define branch cms/%{realversion}
+%define github_user cms-externals
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 Requires: hepmc lhapdf
 
 %prep
-%setup -q -n %{n}%{realversion}
+%setup -q -n %{n}-%{realversion}
 
 ./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-lhapdf6=${LHAPDF_ROOT}
 


### PR DESCRIPTION
Reverts cms-sw/cmsdist#3891

10.2.X DEVEL IB CMSSW_10_2_DEVEL_X_2018-04-12-1100 contains new pythia8 and there are few failtures. So we are reverting this