### PR TITLE
Herwig7 backport to 93x for 2017 production

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -83,6 +83,8 @@ Requires: zlib-toolfile
 Requires: dcap-toolfile
 Requires: frontier_client-toolfile
 Requires: xrootd-toolfile
+Requires: qgraf-toolfile
+Requires: form-toolfile
 %if %isnotaarch64
 Requires: pyqt-toolfile
 %endif

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -148,6 +148,8 @@ Requires: CSCTrackFinderEmulation-toolfile
 Requires: tinyxml-toolfile
 Requires: scons-toolfile
 Requires: md5-toolfile
+Requires: gosamcontrib-toolfile
+Requires: gosam-toolfile
 Requires: madgraph5amcatnlo-toolfile
 Requires: py2-pippkgs-toolfile
 Requires: py2-pippkgs_depscipy-toolfile

--- a/form-toolfile.spec
+++ b/form-toolfile.spec
@@ -1,0 +1,21 @@
+### RPM external form-toolfile 1.0
+Requires: form
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/form.xml
+<tool name="form" version="@TOOL_VERSION@">
+  <client>
+    <environment name="FORM_BASE" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$FORM_BASE/bin"/>
+  </client>
+  <runtime name="PATH" default="$BINDIR" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post
+

--- a/form.spec
+++ b/form.spec
@@ -1,0 +1,28 @@
+### RPM external form 4.1.033e
+Source: https://gosam.hepforge.org/gosam-installer/form-%{realversion}.tar.gz
+
+%if "%{?cms_cxx:set}" != "set"
+%define cms_cxx g++
+%endif
+
+%prep
+%setup -q -n form-4.1
+
+%build
+
+CXX="$(which %{cms_cxx}) -fPIC"
+CC="$(which gcc) -fPIC"
+PLATF_CONF_OPTS="--enable-shared --disable-static"
+
+./configure $PLATF_CONF_OPTS \
+            --prefix=%i \
+            --bindir=%i/bin \
+            --without-gmp \
+            CXX="$CXX" CC="$CC" CXXFLAGS=-fpermissive
+
+make %makeprocesses
+
+%install
+make install 
+
+

--- a/gmp.spec
+++ b/gmp.spec
@@ -1,2 +1,2 @@
-### RPM external gmp 4.2.1
+### RPM external gmp 6.1.2
 Source: ftp://mirrors.kernel.org/gnu/%n/%n-%realversion.tar.gz

--- a/gosam-toolfile.spec
+++ b/gosam-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external gosam-toolfile 2.0
+Requires: gosam
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gosam.xml
+<tool name="gosam" version="@TOOL_VERSION@">
+  <client>
+    <environment name="GOSAM_BASE" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$GOSAM_BASE/bin"/>
+  </client>
+  <runtime name="PATH" default="$BINDIR" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
+
+## IMPORT scram-tools-post

--- a/gosam.spec
+++ b/gosam.spec
@@ -1,0 +1,26 @@
+### RPM external gosam 2.0.4-33b41ed
+Source: http://www.hepforge.org/archive/gosam/gosam-%{realversion}.tar.gz
+
+Requires: qgraf
+Requires: form
+Requires: gosamcontrib
+Requires: python py2-cython
+
+%prep
+%setup -q -n gosam
+
+%build
+CXX="$(which c++) -fPIC"
+CC="$(which gcc) -fPIC"
+FC="$(which gfortran)"
+PLATF_CONF_OPTS="--enable-shared --disable-static"
+python setup.py install --prefix=%{i}
+
+%install
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python$1|" $(grep -r -e "^#\!.*python.*" %i | cut -d: -f1)
+find %{i}/lib -name '*.la' -exec rm -f {} \;
+
+%post
+%{relocateConfig}bin/gosam.py
+%{relocateConfig}bin/gosam-config.py
+%{relocateConfig}lib/python2.7/site-packages/golem/installation.py

