### PR TITLE
backporting sherpa2.2.6 and openloops2.0.0 to 93X

### DIFF
--- a/openloops.spec
+++ b/openloops.spec
@@ -1,18 +1,19 @@
-### RPM external openloops 2.0.b
+### RPM external openloops 2.0.0
 %define tag a0fd88934c5c5b83f66fa4791c07f7872ec00a13
 %define branch cms/v%{realversion}
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+#Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: http://www.hepforge.org/archive/openloops/OpenLoops-2.0.0.tar.gz
 
 BuildRequires: python scons
 
-Patch0: openloops-1.2.3-cpp-use-undef
+#Patch0: openloops-1.2.3-cpp-use-undef
 
 %define keep_archives true
 
 %prep
-%setup -n %{n}-%{realversion}
-%patch0 -p1
+%setup -n OpenLoops-%{realversion}
+#%patch0 -p1
 
 %build
 cat << \EOF >> openloops.cfg
@@ -28,7 +29,8 @@ EOF
 ./openloops update --processes generator=0
 
 %install
-mkdir %i/{lib,proclib}
+#mkdir %i/{lib,proclib}
+mkdir %i/lib
 cp lib/*.so %i/lib
-cp proclib/*.so %i/proclib
-cp proclib/*.info %i/proclib
+#cp proclib/*.so %i/proclib
+#cp proclib/*.info %i/proclib

--- a/openloops.spec
+++ b/openloops.spec
@@ -1,5 +1,5 @@
 ### RPM external openloops 2.0.0
-%define tag 944f9f27fc68d2a14d6df9f877ab49258028c7e6
+%define tag df5dc23c322dd460c4f8f3cdfa331bb190c647f6
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 
@@ -24,7 +24,10 @@ link_optimisation = -O2
 EOF
 
 ./openloops update --processes generator=0
+./openloops libinstall all.coll
 
 %install
-mkdir %i/lib
+mkdir %i/{lib,proclib}
 cp lib/*.so %i/lib
+cp proclib/*.so %i/proclib
+cp proclib/*.info %i/proclib

--- a/openloops.spec
+++ b/openloops.spec
@@ -1,19 +1,16 @@
 ### RPM external openloops 2.0.0
-%define tag a0fd88934c5c5b83f66fa4791c07f7872ec00a13
+%define tag 944f9f27fc68d2a14d6df9f877ab49258028c7e6
 %define branch cms/v%{realversion}
 %define github_user cms-externals
-#Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
-Source: http://www.hepforge.org/archive/openloops/OpenLoops-2.0.0.tar.gz
+
+Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 BuildRequires: python scons
-
-#Patch0: openloops-1.2.3-cpp-use-undef
 
 %define keep_archives true
 
 %prep
-%setup -n OpenLoops-%{realversion}
-#%patch0 -p1
+%setup -n %{n}-%{realversion}
 
 %build
 cat << \EOF >> openloops.cfg
@@ -29,8 +26,5 @@ EOF
 ./openloops update --processes generator=0
 
 %install
-#mkdir %i/{lib,proclib}
 mkdir %i/lib
 cp lib/*.so %i/lib
-#cp proclib/*.so %i/proclib
-#cp proclib/*.info %i/proclib

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,8 +1,8 @@
 ### RPM external sherpa 2.2.6
-%define tag 600078cc741021be898f15563235cf6c809ca5ff
+%define tag ea0b6f6f50f77d2f7479ba81d0715e23b69eabee
 %define branch cms/v%realversion
 %define github_user cms-externals
-Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.6.tar.gz
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl scons python openmpi
 BuildRequires: mcfm swig
 
@@ -16,7 +16,7 @@ Requires: openloops
 %endif # islinux
 
 %prep
-%setup -q -n SHERPA-MC-%{realversion}
+%setup -q -n %{n}-%{realversion}
 
 autoreconf -i --force
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -17,7 +17,7 @@ Requires: openloops
 
 %prep
 %setup -q -n %{n}-%{realversion}
-
+sed -i -e 's|^\s*Manual \s*\\$|\\|' Makefile.am
 autoreconf -i --force
 
 # Force architecture based on %%cmsplatf
@@ -50,7 +50,7 @@ esac
             MPICXX="mpicxx" \
             FC="mpifort" \
             CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF -O2 -std=c++0x -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$OPENSSL_ROOT/include" \
-            LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib"
+            LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib" MAKEINFO=true
 
 make %{makeprocesses}
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,8 +1,8 @@
-### RPM external sherpa 2.2.5
+### RPM external sherpa 2.2.6
 %define tag 600078cc741021be898f15563235cf6c809ca5ff
 %define branch cms/v%realversion
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.6.tar.gz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl scons python openmpi
 BuildRequires: mcfm swig
 
@@ -16,7 +16,7 @@ Requires: openloops
 %endif # islinux
 
 %prep
-%setup -q -n %{n}-%{realversion}
+%setup -q -n SHERPA-MC-%{realversion}
 
 autoreconf -i --force
 


### PR DESCRIPTION
Hi, please apply the mentioned patches in [1] and [2]

[1] cms-externals/openloops@5141c0e
[2] https://gitlab.com/openloops/OpenLoops/commit/8ff8f52fe6e0f9f4f3f666b0d89279da64554fc3