### PR TITLE
Update CUDA to version 10.1 update 2 (10.1.243), on x86_64

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -83,6 +83,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cusolver.xml
   <info url="https://docs.nvidia.com/cuda/cusolver/index.html"/>
   <use name="cuda"/>
   <lib name="cusolver"/>
+  <lib name="cusolverMg"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
  * CUDA version 10.1 update 2 (10.1.243)
    Support for clang 8.0 (from update 1) .
    Support for RHEL 8 / CentOS 8.
    Include new multi-GPU symmetric eigensolver library cusolverMg.
    Various fxes to CUDA libraries and NVCC compiler.

  * NVIDIA drivers version 418.87.00 .

See https://docs.nvidia.com/cuda/archive/10.1/cuda-toolkit-release-notes/index.html#title-u2-new-features .