### PR TITLE
[10.6.X] Update L1Trigger-L1THGCal to V01-00-11

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -10,7 +10,7 @@ RecoCTPPS-TotemRPLocal=V00-02-00
 RecoTracker-FinalTrackSelectors=V01-00-07
 SLHCUpgradeSimulations-Geometry=V01-00-10
 CalibPPS-ESProducers=V01-00-00
-L1Trigger-L1THGCal=V01-00-10
+L1Trigger-L1THGCal=V01-00-11
 Configuration-Generator=V01-00-02
 
 ########################################################################################


### PR DESCRIPTION
Update motherboards mappings for V9/V10 geometries : https://github.com/cms-data/L1Trigger-L1THGCal/pull/12
Resolves https://github.com/cms-sw/cmsdist/issues/4795