--- a/gosamcontrib-toolfile.spec
+++ b/gosamcontrib-toolfile.spec
@@ -1,0 +1,24 @@
+### RPM external gosamcontrib-toolfile 1.0
+Requires: gosamcontrib
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gosamcontrib.xml
+<tool name="gosamcontrib" version="@TOOL_VERSION@">
+  <client>
+    <environment name="GOSAMCONTRIB_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$GOSAMCONTRIB_BASE/lib"/>
+    <environment name="INCLUDE" default="$GOSAMCONTRIB_BASE/include"/>
+  </client>
+  <runtime name="GOSAMCONTRIB_PATH" value="$GOSAMCONTRIB_BASE" type="path"/>
+  <runtime name="ROOT_PATH" value="$GOSAMCONTRIB_BASE" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post
+

--- a/gosamcontrib.spec
+++ b/gosamcontrib.spec
@@ -1,0 +1,29 @@
+### RPM external gosamcontrib 2.0-20150803
+Source: http://www.hepforge.org/archive/gosam/gosam-contrib-%{realversion}.tar.gz
+
+Requires: qgraf
+Requires: form
+
+%prep
+%setup -q -n gosam-contrib-2.0
+
+%build
+CXX="$(which c++) -fPIC"
+CC="$(which gcc) -fPIC"
+FC="$(which gfortran)"
+PLATF_CONF_OPTS="--enable-shared --enable-static"
+
+./configure $PLATF_CONF_OPTS \
+            --prefix=%i \
+            --bindir=%i/bin \
+            --libdir=%i/lib \
+            CXX="$CXX" CC="$CC" FC="$FC" 
+
+make %makeprocesses all
+
+%install
+make install 
+
+%post
+%{relocateConfig}share/gosam-contrib/gosam.conf
+

--- a/herwigpp-toolfile.spec
+++ b/herwigpp-toolfile.spec
@@ -9,12 +9,21 @@ Requires: herwigpp
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/herwigpp.xml
 <tool name="herwigpp" version="@TOOL_VERSION@">
+  <lib name="HerwigAPI"/>
   <client>
     <environment name="HERWIGPP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HERWIGPP_BASE/lib"/>
+    <environment name="LIBDIR" default="$HERWIGPP_BASE/lib/Herwig"/>
     <environment name="INCLUDE" default="$HERWIGPP_BASE/include"/>
+    <environment name="BINDIR" default="$HERWIGPP_BASE/bin"/>
   </client>
-  <runtime name="HERWIGPATH" value="$HERWIGPP_BASE/share/Herwig++"/>
+  <runtime name="HERWIGPATH" value="$HERWIGPP_BASE/share/Herwig"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="PATH" default="$BINDIR" type="path"/>
+  <use name="root_cxxdefaults"/>
+  <use name="lhapdf"/>
+  <use name="thepeg"/>
+  <use name="madgraph5amcatnlo"/>
+  <use name="openloops"/>
 </tool>
 EOF_TOOLFILE
 

--- a/herwigpp.spec
+++ b/herwigpp.spec
@@ -1,35 +1,98 @@
-### RPM external herwigpp 2.7.1
-Source: http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/herwig++/herwig++-%{realversion}-src.tgz
-Requires: boost thepeg gsl hepmc
+### RPM external herwigpp 7.1.4
+Source: https://www.hepforge.org/archive/herwig/Herwig-%{realversion}.tar.bz2
 
-%if "%{?cms_cxx:set}" != "set"
-%define cms_cxx g++
-%endif
+%define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
+%define isaarch64 %(case %{cmsplatf} in (*_aarch64_*) echo 1 ;; (*) echo 0 ;; esac)
 
-%if "%{?cms_cxxflags:set}" != "set"
-%define cms_cxxflags -O2 -std=c++0x
+Requires: lhapdf
+Requires: boost
+Requires: hepmc
+Requires: yoda 
+Requires: thepeg
+Requires: gsl 
+Requires: fastjet
+Requires: gosamcontrib gosam
+Requires: madgraph5amcatnlo
+%if %isamd64
+Requires: openloops
 %endif
+BuildRequires: autotools
+
+# Patch since otherwise Boost wants multithreaded lib, even though only single-threaded lib is installed
+# Problem exists since Herwig++3Beta
+Patch0: herwigpp-missingBoostMTLib
 
 %prep
