### PR TITLE
Update CUDA to version 10.0.130 (10.2.x backport)

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -51,8 +51,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cublas.xml
   <info url="https://docs.nvidia.com/cuda/cublas/index.html"/>
   <use name="cuda"/>
   <lib name="cublas"/>
-  <lib name="cublas_device"/>
-  <lib name="cublas_device" type="cuda"/>
 </tool>
 EOF_TOOLFILE
 
@@ -121,6 +119,14 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvml.xml
   <info url="https://docs.nvidia.com/deploy/nvml-api/index.html"/>
   <use name="cuda"/>
   <lib name="nvidia-ml"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvjpeg.xml
+<tool name="cuda-nvjpeg" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/nvjpeg/index.html"/>
+  <use name="cuda"/>
+  <lib name="nvjpeg"/>
 </tool>
 EOF_TOOLFILE
 

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,9 +1,8 @@
-### RPM external cuda 9.2.148
-%define driversversion 396.37
+### RPM external cuda 10.0.130
+%define driversversion 410.48
 %define cudaversion %(echo %realversion | cut -d. -f 1,2)
 
-Source0: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod2/local_installers/%{n}_%{realversion}_%{driversversion}_linux
-Source1: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod2/patches/1/%{n}_%{realversion}.1_linux
+Source0: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod/local_installers/%{n}_%{realversion}_%{driversversion}_linux
 AutoReq: no
 
 %prep
@@ -14,57 +13,50 @@ AutoReq: no
 mkdir -p %_builddir/tmp
 /bin/sh %{SOURCE0} --silent --tmpdir %_builddir/tmp --extract %_builddir
 # extracts:
-# %_builddir/NVIDIA-Linux-x86_64-396.37.run
-# %_builddir/cuda-linux.9.2.148-24330188.run
-# %_builddir/cuda-samples.9.2.148-24330188-linux.run
+# %_builddir/NVIDIA-Linux-x86_64-410.48.run
+# %_builddir/cuda-linux.10.0.130-24817639.run
+# %_builddir/cuda-samples.10.0.130-24817639-linux.run
 
 # extract and repackage the CUDA runtime, tools and stubs
 /bin/sh %_builddir/%{n}-linux.%{realversion}-*.run -noprompt -nosymlink -tmpdir %_builddir/tmp -prefix %_builddir
 
-# Patch 1 (Released Aug 6, 2018)
-# CUDA 9.2 Patch Update: This update includes performance improvements to cuBLAS GEMM APIs and bug fixes for CUPTI and cuda-gdb.
-# See the CUDA 9.2 release notes for more details.
-/bin/sh %{SOURCE1} --silent --accept-eula --tmpdir %_builddir/tmp --installdir %_builddir
-rm -rf %_builddir/lib64/libcublas.so.9.2.148
-rm -rf %_builddir/lib64/libnvblas.so.9.2.148
-rm -rf %_builddir/lib64/libcuinj64.so.9.2.148
-rm -rf %_builddir/extras/CUPTI/lib64/libcupti.so.9.2.148
-
 mkdir -p %{i}/lib64
-# package only runtime and device static libraries
+mkdir -p %{i}/bin
+
+# package only the runtime static libraries
 cp -ar %_builddir/lib64/libcudart_static.a %{i}/lib64/
 cp -ar %_builddir/lib64/libcudadevrt.a %{i}/lib64/
-cp -ar %_builddir/lib64/lib*_device.a %{i}/lib64/
-rm -rf %_builddir/lib64/lib*.a
+rm -f %_builddir/lib64/lib*.a
 
