### PR TITLE
Revert "[10.2.X]  Ele MVA V2 weight files and gzipped all Run 2 weight files"

### DIFF
--- a/data-RecoEgamma-ElectronIdentification.spec
+++ b/data-RecoEgamma-ElectronIdentification.spec
@@ -1,4 +1,4 @@
-### RPM cms data-RecoEgamma-ElectronIdentification V01-01-00
+### RPM cms data-RecoEgamma-ElectronIdentification V01-00-08
 
 %prep
 


### PR DESCRIPTION
Reverts cms-sw/cmsdist#4056

linked to the revert of cms-sw/cmssw#23473 , due to problems found in the PR