-%setup -q -n herwig++/%{realversion}
+%setup -q -n Herwig-%{realversion}
+
+%patch0 -p1
+
+# Regenerate build scripts
+autoreconf -fiv
 
 %build
-./configure \
-  --disable-silent-rules --with-gsl=$GSL_ROOT --with-thepeg=$THEPEG_ROOT --with-boost=${BOOST_ROOT} --prefix=%i \
-  CXXFLAGS="-fuse-cxa-atexit %cms_cxxflags" CXX="%cms_cxx"
+CXX="$(which g++) -fPIC"
+CC="$(which gcc) -fPIC"
+PLATF_CONF_OPTS="--enable-shared --disable-static"
 
-# Fix up a configuration mistake coming from a test being confused
-# by the "skipping incompatible" linking messages when linking 32bit on 64bit
-perl -p -i -e 's|/usr/lib64/libm.a /usr/lib64/libc.a||' Makefile
-perl -p -i -e 's|/usr/lib64/libm.a /usr/lib64/libc.a||' */Makefile
-perl -p -i -e 's|/usr/lib64/libm.a /usr/lib64/libc.a||' */*/Makefile
-perl -p -i -e 's|/usr/lib64/libm.a /usr/lib64/libc.a||' */*/*/Makefile
-
-make %makeprocesses
+./configure --prefix=%i \
+            --with-thepeg=$THEPEG_ROOT \
+            --with-fastjet=$FASTJET_ROOT \
+            --with-gsl=$GSL_ROOT \
+            --with-boost=$BOOST_ROOT \
+	    --with-madgraph=$MADGRAPH5AMCATNLO_ROOT \
+            --with-gosam=$GOSAM_ROOT \
+            --with-gosam-contrib=$GOSAMCONTRIB_ROOT \
+            --with-hepmc=$HEPMC_ROOT \
+%if %isamd64
+            --with-openloops=$OPENLOOPS_ROOT \
+%endif
+%if %isaarch64
+            FCFLAGS="-fno-range-check" \
+%endif
+            $PLATF_CONF_OPTS \
+            CXX="$CXX" CC="$CC"
+make %makeprocesses all
 
 %install
-#tar -c -h lib include | tar -x -C %i
-make install
+make %makeprocesses install LHAPDF_DATA_PATH=$LHAPDF_ROOT/share/LHAPDF
+
+#FxFx.so needs to be build after herwigpp installation so that it can correctly pick up needed headers
+#FIX for 7.1.4: need to fix path in Makefile to build the FxFx.so library correctly
+#Maybe not needed for future versions.  Bug has been reported to the authors
+sed -i -e "s|UEBase.fh|Shower/UEBase.fh|g" Shower/UEBase.h
+sed -i -e "s|Herwig/Shower/Couplings/ShowerAlpha.h|Herwig/Shower/Core/Couplings/ShowerAlpha.h|g" Contrib/FxFx/FxFxHandler.h
+sed -i -e "s|^HERWIGINCLUDE.*|HERWIGINCLUDE = -I%{i}/include|g" Contrib/FxFx/Makefile
+sed -i -e "s|^RIVETINCLUDE.*|RIVETINCLUDE = -I${RIVET_ROOT}/include|g" Contrib/FxFx/Makefile
+sed -i -e "s|^HEPMCINCLUDE.*|HEPMCINCLUDE = -I${HEPMC_ROOT}/include|g" Contrib/FxFx/Makefile
+sed -i "/^FASTJETLIB.*/a YODAINCLUDE= -I${YODA_ROOT}/include" Contrib/FxFx/Makefile
+sed -i "/^YODAINCLUDE=.*/a BOOSTINCLUDE= -I${BOOST_ROOT}/include" Contrib/FxFx/Makefile
+sed -i -e "/^INCLUDE.*/s/$/ \$(YODAINCLUDE) \$(BOOSTINCLUDE)/" Contrib/FxFx/Makefile
+sed -i "/^FASTJETLIB.*/a HERWIGINSTALL = %{i}" Contrib/FxFx/Makefile
+sed -i -e '0,/\$(HERWIGINSTALL)\/lib\/Herwig/s//\$(HERWIGINSTALL)\/lib\/./' Contrib/FxFx/Makefile
+
+make -C Contrib/FxFx %makeprocesses FxFx.so FxFxHandler.so FxFxAnalysis.so
+cp Contrib/FxFx/*.so %{i}/lib/Herwig/.
+
+mv %{i}/bin/Herwig  %{i}/bin/Herwig-cms
+cat << \HERWIG_WRAPPER > %{i}/bin/Herwig
+#!/bin/bash
+REPO_OPT=""
+if [ "$HERWIGPATH" != "" ] && [ -e "$HERWIGPATH/HerwigDefaults.rpo" ] ; then
+  if [ $(echo " $@" | grep ' --repo' | wc -l) -eq 0 ] ; then REPO_OPT="--repo $HERWIGPATH/HerwigDefaults.rpo" ; fi
+fi
+$(dirname $0)/Herwig-cms $REPO_OPT "$@"
+HERWIG_WRAPPER
+chmod +x %{i}/bin/Herwig
 
 %post
-%{relocateConfig}share/Herwig++/HerwigDefaults.rpo
+%{relocateConfig}bin/herwig-config
+%{relocateConfig}bin/Herwig++
+%{relocateConfig}bin/Herwig-cms
+%{relocateConfig}bin/ufo2herwig
+%{relocateConfig}lib/Herwig/*.la
+%{relocateConfig}lib/Herwig/python/Makefile-FR
+%{relocateConfig}share/Herwig/Makefile-UserModules
+%{relocateConfig}share/Herwig/defaults/PDF.in
+%{relocateConfig}share/Herwig/HerwigDefaults.rpo
+sed -i -e "s|^.*/BUILDROOT/[0-9a-f][0-9a-f]*%{installroot}/|$CMS_INSTALL_PREFIX/|g" $RPM_INSTALL_PREFIX/%{pkgrel}/share/Herwig/HerwigDefaults.rpo

