### PR TITLE
SCRAM:Avoid invalid timestamp on EOS

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_8_pre5
+### RPM lcg SCRAMV1 V2_2_8_pre6
 ## NOCOMPILER
 
 BuildRequires: gmake


### PR DESCRIPTION
This should fix the issue reported here: https://hypernews.cern.ch/HyperNews/CMS/get/softwareDistrib/758/1/1/1/1/1.html