### PR TITLE
Add override option for Cuda on "IB/CMSSW_10_6_X/gcc9"

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -36,7 +36,7 @@ mkdir %_builddir/build %_builddir/tmp
 
 # extract and repackage the CUDA runtime, tools and stubs
 %ifarch x86_64
-/bin/sh %{SOURCE0} --silent --tmpdir %_builddir/tmp --extract=%_builddir/build
+/bin/sh %{SOURCE0} --silent --override --tmpdir %_builddir/tmp --extract=%_builddir/build
 # extracts:
 # %_builddir/build/EULA.txt
 # %_builddir/build/NVIDIA-Linux-x86_64-418.39.run       # linux drivers

--- a/cuda.spec
+++ b/cuda.spec
@@ -24,6 +24,7 @@ Source0: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod/local_ins
 Source0: https://patatrack.web.cern.ch/patatrack/files/cuda-repo-l4t-10-0-local-%{realversion}_1.0-1_arm64.deb
 Source1: https://patatrack.web.cern.ch/patatrack/files/Jetson_Linux_R%{driversversion}_aarch64.tbz2
 %endif
+Requires: python
 AutoReq: no
 
 %prep


### PR DESCRIPTION
Cherry-picked commits from PR https://github.com/cms-sw/cmsdist/pull/4906 .

This should allow building cuda on gcc900. 