### PR TITLE
Fix ROOT-9173: add per object flag for the statsoverflow

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -2,8 +2,8 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 4ae64ea43c3274198f1658b6c6c95e11f8bfb1b5
-%define branch cms/v6-12-00-patches/38e3810
+%define tag 21aa853cd993e6677c2191efda8063154c7cc537
+%define branch cms/v6-12-00-patches/6eb9073
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 

--- a/root.spec
+++ b/root.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 989d72ff9d8878ee5eb893c0b41c3c811f1848e5
+%define tag 4ae64ea43c3274198f1658b6c6c95e11f8bfb1b5
 %define branch cms/v6-12-00-patches/38e3810
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Cherry-pick https://github.com/root-project/root/pull/1503 in to root v6-12-00-patches branch to fix the issue found in online DQMGUI (due to change in version of the TH1 class from 8 to 7).