### PR TITLE
Update RecoTauTag-TrainingFiles to V00-01-01 as master

### DIFF
--- a/data-RecoTauTag-TrainingFiles.spec
+++ b/data-RecoTauTag-TrainingFiles.spec
@@ -1,4 +1,4 @@
-### RPM cms data-RecoTauTag-TrainingFiles V00-01-00
+### RPM cms data-RecoTauTag-TrainingFiles V00-01-01
 
 %prep
 


### PR DESCRIPTION
Update of RecoTauTag-TrainingFiles to V00-01-01 to integrate https://github.com/cms-data/RecoTauTag-TrainingFiles/pull/3 in support of the integration in 10_2_X of cms-sw/cmssw#27148

