### PR TITLE
bug fix: make sure that share/data has correct content after local deprecate local and re-install

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -72,9 +72,13 @@ echo "%{BaseTool}_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{
 echo "set %{BaseTool}_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
 
 for DATA_PATH in %directpkgreqs; do
+  PKG_DIR=$(echo $DATA_PATH | cut -d/ -f2)
+  [ $(echo $PKG_DIR | grep '^data-' | wc -l) -eq 1 ] || continue
+  PKG_DIR=$(echo $PKG_DIR | sed 's|^data-||;s|-|/|')
   SOURCE=$RPM_INSTALL_PREFIX/%{cmsplatf}/$DATA_PATH
-  PKG_DATA=$(ls $SOURCE | grep -v etc*)
-  if [ ! -e $RPM_INSTALL_PREFIX/share/$DATA_PATH/$PKG_DATA ] ; then
+  PKG_DATA=$(echo $PKG_DIR | cut -d/ -f1)
+  if [ ! -e $RPM_INSTALL_PREFIX/share/$DATA_PATH/$PKG_DIR ] ; then
+    rm -rf $RPM_INSTALL_PREFIX/share/$DATA_PATH
     mkdir -p $RPM_INSTALL_PREFIX/share/$DATA_PATH
     if [ -L $SOURCE/$PKG_DATA ] ; then
       ln -fs ../../../../%{cmsplatf}/$DATA_PATH/$PKG_DATA $RPM_INSTALL_PREFIX/share/$DATA_PATH/$PKG_DATA


### PR DESCRIPTION
This is a bug fix to avoid the following situation when building with `--reference /cvmfs/cms-ib.cern.ch/weekN` as reference repository
- A data package is build locally means arch/cms/data-SubSys-Pack/version/SubSys is symlink to share/cms/data-SubSys-Pack/version/SubSys
- newly built RPMs are uploaded
- run deprecate local to force get newly uploaded RPMs. This means rpm erase will remove the contents of arch/cms/data-SubSys-Pack/version/SubSys (which is symlink to share/cms/data-SubSys-Pack/version/SubSys).
- We when re-install this data package from the uploaded repo it does not re-populate the contents of share directory.

This PR should fix this situation.