### PR TITLE
added libunwind-toolfile

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -156,6 +156,7 @@ Requires: python_tools
 Requires: dasgoclient
 Requires: OpenBLAS-toolfile
 Requires: mxnet-predict-toolfile
+Requires: libunwind-toolfile
 
 # Only for Linux platform.
 %if %islinux

--- a/libunwind-toolfile.spec
+++ b/libunwind-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external libunwind-toolfile 1.0
+Requires: libunwind
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/libunwind.xml
+<tool name="libunwind" version="@TOOL_VERSION@">
+  <lib name="unwind"/>
+  <client>
+    <environment name="LIBUNWIND_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$LIBUNWIND_BASE/include"/>
+    <environment name="LIBDIR"       default="$LIBUNWIND_BASE/lib"/>
+  </client>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <use name="root_cxxdefaults"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post


### PR DESCRIPTION
libunwind tool file was missing and we were picking up libunwind.so from igprof. https://github.com/cms-sw/cmsdist/pull/5085 had fixed the igprof spec to not copy libunwind but it broke igprof 
```
cmsRun: error while loading shared libraries: libunwind.so.8: cannot open shared object file: No such file or directory
```
