### PR TITLE
[ROOT 618] Get freetype from externals, move it to 2.10.0

### DIFF
--- a/freetype-toolfile.spec
+++ b/freetype-toolfile.spec
@@ -15,7 +15,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/freetype.xml
     <environment name="INCLUDE"      default="$FREETYPE_BASE/include"/>
     <environment name="LIBDIR"       default="$FREETYPE_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$FREETYPE_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/freetype.spec
+++ b/freetype.spec
@@ -1,4 +1,4 @@
-### RPM external freetype 2.5.3
+### RPM external freetype 2.10.0
 Source: http://download.savannah.gnu.org/releases/freetype/freetype-%{realversion}.tar.bz2
 Requires: bz2lib zlib libpng
 

--- a/root.spec
+++ b/root.spec
@@ -12,14 +12,10 @@ Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 
-Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python fftw3 xz xrootd libxml2 openssl zlib davix tbb OpenBLAS py2-numpy lz4
+Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python fftw3 xz xrootd libxml2 openssl zlib davix tbb OpenBLAS py2-numpy lz4 freetype
 
 %if %islinux
 Requires: dcap
-%endif
-
-%if %isdarwin
-Requires: freetype
 %endif
 
 %define soext so


### PR DESCRIPTION
Remove OSX only requirement and move to new version

