### PR TITLE
Improve Eigen compatibility with CUDA (10.4.x)

### DIFF
--- a/eigen.spec
+++ b/eigen.spec
@@ -1,12 +1,12 @@
-### RPM external eigen 64060da8461a627eb25b5a7bc0616776068db58b
+### RPM external eigen 01ae86b9aad30b1e65cf1b749fd6cd9a645ac00d
 ## INITENV +PATH PKG_CONFIG_PATH %{i}/share/pkgconfig
 ## INITENV SETV EIGEN_SOURCE %{source0}
 ## INITENV SETV EIGEN_STRIP_PREFIX %{source_prefix}
 ## NOCOMPILER
 %define tag %{realversion}
 
-#These are needed by Tensorflow sources
-#NOTE: Never apply any patch in the spec file, this way tensorflow gets the exact same sources
+# These are needed by Tensorflow sources
+# NOTE: Never apply any patch in the spec file, this way tensorflow gets the exact same sources
 %define source0 https://github.com/cms-externals/eigen-git-mirror/archive/%{tag}.tar.gz
 %define source_prefix eigen-git-mirror-%{realversion}
 Source: %{source0}

--- a/eigen.spec
+++ b/eigen.spec
@@ -1,4 +1,4 @@
-### RPM external eigen 01ae86b9aad30b1e65cf1b749fd6cd9a645ac00d
+### RPM external eigen 1f44b667dd9aeeb153284b15fc7fe159d2c09329
 ## INITENV +PATH PKG_CONFIG_PATH %{i}/share/pkgconfig
 ## INITENV SETV EIGEN_SOURCE %{source0}
 ## INITENV SETV EIGEN_STRIP_PREFIX %{source_prefix}

