### PR TITLE
[BuildRules] Improved check-headers rules

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-30
+%define configtag       V05-08-31
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
New rule should 
- avoid internal compiler errors
- only run for public shared libraries interface headers (h, hh, hpp)
- Use local package dependencies