### PR TITLE
[10.6.X] Updated RecoBTag-Combined: Phase II models for DeepCSV and DeepJet

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -11,13 +11,13 @@ RecoTracker-FinalTrackSelectors=V01-00-07
 SLHCUpgradeSimulations-Geometry=V01-00-10
 CalibPPS-ESProducers=V01-00-00
 L1Trigger-L1THGCal=V01-00-10
+RecoBTag-Combined=V01-01-02
 
 ########################################################################################
 #Never update any package After this. Always move an existing package in default section.
 [data-build-github-new]
 PhysicsTools-PatUtils=V00-01-00
 RecoTauTag-TrainingFiles=V00-01-00
-RecoBTag-Combined=V01-01-01
 SimTransport-PPSProtonTransport=V00-01-00
 SimTransport-TotemRPProtonTransportParametrization=V00-01-00
 


### PR DESCRIPTION

This integrates https://github.com/cms-data/RecoBTag-Combined/pull/20 which contains a new Phase II models for DeepCSV and DeepJet

Resolves https://github.com/cms-sw/cmsdist/issues/4750