### PR TITLE
[10.6.X] updating sherpa 2.2.6 to bugfix release sherpa 2.2.7

### DIFF
--- a/openloops.spec
+++ b/openloops.spec
@@ -1,15 +1,17 @@
-### RPM external openloops 2.0.0
-%define tag df5dc23c322dd460c4f8f3cdfa331bb190c647f6
-%define branch cms/v%{realversion}
-%define github_user cms-externals
-Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+### RPM external openloops 2.1.0
+#%define tag df5dc23c322dd460c4f8f3cdfa331bb190c647f6
+#%define branch cms/v%{realversion}
+#%define github_user cms-externals
+#Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: https://openloops.hepforge.org/downloads/OpenLoops-2.1.0.tar.gz
 
 BuildRequires: python scons
 
 %define keep_archives true
 
 %prep
-%setup -n %{n}-%{realversion}
+%setup -n OpenLoops-%{realversion}
+#%setup -n %{n}-%{realversion}
 
 %build
 cat << \EOF >> openloops.cfg

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -2,7 +2,7 @@
 %define tag 600078cc741021be898f15563235cf6c809ca5ff
 %define branch cms/v%realversion
 %define github_user cms-externals
-Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.7.tar.gz
+Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-%{realversion}.tar.gz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl scons python openmpi
 BuildRequires: mcfm swig
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,8 +1,8 @@
-### RPM external sherpa 2.2.6
-%define tag 600078cc741021be898f15563235cf6c809ca5ff
-%define branch cms/v%realversion
-%define github_user cms-externals
-Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.6.tar.gz
+### RPM external sherpa 2.2.7
+#%define tag 600078cc741021be898f15563235cf6c809ca5ff
+#%define branch cms/v%realversion
+#%define github_user cms-externals
+Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.7.tar.gz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl scons python openmpi
 BuildRequires: mcfm swig
 
@@ -10,13 +10,13 @@ BuildRequires: mcfm swig
 %define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
 
 %if %islinux
-%ifnarch ppc64le
+%if %isamd64
 Requires: openloops
-%endif # is not ppc64
-%endif # is linux
+%endif # isamd64
+%endif # islinux
 
 %prep
-%setup -q -n SHERPA-MC-%{realversion}
+%setup -q -n SHERPA-MC-2.2.7
 
 autoreconf -i --force
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,7 +1,7 @@
 ### RPM external sherpa 2.2.7
-#%define tag 600078cc741021be898f15563235cf6c809ca5ff
-#%define branch cms/v%realversion
-#%define github_user cms-externals
+%define tag 600078cc741021be898f15563235cf6c809ca5ff
+%define branch cms/v%realversion
+%define github_user cms-externals
 Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.7.tar.gz
 Requires: hepmc lhapdf blackhat sqlite fastjet openssl scons python openmpi
 BuildRequires: mcfm swig
@@ -10,13 +10,13 @@ BuildRequires: mcfm swig
 %define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
 
 %if %islinux
-%if %isamd64
+%ifnarch ppc64le
 Requires: openloops
-%endif # isamd64
+%endif # is not ppc64
 %endif # islinux
 
 %prep
-%setup -q -n SHERPA-MC-2.2.7
+%setup -q -n SHERPA-MC-%{realversion}
 
 autoreconf -i --force
 


### PR DESCRIPTION
As aforementioned [1], sherpa 2.2.7 is the bugfix release.

Attempted on 106X

[1] https://gitlab.com/sherpa-team/sherpa/-/tags/v2.2.7
