### PR TITLE
[9.4.X][Geant4]: Fixed muon stopping + G4 bug in indexes

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 10.02.p02
-%define tag f9e758d95096c7956792a541549515b3c767d1fb
+%define tag 0f6c7dd7bcf054e57fdc34da9b4696fce5c6ac90
 %define branch cms/4.%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/4143
This PR includes two updates
- https://github.com/cms-externals/geant4/pull/34: Fixed muon stopping
- https://github.com/cms-externals/geant4/pull/29: G4 bug in indexes inside decay class. This wnet in 93X but not 94X