### PR TITLE
Hack CUDA to support GCC 7

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -41,6 +41,8 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
   <flags CUDA_LDFLAGS="-dlink"/>
   <flags CUDA_LDFLAGS="-shared"/>
   <flags CUDA_LDFLAGS="-L$(CUDA_BASE)/lib64"/>
+  <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
+  <flags CUDA_HOST_CXXFLAGS="-std=c++14"/>
   <lib name="cudadevrt" type="cuda"/>
   <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>
 </tool>

--- a/cuda.spec
+++ b/cuda.spec
@@ -42,6 +42,28 @@ rm -rf %_builddir/lib64/libnvblas.so.9.1.85
 rm -rf %_builddir/lib64/libcublas.so.9.1.128
 rm -rf %_builddir/lib64/libnvblas.so.9.1.128
 
+# patch the extracted files
+patch -d%_builddir -p1 <<@EOF
+diff -u a/include/crt/host_config.h b/include/crt/host_config.h
+--- a/include/crt/host_config.h
++++ b/include/crt/host_config.h
+@@ -116,11 +116,11 @@
+ 
+ #if defined(__GNUC__)
+ 
+-#if __GNUC__ > 6
++#if __GNUC__ > 7
+ 
+-#error -- unsupported GNU version! gcc versions later than 6 are not supported!
++#error -- unsupported GNU version! gcc versions later than 7 are not supported!
+ 
+-#endif /* __GNUC__ > 6 */
++#endif /* __GNUC__ > 7 */
+ 
+ #if defined(__APPLE__) && defined(__MACH__) && !defined(__clang__)
+ #error -- clang and clang++ are the only supported host compilers on Mac OS X!
+@EOF
+
 ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
 ln -sf ../libnsight/nsight %_builddir/bin/nsight
 mkdir -p %{i}/lib64


### PR DESCRIPTION
First, patch CUDA headers not to reject GCC 7.

Then, force the host compiler to use C++14 for CUDA code, because with GCC 7 we cannot safely mix C++17 preprocessing with C++14 compilations.