### PR TITLE
[BuildRules] By default run code-format only for changed files

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-25
+%define configtag       V05-08-26
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-24
+%define configtag       V05-08-25
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This make it consistent with code-checks. Use `scram b code-format-all` if you want to run code-format for all files under src directory.