### PR TITLE
Move xgboost back to 0.81

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -192,5 +192,5 @@ webencodings==0.5.1
 Werkzeug==0.15.2
 wheel==0.33.1
 widgetsnbextension==3.4.2
-xgboost==0.82
+xgboost==0.81
 xrootdpyfs==0.1.5


### PR DESCRIPTION
py2-xgboost is failing on arm64 and it breaks the IB build, I want to put it back on 0.81 until I fix the pip build on arm
@davidlange6 