### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient-binary.spec
+++ b/dasgoclient-binary.spec
@@ -1,11 +1,11 @@
-### RPM cms dasgoclient-binary v01.01.08
+### RPM cms dasgoclient-binary v02.00.00
 Source0: git+https://github.com/dmwm/dasgoclient?obj=master/%{realversion}&export=dasgoclient&output=/dasgoclient.tar.gz
 Source1: git+https://github.com/dmwm/cmsauth?obj=master/e9fca92e3335252a5f71d8e6d09c64012f7d3c0c&export=github.com/dmwm/cmsauth&output=/cmsauth.tar.gz
 Source2: git+https://github.com/vkuznet/x509proxy?obj=master/b4622388b3a347c8df75b6e944e9d2a580acee60&export=github.com/vkuznet/x509proxy&output=/x509proxy.tar.gz
 Source3: git+https://github.com/buger/jsonparser?obj=master/6bd16707875b997f7a60327f888a28a3d28cf8c2&export=github.com/buger/jsonparser&output=/jsonparser.tar.gz
 Source4: git+https://github.com/go-mgo/mgo?obj=v2/3f83fa5005286a7fe593b055f0d7771a7dce4655&export=gopkg.in/mgo.v2&output=/mgo.v2.tar.gz
 Source5: git+https://github.com/pkg/profile?obj=master/3a8809bd8a80f8ecfe4ee1b34b3f37194968617c&export=github.com/pkg/profile&output=/profile.tar.gz
-Source6: git+https://github.com/dmwm/das2go?obj=master/2a85022f796b30561929c1da9ff2cc5535d7f48b&export=github.com/dmwm/das2go&output=/das2go.tar.gz
+Source6: git+https://github.com/dmwm/das2go?obj=master/80ecdf8ed439385831258f081f2f38e174f3a56a&export=github.com/dmwm/das2go&output=/das2go.tar.gz
 Source7: git+https://github.com/sirupsen/logrus?obj=master/a3f95b5c423586578a4e099b11a46c2479628cac&export=github.com/sirupsen/logrus&output=/logrus.tar.gz
 %prep
 

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v01.01.08
+### RPM cms dasgoclient v02.00.00
 ## NOCOMPILER
 %define dasgoclient_arch     slc6_amd64_gcc630
 %define dasgoclient_pkg      cms+%{n}-binary+%{realversion}


### PR DESCRIPTION
This is new dasgo client version based on up-coming das2go server which is scheduled to be in production on cmsweb in early June. It fixed several user-based queries and align with new das2go version.