### PR TITLE
Updated cmsdist rootnext to branch v6-16-00-patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -2,8 +2,8 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 30136e62406484c38923b6e68f5c87a4e79eaa68
-%define branch cms/v6-14-00-patches/f72fb18
+%define tag 960e9f49609ffb4b3b235d968e17fd9923a8090d
+%define branch cms/v6-16-00-patches/9858841
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 


### PR DESCRIPTION
Move from 6-14 to 6-16 on rootnext. Version number in build/version still not changed so keep it for now