--- a/madgraph5amcatnlo-compile.patch
+++ b/madgraph5amcatnlo-compile.patch
@@ -1,6 +1,6 @@
-diff -Naur /dev/null MG5_aMC_v2_4_3/bin/compile.py 
+diff -Naur /dev/null MG5_aMC_v2_5_5/bin/compile.py 
 --- /dev/null	2016-01-21 22:33:58.638300539 +0100
-+++ MG5_aMC_v2_4_3/bin/compile.py	2016-01-21 22:33:58.638300539 +0100
++++ MG5_aMC_v2_5_5/bin/compile.py	2016-01-21 22:33:58.638300539 +0100
 @@ -0,0 +1,262 @@
 +#! /usr/bin/env python
 +################################################################################

--- a/madgraph5amcatnlo-config.patch
+++ b/madgraph5amcatnlo-config.patch
@@ -1,6 +1,7 @@
-diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt 
---- MG5_aMC_v2_4_3/input/mg5_configuration.txt	2015-04-10 10:56:31.000000000 +0100
-+++ mg5_configuration.txt	2015-06-09 16:24:18.507580430 +0100
+diff --git a/input/mg5_configuration.txt b/input/mg5_configuration.txt
+index c089808..f6b983f 100644
+--- a/input/mg5_configuration.txt
++++ b/input/mg5_configuration.txt
 @@ -28,14 +28,14 @@
  #! Prefered Fortran Compiler
  #! If None: try to find g77 or gfortran on the system
@@ -18,7 +19,7 @@ diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt
  
  #! Prefered Text Editor
  #!  Default: use the shell default Editor
-@@ -53,26 +53,26 @@
+@@ -53,20 +53,20 @@
  
  #! Time allowed to answer question (if no answer takes default value)
  #!  0: No time limit
@@ -26,22 +27,30 @@ diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt
 +timeout = 0
  
  #! Pythia8 path.
