### PR TITLE
Add mkFit as an external

### DIFF
--- a/mkfit-toolfile.spec
+++ b/mkfit-toolfile.spec
@@ -1,0 +1,24 @@
+### RPM external mkfit-toolfile 2.0.0
+Requires: mkfit
+
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/mkfit.xml
+<tool name="mkfit" version="@TOOL_VERSION@">
+  <lib name="MicCore"/>
+  <lib name="MkFit"/>
+  <client>
+    <environment name="MKFITBASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$MKFITBASE/include"/>
+    <environment name="LIBDIR" default="$MKFITBASE/lib"/>
+  </client>
+  <runtime name="MKFIT_BASE" value="$MKFITBASE"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -10,7 +10,7 @@ Requires: tbb
 %setup -q -n %{n}-%{realversion}
 
 %build
-TBB_PREFIX=$TBB_ROOT make
+make TBB_PREFIX=$TBB_ROOT VEC_GCC="-march=core2"
 
 %install
 mkdir %{i}/include %{i}/include/mkFit %{i}/Geoms

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,0 +1,20 @@
+### RPM external mkfit 2.0.0
+%define tag V2.0.0-1+pr237
+%define branch devel
+%define github_user trackreco
+
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Requires: tbb
+
+%prep
+%setup -q -n %{n}-%{realversion}
+
+%build
+TBB_PREFIX=$TBB_ROOT make
+
+%install
+mkdir %{i}/include %{i}/include/mkFit %{i}/Geoms
+cp -a *.h %{i}/include
+cp -a mkFit/*.h %{i}/include/mkFit
+cp -a Geoms/*.so %{i}/Geoms
+cp -ar lib %{i}/lib


### PR DESCRIPTION
This PR adds the [mkFit](http://trackreco.github.io/) as an external package (the CMSSW side will follow).

Pardon my ignorance, but will the contents of a PR to `gcc700` propagate automatically to other compiler branches?

@slava77 