### PR TITLE
Build Tensorflow in debug mode

### DIFF
--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -58,7 +58,7 @@ rm -rf ../build
 
 ./configure
 
-BAZEL_OPTS="--output_user_root ../build build -s --verbose_failures -c opt --config monolithic --cxxopt=${CXX_OPT_FLAGS}"
+BAZEL_OPTS="--output_user_root ../build build -s --verbose_failures -c dbg --strip=never --config monolithic --cxxopt=${CXX_OPT_FLAGS}"
 BAZEL_EXTRA_OPTS="--action_env PYTHONPATH=${PYTHON27PATH} --distinct_host_configuration=false"
 
 bazel $BAZEL_OPTS $BAZEL_EXTRA_OPTS //tensorflow/tools/pip_package:build_pip_package


### PR DESCRIPTION
This is needed to tests new tensorflow in DEVEL IBs.