### PR TITLE
Bump fastHadd version again

### DIFF
--- a/fasthadd.spec
+++ b/fasthadd.spec
@@ -1,7 +1,7 @@
-### RPM external fasthadd 2.3
+### RPM external fasthadd 2.4
 
 #Change the commit hash every time a new version is needed.
-%define commit 905af02d3369428df677c232537da6fca8982ff3
+%define commit 0fec4de6785e45f6535eff44a6dc23bd0039d154
 Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Components/bin/fastHadd.cc
 Source1: https://raw.githubusercontent.com/cms-sw/cmssw/%commit/DQMServices/Core/src/ROOTFilePB.proto
 Requires: protobuf root


### PR DESCRIPTION
The 2.3 version was most likely build with a ROOT6.12 version that was missing the ROOT-9173 fix and therefore has the wrong `TH1` `ClassDef`. It must not be used in P5.

By now we should have that worked out, and we might need to switch to 2.4 in online once HLT switches to CMSSW10_2.