### PR TITLE
[10.6.X] [BuildRules] Avoid re-creating python/SubSys/__init__.py

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-09
+%define configtag       V05-08-10
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Avoid re-creating python/SubSystem/__init__.py file for deleted packages. https://github.com/cms-sw/cmssw-config/commit/dbe9b3c0f4f90f0eb89291d2bd0a02a5d7038bee

This should avoid the Build Rules error such as https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-26231/33729/summary.html  for cmssw PR testing.