### PR TITLE
Backporting sherpa2.2.6 and openloops2.0.0 to 102X

### DIFF
--- a/openloops.spec
+++ b/openloops.spec
@@ -1,33 +1,36 @@
-### RPM external openloops 2.0.b
-%define tag 0f0826bd718dc28dcc8a457acb59de678b011b96
+### RPM external openloops 2.0.0
+%define tag a0fd88934c5c5b83f66fa4791c07f7872ec00a13
 %define branch cms/v%{realversion}
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+#Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: http://www.hepforge.org/archive/openloops/OpenLoops-2.0.0.tar.gz
 
 BuildRequires: python scons
 
-Patch0: openloops-1.2.3-cpp-use-undef
+#Patch0: openloops-1.2.3-cpp-use-undef
 
 %define keep_archives true
 
 %prep
-%setup -n %{n}-%{realversion}
-%patch0 -p1
+%setup -n OpenLoops-%{realversion}
+#%patch0 -p1
 
 %build
 cat << \EOF >> openloops.cfg
 [OpenLoops]
 fortran_compiler = gfortran
-gfortran_f90_flags = -ffixed-line-length-0 -ffree-line-length-0 -O0
+gfortran_f90_flags = -ffixed-line-length-0 -ffree-line-length-0
+generic_optimisation = -O2
+born_optimisation = -O2
 loop_optimisation = -O0
-generic_optimisation = -O0
-born_optimisation = -O0
+link_optimisation = -O2
 EOF
 
 ./openloops update --processes generator=0
 
 %install
