### PR TITLE
[10.2.X][GCC8] Patch cuda/include/crt/host_config.h to not fail for gcc8

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -69,6 +69,7 @@ ln -sf libcuda.so.%{driversversion}                                     %{i}/dri
 cp -ar %_builddir/nvidia/libnvidia-fatbinaryloader.so.%{driversversion} %{i}/drivers/
 cp -ar %_builddir/nvidia/libnvidia-ptxjitcompiler.so.%{driversversion}  %{i}/drivers/
 ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                    %{i}/drivers/libnvidia-ptxjitcompiler.so.1
+sed -i -e 's|if __GNUC__ > 7|if __GNUC__ > 8|' %{i}/include/crt/host_config.h
 
 %post
 # let nvcc find its components when invoked from the command line


### PR DESCRIPTION
GCC8 IBs fail with errors like
```
.../cuda/9.2.88/include/crt/host_config.h:119:2: error: #error -- unsupported GNU version! gcc versions later than 7 are not supported!
  #error -- unsupported GNU version! gcc versions later than 7 are not supported!
```