### PR TITLE
Updated oracle OCCI which is build with new C++ ABI

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -169,7 +169,6 @@ Requires: igprof-toolfile
 Requires: dmtcp-toolfile
 Requires: tkonlinesw-toolfile
 Requires: oracle-toolfile
-Requires: cms_oracleocci_abi_hack-toolfile
 Requires: cuda-toolfile
 Requires: cub-toolfile
 Requires: cuda-api-wrappers-toolfile
@@ -182,7 +181,6 @@ Requires: glibc-toolfile
 %else
 Requires: tkonlinesw-fake-toolfile
 Requires: oracle-fake-toolfile
-Requires: cms_oracleocci_abi_hack-fake-toolfile
 %endif
 %endif
 

--- a/oracle-fake-toolfile.spec
+++ b/oracle-fake-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external oracle-fake-toolfile 1.0
+### RPM external oracle-fake-toolfile 2.0
 Requires: oracle-fake
 %prep
 
@@ -25,8 +25,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/oracle.xml
 </tool>
 EOF_TOOLFILE
 
-cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci-official.xml
-<tool name="oracleocci-official" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
+<tool name="oracleocci" version="@TOOL_VERSION@">
   <lib name="occi"/>
   <use name="oracle"/>
 </tool>

--- a/oracle-toolfile.spec
+++ b/oracle-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external oracle-toolfile 1.0
+### RPM external oracle-toolfile 2.0
 Requires: oracle
 %prep
 
@@ -27,8 +27,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/oracle.xml
 </tool>
 EOF_TOOLFILE
 
-cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci-official.xml
-<tool name="oracleocci-official" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
+<tool name="oracleocci" version="@TOOL_VERSION@">
   <lib name="occi"/>
   <use name="oracle"/>
 </tool>

--- a/oracle.spec
+++ b/oracle.spec
@@ -33,6 +33,7 @@ Source3: %{http_mirror}/%{client_arch}/instantclient-odbc-%{client_arch}-%{realv
 Source4: %{http_mirror}/%{client_arch}/instantclient-sdk-%{client_arch}-%{realversion}.zip
 Source5: %{http_mirror}/%{client_arch}/instantclient-sqlplus-%{client_arch}-%{realversion}.zip
 Source6: %{http_mirror}/%{client_arch}/instantclient-tools-%{client_arch}-%{realversion}.zip
+Source7: http://cmsrep.cern.ch/cmssw/oracle-mirror/%{client_arch}/libocci.so.12.1.zip
 
 Source10: oracle-license
 
@@ -46,6 +47,8 @@ rm -rf instantclient_*
 %setup -D -T -b 4 -n %{client_dir} instantclient-sdk-%{client_arch}-%{realversion}.zip
 %setup -D -T -b 5 -n %{client_dir} instantclient-sqlplus-%{client_arch}-%{realversion}.zip
 %setup -D -T -b 6 -n %{client_dir} instantclient-tools-linux-%{client_arch}-%{realversion}.zip
+#OCCI lib with new C++ ABI (GCC 5 and above)
+%setup -D -T -b 7 -n %{client_dir} libocci.so.12.1.zip
 
 %build
 chmod a-x sdk/include/*.h *.sql


### PR DESCRIPTION
backport of #4645

This brings in a new libocci.so library which is build using gcc 5 (new C++ ABI). We need a cmssw PR (basically revert of cms-sw/cmssw#22384) to go with this.