### PR TITLE
Update llvm/clang to 7.0.0-svn334210 (prerelease)

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -1,9 +1,13 @@
 ### RPM external llvm 6.0.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
+%define isamd64 %(case %{cmsplatf} in (*_amd64_*) echo 1 ;; (*) echo 0 ;; esac)
 
 BuildRequires: python cmake ninja
-Requires: cuda gcc zlib
+Requires: gcc zlib
+%if %{isamd64}
+Requires: cuda
+%endif
 
 %define llvmCommit 500cb56799157a08a3283a067f172b6c6ad4efa6
 %define llvmBranch cms/release_60/329799

--- a/llvm.spec
+++ b/llvm.spec
@@ -8,6 +8,7 @@ Requires: gcc zlib
 %if %{isamd64}
 Requires: cuda
 %endif
+AutoReq: no
 
 %define llvmCommit 1a079e2deaa1ca5423a305cd6056d0af3f3fd5d0
 %define llvmBranch cms/release_70/334210

--- a/llvm.spec
+++ b/llvm.spec
@@ -1,4 +1,4 @@
-### RPM external llvm 6.0.0
+### RPM external llvm 7.0.0-svn334210
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 %define isamd64 %(case %{cmsplatf} in (*_amd64_*) echo 1 ;; (*) echo 0 ;; esac)
@@ -9,9 +9,9 @@ Requires: gcc zlib
 Requires: cuda
 %endif
 
-%define llvmCommit 500cb56799157a08a3283a067f172b6c6ad4efa6
-%define llvmBranch cms/release_60/329799
-%define iwyuCommit 5082fddccb3d5aabaace2208f1162029a27c0334
+%define llvmCommit 1a079e2deaa1ca5423a305cd6056d0af3f3fd5d0
+%define llvmBranch cms/release_70/334210
+%define iwyuCommit 579007a32e285360f144b5f143da13c3f2ac3b85
 %define iwyuBranch master
 
 Source0: git+https://github.com/cms-externals/llvm-project-20170507.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz

--- a/llvm.spec
+++ b/llvm.spec
@@ -47,7 +47,11 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -DLLVM_ENABLE_EH:BOOL=ON \
   -DLLVM_ENABLE_PIC:BOOL=ON \
   -DLLVM_ENABLE_RTTI:BOOL=ON \
+%if %{isamd64}
+  -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64;NVPTX" \
+%else
   -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64" \
+%endif
   -DCMAKE_REQUIRED_INCLUDES="${ZLIB_ROOT}/include" \
   -DCMAKE_PREFIX_PATH="${ZLIB_ROOT}"
 


### PR DESCRIPTION
Also
  - only add CUDA dependency on amd64 (backport from gcc700 branch)
  - enable support for compiing CUDA code to NVPTX on amd64
  - disable automatic package dependencies