### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient-binary.spec
+++ b/dasgoclient-binary.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient-binary v02.00.11
+### RPM cms dasgoclient-binary v02.00.12
 Source0: git+https://github.com/dmwm/dasgoclient?obj=master/%{realversion}&export=dasgoclient&output=/dasgoclient.tar.gz
 Source1: git+https://github.com/dmwm/cmsauth?obj=master/e9fca92e3335252a5f71d8e6d09c64012f7d3c0c&export=github.com/dmwm/cmsauth&output=/cmsauth.tar.gz
 Source2: git+https://github.com/vkuznet/x509proxy?obj=master/b4622388b3a347c8df75b6e944e9d2a580acee60&export=github.com/vkuznet/x509proxy&output=/x509proxy.tar.gz

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v02.00.11
+### RPM cms dasgoclient v02.00.12
 ## NOCOMPILER
 %define dasgoclient_arch     slc6_amd64_gcc700
 %define dasgoclient_pkg      cms+%{n}-binary+%{realversion}


### PR DESCRIPTION
Fix bug associated with improper look-up of data-services for site dataset=X queries. Once I introduced Rucio data-serivce now it was look-up by default. For CERN users it is not a problem since rucio service is visible on CERN network but for off-site users this query hang for long time trying to resolve rucio auth server. This bug fix resolve the issue and remove rucio from a list of default services to look at. I strongly advise to deploy this dasgoclient version asap to cvmfs to avoid users complaining about these types of queries which will hang for long time.