### PR TITLE
Update llvm/clang to 7.0.0-svn342187 (release) (10.3.x backport)

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -8,6 +8,7 @@ Requires: gcc zlib
 %if %{isamd64}
 Requires: cuda
 %endif
+AutoReq: no
 
 %define llvmCommit ff0a5e8a591ed8bfc14320740863b357b1774f49
 %define llvmBranch cms/release_70/342187

--- a/llvm.spec
+++ b/llvm.spec
@@ -47,7 +47,12 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -DLLVM_ENABLE_EH:BOOL=ON \
   -DLLVM_ENABLE_PIC:BOOL=ON \
   -DLLVM_ENABLE_RTTI:BOOL=ON \
+%if %{isamd64}
+  -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64;NVPTX" \
+  -DLIBOMPTARGET_NVPTX_ALTERNATE_HOST_COMPILER=/usr/bin/gcc \
+%else
   -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64" \
+%endif
   -DCMAKE_REQUIRED_INCLUDES="${ZLIB_ROOT}/include" \
   -DCMAKE_PREFIX_PATH="${ZLIB_ROOT}"
 

--- a/llvm.spec
+++ b/llvm.spec
@@ -11,7 +11,7 @@ Requires: cuda
 
 %define llvmCommit ff0a5e8a591ed8bfc14320740863b357b1774f49
 %define llvmBranch cms/release_70/342187
-%define iwyuCommit 5082fddccb3d5aabaace2208f1162029a27c0334
+%define iwyuCommit 7b8980310f98ea76ac6d4e703d8bd07bde3d8ebc
 %define iwyuBranch master
 
 Source0: git+https://github.com/cms-externals/llvm-project-20170507.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz

--- a/llvm.spec
+++ b/llvm.spec
@@ -10,7 +10,7 @@ Requires: cuda
 %endif
 AutoReq: no
 
-%define llvmCommit ff0a5e8a591ed8bfc14320740863b357b1774f49
+%define llvmCommit 80172b4abd71cf4994cfe944cc237c41ebbd2833
 %define llvmBranch cms/release_70/342187
 %define iwyuCommit 7b8980310f98ea76ac6d4e703d8bd07bde3d8ebc
 %define iwyuBranch master

--- a/llvm.spec
+++ b/llvm.spec
@@ -1,4 +1,4 @@
-### RPM external llvm 6.0.0
+### RPM external llvm 7.0.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 %define isamd64 %(case %{cmsplatf} in (*_amd64_*) echo 1 ;; (*) echo 0 ;; esac)
@@ -9,8 +9,8 @@ Requires: gcc zlib
 Requires: cuda
 %endif
 
-%define llvmCommit 500cb56799157a08a3283a067f172b6c6ad4efa6
-%define llvmBranch cms/release_60/329799
+%define llvmCommit ff0a5e8a591ed8bfc14320740863b357b1774f49
+%define llvmBranch cms/release_70/342187
 %define iwyuCommit 5082fddccb3d5aabaace2208f1162029a27c0334
 %define iwyuBranch master
 


### PR DESCRIPTION
Update IWYU to the current master.

Disable automatic package dependencies: llvm 7 includes a new tool, llvm-exegesis, that depepnds on libpfm.so. Rather than including this library in the CMSSW stack, we assume that it will be available form the host system; as it's not something strictly necessary to have, we avoid a hard dependency on it in the RPM package.

Enable support for compiling CUDA code on amd64.

Backport basic support for compiling with CUDA 10.0 from the llvm 8 master branch.