### PR TITLE
added python-paths tools to provide python27 and python3 files

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-18
+%define configtag       V05-07-19
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scramv1-tool-conf.file
+++ b/scramv1-tool-conf.file
@@ -118,7 +118,7 @@ if [ "${PYTHON3PATH}" != "" ] ; then
   echo '  <runtime name="PYTHON3PATH"  value="%{i}/'${PYTHON3_LIB_SITE_PACKAGES}'" type="path"/>' >> %{i}/tools/selected/python-paths.xml
 fi
 
-echo '<tool>' >> %{i}/tools/selected/python-paths.xml
+echo '</tool>' >> %{i}/tools/selected/python-paths.xml
 
 %post
 %{relocateCmsFiles} $(find $RPM_INSTALL_PREFIX/%{pkgrel}/tools -type f)

--- a/scramv1-tool-conf.file
+++ b/scramv1-tool-conf.file
@@ -95,7 +95,6 @@ if [ -e $SCRAMV1_ROOT/bin/chktool ] ; then
   rm -f %i/errors.log
 fi
 
-
 py27List=`echo ${PYTHON27PATH} | tr ':' '\n'`
 
 mkdir -p %{i}/${PYTHON_LIB_SITE_PACKAGES}
@@ -104,16 +103,22 @@ for pkg in ${py27List} ; do
    echo "adding $pkg"
    echo "$pkg" >> %{i}/${PYTHON_LIB_SITE_PACKAGES}/tool-deps.pth
 done
+echo '<tool name="python-paths" version="1.0">' > %{i}/tools/selected/python-paths.xml
+echo '  <runtime name="PYTHON27PATH"  value="%{i}/'${PYTHON_LIB_SITE_PACKAGES}'" type="path"/>' >> %{i}/tools/selected/python-paths.xml
 
-py3List=`echo ${PYTHON3PATH} | tr ':' '\n'`
+if [ "${PYTHON3PATH}" != "" ] ; then
+  py3List=`echo ${PYTHON3PATH} | tr ':' '\n'`
 
-mkdir -p %{i}/${PYTHON3_LIB_SITE_PACKAGES}
-touch %{i}/${PYTHON3_LIB_SITE_PACKAGES}/tool-deps.pth
-for pkg in ${py3List} ; do
-   echo "adding $pkg"
-   echo "$pkg" >> %{i}/${PYTHON3_LIB_SITE_PACKAGES}/tool-deps.pth
-done
+  mkdir -p %{i}/${PYTHON3_LIB_SITE_PACKAGES}
+  touch %{i}/${PYTHON3_LIB_SITE_PACKAGES}/tool-deps.pth
+  for pkg in ${py3List} ; do
+     echo "adding $pkg"
+     echo "$pkg" >> %{i}/${PYTHON3_LIB_SITE_PACKAGES}/tool-deps.pth
+  done
+  echo '  <runtime name="PYTHON3PATH"  value="%{i}/'${PYTHON3_LIB_SITE_PACKAGES}'" type="path"/>' >> %{i}/tools/selected/python-paths.xml
+fi
 
+echo '<tool>' >> %{i}/tools/selected/python-paths.xml
 
 %post
 %{relocateCmsFiles} $(find $RPM_INSTALL_PREFIX/%{pkgrel}/tools -type f)


### PR DESCRIPTION
Avoid setting cmsw-tool-conf python paths via cmssw-config/Self.xml file. This breaks the cmsdist PR testing as in this case we always points to pythons paths from release. Thsi change should allow us to pick things from local area.