### PR TITLE
Improve Eigen compatibility with CUDA

### DIFF
--- a/eigen.spec
+++ b/eigen.spec
@@ -1,11 +1,11 @@
-### RPM external eigen 1ae2849542a7892089f81f2ee460b510cdb0a16d
+### RPM external eigen 931457f1066dc3e812626f199b91070d5ed16031
 ## INITENV +PATH PKG_CONFIG_PATH %{i}/share/pkgconfig
 ## INITENV SETV EIGEN_SOURCE %{source0}
 ## INITENV SETV EIGEN_STRIP_PREFIX %{source_prefix}
 ## NOCOMPILER
 %define tag %{realversion}
 
-#These are needed by Tensorflow sources 
+#These are needed by Tensorflow sources
 #NOTE: Never apply any patch in the spec file, this way tensorflow gets the exact same sources
 %define source0 https://github.com/cms-externals/eigen-git-mirror/archive/%{tag}.tar.gz
 %define source_prefix eigen-git-mirror-%{realversion}


### PR DESCRIPTION
  - reorganise the CUDA checks, and `#include <thrust/swap.h>` when compiling CUDA device code
  - use `thrust::swap` instead of `std::swap` in CUDA device code
  - mark more functions and methods as `EIGEN_DEVICE_FUNC`