### PR TITLE
Update CUDA to version 10.0.326, on aarch64 (ARMv8 64)

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -58,6 +58,9 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cublas.xml
   <info url="https://docs.nvidia.com/cuda/cublas/index.html"/>
   <use name="cuda"/>
   <lib name="cublas"/>
+%ifarch x86_64
+  <lib name="cublasLt"/>
+%endif
 </tool>
 EOF_TOOLFILE
 
@@ -83,7 +86,9 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cusolver.xml
   <info url="https://docs.nvidia.com/cuda/cusolver/index.html"/>
   <use name="cuda"/>
   <lib name="cusolver"/>
+%ifarch x86_64
   <lib name="cusolverMg"/>
+%endif
 </tool>
 EOF_TOOLFILE
 
@@ -130,6 +135,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvml.xml
 </tool>
 EOF_TOOLFILE
 
+%ifarch x86_64
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvjpeg.xml
 <tool name="cuda-nvjpeg" version="@TOOL_VERSION@">
   <info url="https://docs.nvidia.com/cuda/nvjpeg/index.html"/>
@@ -137,6 +143,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvjpeg.xml
   <lib name="nvjpeg"/>
 </tool>
 EOF_TOOLFILE
+%endif
 
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvrtc.xml
 <tool name="cuda-nvrtc" version="@TOOL_VERSION@">

--- a/cuda.spec
+++ b/cuda.spec
@@ -10,9 +10,9 @@
 %define systemsversion 2019.3.7.5
 %endif
 %ifarch aarch64
-%define fullversion 10.0.166
+%define fullversion 10.0.326
 %define cudaversion %(echo %realversion | cut -d. -f 1,2)
-%define driversversion 32.1.0
+%define driversversion 32.2.0
 %define cudasoversion 1.1
 %define nsightarch linux-v4l_l4t-glx-t210-a64
 %define computeversion 1.0


### PR DESCRIPTION
For aarch64 (ARMv8 64), update to JetPack 4.2.1:
  * Linux for Tegra L4T R32.2
  * CUDA version 10.0.326 for ARMv8

See the release notes at https://docs.nvidia.com/jetson/jetpack/release-notes/index.html .