### PR TITLE
enable geant4 and example/ddcms for dd4hep

### DIFF
--- a/dd4hep-build-static.patch
+++ b/dd4hep-build-static.patch
@@ -1,0 +1,21 @@
+diff --git a/cmake/DD4hepBuild.cmake b/cmake/DD4hepBuild.cmake
+index 1605e96..ac8e06d 100644
+--- a/cmake/DD4hepBuild.cmake
++++ b/cmake/DD4hepBuild.cmake
+@@ -1019,7 +1019,7 @@ function( dd4hep_add_library binary building )
+         dd4hep_include_directories( "${pkg_incs}" )
+         add_definitions ( ${pkg_defs} )
+         #
+-        add_library ( ${binary} SHARED ${sources} )
++        add_library ( ${binary} STATIC ${sources} )
+         target_link_libraries ( ${binary} ${pkg_libs} )
+         if ( "${${pkg}_VERSION}" STREQUAL "" OR "${${pkg}_SOVERSION}" STREQUAL "" )
+           dd4hep_fatal ( "BAD Package versions: VERSION[${pkg}_VERSION] ${${pkg}_VERSION} SOVERSION[${pkg}_SOVERSION] ${${pkg}_SOVERSION} " )
+@@ -1030,6 +1030,7 @@ function( dd4hep_add_library binary building )
+         if ( NOT ${ARG_NOINSTALL} )
+           install ( TARGETS ${binary}  
+             LIBRARY DESTINATION lib 
++            ARCHIVE DESTINATION lib
+             RUNTIME DESTINATION bin)
+         endif()
+         set ( building_binary "ON" )

--- a/dd4hep-toolfile.spec
+++ b/dd4hep-toolfile.spec
@@ -9,15 +9,13 @@ Requires: dd4hep
 %install
 
 mkdir -p %i/etc/scram.d
-cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep.xml
-<tool name="dd4hep" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep-core.xml
+<tool name="dd4hep-core" version="@TOOL_VERSION@">
   <info url="https://github.com/AIDASoft/DD4hep"/>
-  <lib name="DDAlign" />
   <lib name="DDCore" />
-  <lib name="DDCond" />
   <lib name="DDParsers" />
   <client>
-    <environment name="DD4HEP_BASE" default="@TOOL_ROOT@"/>
+    <environment name="DD4HEP_CORE_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$DD4HEP_BASE/lib"/>
     <environment name="INCLUDE" default="$DD4HEP_BASE/include"/>
   </client>
@@ -25,19 +23,32 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep.xml
   <runtime name="PATH" value="$DD4HEP_BASE/bin" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="root"/>
-  <use name="boost"/> 
+  <use name="boost"/>
   <use name="xerces-c"/>
   <use name="clhep"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep.xml
+<tool name="dd4hep" version="@TOOL_VERSION@">
+  <lib name="DDAlign" />
+  <lib name="DDCond" />
+  <use name="dd4hep-core"/>
 </tool>
 EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep-cms.xml
 <tool name="dd4hep-cms" version="@TOOL_VERSION@">
   <lib name="DDCMS" />
-  <client>
-    <environment name="DD4HEP_CMS_BASE" default="@TOOL_ROOT@"/>
-  </client>
   <use name="dd4hep"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep-geant4.xml
+<tool name="dd4hep-geant4" version="@TOOL_VERSION@">
+  <lib anme="DDG4-static"/>
+  <use name="geant4-core"/>
+  <use name="dd4hep-core"/>
 </tool>
 EOF_TOOLFILE
 

--- a/dd4hep-toolfile.spec
+++ b/dd4hep-toolfile.spec
@@ -16,11 +16,11 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep-core.xml
   <lib name="DDParsers" />
   <client>
     <environment name="DD4HEP_CORE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$DD4HEP_BASE/lib"/>
-    <environment name="INCLUDE" default="$DD4HEP_BASE/include"/>
+    <environment name="LIBDIR" default="$DD4HEP_CORE_BASE/lib"/>
+    <environment name="INCLUDE" default="$DD4HEP_CORE_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$DD4HEP_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$DD4HEP_CORE_BASE/bin" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="root"/>
   <use name="boost"/>

--- a/dd4hep-toolfile.spec
+++ b/dd4hep-toolfile.spec
@@ -37,13 +37,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep.xml
 </tool>
 EOF_TOOLFILE
 
-cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep-cms.xml
-<tool name="dd4hep-cms" version="@TOOL_VERSION@">
-  <lib name="DDCMS" />
-  <use name="dd4hep"/>
-</tool>
-EOF_TOOLFILE
-
 cat << \EOF_TOOLFILE >%i/etc/scram.d/dd4hep-geant4.xml
 <tool name="dd4hep-geant4" version="@TOOL_VERSION@">
   <lib anme="DDG4-static"/>

