### PR TITLE
Add mkfit to cmssw-tool-conf

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -160,6 +160,7 @@ Requires: python_tools
 Requires: dasgoclient
 Requires: OpenBLAS-toolfile
 Requires: mxnet-predict-toolfile
+Requires: mkfit-toolfile
 
 # Only for Linux platform.
 %if %islinux


### PR DESCRIPTION
Apparently #5150 was not sufficient, but `mkfit-toolfile` needs to be added to `cmssw-tool-conf`. Is anything else needed to get the external usable from CMSSW?

@slava77 