### PR TITLE
[BuildRule] improve clang-tidy rule

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-65
+%define configtag       V05-08-66
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
New build rule only run clang-tidy for files for which compilation commands are able.