### PR TITLE
Patch MXNet to use a thread-local engine

### DIFF
--- a/mxnet-predict-toolfile.spec
+++ b/mxnet-predict-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external mxnet-predict-toolfile 1.2.1.mod1
+### RPM external mxnet-predict-toolfile 1.2.1.mod3
 Requires: mxnet-predict
 %prep
 

--- a/mxnet-predict-toolfile.spec
+++ b/mxnet-predict-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external mxnet-predict-toolfile 1.2.0
+### RPM external mxnet-predict-toolfile 1.2.1.mod1
 Requires: mxnet-predict
 %prep
 

--- a/mxnet-predict.spec
+++ b/mxnet-predict.spec
@@ -1,4 +1,4 @@
-### RPM external mxnet-predict 1.2.1.mod1
+### RPM external mxnet-predict 1.2.1.mod3
 %define projectname mxnet-predict
 %define releasename apache-mxnet-src-%{realversion}-incubating
 Source: https://hqu.web.cern.ch/hqu/tools/mxnet/apache-mxnet-src-%{realversion}-incubating.tar.gz

--- a/mxnet-predict.spec
+++ b/mxnet-predict.spec
@@ -1,7 +1,7 @@
-### RPM external mxnet-predict 1.2.0
+### RPM external mxnet-predict 1.2.1.mod1
 %define projectname mxnet-predict
 %define releasename apache-mxnet-src-%{realversion}-incubating
-Source: https://github.com/apache/incubator-mxnet/releases/download/%{realversion}/apache-mxnet-src-%{realversion}-incubating.tar.gz
+Source: https://hqu.web.cern.ch/hqu/tools/mxnet/apache-mxnet-src-%{realversion}-incubating.tar.gz
 
 Requires: OpenBLAS
 
@@ -11,12 +11,14 @@ Requires: OpenBLAS
 %build
 make %{makeprocesses} USE_OPENCV=0 USE_OPENMP=0 USE_BLAS=openblas USE_CPP_PACKAGE=1 USE_F16C=0 \
     ADD_LDFLAGS="-L$OPENBLAS_ROOT/lib" \
-    ADD_CFLAGS="-I$OPENBLAS_ROOT/include -DDISABLE_OPENMP=1 -DMSHADOW_RABIT_PS=0 -DMSHADOW_DIST_PS=0 -DMSHADOW_FORCE_STREAM -DMXNET_PREDICT_ONLY=1"
+    ADD_CFLAGS="-I$OPENBLAS_ROOT/include -DDISABLE_OPENMP=1 -DMSHADOW_RABIT_PS=0 -DMSHADOW_DIST_PS=0 -DMXNET_PREDICT_ONLY=1 -DMXNET_THREAD_LOCAL_ENGINE=1"
 
 %install
 mkdir -p %{i}/{lib,include}
-mv lib/libmxnet.so           %{i}/lib/libmxnetpredict.so
-mv include/*                 %{i}/include
-mv cpp-package/include/*     %{i}/include
+mv lib/libmxnet.so                  %{i}/lib/libmxnetpredict.so
+mv include/*                        %{i}/include
+mv 3rdparty/dmlc-core/include/*     %{i}/include
+mv 3rdparty/tvm/nnvm/include/*      %{i}/include
+mv cpp-package/include/*            %{i}/include
 
 

--- a/mxnet-predict.spec
+++ b/mxnet-predict.spec
@@ -1,7 +1,8 @@
-### RPM external mxnet-predict 1.2.1.mod3
-%define projectname mxnet-predict
-%define releasename apache-mxnet-src-%{realversion}-incubating
-Source: https://hqu.web.cern.ch/hqu/tools/mxnet/apache-mxnet-src-%{realversion}-incubating.tar.gz
+### RPM external mxnet-predict 1.2.1
+%define tag 97171b96b2b7efc78eccfbe0a0c2561a377ce153
+%define branch 1.2.1.mod3
+%define github_user cms-externals
+Source: git+https://github.com/%{github_user}/incubator-mxnet.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 Requires: OpenBLAS
 

--- a/mxnet-predict.spec
+++ b/mxnet-predict.spec
@@ -7,7 +7,7 @@ Source: git+https://github.com/%{github_user}/incubator-mxnet.git?obj=%{branch}/
 Requires: OpenBLAS
 
 %prep
-%setup -q -n %releasename
+%setup -q -n %{n}-%{realversion}
 
 %build
 make %{makeprocesses} USE_OPENCV=0 USE_OPENMP=0 USE_BLAS=openblas USE_CPP_PACKAGE=1 USE_F16C=0 \


### PR DESCRIPTION
For testing in https://github.com/cms-sw/cmssw/pull/23768.

The original `NaiveEngine` in MXNet is not thread safe. Here we change the engine to be a thread local object, so it will allow each thread to use a different engine:
https://github.com/hqucms/incubator-mxnet/commit/f31352f26b816d8a2c7080f6fc81377ff4924369