### PR TITLE
Update CMSMonitoring version to 0.2.1

### DIFF
--- a/cmsmonitoring.spec
+++ b/cmsmonitoring.spec
@@ -1,4 +1,4 @@
-### RPM external cmsmonitoring 0.1.7
+### RPM external cmsmonitoring 0.2.1
 ## IMPORT build-with-pip
 
 Requires: python py2-stomp py2-jsonschema py2-genson


### PR DESCRIPTION
This is needed in order to build WMCore/WMAgent RPMs with the correct RPM version (otherwise it picks 0.1.7).
@vkuznet please review whether that's the correct version to build. Thanks