### PR TITLE
Set RUCIO_HOME env var; define a standard config file; update version

### DIFF
--- a/py2-rucio-clients.spec
+++ b/py2-rucio-clients.spec
@@ -1,6 +1,12 @@
-### RPM external py2-rucio-clients 1.18.8.post1
+### RPM external py2-rucio-clients 1.19.3
 ## IMPORT build-with-pip
+## INITENV SET RUCIO_HOME %i/
+
+Source1: rucio-config
 Requires: py2-argcomplete py2-requests py2-urllib3 py2-dogpile-cache py2-nose py2-boto
 Requires: py2-tabulate py2-progressbar2 py2-bz2file py2-python-magic py2-six py2-futures
+
+# setup a CMS rucio configuration standard file
+%define PipPreBuild mkdir -p %i/etc/; cp -f %_sourcedir/rucio-config %i/etc/rucio.cfg
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/rucio-config.file
+++ b/rucio-config.file
@@ -1,0 +1,20 @@
+# Copyright European Organization for Nuclear Research (CERN)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Vincent Garonne, <vgaronne@gmail.com>, 2017
+# - Eric Vaandering, <ewv@fnal.gov>, 2018
+
+[common]
+[client]
+rucio_host = http://cms-rucio-testbed.cern.ch
+auth_host = https://cms-rucio-tb-authz.cern.ch
+auth_type = x509
+ca_cert = /etc/grid-security/certificates/
+client_cert = $X509_USER_CERT
+client_key = $X509_USER_KEY
+client_x509_proxy = $X509_USER_PROXY
+request_retries = 3


### PR DESCRIPTION
Define a default rucio.cfg template in case someone wants to only use the client. It will then find RUCIO_HOME and one can properly `from rucio.client import Client`.