-# do not package dynamic libraries for which we have stubs
-rm -rf %_builddir/lib64/libcublas.so*
-rm -rf %_builddir/lib64/libcufft.so*
-rm -rf %_builddir/lib64/libcufftw.so*
-rm -rf %_builddir/lib64/libcurand.so*
-rm -rf %_builddir/lib64/libcusolver.so*
-rm -rf %_builddir/lib64/libcusparse.so*
-rm -rf %_builddir/lib64/libnpp*.so*
-rm -rf %_builddir/lib64/libnvgraph.so*
-rm -rf %_builddir/lib64/libnvrtc.so*
-rm -rf %_builddir/lib64/libnvrtc-builtins.so*
+# do not package dynamic libraries for which there are stubs
+rm -f %_builddir/lib64/libcublas.so*
+rm -f %_builddir/lib64/libcufft.so*
+rm -f %_builddir/lib64/libcufftw.so*
+rm -f %_builddir/lib64/libcurand.so*
+rm -f %_builddir/lib64/libcusolver.so*
+rm -f %_builddir/lib64/libcusparse.so*
+rm -f %_builddir/lib64/libnpp*.so*
+rm -f %_builddir/lib64/libnvgraph.so*
+rm -f %_builddir/lib64/libnvjpeg.so*
+rm -f %_builddir/lib64/libnvrtc.so*
 
 # package the other dynamic libraries
 cp -ar %_builddir/lib64/* %{i}/lib64/
 
 # package the includes
-rm -rf %_builddir/include/sobol_direction_vectors.h
+rm -f %_builddir/include/sobol_direction_vectors.h
 cp -ar %_builddir/include/ %{i}
 
-# leave out nsight and nvvp
+# leave out the Nsight and NVVP graphical tools
 #cp -ar %_builddir/jre %{i}
 #cp -ar %_builddir/libnsight %{i}
 #ln -sf ../libnsight/nsight %_builddir/bin/nsight
-rm -rf %_builddir/bin/nsight
+rm -f %_builddir/bin/nsight
+rm -f %_builddir/bin/nsight_ee_plugins_manage.sh
 #cp -ar %_builddir/libnvvp %{i}
 #ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
-rm -rf %_builddir/bin/nvvp
-rm -rf %_builddir/bin/computeprof
+rm -f %_builddir/bin/nvvp
+rm -f %_builddir/bin/computeprof
 
 # package the cuda-gdb support files, and rename the binary to use it via a wrapper
 mkdir %{i}/share
@@ -72,8 +64,11 @@ cp -ar %_builddir/share/gdb/ %{i}/share/
 mv %_builddir/bin/cuda-gdb %_builddir/bin/cuda-gdb.real
 
 # package the binaries and tools
-cp -ar %_builddir/bin %{i}
+cp -ar %_builddir/bin/* %{i}
 cp -ar %_builddir/nvvm %{i}
+
+# package the Nsight Compute command line tool
+cp -ar %_builddir/NsightCompute-1.0/target/linux-desktop-glibc_2_11_3-glx-x64/* %{i}/bin/
 
 # package the version file
 cp -ar %_builddir/version.txt %{i}
@@ -83,9 +78,11 @@ cp -ar %_builddir/version.txt %{i}
 mkdir -p %{i}/drivers
 cp -ar %_builddir/nvidia/libcuda.so.%{driversversion}                   %{i}/drivers/
 ln -sf libcuda.so.%{driversversion}                                     %{i}/drivers/libcuda.so.1
+ln -sf libcuda.so.1                                                     %{i}/drivers/libcuda.so
 cp -ar %_builddir/nvidia/libnvidia-fatbinaryloader.so.%{driversversion} %{i}/drivers/
 cp -ar %_builddir/nvidia/libnvidia-ptxjitcompiler.so.%{driversversion}  %{i}/drivers/
 ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                    %{i}/drivers/libnvidia-ptxjitcompiler.so.1
+ln -sf libnvidia-ptxjitcompiler.so.1                                    %{i}/drivers/libnvidia-ptxjitcompiler.so
 
 %post
 # let nvcc find its components when invoked from the command line
@@ -95,4 +92,3 @@ sed \
   -e's|/$(_TARGET_DIR_)||g' \
   -e's|$(_TARGET_SIZE_)|64|g' \
   -i $RPM_INSTALL_PREFIX/%{pkgrel}/bin/nvcc.profile
-

--- a/cuda.spec
+++ b/cuda.spec
@@ -10,79 +10,82 @@ AutoReq: no
 %build
 
 %install
-mkdir -p %_builddir/tmp
-/bin/sh %{SOURCE0} --silent --tmpdir %_builddir/tmp --extract %_builddir
+rm -rf %_builddir/build %_builddir/tmp
+mkdir %_builddir/build %_builddir/tmp
+/bin/sh %{SOURCE0} --silent --tmpdir %_builddir/tmp --extract %_builddir/build
 # extracts:
-# %_builddir/NVIDIA-Linux-x86_64-410.48.run
-# %_builddir/cuda-linux.10.0.130-24817639.run
-# %_builddir/cuda-samples.10.0.130-24817639-linux.run
+# %_builddir/build/NVIDIA-Linux-x86_64-410.48.run
+# %_builddir/build/cuda-linux.10.0.130-24817639.run
+# %_builddir/build/cuda-samples.10.0.130-24817639-linux.run
 
 # extract and repackage the CUDA runtime, tools and stubs
-/bin/sh %_builddir/%{n}-linux.%{realversion}-*.run -noprompt -nosymlink -tmpdir %_builddir/tmp -prefix %_builddir
+/bin/sh %_builddir/build/%{n}-linux.%{realversion}-*.run -noprompt -nosymlink -tmpdir %_builddir/tmp -prefix %_builddir/build
 
-mkdir -p %{i}/lib64
+# create target directory structure
 mkdir -p %{i}/bin
+mkdir -p %{i}/include
+mkdir -p %{i}/lib64
+mkdir -p %{i}/share
 
 # package only the runtime static libraries
-cp -ar %_builddir/lib64/libcudart_static.a %{i}/lib64/
-cp -ar %_builddir/lib64/libcudadevrt.a %{i}/lib64/
-rm -f %_builddir/lib64/lib*.a
+mv %_builddir/build/lib64/libcudart_static.a %{i}/lib64/
+mv %_builddir/build/lib64/libcudadevrt.a %{i}/lib64/
+rm -f %_builddir/build/lib64/lib*.a
 
 # do not package dynamic libraries for which there are stubs
-rm -f %_builddir/lib64/libcublas.so*
-rm -f %_builddir/lib64/libcufft.so*
-rm -f %_builddir/lib64/libcufftw.so*
-rm -f %_builddir/lib64/libcurand.so*
-rm -f %_builddir/lib64/libcusolver.so*
-rm -f %_builddir/lib64/libcusparse.so*
-rm -f %_builddir/lib64/libnpp*.so*
-rm -f %_builddir/lib64/libnvgraph.so*
-rm -f %_builddir/lib64/libnvjpeg.so*
-rm -f %_builddir/lib64/libnvrtc.so*
+rm -f %_builddir/build/lib64/libcublas.so*
+rm -f %_builddir/build/lib64/libcufft.so*
+rm -f %_builddir/build/lib64/libcufftw.so*
+rm -f %_builddir/build/lib64/libcurand.so*
+rm -f %_builddir/build/lib64/libcusolver.so*
+rm -f %_builddir/build/lib64/libcusparse.so*
+rm -f %_builddir/build/lib64/libnpp*.so*
+rm -f %_builddir/build/lib64/libnvgraph.so*
+rm -f %_builddir/build/lib64/libnvjpeg.so*
+rm -f %_builddir/build/lib64/libnvrtc.so*
 
-# package the other dynamic libraries
-cp -ar %_builddir/lib64/* %{i}/lib64/
+# package the other dynamic libraries and the stubs
+mv %_builddir/build/lib64/* %{i}/lib64/
 
 # package the includes
-rm -f %_builddir/include/sobol_direction_vectors.h
-cp -ar %_builddir/include/ %{i}
+rm -f %_builddir/build/include/sobol_direction_vectors.h
+mv %_builddir/build/include/* %{i}/include/
 
 # leave out the Nsight and NVVP graphical tools
-#cp -ar %_builddir/jre %{i}
-#cp -ar %_builddir/libnsight %{i}
-#ln -sf ../libnsight/nsight %_builddir/bin/nsight
-rm -f %_builddir/bin/nsight
-rm -f %_builddir/bin/nsight_ee_plugins_manage.sh
-#cp -ar %_builddir/libnvvp %{i}
-#ln -sf ../libnvvp/nvvp %_builddir/bin/nvvp
-rm -f %_builddir/bin/nvvp
-rm -f %_builddir/bin/computeprof
-
-# package the cuda-gdb support files, and rename the binary to use it via a wrapper
-mkdir %{i}/share
-cp -ar %_builddir/share/gdb/ %{i}/share/
-mv %_builddir/bin/cuda-gdb %_builddir/bin/cuda-gdb.real
-
-# package the binaries and tools
-cp -ar %_builddir/bin/* %{i}
-cp -ar %_builddir/nvvm %{i}
+#mv %_builddir/build/jre %{i}/
+#mv %_builddir/build/libnsight %{i}/
+#ln -sf ../libnsight/nsight %_builddir/build/bin/nsight
+rm -f %_builddir/build/bin/nsight
+rm -f %_builddir/build/bin/nsight_ee_plugins_manage.sh
+#mv %_builddir/build/libnvvp %{i}/
+#ln -sf ../libnvvp/nvvp %_builddir/build/bin/nvvp
+rm -f %_builddir/build/bin/nvvp
+rm -f %_builddir/build/bin/computeprof
 
 # package the Nsight Compute command line tool
-cp -ar %_builddir/NsightCompute-1.0/target/linux-desktop-glibc_2_11_3-glx-x64/* %{i}/bin/
+mv %_builddir/build/NsightCompute-1.0/target/linux-desktop-glibc_2_11_3-glx-x64/* %{i}/bin/
+
+# package the cuda-gdb support files, and rename the binary to use it via a wrapper
+mv %_builddir/build/share/gdb/ %{i}/share/
+mv %_builddir/build/bin/cuda-gdb %{i}/bin/cuda-gdb.real
+
+# package the binaries and tools
+mv %_builddir/build/bin/* %{i}/bin/
+mv %_builddir/build/nvvm %{i}/
 
 # package the version file
-cp -ar %_builddir/version.txt %{i}
+mv %_builddir/build/version.txt %{i}/
 
 # extract and repackage the NVIDIA libraries needed by the CUDA runtime
-/bin/sh %_builddir/NVIDIA-Linux-x86_64-%{driversversion}.run --accept-license --extract-only --tmpdir %_builddir/tmp --target %_builddir/nvidia
+/bin/sh %_builddir/build/NVIDIA-Linux-x86_64-%{driversversion}.run --accept-license --extract-only --tmpdir %_builddir/tmp --target %_builddir/build/nvidia
 mkdir -p %{i}/drivers
-cp -ar %_builddir/nvidia/libcuda.so.%{driversversion}                   %{i}/drivers/
-ln -sf libcuda.so.%{driversversion}                                     %{i}/drivers/libcuda.so.1
-ln -sf libcuda.so.1                                                     %{i}/drivers/libcuda.so
-cp -ar %_builddir/nvidia/libnvidia-fatbinaryloader.so.%{driversversion} %{i}/drivers/
-cp -ar %_builddir/nvidia/libnvidia-ptxjitcompiler.so.%{driversversion}  %{i}/drivers/
-ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                    %{i}/drivers/libnvidia-ptxjitcompiler.so.1
-ln -sf libnvidia-ptxjitcompiler.so.1                                    %{i}/drivers/libnvidia-ptxjitcompiler.so
+mv %_builddir/build/nvidia/libcuda.so.%{driversversion}                   %{i}/drivers/
+ln -sf libcuda.so.%{driversversion}                                       %{i}/drivers/libcuda.so.1
+ln -sf libcuda.so.1                                                       %{i}/drivers/libcuda.so
+mv %_builddir/build/nvidia/libnvidia-fatbinaryloader.so.%{driversversion} %{i}/drivers/
+mv %_builddir/build/nvidia/libnvidia-ptxjitcompiler.so.%{driversversion}  %{i}/drivers/
+ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                      %{i}/drivers/libnvidia-ptxjitcompiler.so.1
+ln -sf libnvidia-ptxjitcompiler.so.1                                      %{i}/drivers/libnvidia-ptxjitcompiler.so
 
 %post
 # let nvcc find its components when invoked from the command line


### PR DESCRIPTION
See https://docs.nvidia.com/cuda/pdf/CUDA_Toolkit_Release_Notes.pdf .

Update the SCRAM tool files for CUDA 10:
  - drop the device-side cublas libraries;
  - add a tool for the new nvjpeg library.