### PR TITLE
[10.4.X] drop sm_35 from cuda toolfile

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -34,7 +34,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
-  <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
   <flags CUDA_FLAGS="-gencode arch=compute_60,code=sm_60"/>
   <flags CUDA_FLAGS="-gencode arch=compute_61,code=sm_61"/>
   <flags CUDA_FLAGS="-gencode arch=compute_70,code=sm_70"/>


### PR DESCRIPTION
@fwyzard , we had added sm_61 for P100 and in order to keep the build time in control we are dropping sm_35.