### PR TITLE
added py2-pybind11 dependency for fwlite

### DIFF
--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -47,6 +47,7 @@ Requires: md5-toolfile
 Requires: davix-toolfile
 Requires: py2-numpy-toolfile
 Requires: OpenBLAS-toolfile
+Requires: py2-pybind11-toolfile
 
 %if %isamd64
 %if %isslc


### PR DESCRIPTION
this is needed to get FWLite builds work. New dependency is needed due to FWCore/PyDevParameterSet dependency of cmsRun