### PR TITLE
[BuildRules] Updated tag V05-08-51

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-50
+%define configtag       V05-08-51
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Added support for REM_GENREFLEX_ARGS via Package's BuildFile
- Bug fix: Make sure scram fails when genrelfex exit with non-zero exit code.