### PR TITLE
Add virtual desctructor for Particle class

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,5 +1,5 @@
 ### RPM external pythia8 230
-%define tag 3c47cdb5c14e5c72f22bf1d4f3f1947042dea848
+%define tag 8f10c17357225aa668deeb67d99e3d9271923f94
 %define branch cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz

--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,5 +1,5 @@
 ### RPM external pythia8 230
-%define tag 74524ba8700857a1a0c08197e05876c93b57f4ec
+%define tag 3c47cdb5c14e5c72f22bf1d4f3f1947042dea848
 %define branch cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
Particle class doesn't have virtual destructor, and CLANG IBs have extra flag 
-Werror=delete-non-virtual-dtor which breaks the IB.
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_10_2_CLANG_X_2018-05-13-2300/FastSimulation/SimplifiedGeometryPropagator
Not sure if it's only this class, but probably is, lets try as it takes time