### PR TITLE
Force rebuild py2-rootpy to fix the lib directory permissions

### DIFF
--- a/pip/py2-rootpy.file
+++ b/pip/py2-rootpy.file
@@ -1,4 +1,4 @@
-%define doPython3 no
+%define doPython3   no
 %define PipPostBuild \
    perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/rootpy %{i}/bin/roosh %{i}/bin/root2hdf5
 Requires: python root py2-matplotlib root


### PR DESCRIPTION
Same issue as we had for py2-root_numpy ( https://github.com/cms-sw/cmsdist/pull/4774#issuecomment-473982222 )