-mkdir %i/{lib,proclib}
+#mkdir %i/{lib,proclib}
+mkdir %i/lib
 cp lib/*.so %i/lib
-cp proclib/*.so %i/proclib
-cp proclib/*.info %i/proclib
+#cp proclib/*.so %i/proclib
+#cp proclib/*.info %i/proclib

--- a/openloops.spec
+++ b/openloops.spec
@@ -1,5 +1,5 @@
 ### RPM external openloops 2.0.0
-%define tag 944f9f27fc68d2a14d6df9f877ab49258028c7e6
+%define tag df5dc23c322dd460c4f8f3cdfa331bb190c647f6
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 
@@ -24,7 +24,10 @@ link_optimisation = -O2
 EOF
 
 ./openloops update --processes generator=0
+./openloops libinstall all.coll
 
 %install
-mkdir %i/lib
+mkdir %i/{lib,proclib}
 cp lib/*.so %i/lib
+cp proclib/*.so %i/proclib
+cp proclib/*.info %i/proclib

--- a/openloops.spec
+++ b/openloops.spec
@@ -1,19 +1,16 @@
 ### RPM external openloops 2.0.0
-%define tag a0fd88934c5c5b83f66fa4791c07f7872ec00a13
+%define tag 944f9f27fc68d2a14d6df9f877ab49258028c7e6
 %define branch cms/v%{realversion}
 %define github_user cms-externals
-#Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
-Source: http://www.hepforge.org/archive/openloops/OpenLoops-2.0.0.tar.gz
+
+Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 BuildRequires: python scons
-
-#Patch0: openloops-1.2.3-cpp-use-undef
 
 %define keep_archives true
 
 %prep
-%setup -n OpenLoops-%{realversion}
-#%patch0 -p1
+%setup -n %{n}-%{realversion}
 
 %build
 cat << \EOF >> openloops.cfg
@@ -29,8 +26,5 @@ EOF
 ./openloops update --processes generator=0
 
 %install
-#mkdir %i/{lib,proclib}
 mkdir %i/lib
 cp lib/*.so %i/lib
-#cp proclib/*.so %i/proclib
-#cp proclib/*.info %i/proclib

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -17,7 +17,7 @@ Requires: openloops
 
 %prep
 %setup -q -n %{n}-%{realversion}
-
+sed -i -e 's|^\s*Manual \s*\\$|\\|' Makefile.am
 autoreconf -i --force
 
 # Force architecture based on %%cmsplatf
@@ -45,20 +45,16 @@ esac
             ${OPENLOOPS_ROOT+--enable-openloops=$OPENLOOPS_ROOT} \
             --enable-mpi \
             --with-sqlite3=$SQLITE_ROOT \
-            --disable-automake.info \
             CC="mpicc" \
             CXX="mpicxx" \
             MPICXX="mpicxx" \
             FC="mpifort" \
             CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF -O2 -std=c++0x -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$OPENSSL_ROOT/include" \
-            LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib"
+            LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib -L$OPENSSL_ROOT/lib" MAKEINFO=true
 
 make %{makeprocesses}
 
 %install
-# circumvent search for makeinfo, used to generate docs. other way of doing the same - patch the makefile as sugested here https://sourceware.org/bugzilla/show_bug.cgi?id=18113
-ln -s /usr/bin/true %_builddir/makeinfo
-export PATH=%_builddir:${PATH}
 make install
 find %{i}/lib -name '*.la' -delete
 sed -i -e 's|^#!/.*|#!/usr/bin/env python|' %{i}/bin/Sherpa-generate-model

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,8 +1,8 @@
 ### RPM external sherpa 2.2.6
-%define tag 600078cc741021be898f15563235cf6c809ca5ff
+%define tag ea0b6f6f50f77d2f7479ba81d0715e23b69eabee
 %define branch cms/v%realversion
 %define github_user cms-externals
-Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.6.tar.gz
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl scons python openmpi
 BuildRequires: mcfm swig
 
@@ -16,7 +16,7 @@ Requires: openloops
 %endif # islinux
 
 %prep
-%setup -q -n SHERPA-MC-%{realversion}
+%setup -q -n %{n}-%{realversion}
 
 autoreconf -i --force
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -57,10 +57,8 @@ make %{makeprocesses}
 
 %install
 # circumvent search for makeinfo, used to generate docs. other way of doing the same - patch the makefile as sugested here https://sourceware.org/bugzilla/show_bug.cgi?id=18113
-mkdir -p /tmp/mibin
-ln -s /usr/bin/true /tmp/mibin/makeinfo
-chmod a+x /tmp/mibin/makeinfo
-export PATH=/tmp/mibin:${PATH}
+ln -s /usr/bin/true %_builddir/makeinfo
+export PATH=%_builddir:${PATH}
 make install
 find %{i}/lib -name '*.la' -delete
 sed -i -e 's|^#!/.*|#!/usr/bin/env python|' %{i}/bin/Sherpa-generate-model

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -57,8 +57,9 @@ make %{makeprocesses}
 
 %install
 # circumvent search for makeinfo, used to generate docs. other way of doing the same - patch the makefile as sugested here https://sourceware.org/bugzilla/show_bug.cgi?id=18113
-ln -s /usr/bin/true makeinfo
-export PATH=${PWD}:${PATH}
+mkdir -p /tmp/mibin
+ln -s /usr/bin/true /tmp/mibin/makeinfo
+export PATH=/tmp/mibin:${PATH}
 make install
 find %{i}/lib -name '*.la' -delete
 sed -i -e 's|^#!/.*|#!/usr/bin/env python|' %{i}/bin/Sherpa-generate-model

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -56,10 +56,10 @@ esac
 make %{makeprocesses}
 
 %install
-make install
 # circumvent search for makeinfo, used to generate docs. other way of doing the same - patch the makefile as sugested here https://sourceware.org/bugzilla/show_bug.cgi?id=18113
 ln -s /usr/bin/true makeinfo
 export PATH=${PWD}:${PATH}
+make install
 find %{i}/lib -name '*.la' -delete
 sed -i -e 's|^#!/.*|#!/usr/bin/env python|' %{i}/bin/Sherpa-generate-model
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -59,6 +59,7 @@ make %{makeprocesses}
 # circumvent search for makeinfo, used to generate docs. other way of doing the same - patch the makefile as sugested here https://sourceware.org/bugzilla/show_bug.cgi?id=18113
 mkdir -p /tmp/mibin
 ln -s /usr/bin/true /tmp/mibin/makeinfo
+chmod a+x /tmp/mibin/makeinfo
 export PATH=/tmp/mibin:${PATH}
 make install
 find %{i}/lib -name '*.la' -delete

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -45,6 +45,7 @@ esac
             ${OPENLOOPS_ROOT+--enable-openloops=$OPENLOOPS_ROOT} \
             --enable-mpi \
             --with-sqlite3=$SQLITE_ROOT \
+            --disable-automake.info \
             CC="mpicc" \
             CXX="mpicxx" \
             MPICXX="mpicxx" \
@@ -56,6 +57,9 @@ make %{makeprocesses}
 
 %install
 make install
+# circumvent search for makeinfo, used to generate docs. other way of doing the same - patch the makefile as sugested here https://sourceware.org/bugzilla/show_bug.cgi?id=18113
+ln -s /usr/bin/true makeinfo
+export PATH=${PWD}:${PATH}
 find %{i}/lib -name '*.la' -delete
 sed -i -e 's|^#!/.*|#!/usr/bin/env python|' %{i}/bin/Sherpa-generate-model
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,8 +1,8 @@
-### RPM external sherpa 2.2.5
+### RPM external sherpa 2.2.6
 %define tag 600078cc741021be898f15563235cf6c809ca5ff
 %define branch cms/v%realversion
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.6.tar.gz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl scons python openmpi
 BuildRequires: mcfm swig
 
@@ -16,7 +16,7 @@ Requires: openloops
 %endif # islinux
 
 %prep
-%setup -q -n %{n}-%{realversion}
+%setup -q -n SHERPA-MC-%{realversion}
 
 autoreconf -i --force
 


### PR DESCRIPTION
Hi, please apply the mentioned patches in [1] and [2]

[1] cms-externals/openloops@5141c0e
[2] https://gitlab.com/openloops/OpenLoops/commit/8ff8f52fe6e0f9f4f3f666b0d89279da64554fc3