### PR TITLE
Update scram-project-build.file

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-16
+%define configtag       V05-07-18
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Build rules for 10.2.X were changed to generate filename.cc.o instead of filename.o . This change broke the classes.h and headers.h (serialization) dependency. This PR should fix the issue.
