### PR TITLE
Build python2 pylint and its dependencies

### DIFF
--- a/py2-astroid.spec
+++ b/py2-astroid.spec
@@ -1,0 +1,4 @@
+### RPM external py2-astroid 1.6.6
+## IMPORT build-with-pip
+
+Requires: py2-lazy-object-proxy py2-six py2-wrapt py2-enum34 py2-singledispatch py2-backports-functools_lru_cache

--- a/py2-backports-functools_lru_cache.spec
+++ b/py2-backports-functools_lru_cache.spec
@@ -1,0 +1,4 @@
+### RPM external py2-backports-functools_lru_cache 1.5
+## IMPORT build-with-pip
+
+%define pip_name backports.functools_lru_cache

--- a/py2-configparser.spec
+++ b/py2-configparser.spec
@@ -1,0 +1,2 @@
+### RPM external py2-configparser 3.7.4
+## IMPORT build-with-pip

--- a/py2-isort.spec
+++ b/py2-isort.spec
@@ -1,0 +1,6 @@
+### RPM external py2-isort 4.3.17
+## IMPORT build-with-pip
+
+Requires: py2-futures py2-backports-functools_lru_cache
+
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py2-lazy-object-proxy.spec
+++ b/py2-lazy-object-proxy.spec
@@ -1,0 +1,3 @@
+### RPM external py2-lazy-object-proxy 1.3.1
+## IMPORT build-with-pip
+

--- a/py2-mccabe.spec
+++ b/py2-mccabe.spec
@@ -1,0 +1,2 @@
+### RPM external py2-mccabe 0.6.1
+## IMPORT build-with-pip

--- a/py2-pylint.spec
+++ b/py2-pylint.spec
@@ -1,0 +1,8 @@
+### RPM external py2-pylint 1.9.4
+## IMPORT build-with-pip
+
+Requires: py2-astroid py2-backports-functools_lru_cache py2-configparser py2-isort py2-mccabe py2-singledispatch py2-six
+
+%define PipPostBuild \
+    perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*; \
+    perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python*/site-packages/pylint/test/data/*

--- a/py2-singledispatch.spec
+++ b/py2-singledispatch.spec
@@ -1,0 +1,4 @@
+### RPM external py2-singledispatch 3.4.0.3
+## IMPORT build-with-pip
+
+Requires: py2-six

--- a/py2-wrapt.spec
+++ b/py2-wrapt.spec
@@ -1,0 +1,3 @@
+### RPM external py2-wrapt 1.11.1
+## IMPORT build-with-pip
+

--- a/wmcore-devtools.spec
+++ b/wmcore-devtools.spec
@@ -1,7 +1,7 @@
-### RPM cms wmcore-devtools 1.4
+### RPM cms wmcore-devtools 1.5
 
 # This is a meta-package to group development tool dependencies
-Requires: yuicompressor py2-coverage py2-lint py2-nose py2-sphinx
+Requires: yuicompressor py2-coverage py2-pylint py2-nose py2-sphinx
 Requires: py2-mox py2-future py2-mock py2-retry py2-pep8 py2-memory-profiler
 
 %prep


### PR DESCRIPTION
Meant to replace `py2-lint` package.