### PR TITLE
force build py2-root_numpy

### DIFF
--- a/pip/py2-root_numpy.file
+++ b/pip/py2-root_numpy.file
@@ -1,2 +1,2 @@
-%define doPython3 no
+%define   doPython3 no
 Requires: py2-numpy root


### PR DESCRIPTION
Previous build was done on a machine whcih has /home as jenkins work directory and looks like root_numpy does not set correct permissions if build in /home
https://github.com/cms-sw/cmsdist/pull/4774#issuecomment-473982222