- #!  Defines the path to the main pythia8 directory (i.e. that containing
- #!  the pythia8 configure script) .
+ #!  Defines the path to the pythia8 installation directory (i.e. the
+ #!  on containing the lib, bin and include directories) .
  #!  If using a relative path, that starts from the mg5 directory
--# pythia8_path =
-+pythia8_path = $PYTHIA8_ROOT
+-# pythia8_path = ./HEPTools/pythia8
++pythia8_path = ${PYTHIA8_ROOT}
  
- #! Herwig++ paths
+ #! MG5aMC_PY8_interface path
+ #!  Defines the path of the C++ driver file that is used by MG5_aMC to
+ #!  steer the Pythia8 shower.
+ #!  Can be installed directly from within MG5_aMC with the following command:
+ #!     MG5_aMC> install mg5amc_py8_interface
+-# mg5amc_py8_interface_path = ./HEPTools/MG5aMC_PY8_interface 
++mg5amc_py8_interface_path = @MADGRAPH5AMCATNLO_ROOT@/HEPTools/MG5aMC_PY8_interface
+ 
+ #! Herwig++/Herwig7 paths
  #!  specify here the paths also to HepMC ant ThePEG
- #!  define the path to the herwig++, thepeg and hepmc directories.
- #!  paths can be absolute or relative from mg5 directory
--# hwpp_path = 
+@@ -76,13 +76,13 @@
+ #!  then please set thepeg_path and hepmc_path to the same value as
+ #!  hwpp_path
+ # hwpp_path = 
 -# thepeg_path = 
 -# hepmc_path = 
-+hwpp_path = $HERWIGPP_ROOT
-+thepeg_path = $THEPEG_ROOT
-+hepmc_path = $HEPMC_ROOT
++thepeg_path = ${THEPEG_ROOT}
++hepmc_path = ${HEPMC_ROOT}
  
  #! Control when MG5 checks if he is up-to-date.
  #! Enter the number of day between two check (0 means never)
@@ -51,7 +60,7 @@ diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt
  
  ################################################################################
  #  INFO FOR MADEVENT / aMC@NLO 
-@@ -83,21 +83,21 @@
+@@ -93,21 +93,20 @@
  
  #! Allow/Forbid the automatic opening of the web browser  (on the status page)
  #!  when launching MadEvent [True/False]
@@ -59,8 +68,8 @@ diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt
 +automatic_html_opening = False
  #! allow notification of finished job in the notification center (Mac Only)
 -# notification_center = True
+-
 +notification_center = False
- 
  
  #! Default Running mode 
  #!  0: single machine/ 1: cluster / 2: multicore
@@ -75,11 +84,11 @@ diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt
 -# cluster_size = 150 
 +cluster_type = lsf
 +cluster_queue = 1nh
-+cluster_size = 150 
++cluster_size = 150
  
  #! Path to a node directory to avoid direct writing on the central disk
  #!  Note that condor clusters avoid direct writing by default (therefore this
-@@ -122,7 +122,7 @@
+@@ -132,7 +131,7 @@
  
  #! Nb_core to use (None = all) This is use only for multicore run
  #!  This correspond also to the number core used for code compilation for cluster mode
@@ -88,21 +97,52 @@ diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt
  
  #! Pythia-PGS Package
  #!  relative path start from main directory
-@@ -147,11 +147,11 @@
+@@ -161,11 +160,11 @@
  
  #! lhapdf-config
  #!  If None: try to find one available on the system
 -# lhapdf = lhapdf-config
-+lhapdf = $LHAPDF_ROOT/bin/lhapdf-config
++lhapdf = ${LHAPDF_ROOT}/bin/lhapdf-config
  
  #! fastjet-config
  #!  If None: try to find one available on the system
 -# fastjet = fastjet-config
-+fastjet = $FASTJET_ROOT/bin/fastjet-config
++fastjet = ${FASTJET_ROOT}/bin/fastjet-config
  
  #! MCatNLO-utilities 
  #!  relative path starting from main directory
