### PR TITLE
update matplotlib to 2.2.4 and freetype to 2.5.3

### DIFF
--- a/freetype.spec
+++ b/freetype.spec
@@ -1,24 +1,29 @@
-### RPM external freetype 2.4.7
-Source: http://download.savannah.gnu.org/releases/freetype/freetype-%realversion.tar.bz2
-Requires: bz2lib zlib
+### RPM external freetype 2.5.3
+Source: http://download.savannah.gnu.org/releases/freetype/freetype-%{realversion}.tar.bz2
+Requires: bz2lib zlib libpng
 
 %prep
-%setup -n %n-%realversion
+%setup -n %{n}-%{realversion}
 
 %build
-./configure --prefix %{i} --with-bzlib2=$BZ2LIB_ROOT --with-zlib=$ZLIB_ROOT
-make %makeprocesses
+./configure \
+  --prefix %{i} \
+  --with-bzip2==${BZ2LIB_ROOT} \
+  --with-zlib=${ZLIB_ROOT} \
+  --with-png=${LIBPNG_ROOT} \
+  --with-harfbuzz=no
+
+make %{makeprocesses}
+
 %install
 make install
-case %cmsos in
-  osx*)
-install_name_tool -id %i/lib/libfreetype-cms.dylib -change %i/lib/libfreetype.6.dylib %i/lib/libfreetype-cms.dylib  %i/lib/libfreetype.6.dylib
-ln -s libfreetype.6.dylib %i/lib/libfreetype-cms.dylib
-perl -p -i -e 's|-lfreetype|-lfreetype-cms|' %i/bin/freetype-config
-  ;;
-esac
+%ifos darwin
+install_name_tool -id %{i}/lib/libfreetype-cms.dylib -change %{i}/lib/libfreetype.6.dylib %{i}/lib/libfreetype-cms.dylib %{i}/lib/libfreetype.6.dylib
+ln -s libfreetype.6.dylib %{i}/lib/libfreetype-cms.dylib
+perl -p -i -e 's|-lfreetype|-lfreetype-cms|' %{i}/bin/freetype-config
+%endif
 
 # Strip libraries, we are not going to debug them.
-%define strip_files %i/lib
+%define strip_files %{i}/lib
 %post
 %{relocateConfig}bin/freetype-config

--- a/py2-cycler.spec
+++ b/py2-cycler.spec
@@ -1,3 +1,3 @@
-### RPM external py2-python-dateutil 2.8.0
+### RPM external py2-cycler 0.10.0
 ## IMPORT build-with-pip
 Requires: py2-six

--- a/py2-kiwisolver.spec
+++ b/py2-kiwisolver.spec
@@ -1,0 +1,2 @@
+### RPM external py2-kiwisolver 1.1.0
+## IMPORT build-with-pip

--- a/py2-matplotlib.spec
+++ b/py2-matplotlib.spec
@@ -1,29 +1,42 @@
-### RPM external py2-matplotlib 1.4.3
+### RPM external py2-matplotlib 2.2.4
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
-Source: http://sourceforge.net/projects/matplotlib/files/matplotlib/matplotlib-%{realversion}/matplotlib-%{realversion}.tar.gz
-Requires: py2-pytz py2-numpy py2-python-dateutil zlib libpng freetype py2-pyparsing py2-six
-BuildRequires: py2-setuptools
+
+Source: https://github.com/matplotlib/matplotlib/archive/v%{realversion}.tar.gz
+Requires: py2-pytz py2-numpy py2-python-dateutil zlib libpng freetype py2-pyparsing py2-six py2-cycler py2-subprocess32 py2-kiwisolver
+#Requires: py2-backports
+BuildRequires: py2-pip
 
 %prep
 %setup -n matplotlib-%{realversion}
 
 cat >> setup.cfg <<- EOF
 [directories]
-basedirlist = ${FREETYPE_ROOT},${LIBPNG_ROOT},${ZLIB_ROOT},${PY2_NUMPY_ROOT},${PY2_PYTZ_ROOT},${PY2_SIX}
+basedirlist = ${FREETYPE_ROOT}:${LIBPNG_ROOT}:${ZLIB_ROOT}:${PY2_NUMPY_ROOT}:${PY2_PYTZ_ROOT}:${PY2_SIX}
 
 [gui_support]
 gtk = False
 gtkagg = False
-tkagg = False
+tkagg = True
 wxagg = False
 macosx = False
 EOF
 
+mkdir no-pkg-config
+(echo '#!/bin/sh'; echo 'exit 1') > no-pkg-config/pkg-config
+chmod +x no-pkg-config/pkg-config
+
 %build
-python setup.py build
+#python setup.py build
 
 %install
-python setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null
+export CPLUS_INCLUDE_PATH=${FREETYPE_ROOT}/include/freetype2:${LIBPNG_ROOT}/include/libpng16
+export MPLCONFIGDIR=$PWD/no-pkg-config
+PATH=$PWD/no-pkg-config:$PATH \
+export CPLUS_INCLUDE_PATH=${FREETYPE_ROOT}/include/freetype2:${LIBPNG_ROOT}/include/libpng16
+export PYTHONUSERBASE=%i
+pip install . --user
+
+#python setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null
 
 # No need for test files
-rm -rf %i/$PYTHON_LIB_SITE_PACKAGES/matplotlib/tests
+rm -rf %i/${PYTHON_LIB_SITE_PACKAGES}/matplotlib/tests

--- a/py2-pyparsing.spec
+++ b/py2-pyparsing.spec
@@ -1,15 +1,2 @@
-### RPM external py2-pyparsing 2.0.2
-## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
-
-Source: https://pypi.python.org/packages/source/p/pyparsing/pyparsing-%realversion.tar.gz
-Requires: python
-
-%prep
-%setup -n pyparsing-%realversion
-
-%build
-python setup.py build
-
-%install
-python setup.py install --prefix=%i
-find %i -name '*.egg-info' -exec rm {} \;
+### RPM external py2-pyparsing 2.4.0
+## IMPORT build-with-pip

--- a/py2-pytz.spec
+++ b/py2-pytz.spec
@@ -1,14 +1,2 @@
-### RPM external py2-pytz 2016.3 
-## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
-
-Source: http://cheeseshop.python.org/packages/source/p/pytz/pytz-%{realversion}.tar.bz2 
-Requires: python
-
-%prep
-%setup -n pytz-%{realversion}
-
-%build
-python setup.py build
-
-%install
-python setup.py install --prefix=%i
+### RPM external py2-pytz 2019.1
+## IMPORT build-with-pip

--- a/py2-six.spec
+++ b/py2-six.spec
@@ -1,2 +1,2 @@
-### RPM external py2-six 1.11.0
+### RPM external py2-six 1.12.0
 ## IMPORT build-with-pip

--- a/py2-subprocess32.spec
+++ b/py2-subprocess32.spec
@@ -1,0 +1,2 @@
+### RPM external py2-subprocess32 3.5.4
+## IMPORT build-with-pip


### PR DESCRIPTION
Synchronizing matplotlib and freetype with the `IB/CMSSW_10_6_X` branch. Also this will be necessary if I want to upgrade CherryPy, as in: https://github.com/cms-sw/cmsdist/pull/4480

@smuzaffar Shahzad, I noticed it triggers the build of almost all packages in comp (I assume it's the freetype spec doing so). Do you see any possible issues with this PR?