### PR TITLE
[10.6.X] updated config tag V05-08-07

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-07-56
+%define configtag       V05-08-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This fixes the cxxmodule build rules.