### PR TITLE
Update setuptools to 40.5.0

### DIFF
--- a/py2-setuptools.spec
+++ b/py2-setuptools.spec
@@ -1,7 +1,7 @@
-### RPM external py2-setuptools 39.2.0
+### RPM external py2-setuptools 40.5.0
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
-Source: https://files.pythonhosted.org/packages/1a/04/d6f1159feaccdfc508517dba1929eb93a2854de729fa68da9d5c6b48fa00/setuptools-%realversion.zip
+Source: https://files.pythonhosted.org/packages/26/e5/9897eee1100b166a61f91b68528cb692e8887300d9cbdaa1a349f6304b79/setuptools-%realversion.zip
 Requires: python
 
 %prep


### PR DESCRIPTION
This version should support namespace packages (packages without the `__init__.py` file).

I had this problem while updating the cherrypy package, which was failing to `import zc.lockfile` for a couple of services, not for others though. Some googling brought me to this issue:
https://github.com/zopefoundation/zc.lockfile/issues/13

For further release notes between 39.2.0 and 40.5.0, please:
https://setuptools.readthedocs.io/en/latest/history.html

PS.: this will trigger a rebuild of basically all python-related packages.