### PR TITLE
Add onnxruntime

### DIFF
--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.10.2
+### RPM external cmake 3.14.5
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -97,6 +97,7 @@ Requires: graphviz-toolfile
 Requires: valgrind-toolfile
 Requires: cmsswdata-toolfile
 Requires: zstd-toolfile
+Requires: onnxruntime-toolfile
 
 Requires: hdf5-toolfile
 Requires: rivet-toolfile

--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -1,0 +1,21 @@
+### RPM external onnxruntime-toolfile 0.4.0
+Requires: onnxruntime
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
+<tool name="onnxruntime" version="@TOOL_VERSION@">
+  <lib name="onnxruntime"/>
+  <client>
+    <environment name="ONNXRUNTIME_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$ONNXRUNTIME_BASE/include"/>
+    <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib64"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external onnxruntime-toolfile 0.4.0
+### RPM external onnxruntime-toolfile 1.0
 Requires: onnxruntime
 %prep
 
@@ -15,6 +15,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
     <environment name="INCLUDE" default="$ONNXRUNTIME_BASE/include"/>
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib64"/>
   </client>
+  <use name="eigen"/>
+  <use name="protobuf"/>
 </tool>
 EOF_TOOLFILE
 

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -13,6 +13,7 @@ BuildRequires: cmake ninja zlib python3
 rm -rf ../build; mkdir ../build; cd ../build
 
 cmake ../%{n}-%{realversion}/cmake -GNinja \
+   -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3 \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="%{i}" \
    -Donnxruntime_BUILD_SHARED_LIB=ON \

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -4,7 +4,7 @@
 %define github_user microsoft
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/v%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
-BuildRequires: cmake ninja
+BuildRequires: cmake ninja zlib python3
 
 %prep
 %setup -n %{n}-%{realversion}

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,10 +1,11 @@
-### RPM external onnxruntime 0.4.0
-%define tag %{realversion}
-%define branch master
-%define github_user microsoft
-Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/v%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
+### RPM external onnxruntime 0.5.0
+%define tag 2a8b02097514ca90ac7471054460dcdc47b69e1b
+%define branch cms/v%{realversion}
+%define github_user cms-externals
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja zlib python3
+Requires: eigen protobuf
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -34,13 +35,16 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -Donnxruntime_USE_EIGEN_THREADPOOL=OFF \
    -Donnxruntime_USE_TENSORRT=OFF \
    -Donnxruntime_CROSS_COMPILING=OFF \
-   -Donnxruntime_USE_FULL_PROTOBUF=OFF \
+   -Donnxruntime_USE_FULL_PROTOBUF=ON \
    -Donnxruntime_DISABLE_CONTRIB_OPS=OFF \
-   -Donnxruntime_BUILD_UNIT_TESTS=OFF
+   -Donnxruntime_BUILD_UNIT_TESTS=OFF \
+   -Donnxruntime_USE_PREINSTALLED_EIGEN=ON \
+   -Deigen_SOURCE_PATH=$EIGEN_ROOT/include/eigen3 \
+   -Donnxruntime_USE_PREINSTALLED_PROTOBUF=ON \
+   -Dprotobuf_INSTALL_PATH=${PROTOBUF_ROOT}
 
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 
 %install
 cd ../build
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
-

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,18 +1,18 @@
 ### RPM external onnxruntime 0.4.0
-Source: https://github.com/microsoft/onnxruntime/archive/v%{realversion}.tar.gz
+%define tag %{realversion}
+%define branch master
+%define github_user microsoft
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/v%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
-BuildRequires: cmake ninja git
+BuildRequires: cmake ninja
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
-cd ../ ; rm -rf %{n}-%{realversion}
-git clone https://github.com/microsoft/%{n}.git %{n}-%{realversion} ; cd %{n}-%{realversion} ; git checkout v%{realversion}
-git submodule update --recursive --init
-mkdir build ; cd build
+rm -rf ../build; mkdir ../build; cd ../build
 
-cmake -GNinja \
+cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="%{i}" \
    -Donnxruntime_BUILD_SHARED_LIB=ON \
@@ -35,12 +35,11 @@ cmake -GNinja \
    -Donnxruntime_CROSS_COMPILING=OFF \
    -Donnxruntime_USE_FULL_PROTOBUF=OFF \
    -Donnxruntime_DISABLE_CONTRIB_OPS=OFF \
-   -Donnxruntime_BUILD_UNIT_TESTS=OFF \
-   ../cmake
+   -Donnxruntime_BUILD_UNIT_TESTS=OFF
 
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 
 %install
-cd build
+cd ../build
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
 

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,0 +1,46 @@
+### RPM external onnxruntime 0.4.0
+Source: https://github.com/microsoft/onnxruntime/archive/v%{realversion}.tar.gz
+
+BuildRequires: cmake ninja git
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+cd ../ ; rm -rf %{n}-%{realversion}
+git clone https://github.com/microsoft/%{n}.git %{n}-%{realversion} ; cd %{n}-%{realversion} ; git checkout v%{realversion}
+git submodule update --recursive --init
+mkdir build ; cd build
+
+cmake -GNinja \
+   -DCMAKE_BUILD_TYPE=Release \
+   -DCMAKE_INSTALL_PREFIX="%{i}" \
+   -Donnxruntime_BUILD_SHARED_LIB=ON \
+   -Donnxruntime_USE_CUDA=OFF \
+   -Donnxruntime_USE_NSYNC=OFF \
+   -Donnxruntime_BUILD_CSHARP=OFF \
+   -Donnxruntime_USE_EIGEN_FOR_BLAS=ON \
+   -Donnxruntime_USE_OPENBLAS=OFF \
+   -Donnxruntime_USE_MKLDNN=OFF \
+   -Donnxruntime_USE_MKLML=OFF \
+   -Donnxruntime_USE_NGRAPH=OFF \
+   -Donnxruntime_USE_OPENMP=OFF \
+   -Donnxruntime_USE_TVM=OFF \
+   -Donnxruntime_USE_LLVM=OFF \
+   -Donnxruntime_ENABLE_MICROSOFT_INTERNAL=OFF \
+   -Donnxruntime_USE_BRAINSLICE=OFF \
+   -Donnxruntime_USE_NUPHAR=OFF \
+   -Donnxruntime_USE_EIGEN_THREADPOOL=OFF \
+   -Donnxruntime_USE_TENSORRT=OFF \
+   -Donnxruntime_CROSS_COMPILING=OFF \
+   -Donnxruntime_USE_FULL_PROTOBUF=OFF \
+   -Donnxruntime_DISABLE_CONTRIB_OPS=OFF \
+   -Donnxruntime_BUILD_UNIT_TESTS=OFF \
+   ../cmake
+
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
+
+%install
+cd build
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
+


### PR DESCRIPTION
As discussed in https://github.com/cms-sw/cmssw/issues/27458.

@davidlange6 This builds only the C API -- but the python package might also be helpful if analyzers want to run some ML inference in their python-based analyses. 