### PR TITLE
llvm: only add cuda dependency for ARM64

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -1,9 +1,13 @@
 ### RPM external llvm 6.0.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
++%define isamd64 %(case %{cmsplatf} in (*_amd64_*) echo 1 ;; (*) echo 0 ;; esac)
 
 BuildRequires: python cmake ninja
-Requires: cuda gcc zlib
+Requires: gcc zlib
+%if %{isamd64}
+Requires: cuda
+%endif
 
 %define llvmCommit 500cb56799157a08a3283a067f172b6c6ad4efa6
 %define llvmBranch cms/release_60/329799


### PR DESCRIPTION
cms cuda distribution is AMD64 specific, added cuda dependency for aarch64 breaks LLVM build
```
-- Could NOT find LIBOMPTARGET_DEP_LIBFFI (missing: LIBOMPTARGET_DEP_LIBFFI_LIBRARIES LIBOMPTARGET_DEP_LIBFFI_INCLUDE_DIRS) 
.../slc7_aarch64_gcc700/external/cuda/9.2.88/bin/nvcc: .../slc7_aarch64_gcc700/external/cuda/9.2.88/bin/nvcc: cannot execute binary file
CMake Error at .../slc7_aarch64_gcc700/external/cmake/3.10.2-gnimlf/share/cmake-3.10/Modules/FindCUDA.cmake:746 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  .../BUILD/slc7_aarch64_gcc700/external/llvm/6.0.0-gnimlf/llvm-6.0.0-500cb56799157a08a3283a067f172b6c6ad4efa6/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake:115 (find_package)
  .../BUILD/slc7_aarch64_gcc700/external/llvm/6.0.0-gnimlf/llvm-6.0.0-500cb56799157a08a3283a067f172b6c6ad4efa6/openmp/libomptarget/CMakeLists.txt:30 (include)


CMake Error at .../slc7_aarch64_gcc700/external/cmake/3.10.2-gnimlf/share/cmake-3.10/Modules/FindCUDA.cmake:747 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  .../BUILD/slc7_aarch64_gcc700/external/llvm/6.0.0-gnimlf/llvm-6.0.0-500cb56799157a08a3283a067f172b6c6ad4efa6/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake:115 (find_package)
  .../BUILD/slc7_aarch64_gcc700/external/llvm/6.0.0-gnimlf/llvm-6.0.0-500cb56799157a08a3283a067f172b6c6ad4efa6/openmp/libomptarget/CMakeLists.txt:30 (include)
```