### PR TITLE
Update CUDA_FLAGS used by CMSSW (10.2.x backport)

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -37,6 +37,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
   <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
   <flags CUDA_FLAGS="-gencode arch=compute_50,code=sm_50"/>
   <flags CUDA_FLAGS="-gencode arch=compute_61,code=sm_61"/>
+  <flags CUDA_FLAGS="-gencode arch=compute_70,code=sm_70"/>
   <flags CUDA_FLAGS="-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda"/>
   <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
   <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -38,6 +38,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
   <flags CUDA_FLAGS="-gencode arch=compute_61,code=sm_61"/>
   <flags CUDA_FLAGS="-gencode arch=compute_70,code=sm_70"/>
   <flags CUDA_FLAGS="-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda"/>
+  <flags CUDA_FLAGS="--generate-line-info --source-in-ptx"/>
   <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
   <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>
   <flags CUDA_HOST_CXXFLAGS="-std=c++14"/>

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -35,7 +35,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
   <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
-  <flags CUDA_FLAGS="-gencode arch=compute_50,code=sm_50"/>
   <flags CUDA_FLAGS="-gencode arch=compute_61,code=sm_61"/>
   <flags CUDA_FLAGS="-gencode arch=compute_70,code=sm_70"/>
   <flags CUDA_FLAGS="-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda"/>


### PR DESCRIPTION
  - drop support for Maxwell GPUs (sm_50)
  - add support for Volta GPUs (sm_70)
  - add line information for device code and interleave source in ptx