### PR TITLE
Update protobuf as tensorflow fails to build with 3.5.2

### DIFF
--- a/protobuf.spec
+++ b/protobuf.spec
@@ -1,4 +1,4 @@
-### RPM external protobuf 3.5.2
+### RPM external protobuf 3.6.1.2
 ## INITENV SETV PROTOBUF_SOURCE %{source0}
 ## INITENV SETV PROTOBUF_STRIP_PREFIX %{source_prefix}
 #============= IMPORTANT NOTE ========================#
@@ -24,22 +24,7 @@ BuildRequires: autotools
 
 %build
 ./autogen.sh
-# Update to detect aarch64 and ppc64le
-rm -f ./config.{sub,guess}
-curl -L -k -s -o ./config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
-curl -L -k -s -o ./config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
-chmod +x ./config.{sub,guess}
 
-
-rm -f ./gmock/gtest/build-aux/config.{sub,guess}
-curl -L -k -s -o ./gmock/gtest/build-aux/config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
-curl -L -k -s -o ./gmock/gtest/build-aux/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
-chmod +x ./gmock/gtest/build-aux/config.{sub,guess}
-
-rm -f ./gmock/build-aux/config.{sub,guess}
-curl -L -k -s -o ./gmock/build-aux/config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
-curl -L -k -s -o ./gmock/build-aux/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
-chmod +x ./gmock/build-aux/config.{sub,guess}
 ./configure --prefix %{i} \
     --disable-static \
     --disable-dependency-tracking \


### PR DESCRIPTION
Using our existing 3.5.2 version leads to this: 
https://github.com/grpc/grpc/issues/17506
update -> 3.6.1.2 to avoid it. 
CMSSW PR to follow if this pass