--- a/tensorflow-1.6.0-eigen-backports.patch
+++ b/tensorflow-1.6.0-eigen-backports.patch
@@ -1,0 +1,121 @@
+commit 87b715325a74d34f1331d14d8df640308ec10d12
+Author: Brian Patton <bjp@google.com>
+Date:   Tue Mar 20 06:25:19 2018 -0700
+
+    Adds float64 support for avg pool and its gradient.
+    
+    Eigen NumTraits is modified to directly use std::numeric_limits, which resolves a broken test caused by inconsistency between the host and devices values of Eigen::NumTraits<double>::highest(). This returns +inf on device, due to third_party/eigen3/Eigen/src/Core/util/Meta.h, and __DBL_MAX__ (1.7976931348623157e+308) on host, making the behavior for doubles (on device) inconsistent with both the behavior of floats Eigen::NumTraits<float>::highest() and the behavior of std::numeric_limits<double>::max()
+    
+    PiperOrigin-RevId: 189731521
+
+diff --git a/tensorflow/core/kernels/eigen_pooling.h b/tensorflow/core/kernels/eigen_pooling.h
+index 896c995..2f83780 100644
+--- a/tensorflow/core/kernels/eigen_pooling.h
++++ b/tensorflow/core/kernels/eigen_pooling.h
+@@ -334,7 +334,8 @@ struct AvgPoolMeanReducer {
+   }
+ 
+   template <typename Packet>
+-  void reducePacketWithType(T, const Packet& p, Packet* accum) {
++  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void reducePacketWithType(
++      T, const Packet& p, Packet* accum) {
+     Packet skip_mask =
+         pequal(p, pset1<Packet>(-Eigen::NumTraits<T>::highest()));
+     (*accum) = padd<Packet>(*accum, psel(p, pset1<Packet>(0), skip_mask));
+@@ -480,11 +481,9 @@ SpatialAvgPooling(const Input& input, DenseIndex patchRows,
+                              Eigen::type2index<3> > >::type reduction_dims;
+ #endif
+   return input
+-      .extract_image_patches(
+-          patchRows, patchCols, strideRows, strideCols, in_strideRows,
+-          in_strideCols, padding_type,
+-          -Eigen::NumTraits<typename internal::remove_const<
+-              typename internal::traits<Input>::Scalar>::type>::highest())
++      .extract_image_patches(patchRows, patchCols, strideRows, strideCols,
++                             in_strideRows, in_strideCols, padding_type,
++                             -Eigen::NumTraits<CoeffReturnType>::highest())
+       .reduce(reduction_dims, mean_with_nan)
+       .reshape(post_reduce_dims);
+ }
+
+commit f84e8257aa88fa45cc7a15835ad386565cd60237
+Author: A. Unique TensorFlower <gardener@tensorflow.org>
+Date:   Fri Jun 1 16:48:10 2018 -0700
+
+    Change the Eigen reduction code to use a tree to improve numerical stability.
+    This changes the InnerMostDimReducer to use a summation tree, which is more numerically stable than the previous approach of sequential addition into an accumulator.
+    This solves the issue for reduction over all or a trailing subset of dimensions.
+    This change does not improve the numerical accuracy for MeanReducer, which maintains state.
+    
+    Benchmarks show a 40% (AVX) to 50% (SSE) slowdown for small row reductions (sum, float). column- and full reductions are unchanged.
+    
+    Cleaned up TensorFunctors.h a bit by moving the traits to reducer_traits and updating the code that uses the reducers accordingly.
+    
+    Introduced a new trait "IsExactlyAssociative" and new template specializations of InnerMostDimReducer to ensure that we only invoke the new and slightly more expensive codepath when it is needed, i.e. for sum reduction of non-integer types.
+    
+    PiperOrigin-RevId: 198946075
+
+diff --git a/tensorflow/core/kernels/eigen_pooling.h b/tensorflow/core/kernels/eigen_pooling.h
+index 2f83780..56de6b1 100644
+--- a/tensorflow/core/kernels/eigen_pooling.h
++++ b/tensorflow/core/kernels/eigen_pooling.h
+@@ -372,16 +372,23 @@ struct reducer_traits<AvgPoolMeanReducer<float>, Device> {
+     Cost = 1,
+ #if (EIGEN_ARCH_i386 || EIGEN_ARCH_x86_64) && !defined(__CUDACC__)
+     // We only support packet access for floats.
+-    PacketAccess = true
++    PacketAccess = true,
+ #else
+-    PacketAccess = false
++    PacketAccess = false,
+ #endif
++    IsStateful = true,
++    IsExactlyAssociative = false
+   };
+ };
+ 
+ template <>
+ struct reducer_traits<AvgPoolMeanReducer<float>, GpuDevice> {
+-  enum { Cost = 1, PacketAccess = false };
++  enum {
++    Cost = 1,
++    PacketAccess = false,
++    IsStateful = true,
++    IsExactlyAssociative = false
++  };
+ };
+ 
+ }  // namespace internal
+
+commit cba65fbcecb828a3e6e7743f7e784c7d08d37ffb
+Author: Eugene Zhulenev <ezhulenev@google.com>
+Date:   Fri Sep 14 12:34:21 2018 -0700
+
+    Define PreferBlockAccess enum to prepare for Eigen upgrade.
+    
+    PiperOrigin-RevId: 213025676
+
+diff --git a/tensorflow/core/kernels/eigen_volume_patch.h b/tensorflow/core/kernels/eigen_volume_patch.h
+index a3d7958..80ab745 100644
+--- a/tensorflow/core/kernels/eigen_volume_patch.h
++++ b/tensorflow/core/kernels/eigen_volume_patch.h
+@@ -43,6 +43,7 @@ struct CustomTensorEvaluator {
+     IsAligned = false,
+     PacketAccess = TensorEvaluator<ArgType, Device>::PacketAccess,
+     BlockAccess = false,
++    PreferBlockAccess = false,
+     Layout = TensorEvaluator<ArgType, Device>::Layout,
+     CoordAccess = NumDims == 6,
+     RawAccess = false
+diff --git a/tensorflow/core/kernels/mirror_pad_op.h b/tensorflow/core/kernels/mirror_pad_op.h
+index cc4b694..62aa7d5 100644
+--- a/tensorflow/core/kernels/mirror_pad_op.h
++++ b/tensorflow/core/kernels/mirror_pad_op.h
+@@ -103,6 +103,7 @@ struct TensorEvaluator<const TensorMirrorPadOp<PaddingDimensions, ArgType>,
+     IsAligned = false,
+     PacketAccess = TensorEvaluator<ArgType, Device>::PacketAccess,
+     BlockAccess = false,
++    PreferBlockAccess = false,
+     Layout = TensorEvaluator<ArgType, Device>::Layout,
+     CoordAccess = true,
+     RawAccess = false

--- a/tensorflow-1.6.0-eigen-rename-sigmoid.patch
+++ b/tensorflow-1.6.0-eigen-rename-sigmoid.patch
@@ -1,0 +1,77 @@
+commit f933c2c13cb014688497fd8a8791ead4fce34014 (HEAD, master)
+Author: Andrea Bocci <andrea.bocci@cern.ch>
+Date:   Thu Sep 27 09:32:00 2018 +0200
+
+    Rename Eigen's internal scalar_sigmoid_op to scalar_logistic_op
+    
+    Rename Eigen::internal::scalar_sigmoid_op to Eigen::internal::scalar_logistic_op,
+    following Eigen pull request #466 (master).
+
+diff --git a/tensorflow/contrib/lite/kernels/internal/optimized/optimized_ops.h b/tensorflow/contrib/lite/kernels/internal/optimized/optimized_ops.h
+index 8163c76..bc4fdf0 100644
+--- a/tensorflow/contrib/lite/kernels/internal/optimized/optimized_ops.h
++++ b/tensorflow/contrib/lite/kernels/internal/optimized/optimized_ops.h
+@@ -2072,12 +2072,12 @@ inline void LstmCell(const float* input_data, const Dims<4>& input_dims,
+   // Combined memory state and final output calculation
+   gemmlowp::ScopedProfilingLabel label2("MemoryStateAndFinalOutput");
+   output_state_map =
+-      input_gate_sm.unaryExpr(Eigen::internal::scalar_sigmoid_op<float>()) *
++      input_gate_sm.unaryExpr(Eigen::internal::scalar_logistic_op<float>()) *
+           new_input_sm.tanh() +
+-      forget_gate_sm.unaryExpr(Eigen::internal::scalar_sigmoid_op<float>()) *
++      forget_gate_sm.unaryExpr(Eigen::internal::scalar_logistic_op<float>()) *
+           prev_state_map;
+   output_activ_map =
+-      output_gate_sm.unaryExpr(Eigen::internal::scalar_sigmoid_op<float>()) *
++      output_gate_sm.unaryExpr(Eigen::internal::scalar_logistic_op<float>()) *
+       output_state_map.tanh();
+ }
+ 
+@@ -2786,7 +2786,7 @@ inline void Logistic(const float* input_data, const Dims<4>& input_dims,
+   auto input_map = MapAsVector(input_data, input_dims);
+   auto output_map = MapAsVector(output_data, output_dims);
+   output_map.array() =
+-      input_map.array().unaryExpr(Eigen::internal::scalar_sigmoid_op<float>());
++      input_map.array().unaryExpr(Eigen::internal::scalar_logistic_op<float>());
+ }
+ 
+ inline void Logistic(const uint8* input_data, const Dims<4>& input_dims,
+diff --git a/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc b/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc
+index 6d3758f..0229ca7 100644
+--- a/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc
++++ b/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc
+@@ -95,7 +95,7 @@ __global__ void lstm_gates(const T* icfo, const T* b, const T* cs_prev,
+   //
+   const int gid = batch_id * cell_size * 4 + act_id;
+   const int cid = batch_id * cell_size + act_id;
+-  Eigen::internal::scalar_sigmoid_op<T> sigmoid_op;
++  Eigen::internal::scalar_logistic_op<T> sigmoid_op;
+   Eigen::internal::scalar_tanh_op<T> tanh_op;
+   Eigen::scalar_clip_op<T> clip_op;
+ 
+diff --git a/tensorflow/core/grappler/costs/op_level_cost_estimator.cc b/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
+index cf31737..e782ca1 100644
+--- a/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
++++ b/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
+@@ -234,7 +234,7 @@ OpLevelCostEstimator::OpLevelCostEstimator() {
+       {"Relu", Eigen::internal::functor_traits<
+                    Eigen::internal::scalar_max_op<float>>::Cost},
+       {"Sigmoid", Eigen::internal::functor_traits<
+-                      Eigen::internal::scalar_sigmoid_op<float>>::Cost},
++                      Eigen::internal::scalar_logistic_op<float>>::Cost},
+       {"Sign", Eigen::internal::functor_traits<
+                    Eigen::internal::scalar_sign_op<float>>::Cost},
+       {"Sin", Eigen::internal::functor_traits<
+diff --git a/tensorflow/core/kernels/cwise_ops.h b/tensorflow/core/kernels/cwise_ops.h
+index 0691807..0c0e6b4 100644
+--- a/tensorflow/core/kernels/cwise_ops.h
++++ b/tensorflow/core/kernels/cwise_ops.h
+@@ -617,7 +617,7 @@ template <typename T>
+ struct erfc : base<T, Eigen::internal::scalar_erfc_op<T>> {};
+ 
+ template <typename T>
+-struct sigmoid : base<T, Eigen::internal::scalar_sigmoid_op<T>> {};
++struct sigmoid : base<T, Eigen::internal::scalar_logistic_op<T>> {};
+ 
+ template <typename T>
+ struct sin : base<T, Eigen::internal::scalar_sin_op<T>> {};

--- a/tensorflow-1.6.0-eigen-update-gemm_pack_lhs.patch
+++ b/tensorflow-1.6.0-eigen-update-gemm_pack_lhs.patch
@@ -1,0 +1,20 @@
+commit 724e558629ded6ff82563a42170337fd2a06e354 (HEAD, master)
+Author: Andrea Bocci <andrea.bocci@cern.ch>
+Date:   Thu Sep 27 10:07:30 2018 +0200
+
+    Add "packet" template parameter to gemm_pack_lhs<>
+
+diff --git a/tensorflow/core/kernels/deep_conv2d.cc b/tensorflow/core/kernels/deep_conv2d.cc
+index 829155f..693eb25 100644
+--- a/tensorflow/core/kernels/deep_conv2d.cc
++++ b/tensorflow/core/kernels/deep_conv2d.cc
+@@ -500,7 +500,8 @@ class GemmFilterPacker {
+       LhsMapper;
+   typedef Eigen::internal::gebp_traits<T, T> Traits;
+   Eigen::internal::gemm_pack_lhs<T, int64, LhsMapper, Traits::mr,
+-                                 Traits::LhsProgress, Eigen::RowMajor>
++                                 Traits::LhsProgress, typename Traits::LhsPacket,
++                                 Eigen::RowMajor>
+       pack_lhs;
+ 
+   GemmFilterPacker(const int64 rows, const int64 depth, const T* lhs_input,

--- a/tensorflow-python3-sources.spec
+++ b/tensorflow-python3-sources.spec
@@ -6,6 +6,9 @@
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}-%{tag}.tgz
+Patch1: tensorflow-1.6.0-eigen-backports
+Patch2: tensorflow-1.6.0-eigen-update-gemm_pack_lhs
+Patch3: tensorflow-1.6.0-eigen-rename-sigmoid
 
 BuildRequires: bazel eigen protobuf gcc
 BuildRequires: py2-setuptools java-env
@@ -14,6 +17,9 @@ Requires: py2-numpy python3 py2-wheel
 %prep
 
 %setup -q -n tensorflow-%{realversion}
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
 
 %build
 export PYTHON_BIN_PATH=`which python3`

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -7,6 +7,9 @@
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}-%{tag}.tgz
 Patch0: tensorflow-1.6.0-rename-runtime
+Patch1: tensorflow-1.6.0-eigen-backports
+Patch2: tensorflow-1.6.0-eigen-update-gemm_pack_lhs
+Patch3: tensorflow-1.6.0-eigen-rename-sigmoid
 BuildRequires: bazel eigen protobuf gcc
 BuildRequires: py2-setuptools java-env
 Requires: py2-numpy python py2-wheel
@@ -15,6 +18,9 @@ Requires: py2-numpy python py2-wheel
 
 %setup -q -n tensorflow-%{realversion}
 %patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
 
 %build
 export PYTHON_BIN_PATH=`which python`


### PR DESCRIPTION
Update Eigen to the master branch as of Tue Sep 25 20:26:16 2018 +0200
  - hg hash  66ba78bf7efa93f69a075830a87a010ed1b1fe30
  - git hash 01ae86b9aad30b1e65cf1b749fd6cd9a645ac00d

Patch Tensorflow to follow Eigen internal changes
  - cherry-pick changes from upstream repository
  - add local changes for the latest updates

Improve Eigen compatibility with CUDA
  - add support for cache-size queries on CUDA devices.
  - extend support for matrix inversion on CUDA devices above 4x4 matrices;
the size of the matrices that can be inverted is limited at runtime by the per-thread stack size.
  - extend support for diagonal matrices on CUDA devices.
  - fix deprecation warning in CUDA 10.0.