### PR TITLE
[10.2.X][EgammaAnalysis-ElectronTools] Push the 2018 S+S files

### DIFF
--- a/data-EgammaAnalysis-ElectronTools.spec
+++ b/data-EgammaAnalysis-ElectronTools.spec
@@ -1,4 +1,4 @@
-### RPM cms data-EgammaAnalysis-ElectronTools V00-01-03
+### RPM cms data-EgammaAnalysis-ElectronTools V00-01-04
 
 %prep
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/4969
Note that this just adds couple of new files cms-data/EgammaAnalysis-ElectronTools#7 
