### PR TITLE
[SCRAM] updates build rules and SCRAM

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_9_pre03
+### RPM lcg SCRAMV1 V2_2_9_pre04
 ## NOCOMPILER
 
 BuildRequires: gmake
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::Template::Plugins::PluginCore)
 Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 
-%define tag ae1a90db14bf16e4ec0742e3c856459795e98e18
+%define tag %{realversion}
 %define branch master
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-54
+%define configtag       V05-07-56
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- source_only dependency attribute added for dependency e.g.
```
<use name="foo" source_only="1"/>
```
to add a source level dependency without linking.

- Rootmap build rule fixed to avoid rebuilds