### PR TITLE
Updated scram build rules to fix the missing cuda dependency

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-33
+%define configtag       V05-07-34
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
cuda automatic dependency, due to .cu files, was dropped when -fsyntax-only flag is passed via USER_CXXFLAGS. New build rules tag should fix this issue.