### PR TITLE
[BuildRules] disbaled UBSAN flags for Boost Serialization source files

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-55
+%define configtag       V05-08-56
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-56
+%define configtag       V05-08-57
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
See https://github.com/cms-sw/cmssw/issues/26669
New Build rules will not pass UBSAN flags to when SCRAM compiles Serialization.cc