### PR TITLE
Update scram tag V2_2_9_pre00

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_8
+### RPM lcg SCRAMV1 V2_2_9_pre00
 ## NOCOMPILER
 
 BuildRequires: gmake


### PR DESCRIPTION
bug fix: make sure to set default compiler at scram project setup time.