### PR TITLE
[BuildRule] Disable rootmap dependency rule added for CXXMODULE IBs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-53
+%define configtag       V05-07-54
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
this was causing shared libraries to be copied at `scrab build runtests` time causing unit tests to fail during PR tests