### PR TITLE
add ofast-flag tool and updated SCRAM

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_8_pre9
+### RPM lcg SCRAMV1 V2_2_8
 ## NOCOMPILER
 
 BuildRequires: gmake

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -127,6 +127,18 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-plugin.xml
     </client>
   </tool>
 EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/ofast-flag.xml
+  <tool name="ofast-flag" version="1.0">
+    <flags CXXFLAGS="-Ofast"/>
+    <ifarchitecture name="slc6_">
+      <ifcompiler name="llvm">
+        <flags CXXFLAGS="-fno-builtin"/>
+      </ifcompiler>
+    </ifarchitecture>
+    <flags NO_RECURSIVE_EXPORT="1"/>
+  </tool>
+EOF_TOOLFILE
 export GCC_PLUGIN_DIR=$(gcc -print-file-name=plugin)
 
 # NON-empty defaults


### PR DESCRIPTION
- new ofast-flag tools added to allow to include -Ofast for compilations. It also takes care of properly adding the no-builtin flags for arch where needed.
- updated scram version to V2_2_8 which now supports 
```
<if[condition] name|value|match="value">
  <use name="foo"/>
<else/>
  <use name="bar"/>
<if[condition]>
```