### PR TITLE
enables sized-deallocation for llvm

### DIFF
--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -64,6 +64,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags CXXFLAGS="-Wno-unknown-warning-option"/>
     <flags CXXFLAGS="-ftemplate-depth=512"/>
     <flags CXXFLAGS="-Wno-error=potentially-evaluated-expression"/>
+    <flags CXXFLAGS="-fsized-deallocation"/>
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LLVM_CXXCOMPILER_BASE/lib64" type="path"/>
     <runtime name="PATH" value="$LLVM_CXXCOMPILER_BASE/bin" type="path"/>
   </tool>


### PR DESCRIPTION
`-fsized-deallocation` is enabled by default by GCC under -std=c++14 and above. PyBind11 version 2.3.0 makes use of this ( https://github.com/pybind/pybind11/blob/v2.3/include/pybind11/pybind11.h#L1006) but as clang does not enable sized-deallocation`  by default so CMSSW CLANG builds are failing. 
```
In file included from FWCore/PyDevParameterSet/interface/Python11ParameterSet.h:3:
  py2-pybind11/2.3.0/include/python2.7/pybind11/pybind11.h:1009:9: error: no matching function for call to 'operator delete'
         ::operator delete(p, s, std::align_val_t(a));
        ^~~~~~~~~~~~~~~~~
```
This PR suggest to enable sized-deallocation for clang too