### PR TITLE
RFC: mirror and build from the (unofficial) LLVM git "monorepo"

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -3,60 +3,37 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 
 BuildRequires: python cmake ninja
-Requires: gcc zlib
+Requires: cuda gcc zlib
 
-%define llvmCommit 0b57b47378e5b31693c6b2ef899ffb10c6b09e09
-%define llvmBranch release_60
-%define clangCommit cf7d5ae226a30948c102368399f4992c8833694a
-%define clangBranch cms/release_60/e74607
-%define clangToolsExtraCommit 0ea5aed4817afebb7fbdea644b723052a0ef370c
-%define clangToolsExtraBranch release_60
-%define compilerRtCommit 9d61c78bced84866cc886f1f1111c8e51c1d52d5
-%define compilerRtBranch release_60
-%define openmpCommit d5aa29cb3bcf51289d326b4e565613db8aff65ef
-%define openmpBranch release_60
+%define llvmCommit 500cb56799157a08a3283a067f172b6c6ad4efa6
+%define llvmBranch cms/release_60/329799
 %define iwyuCommit 5082fddccb3d5aabaace2208f1162029a27c0334
 %define iwyuBranch master
-%define lldCommit bd6eb65ebaed5ee94d35d8073c417ec3c26f0b8a
-%define lldBranch release_60
 
-Source0: git+https://github.com/llvm-mirror/llvm.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz
-Source1: git+https://github.com/cms-externals/clang.git?obj=%{clangBranch}/%{clangCommit}&export=clang-%{realversion}-%{clangCommit}&module=clang-%{realversion}-%{clangCommit}&output=/clang-%{realversion}-%{clangCommit}.tgz
-Source2: git+https://github.com/llvm-mirror/clang-tools-extra.git?obj=%{clangToolsExtraBranch}/%{clangToolsExtraCommit}&export=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&module=clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}&output=/clang-tools-extra-%{realversion}-%{clangToolsExtraCommit}.tgz
-Source3: git+https://github.com/llvm-mirror/compiler-rt.git?obj=%{compilerRtBranch}/%{compilerRtCommit}&export=compiler-rt-%{realversion}-%{compilerRtCommit}&module=compiler-rt-%{realversion}-%{compilerRtCommit}&output=/compiler-rt-%{realversion}-%{compilerRtCommit}.tgz
-Source4: git+https://github.com/llvm-mirror/openmp.git?obj=%{openmpBranch}/%{openmpCommit}&export=openmp-%{realversion}-%{openmpCommit}&module=openmp-%{realversion}-%{openmpCommit}&output=/openmp-%{realversion}-%{openmpCommit}.tgz
-Source5: git+https://github.com/include-what-you-use/include-what-you-use.git?obj=%{iwyuBranch}/%{iwyuCommit}&export=iwyu-%{realversion}-%{iwyuCommit}&module=iwyu-%{realversion}-%{iwyuCommit}&output=/iwyu-%{realversion}-%{iwyuCommit}.tgz
-Source6: git+https://github.com/llvm-mirror/lld.git?obj=%{lldBranch}/%{lldCommit}&export=lld-%{realversion}-%{lldCommit}&module=lld-%{realversion}-%{lldCommit}&output=/lld-%{realversion}-%{lldCommit}.tgz
+Source0: git+https://github.com/cms-externals/llvm-project-20170507.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz
+Source1: git+https://github.com/include-what-you-use/include-what-you-use.git?obj=%{iwyuBranch}/%{iwyuCommit}&export=iwyu-%{realversion}-%{iwyuCommit}&module=iwyu-%{realversion}-%{iwyuCommit}&output=/iwyu-%{realversion}-%{iwyuCommit}.tgz
 
 %define keep_archives true
 
 %prep
 %setup -T -b0 -n llvm-%{realversion}-%{llvmCommit}
-%setup -T -D -a1 -c -n llvm-%{realversion}-%{llvmCommit}/tools
-mv clang-%{realversion}-%{clangCommit} clang
-%setup -T -D -a6 -c -n llvm-%{realversion}-%{llvmCommit}/tools
-mv lld-%{realversion}-%{lldCommit} lld
-%setup -T -D -a2 -c -n llvm-%{realversion}-%{llvmCommit}/tools/clang/tools
-mv clang-tools-extra-%{realversion}-%{clangToolsExtraCommit} extra
-%setup -T -D -a5 -c -n llvm-%{realversion}-%{llvmCommit}/tools/clang/tools
-mv iwyu-%{realversion}-%{iwyuCommit} include-what-you-use
-%setup -T -D -a3 -c -n llvm-%{realversion}-%{llvmCommit}/projects
-mv compiler-rt-%{realversion}-%{compilerRtCommit} compiler-rt
-%setup -T -D -a4 -c -n llvm-%{realversion}-%{llvmCommit}/projects
-mv openmp-%{realversion}-%{openmpCommit} openmp
-%setup -T -D -n llvm-%{realversion}-%{llvmCommit}
 
-# include-what-you-see is not LLVM project, we have to
-# add it explicitly.
-sed -ibak '/add_clang_subdirectory(libclang)/a add_subdirectory(include-what-you-use)' tools/clang/tools/CMakeLists.txt
+# include-what-you-see is not LLVM project, we add it explicitly to the clang tools
+%setup -T -D -a1 -c -n llvm-%{realversion}-%{llvmCommit}/clang/tools
+mv iwyu-%{realversion}-%{iwyuCommit} include-what-you-use
+sed -ibak '/add_clang_subdirectory(libclang)/a add_subdirectory(include-what-you-use)' CMakeLists.txt
+
+# move back to the main setup directory
+%setup -T -D -n llvm-%{realversion}-%{llvmCommit}
 
 %build
 rm -rf %{_builddir}/build
 mkdir -p %{_builddir}/build
 cd %{_builddir}/build
 
-cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit} \
+cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -G Ninja \
+  -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lld;openmp" \
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DLLVM_LIBDIR_SUFFIX:STRING=64 \
@@ -77,11 +54,11 @@ ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
 
 BINDINGS_PATH=%{i}/lib64/python$(echo $PYTHON_VERSION | cut -d. -f 1,2)/site-packages
 mkdir -p $BINDINGS_PATH
-cp -r %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/bindings/python/clang $BINDINGS_PATH
+cp -r %{_builddir}/llvm-%{realversion}-%{llvmCommit}/clang/bindings/python/clang $BINDINGS_PATH
 
-rm -f %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/tools/scan-build/set-xcode*
-find %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/tools/scan-build -exec install {} %{i}/bin \;
-find %{_builddir}/llvm-%{realversion}-%{llvmCommit}/tools/clang/tools/scan-view -type f -exec install {} %{i}/bin \;
+rm -f %{_builddir}/llvm-%{realversion}-%{llvmCommit}/clang/tools/scan-build/set-xcode*
+find %{_builddir}/llvm-%{realversion}-%{llvmCommit}/clang/tools/scan-build -exec install {} %{i}/bin \;
+find %{_builddir}/llvm-%{realversion}-%{llvmCommit}/clang/tools/scan-view -type f -exec install {} %{i}/bin \;
 # Remove compiled AppleScript scripts, otherwise install_name_tool from
 # DEFAULT_INSTALL_POSTAMBLE will fail. These are non-object files.
 # TODO: Improve DEFAULT_INSTALL_POSTAMBLE for OS X.


### PR DESCRIPTION
The "monorepo" is hosted at https://github.com/llvm-project/llvm-project-20170507/ .
See http://llvm.org/docs/GettingStarted.html#for-developers-to-work-with-a-git-monorepo for details about the "monorepo" and build commands.