### PR TITLE
Upgrade RecoEgamma-ElectronIdentification to V01-01-03 on IB/CMSSW_10_6_X/gcc700

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -5,7 +5,7 @@
 [default]
 FWCore-Modules=V00-01-00
 IOPool-Input=V00-01-00
-RecoEgamma-ElectronIdentification=V01-01-02
+RecoEgamma-ElectronIdentification=V01-01-03
 RecoCTPPS-TotemRPLocal=V00-02-00
 RecoTracker-FinalTrackSelectors=V01-00-07
 


### PR DESCRIPTION
Description: [cms-data/RecoEgamma-ElectronIdentification#13](https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/13)
Needed for: [cms-sw/cmssw#26012](https://github.com/cms-sw/cmssw/pull/26012)