### PR TITLE
Initialization fixes on top of pythia8 240 (from fixes on top of 230 not yet integrated)

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -3,7 +3,7 @@
 %define tag 6973bbaf0d4d4bab9f9aa20d58b1ff8276099277
 %define branch cms/%{realversion}
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}%{realversion}&output=/%{n}-%{realversion}.tgz
 
 Requires: hepmc lhapdf
 

--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,6 +1,9 @@
 ### RPM external pythia8 240
 
-Source: http://home.thep.lu.se/~torbjorn/pythia8/%{n}%{realversion}.tgz
+%define tag 6973bbaf0d4d4bab9f9aa20d58b1ff8276099277
+%define branch cms/%{realversion}
+%define github_user cms-externals
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 Requires: hepmc lhapdf
 


### PR DESCRIPTION
Update pythia8 with K. Pedro's patch to preserve fixes of initializations not yet imported in the official package.