### PR TITLE
Update OpenMPI to version 2.1.5 (critical bugfix release)

### DIFF
--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 2.1.4
+### RPM external openmpi 2.1.5
 ## INITENV SET OPAL_PREFIX %{i}
 Source: http://download.open-mpi.org/release/open-mpi/v2.1/%{n}-%{realversion}.tar.gz
 BuildRequires: autotools

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -10,7 +10,7 @@ sed -i -e 's|#!/usr/bin/perl|#!/usr/bin/env perl|' opal/asm/generate-all-asm.pl
 sed -i -e 's|/usr/bin/perl|/usr/bin/env perl|' ./Doxyfile
 sed -i -e 's|/usr/bin/perl|/usr/bin/env perl|' ./orte/Doxyfile
 ./autogen.pl --force
-./configure --prefix=%i --without-lsf --disable-libnuma --enable-mpi-cxx
+./configure --prefix=%i --without-lsf --disable-libnuma --enable-mpi-cxx --enable-mpi-thread-multiple
 
 %build
 make %{makeprocesses} 


### PR DESCRIPTION
Open MPI v2.1.5 is a critical bug fix release, and is likely the last release in the v2.1.x series.
Open MPI v2.1.5 is only recommended for those who are still running Open MPI v2.0.x or v2.1.x.

In addition, enable support for multithreading in OpenMPI.