### PR TITLE
Bump DQM GUI version to 9.3.5

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.3.4
+### RPM cms dqmgui 9.3.5
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
The new version of DQM GUI provides a workaround to a breaking change in Google URL Shortener API when parsing URL arguments.