### PR TITLE
generate cuda-gcc-support toolfile if cuda supports the existing gcc version

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_9_pre01
+### RPM lcg SCRAMV1 V2_2_9_pre02
 ## NOCOMPILER
 
 BuildRequires: gmake
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::Template::Plugins::PluginCore)
 Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 
-%define tag eb2a200233e34f2aac87d610f7fd4aa686f3e01c
+%define tag 27663debe4d4f30304885e17272e076022c34727
 %define branch master
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -143,4 +143,13 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/nvidia-drivers.xml
 </tool>
 EOF_TOOLFILE
 
+touch cuda_gcc_supported.cu
+if [ $(nvcc -dc cuda_gcc_supported.cu -o cuda_gcc_supported.cu.o 2>&1 | grep 'unsupported GNU version' | wc -l) -eq 0 ] ; then
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-gcc-support.xml
+<tool name="cuda-gcc-support" version="@TOOL_VERSION@">
+</tool>
+EOF_TOOLFILE
+fi
+rm -f cuda_gcc_supported.*
+
 ## IMPORT scram-tools-post


### PR DESCRIPTION
This tool could be used to build/run some cuda unit tests in cmssw.