### PR TITLE
Fix Professor2 and update to 2.2.2

### DIFF
--- a/professor2-toolfile.spec
+++ b/professor2-toolfile.spec
@@ -11,6 +11,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/professor2.xml
 <tool name="professor2" version="@TOOL_VERSION@">
 <client>
 <environment name="PROFESSOR2_BASE" default="@TOOL_ROOT@"/>
+<environment name="LIBDIR" default="$PROFESSOR2_BASE/lib"/>
 </client>
 <use name="py2-numpy"/>
 <use name="py2-sympy"/>

--- a/professor2-toolfile.spec
+++ b/professor2-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external professor2-toolfile 1.0
+### RPM external professor2-toolfile 2.0
 Requires: professor2
 %prep
 

--- a/professor2.spec
+++ b/professor2.spec
@@ -1,4 +1,4 @@
-### RPM external professor2 2.2.1
+### RPM external professor2 2.2.2
 ## INITENV +PATH PYTHON27PATH %i/lib/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 Source: http://www.hepforge.org/archive/professor/Professor-%{realversion}.tar.gz
 


### PR DESCRIPTION
Need to specify `LIBDIR` to find `libProfessor2.so`. Also updated to 2.2.2 then.