### PR TITLE
Add test-simple dependency to spacemon spec

### DIFF
--- a/spacemon-client.spec
+++ b/spacemon-client.spec
@@ -8,7 +8,7 @@
 %define downloadt %(echo %realversion | tr '.' '_')
 %define setupdir  %{downloadm}-%{n}_%{downloadt}
 Source: https://github.com/dmwm/DMWMMON/archive/%{n}_%{downloadt}.tar.gz
-Requires: p5-crypt-ssleay
+Requires: p5-crypt-ssleay p5-test-simple
 
 %prep
 


### PR DESCRIPTION
Fix the error dependency:
```
	perl(Test::More) is needed by cms+spacemon-client+1.0.3-1-1.x86_64
```

reported in 
https://hypernews.cern.ch/HyperNews/CMS/get/webInterfaces/1617/1.html

FYI @nataliaratnikova