### PR TITLE
Enable error reporting for CUDA library calls

### DIFF
--- a/cub-toolfile.spec
+++ b/cub-toolfile.spec
@@ -15,6 +15,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cub.xml
     <environment name="CUB_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE"  default="$CUB_BASE/include"/>
   </client>
+  <flags CXXFLAGS="-DCUB_STDERR"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
Define `CUB_STDERR` when compiling code that uses `cub` to enable (non fatal) error reporting for calls to CUDA library functions.