### PR TITLE
[10.5.X][GCC 8] Patch boost to avoid unnecessary parentheses warnings

### DIFF
--- a/boost.spec
+++ b/boost.spec
@@ -1,6 +1,6 @@
 ### RPM external boost 1.67.0
 
-%define tag 335c397d45bb737e96f7ee232f85f4c0faa0e227
+%define tag 8dbeeb4f04f377fea15f64725918b75dbf6e1843
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%n.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
back ported boost patch: https://github.com/boostorg/mpl/pull/34 
```
slc7_amd64_gcc820/external/boost/1.67.0-cms/include/boost/mpl/assert.hpp:188:21: warning: unnecessary parentheses in declaration of 'assert_arg' [-Wparentheses]
  failed ************ (Pred::************
                      ^
slc7_amd64_gcc820/external/boost/1.67.0-cms/include/boost/mpl/assert.hpp:193:21: warning: unnecessary parentheses in declaration of 'assert_not_arg' [-Wparentheses]
  failed ************ (boost::mpl::not_<Pred>::************
```