### PR TITLE
[BuildRules] To fix the failures in ROOT6 and 618 IBs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-51
+%define configtag       V05-08-52
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
New root (6.18 and master) now look for library in the same directory as of the PCM. Existing build rules works for full release build but they fail for patch releases as they do not have biglib/arch/SimDataFormatsValidationFormats_xr_rdict.pcm .  New build rules make sure that if biglib/Simulation pluginis locally built then it also have the correct PCM