### PR TITLE
updated libunwind to 1.3.1 and drop libatomic_ops deps

### DIFF
--- a/igprof.spec
+++ b/igprof.spec
@@ -6,7 +6,7 @@
 Source0: git://github.com/%{git_user}/igprof.git?obj=%{git_branch}/%{git_commit}&export=igprof-%{git_commit}&output=/igprof-%{git_commit}.tgz
 
 Requires: pcre libunwind
-BuildRequires: cmake libatomic_ops
+BuildRequires: cmake
 %prep
 %setup -T -b 0 -n igprof-%{git_commit}
 
@@ -17,7 +17,7 @@ rm -rf ../build; mkdir ../build; cd ../build
 cmake ../igprof-%{git_commit} \
    -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE \
    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3" \
-   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$PCRE_ROOT;$LIBATOMIC_OPS_ROOT"
+   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$PCRE_ROOT"
 make %makeprocesses
 
 %install

--- a/libunwind-fix-comma.patch
+++ b/libunwind-fix-comma.patch
@@ -1,5 +1,5 @@
 diff --git a/include/libunwind-aarch64.h b/include/libunwind-aarch64.h
-index fe9e83d..271fc31 100644
+index 85812e1..18e47d6 100644
 --- a/include/libunwind-aarch64.h
 +++ b/include/libunwind-aarch64.h
 @@ -154,7 +154,7 @@ typedef enum
@@ -11,6 +11,19 @@ index fe9e83d..271fc31 100644
  
    }
  aarch64_regnum_t;
+diff --git a/include/libunwind-common.h.in b/include/libunwind-common.h.in
+index 8d96ddc..6cc2bb6 100644
+--- a/include/libunwind-common.h.in
++++ b/include/libunwind-common.h.in
+@@ -88,7 +88,7 @@ unw_caching_policy_t;
+ 
+ typedef enum
+   {
+-    UNW_INIT_SIGNAL_FRAME = 1,          /* We know this is a signal frame */
++    UNW_INIT_SIGNAL_FRAME = 1          /* We know this is a signal frame */
+   }
+ unw_init_local2_flags_t;
+ 
 diff --git a/include/libunwind-dynamic.h b/include/libunwind-dynamic.h
 index edb0bbd..c902ccd 100644
 --- a/include/libunwind-dynamic.h

--- a/libunwind.spec
+++ b/libunwind.spec
@@ -1,9 +1,8 @@
-### RPM external libunwind 1.2.1
-%define tag a77b0cd7bd14c27ff7c18463f432599ce9469c75
-%define branch v1.2-stable
+### RPM external libunwind 1.3.1
+%define tag 94aa304960927c130ecb5f664a642b32d9850688
+%define branch v1.3-stable
 Source0: git://github.com/%{n}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
-Requires: libatomic_ops
-BuildRequires: autotools
+BuildRequires: autotools gmake
 
 Patch0: libunwind-fix-comma
 
@@ -13,7 +12,7 @@ Patch0: libunwind-fix-comma
 
 %build
 autoreconf -fiv
-./configure CFLAGS="-g -O3" CPPFLAGS="-I${LIBATOMIC_OPS_ROOT}/include" --prefix=%{i} --disable-block-signals
+./configure CFLAGS="-g -O3" --prefix=%{i} --disable-block-signals
 make %{makeprocesses}
 
 %install


### PR DESCRIPTION
- Updated libunwind to version 1.3.1
- Drop linatomic_ops: https://github.com/libunwind/libunwind/blob/master/NEWS#L71
```
** Dont link against libatomic_ops for now.  Due to a packaging bug on
   Debian, linking against this library causes libunwind.so to get
   a dependency on libatomic_ops.so, which is not at all what we want.
   Fortunately, we don't have to link against that library on x86 or
   ia64 since the library is strictly needed only for platforms with
   poor atomic operation support.  Once the libatomic_ops package is fixed,
   we can re-enable linking against libatomic_ops.
```