### PR TITLE
[10.6.X] Fix Rivet build for GCC 8.2.0

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -37,6 +37,7 @@ case %{cmsplatf} in
   slc6*) sed -i -e 's#^ *OPENMP_CXXFLAGS=.*#OPENMP_CXXFLAGS=#' configure ;;
 esac
 sed -i -e "s#if test x\$ASCIIDOC != x#if false#g" configure
+autoreconf --install
 ./configure --disable-silent-rules --prefix=%{i} --with-hepmc=${HEPMC_ROOT} \
             --with-fastjet=${FASTJET_ROOT} --with-yoda=${YODA_ROOT} \
             --disable-doxygen --disable-pdfmanual --with-pic \


### PR DESCRIPTION
We need to re-generate Makefiles using newer autoreconf