-@@ -190,7 +190,7 @@
+@@ -178,14 +177,14 @@
+ #! if auto: try to find it automatically on the system (default)
+ #! if '' or None: disabling pjfry
+ #! if pjfry=/PATH/TO/pjfry/lib: use that specific installation path for PJFry++
+-# pjfry = auto
++pjfry = None #
+ 
+ #! Set the Golem95 directory containing golem's library
+ #! It only supports version higher than 1.3.0
+ #! if auto: try to find it automatically on the system (default)
+ #! if '' or None: disabling Golem95
+ #! if golem=/PATH/TO/golem/lib: use that speficif installation path for Golem95
+-# golem = auto
++golem = ${GOSAMCONTRIB_ROOT}/lib #
+ 
+ #! Set the samurai directory containing samurai's library
+ #! It only supports version higher than 2.0.0
+@@ -197,19 +196,19 @@
+ #! Set the Ninja directory containing ninja's library
+ #! if '' or None: disabling ninja 
+ #! if ninja=/PATH/TO/ninja/lib: use that specific installation path for ninja 
+-# ninja = ./HEPTools/lib
++ninja = @MADGRAPH5AMCATNLO_ROOT@/HEPTools/lib
+ 
+ #! Set the COLLIER directory containing COLLIER's library
+ #! if '' or None: disabling COLLIER 
+ #! if ninja=/PATH/TO/ninja/lib: use that specific installation path for COLLIER
+ # Note that it is necessary that you have generated a static library for COLLIER
+-# collier = ./HEPTools/lib 
++collier = @MADGRAPH5AMCATNLO_ROOT@/HEPTools/lib
+ 
+ #! Set how MadLoop dependencies (such as CutTools) should be handled
  #!  > external : ML5 places a link to the MG5_aMC-wide libraries
  #!  > internal : ML5 copies all dependencies in the output so that it is independent
  #!  > environment_paths : ML5 searches for the dependencies in your environment path
@@ -111,3 +151,8 @@ diff  -Naur MG5_aMC_v2_4_3/input/mg5_configuration.txt mg5_configuration.txt
  
  #! SysCalc PATH
  #! Path to the directory containing syscalc executables
+@@ -220,4 +219,3 @@
+ # applgrid = applgrid-config
+ # amcfast = amcfast-config
+ 
+-

--- a/madgraph5amcatnlo-toolfile.spec
+++ b/madgraph5amcatnlo-toolfile.spec
@@ -9,13 +9,13 @@ Requires: madgraph5amcatnlo
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/madgraph5amcatnlo.xml
 <tool name="madgraph5amcatnlo" version="@TOOL_VERSION@">
-  <lib name="MadGraph5aMCatNLO"/>
   <client>
     <environment name="MADGRAPH5AMCATNLO_BASE" default="@TOOL_ROOT@"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$MADGRAPH5AMCATNLO_BASE" type="path"/>
   <runtime name="ROOT_PATH" value="$MADGRAPH5AMCATNLO_BASE" type="path"/>
   <use name="root_cxxdefaults"/>
+  <use name="gosamcontrib"/>
 </tool>
 EOF_TOOLFILE
 

--- a/madgraph5amcatnlo.spec
+++ b/madgraph5amcatnlo.spec
@@ -1,8 +1,9 @@
-### RPM external madgraph5amcatnlo 2.4.3
-%define versiontag 2_4_3
+### RPM external madgraph5amcatnlo 2.6.0
+%define versiontag 2_6_0
 Provides: perl(Compress::Zlib)
 Provides: perl(List::Util)
-Source: https://launchpad.net/mg5amcnlo/2.0/2.4.x/+download/MG5_aMC_v%{realversion}.tar.gz
+#Source: https://launchpad.net/mg5amcnlo/2.0/2.5.x/+download/MG5_aMC_v%{realversion}.tar.gz
+Source: https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v%{realversion}.tar.gz
 Patch0: madgraph5amcatnlo-config
 # Compile and install internal and external packages
 Patch1: madgraph5amcatnlo-compile    
@@ -13,15 +14,24 @@ Requires: hepmc
 Requires: root   
 # Needed for Syscalc package
 Requires: lhapdf
