### PR TITLE
Remove --deep. It has no meaning for ROOT6.

### DIFF
--- a/root-toolfile.spec
+++ b/root-toolfile.spec
@@ -253,7 +253,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/rootrflx.xml
   </client>
   <flags GENREFLEX_GCCXMLOPT="@GENREFLEX_GCCXMLOPT@"/>
   <flags GENREFLEX_CPPFLAGS="-DCMS_DICT_IMPL -D_REENTRANT -DGNUSOURCE -D__STRICT_ANSI__"/>
-  <flags GENREFLEX_ARGS="--deep"/>
   <runtime name="GENREFLEX" value="$ROOTRFLX_BASE/bin/genreflex"/>
   <use name="root_interface"/>
   <use name="rootcling"/>


### PR DESCRIPTION
Follows cms-sw/cmssw-config#70