### PR TITLE
Bump DQMGUI version to 9.3.8

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.3.7
+### RPM cms dqmgui 9.3.8
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
This is the second version of the fix for broken links with references that where created before labeled references where introduced.

Fix for the fix in #5181.