### PR TITLE
Bump DQMGUI to 9.3.7

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.3.6
+### RPM cms dqmgui 9.3.7
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
This version should make DQMGUI able to understand some old links again.

The problem was reported recently by @mmusich affecting old links to plots with references such as this: https://goo.gl/u1rO51 .


