### PR TITLE
[10.2.X] Backport 4312 and 4332 to enable backport of cmssw/24432

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 44.0
+### RPM cms cmssw-tool-conf 45.0
 ## NOCOMPILER
 # With cmsBuild, change the above version only when a new tool is added
 
@@ -144,6 +144,7 @@ Requires: utm-toolfile
 Requires: libffi-toolfile
 Requires: CSCTrackFinderEmulation-toolfile
 Requires: tinyxml-toolfile
+Requires: tinyxml2-toolfile
 Requires: scons-toolfile
 Requires: md5-toolfile
 Requires: gosamcontrib-toolfile

--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms fwlite-tool-conf 10.0
+### RPM cms fwlite-tool-conf 11.0
 ## NOCOMPILER
 # with cmsBuild, change the above version only when a new
 # tool is added
@@ -43,6 +43,7 @@ Requires: libxml2-toolfile
 Requires: llvm-gcc-toolfile
 Requires: vdt-toolfile
 Requires: tinyxml-toolfile
+Requires: tinyxml2-toolfile
 Requires: md5-toolfile
 Requires: davix-toolfile
 Requires: py2-numpy-toolfile

--- a/tinyxml2-toolfile.spec
+++ b/tinyxml2-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external tinyxml2-toolfile 1.0
+Requires: tinyxml2
+
+%prep
+%build
+%install
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/tinyxml2.xml
+<tool name="tinyxml2" version="@TOOL_VERSION@">
+  <info url="https://github.com/leethomason/tinyxml2"/>
+  <lib name="tinyxml2"/>
+  <client>
+    <environment name="TINYXML2_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$TINYXML2_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TINYXML2_BASE/include"/>
+  </client>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/> 
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post
+

--- a/tinyxml2.spec
+++ b/tinyxml2.spec
@@ -1,0 +1,23 @@
+### RPM external tinyxml2 6.2.0
+Source: https://github.com/leethomason/%{n}/archive/%{realversion}.tar.gz
+
+BuildRequires: gmake cmake
+
+%prep
+%setup -n %setup -q -n %{n}-%{realversion}
+
+%build
+rm -rf ../build; mkdir ../build ; cd ../build
+cmake ../%{n}-%{realversion} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="%{i}"
+
+gmake %{makeprocesses}
+
+%install
+cd ../build
+gmake %{makeprocesses} install
+
+%post
+%{relocateConfig}lib64/pkgconfig/tinyxml2.pc
+%{relocateConfig}lib64/cmake/tinyxml2/tinyxml2Targets.cmake


### PR DESCRIPTION
This is the backport of external PR https://github.com/cms-sw/cmsdist/pull/4312 to 10_2_X:

This is to enable the backport of https://github.com/cms-sw/cmssw/pull/24432 which should fix issue https://github.com/cms-sw/cmssw/issues/26154.