### PR TITLE
Update SQLAlchemy to 1.3.3

### DIFF
--- a/asyncstageout.spec
+++ b/asyncstageout.spec
@@ -10,9 +10,9 @@
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/AsyncStageout.git?obj=master/%{realversion}&export=AsyncStageout-%{realversion}&output=/AsyncStageout-%{realversion}.tar.gz
-Requires: python py2-simplejson py2-sqlalchemy10 py2-httplib2 rotatelogs pystack py2-sphinx dbs-client couchdb15 py2-pycurl couchskel py2-stomp dbs3-client
+Requires: python py2-simplejson py2-httplib2 rotatelogs pystack py2-sphinx dbs-client couchdb15 py2-pycurl couchskel py2-stomp dbs3-client
 Requires: PHEDEX-micro PHEDEX-lifecycle
-Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy10 py2-cx-oracle51
+Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle51
 Requires: jemalloc
 BuildRequires: py2-sphinx
 Patch1: aso_splitviews

--- a/crabcache.spec
+++ b/crabcache.spec
@@ -10,7 +10,7 @@
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy10 py2-cx-oracle
+Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle
 BuildRequires: py2-sphinx
 #Patch0: crabserver3-setup
 

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -11,7 +11,7 @@
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy10 py2-cx-oracle51
+Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle51
 Requires: py2-pyOpenSSL condor py2-mysqldb dbs3-pycurl-client dbs-client dbs3-client
 Requires: jemalloc
 BuildRequires: py2-sphinx

--- a/py2-sqlalchemy.spec
+++ b/py2-sqlalchemy.spec
@@ -1,4 +1,4 @@
-### RPM external py2-sqlalchemy 0.9.6
+### RPM external py2-sqlalchemy 1.3.3
 ## IMPORT build-with-pip
 
 %define pip_name SQLAlchemy


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9153

There has been a couple of moderate severity vulnerabilities found in the SQLAlchemy version that we use in COMP and the suggestion is to update it to >= 1.3.0

I'm not updating this spec:
https://github.com/cms-sw/cmsdist/blob/comp_gcc630/py2-sqlalchemy10.spec

but I think projects should move away from it and it should be removed.