### PR TITLE
Update py2-lint package

### DIFF
--- a/py2-lint.spec
+++ b/py2-lint.spec
@@ -1,18 +1,20 @@
-### RPM external py2-lint 1.4.4
+### RPM external py2-lint 2.2.3
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
-Source0: https://pypi.python.org/packages/source/l/logilab-common/logilab-common-1.0.2.tar.gz
-Source1: https://bitbucket.org/logilab/astroid/get/astroid-1.3.6.tar.gz
+%define logilab_ver 1.4.2
+%define astroid_ver 1.6.6
+Source0: https://pypi.python.org/packages/source/l/logilab-common/logilab-common-%{logilab_ver}.tar.gz
+Source1: https://pypi.python.org/packages/source/a/astroid/astroid-%{astroid_ver}.tar.gz
 Source2: https://pypi.python.org/packages/source/p/pylint/pylint-%realversion.tar.gz
 Requires: python
 BuildRequires: py2-setuptools
 
 %prep
-%setup -T -b 0 -n logilab-common-1.0.2
-%setup -D -T -b 1 -n logilab-astroid-bae72378bead
+%setup -T -b 0 -n logilab-common-%{logilab_ver}
+%setup -D -T -b 1 -n astroid-%{astroid_ver}
 %setup -D -T -b 2 -n pylint-%{realversion}
 
 %build
-for d in ../logilab-common-* ../logilab-astroid-* ../pylint-*; do
+for d in ../logilab-common-* ../astroid-* ../pylint-*; do
   cd $d
   python setup.py build
 done
@@ -20,11 +22,12 @@ done
 %install
 mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH
-for d in ../logilab-common-* ../logilab-astroid-* ../pylint-*; do
+for d in ../logilab-common-* ../astroid-* ../pylint-*; do
   cd $d
   python setup.py install --prefix=%i
 done
 find %i -name '*.egg-info' -exec rm {} \;
-perl -p -i -e 's{^#!.*/python}{#!/usr/bin/env python}' %i/bin/* \
-                                                       %i/lib/python*/site-packages/pylint-*.egg/EGG-INFO/scripts/* \
-                                                       %i/lib/python*/site-packages/logilab_common-*.egg/EGG-INFO/scripts/*
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/* \
+                                                     %{i}/lib/python*/site-packages/pylint-*.egg/EGG-INFO/scripts/* \
+                                                     %{i}/lib/python*/site-packages/pylint-*.egg/pylint/test/data/* \
+                                                     %{i}/lib/python*/site-packages/logilab_common-*.egg/EGG-INFO/scripts/*


### PR DESCRIPTION
Might superseed https://github.com/cms-sw/cmsdist/pull/4904 , now that I figured this package is also distributing pylint.

Apparently it builds fine now, but then it fails to install with this error:
```
* The action "install-external+py2-lint+2.2.3" was not completed successfully because Traceback (most recent call last):
File "/build/amaltaro/pkgtools/scheduler.py", line 199, in doSerial
result = commandSpec[0](*commandSpec[1:])
File "pkgtools/cmsBuild", line 3243, in installPackage
File "pkgtools/cmsBuild", line 3040, in installRpm
RpmInstallFailed: Failed to install package py2-lint. Reason:
error: Failed dependencies:
	/usr/bin/python is needed by external+py2-lint+2.2.3-1-1.x86_64
```

I read about `AutoReq: no`, but then there are disadvantages if I try fixing it that way.

Perhaps you've seen in the past and know how to fix it? @mrodozov @gudrutis @davidlange6 @h4d4 

Hmm, now that I look at the build log:
http://amaltaro.web.cern.ch/amaltaro/for_cmsdist/log
I see a bunch of exceptions in there. I'm not sure how much I should worry about those...