### PR TITLE
Bump DQM GUI version to 9.3.6

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.3.5
+### RPM cms dqmgui 9.3.6
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
9.3.6 version of DQM GUI uses tinyurl.com as a replacement for deprecated google url shortening service.