### PR TITLE
Update dd4hep to tag 01-08

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -1,7 +1,7 @@
-### RPM external dd4hep v01-07x
+### RPM external dd4hep v01-08x
 
-%define tag 96bc2f3fc6557a0d91962fe559478f1e60565270
-%define branch cms/master/68a6e630
+%define tag 387ff92cc096cb7980a17e651ad5690b330a64d7
+%define branch cms/master/dfd9760
 %define github_user cms-externals
 
 Source: git+https://github.com/%{github_user}/DD4hep.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
Get the latest commits and new tag 01-08 from https://github.com/AIDASoft/DD4hep