### PR TITLE
fix igprof:properly use cmake to find unwind and pcre instead of copying their headers in igprof

### DIFF
--- a/igprof.spec
+++ b/igprof.spec
@@ -5,18 +5,22 @@
 %define git_commit 4235186fd1a9b9adb86a8a45bb7a8ece74953039
 Source0: git://github.com/%{git_user}/igprof.git?obj=%{git_branch}/%{git_commit}&export=igprof-%{git_commit}&output=/igprof-%{git_commit}.tgz
 
-Requires: pcre
-BuildRequires: cmake libunwind libatomic_ops
+Requires: pcre libunwind
+BuildRequires: cmake libatomic_ops
 %prep
 %setup -T -b 0 -n igprof-%{git_commit}
 
 %build
 mkdir -p %i
-rsync -av $LIBUNWIND_ROOT/ %i/
-rsync -av $LIBATOMIC_OPS_ROOT/ %i/
-cmake -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE -DPCRE_INCLUDE_DIR=$PCRE_ROOT/include -DPCRE_LIBRARY=$PCRE_ROOT/lib/libpcre.so -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-I%i/include -I$PCRE_ROOT/include -g -O3" .
+rm -rf ../build; mkdir ../build; cd ../build
+
+cmake ../igprof-%{git_commit} \
+   -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+   -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3" \
+   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$PCRE_ROOT;$LIBATOMIC_OPS_ROOT"
 make %makeprocesses
 
 %install
+cd ../build
 make %makeprocesses install
 %define drop_files %i/share/man


### PR DESCRIPTION
- igprof failed to build when `--reference /local/repo` option is used e.g. this is used during PR tests. This PR make use of cmake to find unwind headers and libraries instead of copying them in the igprof
- libunwind is needed at runtime too so make it a `Require` instead of `BuildRequire`