### PR TITLE
[10.6.X] cherry pick root-project/root#3485

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag e65e0ebfbc30046951fe07dda42bd545bcf853ad
+%define tag 78c5af9a8bf237b4e4a07145b1b92579903b6e57
 %define branch cms/v6-12-00-patches/34f75bf
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Set offset of the used-for-write element in case of I/O rule on 'current' StreamerInfo.

This fixes ROOT-10016