### PR TITLE
add cmssw-osenv dependency

### DIFF
--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,0 +1,41 @@
+### RPM cms cmssw-osenv 190128.0
+## NOCOMPILER
+
+# ***Do not change minor number of the above version. ***
+
+%define commit 00d838b373f0795e8e5ca21811f9c3c395afdb6f
+%define branch master
+# We do not use a revision explicitly, because revisioned packages do not get
+# updated automatically when there are dependencies.
+%define fakerevision %(echo %realversion | cut -d. -f1)
+Source0: git://github.com/cms-sw/cmssw-osenv.git?obj=%{branch}/%{commit}&export=cmssw-osenv&output=/cmssw-osenv-%{commit}.tgz
+
+%prep
+%setup -n %{n}
+
+%build
+
+%install
+mkdir -p %{i}/common
+mv * %{i}/common
+
+%post
+cd ${RPM_INSTALL_PREFIX}/%{pkgrel}
+mkdir -p ${RPM_INSTALL_PREFIX}/common ${RPM_INSTALL_PREFIX}/etc/%{pkgname}
+
+#Check if a newer revision is already installed
+if [ -f ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version ] ; then
+  oldrev=$(cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version )
+  if [ ${oldrev} -ge %{fakerevision} ] ; then
+    exit 0
+  fi
+fi
+
+for file in $(find . -name '*' -type f -path '*/common/*') ; do
+  cp -f ${file} ${RPM_INSTALL_PREFIX}/${file}
+done
+for file in $(find . -name '*' -type l -path '*/common/*') ; do
+  cp -pRf ${file} ${RPM_INSTALL_PREFIX}/${file}
+done
+
+echo %{fakerevision} > ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version

--- a/cmssw.spec
+++ b/cmssw.spec
@@ -1,6 +1,6 @@
 ### RPM cms cmssw CMSSW_10_1_0_pre1
 
-Requires: cmssw-tool-conf python cms-git-tools
+Requires: cmssw-tool-conf python cms-git-tools cmssw-osenv
 
 %define runGlimpse      yes
 %define saveDeps        yes


### PR DESCRIPTION
This new package ( https://github.com/cms-sw/cmssw-osenv ) provides simple script for setting up cmssw os environment using singularity and unpacked docker imsages from /cvmfs/unpacked.cern.ch . Once available in cmssw env then once should be able to run `cmssw-cc7` or `cmssw-cc6 (cmssw-slc6)` to get cmssw envionment.

```
[muzaffar@cmsdev15 w]$ cat /etc/redhat-release 
Scientific Linux CERN SLC release 6.10 (Carbon)
[muzaffar@cmsdev15 w]$ cmssw-cc7
[muzaffar@cmsdev15 w]$  cat /etc/redhat-release 
CentOS Linux release 7.5.1804 (Core) 
[muzaffar@cmsdev15 w]$ which scram
/cvmfs/cms.cern.ch/common/scram
```