### PR TITLE
[9.4.X] PhysicsTools-NanoAOD: btag weights and bregression training for nanoaod

### DIFF
--- a/data-PhysicsTools-NanoAOD.spec
+++ b/data-PhysicsTools-NanoAOD.spec
@@ -1,4 +1,4 @@
-### RPM cms data-PhysicsTools-NanoAOD V01-00-02
+### RPM cms data-PhysicsTools-NanoAOD V01-00-03
 
 %prep
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/4077