### PR TITLE
Add override option and python dependency

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -36,7 +36,7 @@ mkdir %_builddir/build %_builddir/tmp
 
 # extract and repackage the CUDA runtime, tools and stubs
 %ifarch x86_64
-/bin/sh %{SOURCE0} --silent --tmpdir %_builddir/tmp --extract=%_builddir/build
+/bin/sh %{SOURCE0} --silent --override --tmpdir %_builddir/tmp --extract=%_builddir/build
 # extracts:
 # %_builddir/build/EULA.txt
 # %_builddir/build/NVIDIA-Linux-x86_64-418.39.run       # linux drivers

--- a/cuda.spec
+++ b/cuda.spec
@@ -24,6 +24,7 @@ Source0: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod/local_ins
 Source0: https://patatrack.web.cern.ch/patatrack/files/cuda-repo-l4t-10-0-local-%{realversion}_1.0-1_arm64.deb
 Source1: https://patatrack.web.cern.ch/patatrack/files/Jetson_Linux_R%{driversversion}_aarch64.tbz2
 %endif
+Requires: python
 AutoReq: no
 
 %prep


### PR DESCRIPTION
Pass the `--override` option to the CUDA installer, to "ignore compiler, third-party library, and toolkit detection checks which would prevent the CUDA Toolkit and CUDA Samples from installing."
This is needed in the GCC 9 builds.

Add an explicit dependency on `python` in order to fix the `cuda-gdb` wrapper.