### PR TITLE
Herwig 7.1.4 and it's dependencies

### DIFF
--- a/gsl.spec
+++ b/gsl.spec
@@ -1,4 +1,4 @@
-### RPM external gsl 2.2.1
+### RPM external gsl 2.4
 Source: ftp://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
 
 %define keep_archives true

--- a/herwigpp.spec
+++ b/herwigpp.spec
@@ -1,4 +1,4 @@
-### RPM external herwigpp 7.1.2
+### RPM external herwigpp 7.1.4
 Source: https://www.hepforge.org/archive/herwig/Herwig-%{realversion}.tar.bz2
 
 # Tried to comment out the parts which build HerwigDefaults.rpo during make install
@@ -8,9 +8,10 @@ Source: https://www.hepforge.org/archive/herwig/Herwig-%{realversion}.tar.bz2
 
 Requires: lhapdf
 Requires: boost 
+Requires: hepmc
+Requires: yoda
 Requires: thepeg
 Requires: gsl 
-Requires: hepmc
 Requires: fastjet
 Requires: gosamcontrib gosam
 Requires: madgraph5amcatnlo
@@ -25,7 +26,6 @@ Requires: openloops
 
 Patch0: herwigpp-missingBoostMTLib
 
-
 BuildRequires: autotools
 
 %if "%{?cms_cxx:set}" != "set"
@@ -36,6 +36,9 @@ BuildRequires: autotools
 %setup -q -n Herwig-%{realversion}
 
 %patch0 -p1 
+
+
+
 
 # Regenerate build scripts
 autoreconf -fiv
@@ -53,6 +56,7 @@ PLATF_CONF_OPTS="--enable-shared --disable-static"
 	    --with-madgraph=$MADGRAPH5AMCATNLO_ROOT \
             --with-gosam=$GOSAM_ROOT \
             --with-gosam-contrib=$GOSAMCONTRIB_ROOT \
+	    --with-hepmc=$HEPMC_ROOT \
 %if %isamd64
             --with-openloops=$OPENLOOPS_ROOT \
 %endif
@@ -62,12 +66,30 @@ PLATF_CONF_OPTS="--enable-shared --disable-static"
             FCFLAGS="-fno-range-check" \
 %endif
 	    BOOST_ROOT="$BOOST_ROOT" LDFLAGS="$LDFLAGS -L$BOOST_ROOT/lib" \
-            LD_LIBRARY_PATH=$LHAPDF_ROOT/lib:$GSL_ROOT/lib:$GOSAMCONTRIB_ROOT/lib:$MADGRAPH5AMCATNLO_ROOT/HEPTools/lib:$LD_LIBRARY_PATH
+            LD_LIBRARY_PATH=$LHAPDF_ROOT/lib:$GSL_ROOT/lib:$GOSAMCONTRIB_ROOT/lib:$MADGRAPH5AMCATNLO_ROOT/HEPTools/lib:$HEPMC_ROOT/lib:$LD_LIBRARY_PATH
 
