### PR TITLE
[10.6.X][BuildRule] Update to tag V05-08-11

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-10
+%define configtag       V05-08-11
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Make sure to build PCMs of in-directly dependent packages first