### PR TITLE
Dire 2.002

### DIFF
--- a/dire-toolfile.spec
+++ b/dire-toolfile.spec
@@ -14,7 +14,9 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/dire.xml
     <environment name="DIRE_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$DIRE_BASE/lib"/>
     <environment name="INCLUDE" default="$DIRE_BASE/include"/>
+    <environment name="BINDIR" default="$DIRE_BASE/bin"/>
   </client>
+  <runtime name="PATH" default="$BINDIR" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="pythia8"/>
 </tool>

--- a/dire.spec
+++ b/dire.spec
@@ -1,4 +1,4 @@
-### RPM external dire 2.001
+### RPM external dire 2.002
 
 Requires: pythia8
 


### PR DESCRIPTION
Updating Dire to version 2.002

> DIRE-2.002.tar.gz release dated 2018/06/05. This version improves the handling of resonance showers, and is important for e.g. a correct handling of top production & decay. Code changes beyond resonance showers are preliminary, switched off by default, not endorsed by the authors, and not checked for correctness.
