### PR TITLE
CRABTaskWorker 3.3.1810.patch4

### DIFF
--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,4 +1,4 @@
-### RPM cms crabtaskworker 3.3.1810.patch3
+### RPM cms crabtaskworker 3.3.1810.patch4
 
 
 ## INITENV +PATH PATH %i/xbin


### PR DESCRIPTION
In the TaskWorker checkBlocksSize function, use only blocks with locations to avoid Exception from DBS API