+Requires: gosamcontrib
+Requires: fastjet
+Requires: pythia8
+Requires: thepeg
                    
 %prep
 %setup -n MG5_aMC_v%{versiontag}
-
 %patch0 -p1
 %patch1 -p1
 
-%build
+sed -i -e "s|\${HEPMC_ROOT}|${HEPMC_ROOT}|g" input/mg5_configuration.txt
+sed -i -e "s|\${PYTHIA8_ROOT}|${PYTHIA8_ROOT}|g" input/mg5_configuration.txt
+sed -i -e "s|\${LHAPDF_ROOT}|${LHAPDF_ROOT}|g" input/mg5_configuration.txt
+sed -i -e "s|\${FASTJET_ROOT}|${FASTJET_ROOT}|g" input/mg5_configuration.txt
+sed -i -e "s|\${GOSAMCONTRIB_ROOT}|${GOSAMCONTRIB_ROOT}|g" input/mg5_configuration.txt
+sed -i -e "s|\${THEPEG_ROOT}|${THEPEG_ROOT}|g" input/mg5_configuration.txt
 
+%build
 # Save patched config
 cp input/mg5_configuration.txt input/mg5_configuration_patched.txt
 
@@ -35,12 +45,25 @@ rm bin/compile.py
 # Save patched config
 mv input/mg5_configuration_patched.txt input/mg5_configuration.txt
 
+# Start small NLO event generation to make sure that all additional packages are compiled
+cat <<EOF > basiceventgeneration.txt
+generate p p > t t~ [QCD]
+output basiceventgeneration
+launch
+set nevents 5
+EOF
+./bin/mg5_aMC ./basiceventgeneration.txt
+
 # Remove all downloaded tgz files before building the package
 find . -type f -name '*.tgz' -delete
 
 %install
+sed -i -e "s|@MADGRAPH5AMCATNLO_ROOT@|%{i}|g" input/mg5_configuration.txt
 rsync -avh %{_builddir}/MG5_aMC_v%{versiontag}/ %{i}/
 sed -ideleteme 's|#!.*/bin/python|#!/usr/bin/env python|' \
     %{i}/Template/LO/bin/internal/addmasses_optional.py \
     %{i}/madgraph/various/progressbar.py
 find %{i} -name '*deleteme' -delete
+
+%post
+%{relocateConfig}input/mg5_configuration.txt

--- a/qgraf-toolfile.spec
+++ b/qgraf-toolfile.spec
@@ -1,0 +1,21 @@
+### RPM external qgraf-toolfile 1.0
+Requires: qgraf
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/qgraf.xml
+<tool name="qgraf" version="@TOOL_VERSION@">
+  <client>
+    <environment name="QGRAF_BASE" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$QGRAF_BASE/bin"/>
+  </client>
+  <runtime name="PATH" default="$BINDIR" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post
+

--- a/qgraf.spec
+++ b/qgraf.spec
@@ -1,0 +1,14 @@
+### RPM external qgraf 3.1.4
+Source: https://gosam.hepforge.org/gosam-installer/qgraf-%{realversion}.tgz
+
+%prep
+%setup -q -c -n qgraf-%{realversion}
+
+%build
+FC="$(which gfortran)"
+
+${FC} qgraf*.f -o qgraf -O2
+
+%install
+mkdir %{i}/bin
+cp qgraf %{i}/bin

--- a/thepeg-toolfile.spec
+++ b/thepeg-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external thepeg-toolfile 2.0
+### RPM external thepeg-toolfile 2.1
 Requires: thepeg
 %prep
 
@@ -16,6 +16,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/thepeg.xml
     <environment name="LIBDIR" default="$THEPEG_BASE/lib/ThePEG"/>
     <environment name="INCLUDE" default="$THEPEG_BASE/include"/>
   </client>
+  <runtime name="THEPEGPATH" value="$THEPEG_BASE/share/ThePEG"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="lhapdf"/>

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -1,29 +1,30 @@
-### RPM external thepeg 1.9.2p1
+### RPM external thepeg 2.1.4
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib/ThePEG
 ## INITENV +PATH DYLD_LIBRARY_PATH %{i}/lib/ThePEG
 
