### PR TITLE
Add MXNet prediction tool

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -152,6 +152,7 @@ Requires: madgraph5amcatnlo-toolfile
 Requires: python_tools
 Requires: dasgoclient
 Requires: OpenBLAS-toolfile
+Requires: mxnet-predict-toolfile
 
 # Only for Linux platform.
 %if %islinux

--- a/mxnet-predict-toolfile.spec
+++ b/mxnet-predict-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external mxnet-predict-toolfile 1.2.0
+Requires: mxnet-predict
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/mxnet-predict.xml
+<tool name="mxnet-predict" version="@TOOL_VERSION@">
+  <lib name="mxnetpredict"/>
+  <client>
+    <environment name="MXNET_PREDICT_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$MXNET_PREDICT_BASE/include"/>
+    <environment name="LIBDIR" default="$MXNET_PREDICT_BASE/lib"/>
+  </client>
+  <use name="openblas"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/mxnet-predict.spec
+++ b/mxnet-predict.spec
@@ -1,0 +1,22 @@
+### RPM external mxnet-predict 1.2.0
+%define projectname mxnet-predict
+%define releasename apache-mxnet-src-%{realversion}-incubating
+Source: https://github.com/apache/incubator-mxnet/releases/download/%{realversion}/apache-mxnet-src-%{realversion}-incubating.tar.gz
+
+Requires: OpenBLAS
+
+%prep
+%setup -q -n %releasename
+
+%build
+make %{makeprocesses} USE_OPENCV=0 USE_OPENMP=0 USE_BLAS=openblas USE_CPP_PACKAGE=1 \
+    ADD_LDFLAGS="-L$OPENBLAS_ROOT/lib" \
+    ADD_CFLAGS="-I$OPENBLAS_ROOT/include -DDISABLE_OPENMP=1 -DMSHADOW_RABIT_PS=0 -DMSHADOW_DIST_PS=0 -DMSHADOW_FORCE_STREAM -DMXNET_PREDICT_ONLY=1"
+
+%install
+mkdir -p %{i}/{lib,include}
+mv lib/libmxnet.so           %{i}/lib/libmxnetpredict.so
+mv include/*                 %{i}/include
+mv cpp-package/include/*     %{i}/include
+
+


### PR DESCRIPTION
This is to add [MXNet](https://mxnet.incubator.apache.org/) to CMSSW externals following the discussions in https://github.com/cms-sw/cmssw/issues/21314. It is needed for the integration of the [DeepAK8](https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging) tagger into CMSSW. 

This includes both the C and C++ APIs. MXNet is built in prediction-only mode (`MXNET_PREDICT_ONLY=1`) here, as so far we only intend to use it for the evaluation of the neural networks, not for training (which is typically done on a GPU w/ the python API). By compiling in the prediction-only mode, MXNet is also set to run in [Native Engine](https://mxnet.incubator.apache.org/faq/env_var.html#engine-type) mode such that it runs in the master thread instead of creating its own thread pool.