### PR TITLE
use default to openloops docs optimization, pick up factorial calc improvement

### DIFF
--- a/openloops.spec
+++ b/openloops.spec
@@ -1,5 +1,5 @@
 ### RPM external openloops 2.0.b
-%define tag 0f0826bd718dc28dcc8a457acb59de678b011b96
+%define tag 5141c0eab4286a4a685f03c4731ff0358e635e54
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
@@ -18,10 +18,11 @@ Patch0: openloops-1.2.3-cpp-use-undef
 cat << \EOF >> openloops.cfg
 [OpenLoops]
 fortran_compiler = gfortran
-gfortran_f90_flags = -ffixed-line-length-0 -ffree-line-length-0 -O0
+gfortran_f90_flags = -ffixed-line-length-0 -ffree-line-length-0
+generic_optimisation = -O2
+born_optimisation = -O2
 loop_optimisation = -O0
-generic_optimisation = -O0
-born_optimisation = -O0
+link_optimisation = -O2
 EOF
 
 ./openloops update --processes generator=0


### PR DESCRIPTION
IB tests notices very long startup times for herwig NLO workflows (eg 3 hours for "simple" physics process. While probably this is a sign that a different approach is needed to cache these long to compute results, this PR speeds this calculation up.

Two changes are proposed
1) to use the optimization flags suggested by openloops documentation for openloops. Note that adding the last possible -02 flag makes compilation go forever.
2) to improve one of the hotspots in openloops for the benchmark workflow.

There are other clear optimizations to make. I need to work a bit on my integer mathematics skills before pushing them forward.