### PR TITLE
Update python requests package to 2.20.0

### DIFF
--- a/py2-requests.spec
+++ b/py2-requests.spec
@@ -1,4 +1,4 @@
-### RPM external py2-requests 2.18.4
+### RPM external py2-requests 2.20.0
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
 Requires: py2-urllib3 py2-chardet py2-idna py2-certifi


### PR DESCRIPTION
From the automatic GH alert, the previous version has moderate severity security vulnerability, as can be seen in the alert raised for the other repo I'm member of:
https://github.com/CMSCompOps/wtc-console/network/alert/py-requirements/base.txt/requests/open