### PR TITLE
[MKFIT] patch mkfit to build on aarch64/ppc64

### DIFF
--- a/mkfit-2.0.0-non-x86_64-fix.patch
+++ b/mkfit-2.0.0-non-x86_64-fix.patch
@@ -1,4 +1,4 @@
-diff --git a/mkFit/immintrin.h b/mkFit/immintrin.h
+diff --git a/immintrin.h b/immintrin.h
 new file mode 100644
 index 0000000..363d136
 --- /dev/null

--- a/mkfit-2.0.0-non-x86_64-fix.patch
+++ b/mkfit-2.0.0-non-x86_64-fix.patch
@@ -1,0 +1,10 @@
+diff --git a/mkFit/immintrin.h b/mkFit/immintrin.h
+new file mode 100644
+index 0000000..363d136
+--- /dev/null
++++ b/immintrin.h
+@@ -0,0 +1,4 @@
++#include <stdlib.h>
++#define _mm_malloc(a, b) aligned_alloc(b, a)
++#define _mm_free(p) free(p)
++#define _mm_prefetch(a,b)  __builtin_prefetch(a)

--- a/mkfit-toolfile.spec
+++ b/mkfit-toolfile.spec
@@ -17,6 +17,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/mkfit.xml
     <environment name="INCLUDE" default="$MKFITBASE/include"/>
     <environment name="LIBDIR" default="$MKFITBASE/lib"/>
   </client>
+  <use name="tbb"/>
   <runtime name="MKFIT_BASE" value="$MKFITBASE"/>
 </tool>
 EOF_TOOLFILE

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -5,12 +5,29 @@
 
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Requires: tbb
+BuildRequires: gmake
+Patch0: mkfit-2.0.0-non-x86_64-fix
 
 %prep
 %setup -q -n %{n}-%{realversion}
 
+%ifnarch x86_64
+%patch0 -p1
+%endif
+
+sed -i -e 's|-std=c++14|-std=c++1z|' Makefile.config
+
 %build
-make TBB_PREFIX=$TBB_ROOT VEC_GCC="-march=core2"
+%ifarch x86_64
+BUILD_ARGS=VEC_GCC="-march=core2"
+%endif
+%ifarch aarch64
+BUILD_ARGS=VEC_GCC="-march=native"
+%endif
+%ifarch ppc64le
+BUILD_ARGS=VEC_GCC="-mcpu=native"
+%endif
+make %{makeprocesses} TBB_PREFIX=$TBB_ROOT ${BUILD_ARGS}
 
 %install
 mkdir %{i}/include %{i}/include/mkFit %{i}/Geoms


### PR DESCRIPTION
- Build with -sdt=c++1z
- use `allign_alloc` and `__buildin_prefetch` on non-x86_64 arch 
- set the correct VEC_GCC 