### PR TITLE
Import root from 10_2_X_gcc700

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,8 +1,8 @@
 ### RPM lcg root 6.12.07
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 989d72ff9d8878ee5eb893c0b41c3c811f1848e5
-%define branch cms/v6-12-00-patches/38e3810
+%define tag 21aa853cd993e6677c2191efda8063154c7cc537
+%define branch cms/v6-12-00-patches/6eb9073
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 


### PR DESCRIPTION
Update the version of root to the one which contains the correct version of TH1.
@h4d4 Could you please put this in CMSWeb. Previous update was not correct.