### PR TITLE
Revert pyopenssl upgrade to 18.0.0

### DIFF
--- a/py2-pyopenssl.spec
+++ b/py2-pyopenssl.spec
@@ -1,7 +1,21 @@
-### RPM external py2-pyopenssl 18.0.0
+### RPM external py2-pyopenssl 0.11
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-%define pip_name pyOpenSSL
+Source: https://launchpad.net/pyopenssl/main/%realversion/+download/pyOpenSSL-%realversion.tar.gz
+Requires: python openssl
 
-## IMPORT build-with-pip
+%prep
+%setup -n pyOpenSSL-%realversion
 
+cat >> setup.cfg <<CMS_EOF
+[build_ext]
+include_dirs = $OPENSSL_ROOT/include
+library_dirs = $OPENSSL_ROOT/lib
+CMS_EOF
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;


### PR DESCRIPTION
Manually revert #4467

I'll create a new PR in the next week with a proper upgrade of that spec.