### PR TITLE
[BuildRules] cmssw-config tag V05-08-33

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-31
+%define configtag       V05-08-33
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- avoid `YAMLLoadWarning: calling yaml.load() without Loader=...` warning
- Make sure to not fail `scram build code-checks` if there are no code changes found.