### PR TITLE
[CVE-2019-10255] Update py2-notebook to 5.7.8

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -96,7 +96,7 @@ networkx==2.2
 neurolab==0.3.5
 nose-parameterized==0.6.0
 nose==1.3.7
-notebook==5.7.4
+notebook==5.7.8
 numba==0.42.1
 numexpr==2.6.9
 oamap==0.12.4


### PR DESCRIPTION
An Open Redirect vulnerability for all browsers in Jupyter Notebook before 5.7.8 and some browsers (Chrome, Firefox) in JupyterHub before 0.9.6 allows crafted links to the login page, which will redirect to a malicious site after successful login. Servers running on a base_url prefix are not affected.