### PR TITLE
Disable CUDA 10.0 deprecation warnings

### DIFF
--- a/cuda-api-wrappers-toolfile.spec
+++ b/cuda-api-wrappers-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external cuda-api-wrappers-toolfile 2.0
+### RPM external cuda-api-wrappers-toolfile 2.1
 Requires: cuda-api-wrappers
 
 %prep
@@ -12,6 +12,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cuda-api-wrappers.xml
 <tool name="cuda-api-wrappers" version="@TOOL_VERSION@">
   <lib name="cuda-api-wrappers"/>
   <use name="cuda"/>
+  <flags CXXFLAGS="-DCUDA_ENABLE_DEPRECATED"/>
   <client>
     <environment name="CUDA_API_WRAPPERS_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$CUDA_API_WRAPPERS_BASE/include"/>


### PR DESCRIPTION
CUDA 10.0 deprecates some `cudaPointerAttributes` members.
The development branch of the cuda-api-wrappers works around this, but
those changes have not yet been merged into the stable branch.

For the time being, simply disable the CUDA deprecation warning. We can
re-enable them once the stable branch will include support for CUDA 10.