### PR TITLE
[10.6.X] update tkonlinesw-fake to implement extra symbols

### DIFF
--- a/tkonlinesw-fake.spec
+++ b/tkonlinesw-fake.spec
@@ -1,6 +1,6 @@
 ### RPM external tkonlinesw-fake 4.2.0-1_gcc7
 
-%define tag 6bf27b3db8d4c0737b477cc38095fd05d2be3191
+%define tag 97afe74471b299148ac9ccdea21e9cda961ec885
 Source: https://github.com/cms-externals/%{n}/archive/%{tag}.tar.gz
 
 %prep


### PR DESCRIPTION
cmssw aarch64 IBs fails to build due to following issing symbols. This PR provides these symbols via tkonlnesw-fake package
```
  CalibrationHistosUsingDb.cc:(.text+0x828): undefined reference to `apvDescription::getIsha()'
   CalibrationHistosUsingDb.cc:(.text+0x850): undefined reference to `apvDescription::getVfs()'
```

https://github.com/cms-externals/tkonlinesw-fake/commit/97afe74471b299148ac9ccdea21e9cda961ec885