### PR TITLE
 Update llvm/clang to version 7.0.0 (release) 

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -8,6 +8,7 @@ Requires: gcc zlib
 %if %{isamd64}
 Requires: cuda
 %endif
+AutoReq: no
 
 %define llvmCommit ff0a5e8a591ed8bfc14320740863b357b1774f49
 %define llvmBranch cms/release_70/342187

--- a/llvm.spec
+++ b/llvm.spec
@@ -47,7 +47,12 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -DLLVM_ENABLE_EH:BOOL=ON \
   -DLLVM_ENABLE_PIC:BOOL=ON \
   -DLLVM_ENABLE_RTTI:BOOL=ON \
+%if %{isamd64}
+  -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64;NVPTX" \
+  -DLIBOMPTARGET_NVPTX_ALTERNATE_HOST_COMPILER=/usr/bin/gcc \
+%else
   -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64" \
+%endif
   -DCMAKE_REQUIRED_INCLUDES="${ZLIB_ROOT}/include" \
   -DCMAKE_PREFIX_PATH="${ZLIB_ROOT}"
 

--- a/llvm.spec
+++ b/llvm.spec
@@ -11,7 +11,7 @@ Requires: cuda
 
 %define llvmCommit ff0a5e8a591ed8bfc14320740863b357b1774f49
 %define llvmBranch cms/release_70/342187
-%define iwyuCommit 5082fddccb3d5aabaace2208f1162029a27c0334
+%define iwyuCommit 7b8980310f98ea76ac6d4e703d8bd07bde3d8ebc
 %define iwyuBranch master
 
 Source0: git+https://github.com/cms-externals/llvm-project-20170507.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz

--- a/llvm.spec
+++ b/llvm.spec
@@ -1,4 +1,4 @@
-### RPM external llvm 6.0.0
+### RPM external llvm 7.0.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 %define isamd64 %(case %{cmsplatf} in (*_amd64_*) echo 1 ;; (*) echo 0 ;; esac)
@@ -9,8 +9,8 @@ Requires: gcc zlib
 Requires: cuda
 %endif
 
-%define llvmCommit 500cb56799157a08a3283a067f172b6c6ad4efa6
-%define llvmBranch cms/release_60/329799
+%define llvmCommit ff0a5e8a591ed8bfc14320740863b357b1774f49
+%define llvmBranch cms/release_70/342187
 %define iwyuCommit 5082fddccb3d5aabaace2208f1162029a27c0334
 %define iwyuBranch master
 

--- a/py2-dxr-clang700.patch
+++ b/py2-dxr-clang700.patch
@@ -1,0 +1,13 @@
+diff --git a/dxr/plugins/clang/dxr-index.cpp b/dxr/plugins/clang/dxr-index.cpp
+index 460d373..6b35340 100644
+--- a/dxr/plugins/clang/dxr-index.cpp
++++ b/dxr/plugins/clang/dxr-index.cpp
+@@ -923,7 +923,7 @@ public:
+       if (sm.isMacroArgExpansion(loc))
+         loc = sm.getImmediateSpellingLoc(loc);
+       else
+-        loc = sm.getImmediateExpansionRange(loc).first;
++        loc = sm.getImmediateExpansionRange(loc).getBegin();
+     }
+     return loc;
+   }

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -16,6 +16,7 @@ Patch2: py2-dxr-fix-clang-linker-flags
 Patch3: py2-dxr-clang36
 Patch4: py2-dxr-sqlite38
 Patch5: py2-dxr-clang37
+Patch6: py2-dxr-clang700
 %define keep_archives true
 
 %prep
@@ -29,6 +30,7 @@ cd ..
 %patch3 -p1
 %patch4 -p1
 %patch5 -p1
+%patch6 -p1
 mv trilite-%triliteCommit/* trilite
 %setup -T -D -n dxr-%dxrCommit
 

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -25,8 +25,8 @@ Requires: py2-bottleneck
 Requires: py2-downhill 
 Requires: py2-theanets
 Requires: py2-xgboost
-Requires: py2-llvmlite
-Requires: py2-numba
+#Requires: py2-llvmlite
+#Requires: py2-numba
 Requires: py2-hep_ml
 Requires: py2-rep
 Requires: py2-uncertainties


### PR DESCRIPTION
Also
  -  enable support for compiling CUDA code to NVPTX on amd64;
  -  disable automatic package dependencies.

For the moment, skip building dxr, numba and llvmlite, until they support LLVM 7.