### PR TITLE
The Atlas GccCheckerPlugins package as an external.

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -162,6 +162,7 @@ Requires: py2-pip-toolfile
 
 # Only for Linux platform.
 %if %islinux
+Requires: gcc-checker-plugin-toolfile
 Requires: openldap-toolfile
 Requires: gperftools-toolfile
 

--- a/gcc-checker-plugin-toolfile.spec
+++ b/gcc-checker-plugin-toolfile.spec
@@ -34,6 +34,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-checker-plugin.xml
       <environment name="LIBRARY"   default="$GCC_CHECKER_PLUGIN_ROOT/lib"/>
     </client>
   </tool>
+  <runtime name="GCC_CHECKER_PLUGIN" default="$GCC_CHECKER_PLUGIN_ROOT/lib/libchecker_gccplugins.so"/>
 EOF_TOOLFILE
 export GCC_CHECKER_PLUGIN_ROOT
 

--- a/gcc-checker-plugin-toolfile.spec
+++ b/gcc-checker-plugin-toolfile.spec
@@ -1,0 +1,46 @@
+### RPM cms gcc-checker-plugin-toolfile 1.0
+
+# gcc has a separate spec file for the generating a 
+# toolfile because gcc.spec could be not build because of the 
+# "--use-system-compiler" option.
+
+Source: none
+Requires: gcc-checker-plugin
+
+%prep
+%build
+%install
+mkdir -p %{i}/etc/scram.d
+
+# Determine the GCC_ROOT if "use system compiler" is used.
+if [ "X$GCC_ROOT" = X ]
+then
+    export GCC_PATH=$(which gcc) || exit 1
+    export GCC_ROOT=$(echo $GCC_PATH | sed -e 's|/bin/gcc||')
+    export GCC_VERSION=$(gcc -dumpversion) || exit 1
+    export G77_ROOT=$GCC_ROOT
+else
+    export GCC_PATH
+    export GCC_ROOT
+    export GCC_VERSION
+    export G77_ROOT=$GCC_ROOT
+fi
+# GCC tool file for explicity linking gcc plugin library
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-checker-plugin.xml
+  <tool name="gcc-checker-plugin" version="@GCC_VERSION@">
+    <lib name="checker_gccplugins"/>
+    <client>
+      <environment name="GCC_CHECKER_PLUGIN_ROOT" default="@GCC_CHECKER_PLUGIN_ROOT@"/>
+      <environment name="LIBRARY"   default="$GCC_CHECKER_PLUGIN_ROOT/lib"/>
+    </client>
+  </tool>
+EOF_TOOLFILE
+export GCC_CHECKER_PLUGIN_ROOT
+
+# General substitutions
+perl -p -i -e 's|\@([^@]*)\@|$ENV{$1}|g' %{i}/etc/scram.d/*.xml
+
+%post
+%{relocateConfig}etc/scram.d/*.xml
+echo "GCC_CHECKER_PLUGIN_TOOLFILE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'; export GCC_CHECKER_PLUGIN_TOOLFILE_ROOT" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
+echo "setenv GCC_CHECKER_PLUGIN_TOOLFILE_ROOT '$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh

--- a/gcc-checker-plugin-toolfile.spec
+++ b/gcc-checker-plugin-toolfile.spec
@@ -13,25 +13,13 @@ Requires: gcc-checker-plugin
 mkdir -p %{i}/etc/scram.d
 
 # Determine the GCC_ROOT if "use system compiler" is used.
-if [ "X$GCC_ROOT" = X ]
-then
-    export GCC_PATH=$(which gcc) || exit 1
     export GCC_ROOT=$(echo $GCC_PATH | sed -e 's|/bin/gcc||')
-    export GCC_VERSION=$(gcc -dumpversion) || exit 1
-    export G77_ROOT=$GCC_ROOT
-else
-    export GCC_PATH
-    export GCC_ROOT
-    export GCC_VERSION
-    export G77_ROOT=$GCC_ROOT
-fi
-# GCC tool file for explicity linking gcc plugin library
+
 cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-checker-plugin.xml
   <tool name="gcc-checker-plugin" version="@GCC_VERSION@">
-    <lib name="checker_gccplugins"/>
     <client>
       <environment name="GCC_CHECKER_PLUGIN_ROOT" default="@GCC_CHECKER_PLUGIN_ROOT@"/>
-      <environment name="LIBRARY"   default="$GCC_CHECKER_PLUGIN_ROOT/lib"/>
+      <environment name="INCLUDE"   default="$GCC_CHECKER_PLUGIN_ROOT/include"/>
     </client>
   </tool>
   <runtime name="GCC_CHECKER_PLUGIN" default="$GCC_CHECKER_PLUGIN_ROOT/lib/libchecker_gccplugins.so"/>

--- a/gcc-checker-plugin-toolfile.spec
+++ b/gcc-checker-plugin-toolfile.spec
@@ -1,10 +1,4 @@
 ### RPM cms gcc-checker-plugin-toolfile 1.0
-
-# gcc has a separate spec file for the generating a 
-# toolfile because gcc.spec could be not build because of the 
-# "--use-system-compiler" option.
-
-Source: none
 Requires: gcc gcc-checker-plugin
 
 %prep
@@ -13,9 +7,9 @@ Requires: gcc gcc-checker-plugin
 mkdir -p %{i}/etc/scram.d
 
 cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-checker-plugin.xml
-  <tool name="gcc-checker-plugin" version="@GCC_VERSION@">
+  <tool name="gcc-checker-plugin" version="@TOOL_VERSION@">
     <client>
-      <environment name="GCC_CHECKER_PLUGIN_ROOT" default="@GCC_CHECKER_PLUGIN_ROOT@"/>
+      <environment name="GCC_CHECKER_PLUGIN_ROOT" default="@TOOL_ROOT@"/>
       <environment name="INCLUDE"   default="$GCC_CHECKER_PLUGIN_ROOT/include"/>
     </client>
   </tool>
@@ -23,37 +17,27 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-checker-plugin.xml
 EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-analyzer-cxxcompiler.xml
-  <tool name="gcc-checker-cxxcompiler" version="@GCC_VERSION@">
+  <tool name="gcc-analyzer-cxxcompiler" version="@TOOL_VERSION@" type="compiler">
     <client>
-      <environment name="GCC_CHECKER_PLUGIN_ROOT" default="@GCC_CHECKER_PLUGIN_ROOT@"/>
       <environment name="CXX"   default="@GCC_ROOT@/bin/c++"/>
     </client>
   </tool>
-  <flags CXXFLAGS="-fplugin=@GCC_CHECKER_PLUGIN_ROOT@/lib/libchecker_gccplugins.so"/>
+  <flags CXXFLAGS="-fplugin=@TOOL_ROOT@/lib/libchecker_gccplugins.so"/>
   <flags CXXFLAGS="-fplugin-arg-libchecker_gccplugins-checkers=all"/>
   <flags CXXFLAGS="-fsyntax-only"/>
 EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-analyzer-ccompiler.xml
-  <tool name="gcc-checker-ccompiler" version="@GCC_VERSION@">
+  <tool name="gcc-analyzer-ccompiler" version="@TOOL_VERSION@" type="compiler">
     <client>
-      <environment name="GCC_CHECKER_PLUGIN_ROOT" default="@GCC_CHECKER_PLUGIN_ROOT@"/>
       <environment name="CC"   default="@GCC_ROOT@/bin/cc"/>
     </client>
   </tool>
-  <flags CFLAGS="-fplugin=@GCC_CHECKER_PLUGIN_ROOT@/lib/libchecker_gccplugins.so"/>
+  <flags CFLAGS="-fplugin=@TOOL_ROOT@/lib/libchecker_gccplugins.so"/>
   <flags CFLAGS="-fplugin-arg-libchecker_gccplugins-checkers=all"/>
   <flags CFLAGS="-fsyntax-only"/>
 EOF_TOOLFILE
 
-export GCC_CHECKER_PLUGIN_ROOT
-export GCC_VERSION
 export GCC_ROOT
 
-# General substitutions
-perl -p -i -e 's|\@([^@]*)\@|$ENV{$1}|g' %{i}/etc/scram.d/*.xml
-
-%post
-%{relocateConfig}etc/scram.d/*.xml
-echo "GCC_CHECKER_PLUGIN_TOOLFILE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'; export GCC_CHECKER_PLUGIN_TOOLFILE_ROOT" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
-echo "setenv GCC_CHECKER_PLUGIN_TOOLFILE_ROOT '$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
+## IMPORT scram-tools-post

--- a/gcc-checker-plugin-toolfile.spec
+++ b/gcc-checker-plugin-toolfile.spec
@@ -13,7 +13,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-checker-plugin.xml
       <environment name="INCLUDE"   default="$GCC_CHECKER_PLUGIN_ROOT/include"/>
     </client>
   </tool>
-  <runtime name="GCC_CHECKER_PLUGIN" default="$GCC_CHECKER_PLUGIN_ROOT/lib/libchecker_gccplugins.so"/>
 EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-analyzer-cxxcompiler.xml

--- a/gcc-checker-plugin.spec
+++ b/gcc-checker-plugin.spec
@@ -1,13 +1,21 @@
-### RPM external gcc-checker-plugin 1.1
-Source0:	https://github.com/cms-externals/CheckerGccPlugins/archive/1.1.tar.gz
+### RPM external gcc-checker-plugin 1.2
+Source0:	https://github.com/cms-externals/CheckerGccPlugins/archive/1.2.tar.gz
 
+BuildRequires: cmake
 Requires: gcc
 
 %prep
-%setup -n CheckerGccPlugins-1.1
+%setup -n CheckerGccPlugins-1.2
 
 %build
-make 
+mkdir build
+cd build
+cmake ../
+make
+make test
 
 %install
+mkdir lib
+cp build/libchecker_gccplugins.so lib
+rm -rf build
 cp -rp * %{i}

--- a/gcc-checker-plugin.spec
+++ b/gcc-checker-plugin.spec
@@ -1,23 +1,13 @@
-### RPM external gcc-checker-plugin 1.0
-Source0:	https://gitlab.cern.ch/atlas/atlasexternals/-/archive/2.0.9/atlasexternals-2.0.9.tar.gz
+### RPM external gcc-checker-plugin 1.1
+Source0:	https://github.com/gartung/CheckerGccPlugins/archive/1.1.tar.gz
 
 Requires: gcc
 
 %prep
-%setup -n atlasexternals-2.0.9
+%setup -n CheckerGccPlugins-1.1
 
 %build
-  plugindir=`gcc --print-file-name plugin`
-  compilerdir=`gcc --print-file-name include`
-
-
-  for f in External/CheckerGccPlugins/src/*.cxx; do
-    g++ -c -g --std=c++11 -fPIC -O2 -fno-rtti -I${plugindir}/include -I${compilerdir} $f -o `basename $f`.o
-  done
-  g++ -shared -o libchecker_gccplugins.so *.o
-
+make 
 
 %install
-mkdir -p %{i}/lib
-cp -p libchecker_gccplugins.so %{i}/lib
-cp -rp External/CheckerGccPlugins/* %{i}
+cp -rp * %{i}

--- a/gcc-checker-plugin.spec
+++ b/gcc-checker-plugin.spec
@@ -1,0 +1,23 @@
+### RPM external gcc-checker-plugin 1.0
+Source0:	https://gitlab.cern.ch/atlas/atlasexternals/-/archive/2.0.9/atlasexternals-2.0.9.tar.gz
+
+Requires: gcc
+
+%prep
+%setup -n atlasexternals-2.0.9
+
+%build
+  plugindir=`gcc --print-file-name plugin`
+  compilerdir=`gcc --print-file-name include`
+
+
+  for f in External/CheckerGccPlugins/src/*.cxx; do
+    g++ -c -g --std=c++11 -fPIC -O2 -fno-rtti -I${plugindir}/include -I${compilerdir} $f -o `basename $f`.o
+  done
+  g++ -shared -o libchecker_gccplugins.so *.o
+
+
+%install
+mkdir -p %{i}/lib
+cp -p libchecker_gccplugins.so %{i}/lib
+cp -rp External/CheckerGccPlugins/* %{i}

--- a/gcc-checker-plugin.spec
+++ b/gcc-checker-plugin.spec
@@ -1,5 +1,5 @@
 ### RPM external gcc-checker-plugin 1.1
-Source0:	https://github.com/gartung/CheckerGccPlugins/archive/1.1.tar.gz
+Source0:	https://github.com/cms-externals/CheckerGccPlugins/archive/1.1.tar.gz
 
 Requires: gcc
 

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -118,7 +118,7 @@ EOF_TOOLFILE
 # GCC tool file for explicity linking gcc plugin library
 cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-plugin.xml
   <tool name="gcc-plugin" version="@GCC_VERSION@">
-    <lib name="cc1plugin"/>
+    <lib name="cc1plugin cp1plugin"/>
     <client>
       <environment name="GCC_PLUGIN_BASE" default="@GCC_PLUGIN_DIR@"/>
       <environment name="INCLUDE"   default="$GCC_PLUGIN_BASE/include"/>

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -115,6 +115,19 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-atomic.xml
   </tool>
 EOF_TOOLFILE
 
+# GCC tool file for explicity linking gcc plugin library
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-plugin.xml
+  <tool name="gcc-plugin" version="@GCC_VERSION@">
+    <lib name="cc1plugin"/>
+    <client>
+      <environment name="GCC_PLUGIN_BASE" default="@GCC_PLUGIN_DIR@"/>
+      <environment name="INCLUDE"   default="$GCC_PLUGIN_BASE/include"/>
+      <environment name="LIBDIR"    default="$GCC_PLUGIN_BASE"/>
+    </client>
+  </tool>
+EOF_TOOLFILE
+export GCC_PLUGIN_DIR=$(gcc -print-file-name=plugin)
+
 # NON-empty defaults
 # First of all handle OS specific options.
 %ifos linux


### PR DESCRIPTION
Although the PR is based on the gcc7 branch it can be back ported to any branch with a compiler that supports plugins and c++11.