-make %makeprocesses all LD_LIBRARY_PATH=$LHAPDF_ROOT/lib:$THEPEG_ROOT/lib/ThePEG:$GSL_ROOT/lib:$FASTJET_ROOT/lib:$BOOST_ROOT/lib:$GOSAMCONTRIB_ROOT/lib:$MADGRAPH5AMCATNLO_ROOT/HEPTools/lib:$LD_LIBRARY_PATH LIBRARY_PATH=$FASTJET_ROOT/lib
+
+make %makeprocesses all LD_LIBRARY_PATH=$LHAPDF_ROOT/lib:$THEPEG_ROOT/lib/ThePEG:$GSL_ROOT/lib:$FASTJET_ROOT/lib:$BOOST_ROOT/lib:$GOSAMCONTRIB_ROOT/lib:$MADGRAPH5AMCATNLO_ROOT/HEPTools/lib:$LD_LIBRARY_PATH:$HEPMC_ROOT/lib LIBRARY_PATH=$FASTJET_ROOT/lib
+#FIX for 7.1.4: need to fix path in Makefile to build the FxFx.so library correctly
+#Maybe not needed for future versions.  Bug has been reported to the authors
+
+sed -i -e "s|^HERWIGINCLUDE.*|HERWIGINCLUDE = -I${PWD}/include|g" Contrib/FxFx/Makefile
+sed -i -e "s|^RIVETINCLUDE.*|RIVETINCLUDE = -I${RIVET_ROOT}/include|g" Contrib/FxFx/Makefile
+sed -i -e "s|^HEPMCINCLUDE.*|HEPMCINCLUDE = -I${HEPMC_ROOT}/include|g" Contrib/FxFx/Makefile
+sed -i "/^FASTJETLIB.*/a YODAINCLUDE= -I${YODA_ROOT}/include" Contrib/FxFx/Makefile
+sed -i -e "/^INCLUDE.*/s/$/ \$(YODAINCLUDE)/" Contrib/FxFx/Makefile
+sed -i "/^FASTJETLIB.*/a HERWIGINSTALL = ${PWD}" Contrib/FxFx/Makefile
+sed -i -e '0,/\$(HERWIGINSTALL)\/lib\/Herwig/s//\$(HERWIGINSTALL)\/lib\/./' Contrib/FxFx/Makefile
+
+cd Contrib/FxFx           
+make FxFx.so LD_LIBRARY_PATH=${GCC_ROOT}/lib:$LD_LIBRARY_PATH   
+make install                                                                                                                                                            
+cd - 
+# end of fix
 
 %install
-make install LD_LIBRARY_PATH=$LHAPDF_ROOT/lib:$THEPEG_ROOT/lib/ThePEG:$GSL_ROOT/lib:$FASTJET_ROOT/lib:$BOOST_ROOT/lib:$GOSAMCONTRIB_ROOT/lib:$MADGRAPH5AMCATNLO_ROOT/HEPTools/lib:$LD_LIBRARY_PATH LIBRARY_PATH=$FASTJET_ROOT/lib:$THEPEG_ROOT/lib/ThePEG:$LHAPDF_ROOT/lib:$GOSAMCONTRIB_ROOT/lib LHAPDF_DATA_PATH=$LHAPDF_ROOT/share/LHAPDF
+make install LD_LIBRARY_PATH=$LHAPDF_ROOT/lib:$THEPEG_ROOT/lib/ThePEG:$GSL_ROOT/lib:$FASTJET_ROOT/lib:$BOOST_ROOT/lib:$GOSAMCONTRIB_ROOT/lib:$MADGRAPH5AMCATNLO_ROOT/HEPTools/lib:$LD_LIBRARY_PATH LIBRARY_PATH=$FASTJET_ROOT/lib:$THEPEG_ROOT/lib/ThePEG:$LHAPDF_ROOT/lib:$GOSAMCONTRIB_ROOT/lib:$HEPMC_ROOT/lib LHAPDF_DATA_PATH=$LHAPDF_ROOT/share/LHAPDF
+cp lib/FxFx.so %{i}/lib/Herwig/FxFx.so
 mv %{i}/bin/Herwig  %{i}/bin/Herwig-cms
 cat << \HERWIG_WRAPPER > %{i}/bin/Herwig
 #!/bin/bash
@@ -78,6 +100,7 @@ fi
 $(dirname $0)/Herwig-cms $REPO_OPT "$@"
 HERWIG_WRAPPER
 chmod +x %{i}/bin/Herwig
+
 
 %post
 %{relocateConfig}bin/herwig-config

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -1,4 +1,4 @@
-### RPM external thepeg 2.1.1
+### RPM external thepeg 2.1.4
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib/ThePEG
 ## INITENV +PATH DYLD_LIBRARY_PATH %{i}/lib/ThePEG
 


### PR DESCRIPTION
Dear @all,
This is the rpm package settings for Herwig7.1.4 and its dependencies. I had to make a dirty fix in herwigpp.spec for the FxFx.so library, because it doesn't get built properly by Herwig 7 itself.

Kind regards,
Andrej