### PR TITLE
[10.2.X][Root]: Running rules when sub-object is split

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 16046cdd3229f8fe3a5bc82d01a63b73edce3004
+%define tag b4ecbc6c9d942c5d6863bb4e0cf21aa6fe7d16e5
 %define branch cms/v6-12-00-patches/7a7d314569-pr2217
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/root.spec
+++ b/root.spec
@@ -2,8 +2,8 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag a5c325d2cfe743a839f0e5c56e04fd0907769203
-%define branch cms/v6-12-00-patches/80d4607
+%define tag 16046cdd3229f8fe3a5bc82d01a63b73edce3004
+%define branch cms/v6-12-00-patches/7a7d314569-pr2217
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 

--- a/root.spec
+++ b/root.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag b4ecbc6c9d942c5d6863bb4e0cf21aa6fe7d16e5
+%define tag 978c8ebf10450c46a9a62b40284753327a34d109
 %define branch cms/v6-12-00-patches/7a7d314569-pr2217
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
This PR cherry-picked https://github.com/root-project/root/pull/2217 on top of root 6.12. This is suppose to fix the issue we see in https://github.com/cms-sw/cmssw/pull/22594