### PR TITLE
update py2-notebook to version 5.7.2

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -91,7 +91,7 @@ networkx==2.1
 neurolab==0.3.5
 nose-parameterized==0.6.0
 nose==1.3.7
-notebook==5.6.0
+notebook==5.7.2
 numba==0.39.0
 numexpr==2.6.8
 oamap==0.12.4


### PR DESCRIPTION
please test

CVE-2018-19352 More information
moderate severity
Vulnerable versions: < 5.7.2
Patched version: 5.7.2
Jupyter Notebook before 5.7.2 allows XSS via a crafted directory name because notebook/static/tree/js/notebooklist.js handles certain URLs unsafely.