### PR TITLE
Update pythia8.spec

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,5 +1,5 @@
 ### RPM external pythia8 230
-%define tag 3a07a17386fcbc5dd451c1900d96551430d84790
+%define tag 74524ba8700857a1a0c08197e05876c93b57f4ec
 %define branch cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
Backport of #3931
A crash was found in Phase2 production using 9_3_6: see detail here cms-externals/pythia8#10