### PR TITLE
use openblas instead of gslcblas

### DIFF
--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -10,12 +10,12 @@ Source: https://github.com/xianyi/OpenBLAS/archive/v%{realversion}.tar.gz
 
 # PRESCOTT is a generic x86-64 target https://github.com/xianyi/OpenBLAS/issues/685 
 %ifarch x86_64
-make FC=gfortran BINARY=64 TARGET=PENRYN NUM_THREADS=256 DYNAMIC_ARCH=0
+make FC=gfortran BINARY=64 TARGET=PENRYN NUM_THREADS=256 DYNAMIC_ARCH=1
 %else
 %ifarch aarch64
-make FC=gfortran BINARY=64 TARGET=ARMV8 NUM_THREADS=256 DYNAMIC_ARCH=0
+make FC=gfortran BINARY=64 TARGET=ARMV8 NUM_THREADS=256 DYNAMIC_ARCH=1
 %else
-make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=0
+make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=1
 %endif # aarch64
 %endif # x86_64
 

--- a/geneva.spec
+++ b/geneva.spec
@@ -4,7 +4,7 @@ Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{real
 
 BuildRequires: cmake gmake
 
-Requires: python py2-setuptools py2-numpy gsl boost lhapdf hepmc pythia8
+Requires: python py2-setuptools py2-numpy gsl OpenBLAS lhapdf hepmc pythia8
 %ifnarch ppc64le
 Requires: openloops
 %endif
@@ -18,18 +18,16 @@ Requires: openloops
 export OPENLOOPS_FLAG="-Dopenloops_ROOT=${OPENLOOPS_ROOT}"
 %endif
 
-rm -rf ../build
-mkdir ../build
-cd ../build
+export LDFLAGS="-L${OPENBLAS_ROOT}/lib -lopenblas"
+sed -i -e 's|OPTIONAL_COMPONENTS  *gslcblas||' cmake/configure-packages.cmake
+rm -rf ../build; mkdir ../build; cd ../build
 cmake ../%{n}-%{realversion} \
       -DCMAKE_INSTALL_PREFIX=%{i} \
       -DCMAKE_CXX_STANDARD=11 \
       -Dgsl_ROOT=${GSL_ROOT} \
-      -Dboost_ROOT=${BOOST_ROOT} \
       -Dlhapdf_ROOT=${LHAPDF_ROOT} \
       -Dhepmc_ROOT=${HEPMC_ROOT} \
-      -Dpythia8_ROOT=${PYTHIA8_ROOT} \
-      ${OPENLOOPS_FLAG}
+      -Dpythia8_ROOT=${PYTHIA8_ROOT} ${OPENLOOPS_FLAG}
 
 make %{makeprocesses}
 make beamfunc-install-data LHAPDF_DATA_PATH=${LHAPDF_ROOT}/share/LHAPDF
@@ -37,5 +35,4 @@ make beamfunc-install-data LHAPDF_DATA_PATH=${LHAPDF_ROOT}/share/LHAPDF
 %install
 cd ../build
 make install
-cd %{i}/bin
-sed -i '/#!/c\#!/usr/bin/env python' *
+sed -i '/#!/c\#!/usr/bin/env python' %{i}/bin/*

--- a/gsl-toolfile.spec
+++ b/gsl-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external gsl-toolfile 1.0
+### RPM external gsl-toolfile 2.0
 Requires: gsl
 %prep
 
@@ -11,13 +11,13 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gsl.xml
 <tool name="gsl" version="@TOOL_VERSION@">
   <info url="http://www.gnu.org/software/gsl/gsl.html"/>
   <lib name="gsl"/>
-  <lib name="gslcblas"/>
   <client>
     <environment name="GSL_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$GSL_BASE/lib"/>
     <environment name="INCLUDE" default="$GSL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <use name="OpenBLAS"/>
   <use name="root_cxxdefaults"/>
 </tool>
 EOF_TOOLFILE

--- a/gsl.spec
+++ b/gsl.spec
@@ -1,5 +1,7 @@
 ### RPM external gsl 2.2.1
+## INITENV SET GSL_CBLAS_LIB -L${OPENBLAS_ROOT}/lib -lopenblas
 Source: ftp://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
+Requires: OpenBLAS
 
 %define keep_archives true
 

--- a/herwigpp.spec
+++ b/herwigpp.spec
@@ -6,7 +6,7 @@ Requires: boost
 Requires: hepmc
 Requires: yoda 
 Requires: thepeg
-Requires: gsl 
+Requires: gsl OpenBLAS
 Requires: fastjet
 Requires: gosamcontrib gosam
 Requires: madgraph5amcatnlo
@@ -32,6 +32,7 @@ CXX="$(which g++) -fPIC"
 CC="$(which gcc) -fPIC"
 PLATF_CONF_OPTS="--enable-shared --disable-static"
 
+sed -i -e "s|-lgslcblas|-lopenblas|" ./configure
 ./configure --prefix=%i \
             --with-thepeg=$THEPEG_ROOT \
             --with-fastjet=$FASTJET_ROOT \
@@ -48,7 +49,7 @@ PLATF_CONF_OPTS="--enable-shared --disable-static"
             FCFLAGS="-fno-range-check" \
 %endif
             $PLATF_CONF_OPTS \
-            CXX="$CXX" CC="$CC"
+            CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib"
 make %makeprocesses all
 
 %install

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -6,7 +6,7 @@
 Source: http://www.hepforge.org/archive/thepeg/ThePEG-%{realversion}.tar.bz2
 
 Requires: lhapdf
-Requires: gsl
+Requires: gsl OpenBLAS
 Requires: hepmc
 Requires: zlib
 Requires: fastjet
@@ -42,6 +42,7 @@ curl -L -k -s -o ./Config/config.sub 'http://git.savannah.gnu.org/gitweb/?p=conf
 curl -L -k -s -o ./Config/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
 chmod +x ./Config/config.{sub,guess}
 
+sed -i -e "s|-lgslcblas|-lopenblas|" ./configure
 ./configure $PLATF_CONF_OPTS \
             --with-lhapdf=$LHAPDF_ROOT \
             --with-boost=$BOOST_ROOT \
@@ -52,9 +53,7 @@ chmod +x ./Config/config.{sub,guess}
             --with-rivet=$RIVET_ROOT \
             --without-javagui \
             --prefix=%{i} \
-            --disable-readline CXX="$CXX" CC="$CC"  
-
-
+            --disable-readline CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib"
 
 make %{makeprocesses}
 
@@ -73,6 +72,3 @@ find %{i}/lib -name '*.la' -exec rm -f {} \;
 
 cd $RPM_INSTALL_PREFIX/%{pkgrel}/lib/ThePEG/
 ln -s LesHouches.so libLesHouches.so
-cd -
-
-


### PR DESCRIPTION
- Build OpenBlas with `DYNAMIC_ARCH=1`
- Drop `gslcblas` library from gsl toolfile and add `openblas` dependency to make sure that any cmssw package using gsl links `openblas` instead of  `gslcblas`
- set GSL_CBLAS_LIB so that gsl-config properly return `-lopenblas` instead of `-lgslcblas`
- Fixed `geneva`, `thepeg` and `herwigpp` specs to link against `openblas`