### PR TITLE
cleanup build rules

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-60
+%define configtag       V05-08-61
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- drop obsolete capabilities support
- drop root's non-pcm based build support. cmssw based on root6 always build with PCMs