### PR TITLE
Update scram-project-build.file

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-41
+%define configtag       V05-07-52
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
updated build rules to recognize cxxmodule flags probides via  `GENREFLEX_CPPFLAGS` or  `GENREFLEX_ARGS` (in toolfile or BuildFile)