### PR TITLE
Add build dependency on tensorflow-sources to avoid build conflicts

### DIFF
--- a/tensorflow-python3-sources.spec
+++ b/tensorflow-python3-sources.spec
@@ -12,6 +12,7 @@ Patch3: tensorflow-1.6.0-eigen-rename-sigmoid
 
 BuildRequires: bazel eigen protobuf gcc
 BuildRequires: py2-setuptools java-env
+BuildRequires: tensorflow-sources
 Requires: py2-numpy python3 py2-wheel
 
 %prep


### PR DESCRIPTION
By default, cmsBuild tries to build `tensorflow-sources` and `tensorflow-python3-sources` in parallel, leading to conflicts with the Bazel builds.
Declaring a build dependency on `tensorflow-sources` should force cmsBuild to build these packages one after the other.