### PR TITLE
[BuildRukes] Bugfix: update cmssw-config tag to V05-08-35

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-33
+%define configtag       V05-08-35
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
code-format rule in V05-08-33 was no broken and it was not picking up the src/.clang-format.
New tag should fix this issue.