### PR TITLE
Improve the procedure to install the CUDA tools in CMSSW

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 43.0
+### RPM cms cmssw-tool-conf 44.0
 ## NOCOMPILER
 # With cmsBuild, change the above version only when a new tool is added
 
@@ -167,6 +167,7 @@ Requires: tkonlinesw-toolfile
 Requires: oracle-toolfile
 Requires: cms_oracleocci_abi_hack-toolfile
 Requires: cuda-toolfile
+Requires: cuda-gdb-wrapper-toolfile
 Requires: cub-toolfile
 Requires: cuda-api-wrappers-toolfile
 Requires: intel-vtune

--- a/cuda-gdb-wrapper-toolfile.spec
+++ b/cuda-gdb-wrapper-toolfile.spec
@@ -1,0 +1,19 @@
+### RPM external cuda-gdb-wrapper-toolfile 1.0
+Requires: cuda-gdb-wrapper
+
+%prep
+
+%build
+
+%install
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/cuda-gdb-wrapper.xml
+<tool name="cuda-gdb-wrapper" version="@TOOL_VERSION@">
+  <client>
+    <environment name="CUDA_GDB_WRAPPER_BASE" default="@TOOL_ROOT@"/>
+  </client>
+  <runtime name="PATH" value="$CUDA_GDB_WRAPPER_BASE/bin" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/cuda-gdb-wrapper.spec
+++ b/cuda-gdb-wrapper.spec
@@ -1,0 +1,20 @@
+### RPM external cuda-gdb-wrapper 1.0
+
+Requires: cuda python
+
+%prep
+
+%build
+
+%install
+# add a wrapper for cuda-gdb
+mkdir %{i}/bin
+cat > %{i}/bin/cuda-gdb << @EOF
+#! /bin/bash
+export PYTHONHOME=$PYTHON_ROOT
+exec $CUDA_ROOT/bin/cuda-gdb.real "\$@"
+@EOF
+chmod a+x %{i}/bin/cuda-gdb
+
+%post
+%{relocateConfig}bin/cuda-gdb

--- a/cuda.spec
+++ b/cuda.spec
@@ -28,8 +28,6 @@ mkdir -p %_builddir/tmp
 rm -rf %_builddir/lib64/libcublas.so.9.2.88
 rm -rf %_builddir/lib64/libnvblas.so.9.2.88
 
-ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
-ln -sf ../libnsight/nsight %_builddir/bin/nsight
 mkdir -p %{i}/lib64
 # package only runtime and device static libraries
 cp -ar %_builddir/lib64/libcudart_static.a %{i}/lib64/