--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -34,14 +34,6 @@ cmake $CMAKE_ARGS ../%{n}-%{realversion}
 make %{makeprocesses} VERBOSE=1
 make install
 
-#Build DDCMS example
-rm -rf ../build-cms; mkdir ../build-cms; cd ../build-cms
-cmake $CMAKE_ARGS ../%{n}-%{realversion}/examples
-cd DDCMS
-make %{makeprocesses} VERBOSE=1
-cp lib/libDDCMS* %i/lib
-cp bin/*DDCMS*   %i/bin
-
 #Building DDG4 static
 cd %{_builddir}/%{n}-%{realversion}
 patch -p1 < %{_sourcedir}/dd4hep-build-static

--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -3,12 +3,14 @@
 %define tag 0a44b413788a34fcadb6646ed83ee3f17fdf0bd9
 %define branch cms/master/9835d18
 %define github_user cms-externals
+%define keep_archives true
 
 Source: git+https://github.com/%{github_user}/DD4hep.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Patch0: dd4hep-build-static
 
 BuildRequires: cmake
 
-Requires: root boost clhep xerces-c
+Requires: root boost clhep xerces-c geant4
 
 %prep
 
@@ -16,27 +18,42 @@ Requires: root boost clhep xerces-c
 
 %build
 
-rm -rf ../build
-mkdir ../build
-cd ../build
-
 export BOOST_ROOT
-cmake -DCMAKE_INSTALL_PREFIX="%{i}" \
-      -DBoost_NO_BOOST_CMAKE=ON \
-      -DCMAKE_PREFIX_PATH=${CLHEP_ROOT} \
-      -DDD4HEP_USE_XERCESC=ON \
-      -DXERCESC_ROOT_DIR=${XERCES_C_ROOT} \
-      -DDD4HEP_USE_PYROOT=ON \
-      -DCMAKE_CXX_STANDARD=17 \
-      -DCMAKE_BUILD_TYPE=Release \
-      ../%{n}-%{realversion}
+CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX='%{i}'
+      -DBoost_NO_BOOST_CMAKE=ON
+      -DCMAKE_PREFIX_PATH=${CLHEP_ROOT}
+      -DDD4HEP_USE_XERCESC=ON
+      -DXERCESC_ROOT_DIR=${XERCES_C_ROOT}
+      -DDD4HEP_USE_PYROOT=ON
+      -DCMAKE_CXX_STANDARD=17
+      -DCMAKE_BUILD_TYPE=Release"
 
+#Build normal Shared D4Hep without Geant4
+rm -rf ../build; mkdir ../build; cd ../build
+cmake $CMAKE_ARGS ../%{n}-%{realversion}
 make %{makeprocesses} VERBOSE=1
+make install
+
+#Build DDCMS example
+rm -rf ../build-cms; mkdir ../build-cms; cd ../build-cms
+cmake $CMAKE_ARGS ../%{n}-%{realversion}/examples
+cd DDCMS
+make %{makeprocesses} VERBOSE=1
+cp lib/libDDCMS* %i/lib
+cp bin/*DDCMS*   %i/bin
+
+#Building DDG4 static
+cd %{_builddir}/%{n}-%{realversion}
+patch -p1 < %{_sourcedir}/dd4hep-build-static
+rm -rf ../build-g4; mkdir ../build-g4; cd ../build-g4
+cmake $CMAKE_ARGS -DDD4HEP_USE_GEANT4=ON ../%{n}-%{realversion}
+cd DDG4
+make %{makeprocesses} VERBOSE=1
+for lib in $(ls ../lib/libDDG4*.a | sed 's|.a$||'); do
+  mv ${lib}.a %i/lib/${lib}-static.a
+done
 
 %install
-
-cd ../build
-make install
 
 %post
 %{relocateConfig}*.cmake


### PR DESCRIPTION
We now build DD4Hep with Geant4 enabled. This change does the following
- build normal DD4Hep with out Geant4
- Build DDG4 part of DD4Hep as static libraries. This is done to avoid loading of Geant4 shared libraries via DDG4.so if this end up as dependency on big simulation plugin in CMSSW (which only links against static geant4).
- Enabled building of DDCMS example. In past we had added a dd4hep-cms tool but the libDDCMS.so was not actually build. One has to explicitly build examples/DDCMS to get it generated.

This should resolve https://github.com/cms-sw/cmssw/issues/26242
FYI @ianna 