### PR TITLE
[FWLITE] Added py2-six deps for fwlite

### DIFF
--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -48,6 +48,7 @@ Requires: davix-toolfile
 Requires: py2-numpy-toolfile
 Requires: OpenBLAS-toolfile
 Requires: py2-pybind11-toolfile
+Requires: fwlite_python_tools
 
 %if %isamd64
 %if %isslc

--- a/fwlite_python_tools.spec
+++ b/fwlite_python_tools.spec
@@ -1,0 +1,21 @@
+### RPM external fwlite_python_tools 1.0
+## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
+## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
+Source: none
+ 
+%define isslc7 %(case %{cmsplatf} in (slc7_amd64*) echo 1 ;; (*) echo 0 ;; esac)
+%define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
+Requires: py2-six
+Requires: py2-scipy
+Requires: py2-numpy
+
+%prep
+
+%build
+
+%install
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/python_tools.xml
+<tool name="%{n}" version="%{v}">
+</tool>
+EOF_TOOLFILE


### PR DESCRIPTION
FWLite builds are failing due to missing `six` python package. This PR include the needed python packages for fwlite releases.