### PR TITLE
[10.4.X] updated cmssw build rules

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-37
+%define configtag       V05-07-38
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Added new build target ignore-deleted to ignore checking for deleted packages which requires `git diff` and can hang if reference cmssw repository is not accessible.
- Update help message for few targets.