### PR TITLE
[BuildRules] Use c++ to generate precompiled headers

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-63
+%define configtag       V05-08-65
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This should fix CommonTools/Utils  unit tests which are failing in CLANG IBs. Reason of failure is that PCH are generated using clang++ while the unit tests are using c++. This PR updates the build rules to always use c++ for generating PCH.