### PR TITLE
Condition for ppc64 for tfcompile

### DIFF
--- a/tensorflow-toolfile.spec
+++ b/tensorflow-toolfile.spec
@@ -13,7 +13,9 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/tensorflow.xml
     <environment name="TENSORFLOW_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$TENSORFLOW_BASE/lib"/>
     <environment name="INCLUDE" default="$TENSORFLOW_BASE/include"/>
+%ifnarch ppc64le
     <environment name="TFCOMPILE" default="$TENSORFLOW_BASE/bin/tfcompile"/>
+%endif
   </client>
   <runtime name="PATH" value="$TENSORFLOW_BASE/bin" type="path"/>
 </tool>


### PR DESCRIPTION
cms-sw doesn't compile as it can't find tfcompile binary, since it's not compiled on ppc (llvm missing references)