### PR TITLE
Added macro to auto-generate dependencies-setup*

### DIFF
--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -252,3 +252,29 @@ for f in `find %{pkginstroot} -type f`; do \
         perl -p -i -e 's{.*}{#!/usr/bin/env python3} if $. == 1 && m{#!.*/bin/python.*}' $f \
     fi \
 done
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+%define AutoSetupDependencies \
+if [ ! -e %i/etc/profile.d/dependencies-setup.sh ] ; then \
+mkdir -p %i/etc/profile.d \
+: > %i/etc/profile.d/dependencies-setup.sh \
+: > %i/etc/profile.d/dependencies-setup.csh \
+  echo 'if [ "X${_CMSBUILD_BUILD_ENV_}" = "X" ] ; then' >> %i/etc/profile.d/dependencies-setup.sh \
+  echo "  true" >> %i/etc/profile.d/dependencies-setup.sh \
+  for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do \
+    root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\\$$root \
+    if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then \
+      echo "  test X\\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh \
+      echo "test \\$?$root != 0 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh \
+    fi \
+  done \
+  echo "fi" >> %i/etc/profile.d/dependencies-setup.sh \
+  touch %i/etc/profile.d/.autodependencies \
+fi
+
+#Relocate dependencies
+%define AutoSetupDependenciesRelocate \
+if [ -f $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/.autodependencies ] ; then \
+  %{relocateConfig}etc/profile.d/dependencies-setup.sh \
+  %{relocateConfig}etc/profile.d/dependencies-setup.csh \
+fi


### PR DESCRIPTION
As discussed in this other PR:
https://github.com/cms-sw/cmsdist/pull/4479#issuecomment-440573696

we need to have these two macros in order to automatically generate the dependencies-setup.* scripts  when building RPMs. If a spec already generates then, then that macro doesn't run.

@smuzaffar did I miss anything? Apparently the only difference with the macro @vkuznet already has in place is that this one checks whether dependencies has already been created (if so, do nothing) and it also uses that `_CMSBUILD_BUILD_ENV_` var, which I wonder whether we need it or not?