### PR TITLE
set the COMPILER_PATH env variable instead of COMPILER_RUNTIME_OBJECTS

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -73,6 +73,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-cxxcompiler.xml
     <runtime name="GCC_RUNTIME_UBSAN" value="$GCC_CXXCOMPILER_BASE/@ARCH_LIB64DIR@/libubsan.so" type="path"/>
     <runtime name="GCC_RUNTIME_TSAN" value="$GCC_CXXCOMPILER_BASE/@ARCH_LIB64DIR@/libtsan.so" type="path"/>
     <runtime name="GCC_RUNTIME_LSAN" value="$GCC_CXXCOMPILER_BASE/@ARCH_LIB64DIR@/libasan.so" type="path"/>
+    <runtime name="COMPILER_PATH"    value="@GCC_ROOT@"/>
   </tool>
 EOF_TOOLFILE
 

--- a/icc-gcc-toolfile.spec
+++ b/icc-gcc-toolfile.spec
@@ -68,7 +68,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/icc-cxxcompiler.xml
     </architecture>
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$ICC_CXXCOMPILER_BASE/%{icclib_dir}" type="path" handler="warn"/>
     <runtime name="PATH" value="$ICC_CXXCOMPILER_BASE/%{iccbin_dir}" type="path" handler="warn"/>
-    <runtime name="COMPILER_RUNTIME_OBJECTS" value="@GCC_ROOT@" handler="warn"/>
   </tool>
 EOF_TOOLFILE
 

--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -65,7 +65,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags CXXFLAGS="-Wno-error=potentially-evaluated-expression"/>
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LLVM_CXXCOMPILER_BASE/lib64" type="path"/>
     <runtime name="PATH" value="$LLVM_CXXCOMPILER_BASE/bin" type="path"/>
-    <runtime name="COMPILER_RUNTIME_OBJECTS" value="@GCC_ROOT@"/>
   </tool>
 EOF_TOOLFILE
 
@@ -106,7 +105,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-analyzer-cxxcompiler.xml
       <environment name="LLVM_ANALYZER_CXXCOMPILER_BASE" default="@LLVM_ROOT@"/>
       <environment name="CXX" value="$LLVM_ANALYZER_CXXCOMPILER_BASE/bin/c++-analyzer"/>
     </client>
-    <runtime name="COMPILER_RUNTIME_OBJECTS" value="@GCC_ROOT@"/>
   </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
clang use COMPILER_PATH env variable to find the GCC toolchain. We were patching clang ( https://github.com/cms-externals/llvm-project-20170507/commit/85a9c36d893831f7c7ea73eaa6a74997739a0a0b#diff-c338d6d0b1a666a15fa597e194768aa3R1571 ) to get the gcc from the cms external area. With this change, the clang patch is not needed any more.