-%define tag 56bf5bd49ac1bfdb28cd7d7022e8ecf4392743eb
-%define branch cms/v%realversion
+# Download from official webpage
+Source: http://www.hepforge.org/archive/thepeg/ThePEG-%{realversion}.tar.bz2
 
-Source: git+https://github.com/cms-externals/thepeg.git?obj=%{branch}/%{tag}&export=thepeg-%{realversion}-%{tag}&module=thepeg-%realversion-%{tag}&output=/thepeg-%{realversion}-%{tag}.tgz
 Requires: lhapdf
 Requires: gsl
 Requires: hepmc
 Requires: zlib
+Requires: fastjet
+Requires: rivet
+
+
 BuildRequires: autotools
-# FIXME: rivet?
+BuildRequires: lhapdf
+
 %define keep_archives true
 
 %if "%{?cms_cxx:set}" != "set"
 %define cms_cxx c++
 %endif
 
-%if "%{?cms_cxxflags:set}" != "set"
-%define cms_cxxflags -O2 -std=c++11
-%endif
 
 %prep
-%setup -q -n thepeg-%{realversion}-%{tag}
+%setup -q -n ThePEG-%{realversion}
 
 # Regenerate build scripts
 autoreconf -fiv
@@ -33,20 +34,26 @@ CXX="$(which %{cms_cxx}) -fPIC"
 CC="$(which gcc) -fPIC"
 PLATF_CONF_OPTS="--enable-shared --disable-static"
 
-case %{cmsplatf} in
-  osx*)
-    LIBQUADMATH="-lquadmath"
-    ;;
-esac
+
+# Update to detect aarch64 and ppc64le
+rm -f ./Config/config.{sub,guess}
+curl -L -k -s -o ./Config/config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+curl -L -k -s -o ./Config/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+chmod +x ./Config/config.{sub,guess}
 
 ./configure $PLATF_CONF_OPTS \
-            --disable-silent-rules \
-            --with-LHAPDF=$LHAPDF_ROOT \
+            --with-lhapdf=$LHAPDF_ROOT \
+            --with-boost=$BOOST_ROOT \
             --with-hepmc=$HEPMC_ROOT \
-            --with-gsl=$GSL_ROOT --with-zlib=$ZLIB_ROOT \
-            --without-javagui --prefix=%{i} \
-            --disable-readline CXX="$CXX" CC="$CC" CXXFLAGS="%{cms_cxxflags}" \
-            LIBS="-lz $LIBQUADMATH"
+            --with-gsl=$GSL_ROOT \
+            --with-zlib=$ZLIB_ROOT \
+            --with-fastjet=$FASTJET_ROOT \
+            --with-rivet=$RIVET_ROOT \
+            --without-javagui \
+            --prefix=%{i} \
+            --disable-readline CXX="$CXX" CC="$CC"  
+
+
 
 make %{makeprocesses}
 
@@ -54,8 +61,17 @@ make %{makeprocesses}
 make install
 find %{i}/lib -name '*.la' -exec rm -f {} \;
 
+
 %post
 %{relocateConfig}lib/ThePEG/Makefile.common
 %{relocateConfig}lib/ThePEG/Makefile
 %{relocateConfig}lib/ThePEG/ThePEGDefaults.rpo
-%{relocateConfig}lib/ThePEG/ThePEGDefaults-1.9.2.rpo
+%{relocateConfig}lib/ThePEG/ThePEGDefaults-%{realversion}.rpo
+
+#create link to LesHouches library
+
+cd $RPM_INSTALL_PREFIX/%{pkgrel}/lib/ThePEG/
+ln -s LesHouches.so libLesHouches.so
+cd -
+
+


### PR DESCRIPTION
Dear all,
these are the externals required for the Herwig7interface in 9_3_X. Requested by GEN for the Fall17 MC production.
This superseeds Herwig++.

to be tested with: https://github.com/cms-sw/cmssw/pull/25484
Kind regards,
Andrej