### PR TITLE
Improve CUDA build rules to support linking device code across different libraries 

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -38,9 +38,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
   <flags CUDA_FLAGS="-gencode arch=compute_50,code=sm_50"/>
   <flags CUDA_FLAGS="-gencode arch=compute_61,code=sm_61"/>
   <flags CUDA_FLAGS="-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda"/>
-  <flags CUDA_LDFLAGS="-dlink"/>
-  <flags CUDA_LDFLAGS="-shared"/>
-  <flags CUDA_LDFLAGS="-L$(CUDA_BASE)/lib64"/>
   <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
   <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>
   <flags CUDA_HOST_CXXFLAGS="-std=c++14"/>

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-25
+%define configtag       V05-07-30
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Update to the CUDA tool:
  - drop `-dlink`, which should be moved to the SCRAM build rules
  - drop `-shared`, which should be replaced by `--compiler-options '$(CXXSHAREDOBJECTFLAGS)'` in the SCRAM build rules, which includes `-fPIC`
  - drop `-L$(CUDA_BASE)/lib64`, which is included automatically by `nvcc`

Update to the SCRAM build rules for CUDA code (by Shahzad):
  - See https://github.com/cms-sw/cmssw-config/issues/65
  -  Update cmssw-config to V05-07-30: Update cuda compilation rules for device code