### PR TITLE
[BuildRules]  Fixed quotation for compile_commands.json

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-37
+%define configtag       V05-08-38
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Use correct quotations e.g.
```
-DPROJECT_NAME='\"CMSSW\"'
```
instead of
```
-DPROJECT_NAME=\"CMSSW\"
```
to avoid compilation errors during code-checks
```
L1MuGMTParametersOnlineProducer.cc:118:65: error: expected ')' [clang-diagnostic-error]
	edm::LogInfo("No CMSSW version set in database, accepting " PROJECT_VERSION);
                                                                                                            ^
note: expanded from here
```