@@ -49,15 +47,21 @@ rm -rf %_builddir/lib64/libnvrtc.so*
 rm -rf %_builddir/lib64/libnvrtc-builtins.so*
 # package the other dynamic libraries
 cp -ar %_builddir/lib64/* %{i}/lib64/
-cp -ar %_builddir/libnvvp %{i}
-cp -ar %_builddir/libnsight %{i}
 # package the includes
 rm -rf %_builddir/include/sobol_direction_vectors.h
 cp -ar %_builddir/include %{i}
+# leave out nsight and nvvp
+#cp -ar %_builddir/jre %{i}
+#cp -ar %_builddir/libnsight %{i}
+#ln -sf ../libnsight/nsight %_builddir/bin/nsight
+rm -rf %_builddir/bin/nsight
+#cp -ar %_builddir/libnvvp %{i}
+#ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
+rm -rf %_builddir/bin/nvvp
+rm -rf %_builddir/bin/computeprof
 # package the binaries and tools
 cp -ar %_builddir/bin %{i}
 cp -ar %_builddir/nvvm %{i}
-cp -ar %_builddir/jre %{i}
 # package the version file
 cp -ar %_builddir/version.txt %{i}
 

--- a/cuda.spec
+++ b/cuda.spec
@@ -49,7 +49,8 @@ rm -rf %_builddir/lib64/libnvrtc-builtins.so*
 cp -ar %_builddir/lib64/* %{i}/lib64/
 # package the includes
 rm -rf %_builddir/include/sobol_direction_vectors.h
-cp -ar %_builddir/include %{i}
+cp -ar %_builddir/include/ %{i}
+
 # leave out nsight and nvvp
 #cp -ar %_builddir/jre %{i}
 #cp -ar %_builddir/libnsight %{i}

--- a/cuda.spec
+++ b/cuda.spec
@@ -64,18 +64,10 @@ rm -rf %_builddir/bin/nsight
 rm -rf %_builddir/bin/nvvp
 rm -rf %_builddir/bin/computeprof
 
-# add a wrapper for cuda-gdb and package the support files
+# package the cuda-gdb support files, and rename the binary to use it via a wrapper
 mkdir %{i}/share
 cp -ar %_builddir/share/gdb/ %{i}/share/
 mv %_builddir/bin/cuda-gdb %_builddir/bin/cuda-gdb.real
-cat > %_builddir/bin/cuda-gdb << @EOF
-#! /bin/bash
-cd \$CMSSW_BASE
-export PYTHONHOME=\$(scram tool tag python PYTHON_BASE)
-CUDA_BASE=\$(scram tool tag cuda CUDA_BASE)
-cd \$OLDPWD
-exec \$CUDA_BASE/bin/cuda-gdb.real "\$@"
-@EOF
 
 # package the binaries and tools
 cp -ar %_builddir/bin %{i}

--- a/cuda.spec
+++ b/cuda.spec
@@ -34,6 +34,7 @@ cp -ar %_builddir/lib64/libcudart_static.a %{i}/lib64/
 cp -ar %_builddir/lib64/libcudadevrt.a %{i}/lib64/
 cp -ar %_builddir/lib64/lib*_device.a %{i}/lib64/
 rm -rf %_builddir/lib64/lib*.a
+
 # do not package dynamic libraries for which we have stubs
 rm -rf %_builddir/lib64/libcublas.so*
 rm -rf %_builddir/lib64/libcufft.so*
@@ -45,8 +46,10 @@ rm -rf %_builddir/lib64/libnpp*.so*
 rm -rf %_builddir/lib64/libnvgraph.so*
 rm -rf %_builddir/lib64/libnvrtc.so*
 rm -rf %_builddir/lib64/libnvrtc-builtins.so*
+
 # package the other dynamic libraries
 cp -ar %_builddir/lib64/* %{i}/lib64/
+
 # package the includes
 rm -rf %_builddir/include/sobol_direction_vectors.h
 cp -ar %_builddir/include/ %{i}
@@ -60,9 +63,24 @@ rm -rf %_builddir/bin/nsight
 #ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
 rm -rf %_builddir/bin/nvvp
 rm -rf %_builddir/bin/computeprof
+
+# add a wrapper for cuda-gdb and package the support files
+mkdir %{i}/share
+cp -ar %_builddir/share/gdb/ %{i}/share/
+mv %_builddir/bin/cuda-gdb %_builddir/bin/cuda-gdb.real
+cat > %_builddir/bin/cuda-gdb << @EOF
+#! /bin/bash
+cd \$CMSSW_BASE
+export PYTHONHOME=\$(scram tool tag python PYTHON_BASE)
+CUDA_BASE=\$(scram tool tag cuda CUDA_BASE)
+cd \$OLDPWD
+exec \$CUDA_BASE/bin/cuda-gdb.real "\$@"
+@EOF
+
 # package the binaries and tools
 cp -ar %_builddir/bin %{i}
 cp -ar %_builddir/nvvm %{i}
+
 # package the version file
 cp -ar %_builddir/version.txt %{i}
 


### PR DESCRIPTION
### Leave out nvidia `nsight` (IDE) and `nvvp` (visual profiler) from the CUDA distribution.

These tools are only useful on the developer's machine, not on the worker nodes, and we expect the developers to run them on their local desktops/notebooks rather than on lxplus.
Leaving them out saves almost 500 MB from the archive and installation.

###  Handle the case where `$CUDA_BASE/include` is a symlink

This is needed for the AMR64 packaging of CUDA.

###  Add a wrapper for `cuda-gdb` and package its support files
Set `PYTHONHOME` to scram's `$PYTHON_BASE` to fix the error:

> Could not find platform independent libraries <prefix>
> Could not find platform dependent libraries <exec_prefix>
> Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
> ImportError: No module named site

Package `$CUDA_BASE/share/gdb` to fix the error:

  > Python Exception <type 'exceptions.NameError'> Installation error: gdb.execute_unwinders function is missing: