### PR TITLE
[CXXModules] drop module.modulemap source

### DIFF
--- a/cmssw-queue-override.file
+++ b/cmssw-queue-override.file
@@ -30,6 +30,5 @@
 %if "%(case %realversion in (*CXXMODULE_X*) echo true ;; (*) echo false ;; esac)" == "true"
 Source20: CXXModules.mk
 %define patchsrc20     cp %{_sourcedir}/CXXModules.mk config/SCRAM/GMake/CXXModules.mk
-%define additionalSrc0 git://github.com/cms-sw/cmssw-modulemap.git?protocol=https&obj=master/b6eb71106e7727946c79042fe836d9517d6d7511&module=src&export=src
 %endif
 


### PR DESCRIPTION
module.modulemap is not generated at build time