### PR TITLE
use seperate tool for qd_f_main

### DIFF
--- a/qd-toolfile.spec
+++ b/qd-toolfile.spec
@@ -9,14 +9,20 @@ Requires: qd
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/qd.xml
 <tool name="qd" version="@TOOL_VERSION@">
-<lib name="qd_f_main"/>
-<lib name="qdmod"/>
-<lib name="qd"/>
-<client>
-<environment name="QD_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$QD_BASE/lib"/>
-<environment name="INCLUDE" default="$QD_BASE/include"/>
-</client>
+  <lib name="qdmod"/>
+  <lib name="qd"/>
+  <client>
+    <environment name="QD_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$QD_BASE/lib"/>
+    <environment name="INCLUDE" default="$QD_BASE/include"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/qd_f_main.xml
+<tool name="qd_f_main" version="@TOOL_VERSION@">
+  <lib name="qd_f_main"/>
+  <use name="qd"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
libqd_f_main.so contains main() so it should not be linked directly to cmssw libs. This PR breaks the qd toolfile in to two
- qd.xml:  which contains qd and qdmod libs
- qd_f_main.xml: which depends on qd.xml and adds qd_f_main.