### PR TITLE
cppunit updated to 1.15.x; patch it for defaulted-function-deleted warnings

### DIFF
--- a/cppunit-1.14-defaulted-function-deleted.patch
+++ b/cppunit-1.14-defaulted-function-deleted.patch
@@ -1,0 +1,13 @@
+diff --git a/include/cppunit/extensions/TestSuiteBuilderContext.h b/include/cppunit/extensions/TestSuiteBuilderContext.h
+index 12d157e..ad1a34f 100644
+--- a/include/cppunit/extensions/TestSuiteBuilderContext.h
++++ b/include/cppunit/extensions/TestSuiteBuilderContext.h
+@@ -42,8 +42,6 @@ public:
+ 
+   TestSuiteBuilderContextBase(TestSuiteBuilderContextBase const &) = default;
+   TestSuiteBuilderContextBase(TestSuiteBuilderContextBase &&) = default;
+-  TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase const &) = default;
+-  TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase &&) = default;
+ 
+   /*! \brief Adds a test to the fixture suite.
+    *

--- a/cppunit.spec
+++ b/cppunit.spec
@@ -1,9 +1,16 @@
-### RPM external cppunit 1.40.1
-Source: git://anongit.freedesktop.org/git/libreoffice/%{n}.git?=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+### RPM external cppunit 1.15.x
+%define tag    78e64f0edb4f3271a6ddbcdf9cba05138597bfca
+%define branch master
+%define github_user git/libreoffice
+Source: git+https://anongit.freedesktop.org/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+
+#Source: git://anongit.freedesktop.org/git/libreoffice/%{n}.git?=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake autotools
+Patch1: cppunit-1.14-defaulted-function-deleted
 
 %prep
-%setup -n %n-%realversion
+%setup -n %{n}-%{realversion}
+%patch1 -p1
 
 %build
 # Update to detect aarch64 and ppc64le


### PR DESCRIPTION
- Updated cppunit to latest development
- patch it to avoid defaulted-function-deleted warning in CLANG IBs
```
  In file included from cppunit/1.40.1-pafccj/include/cppunit/extensions/HelperMacros.h:15:
  cppunit/1.40.1-pafccj/include/cppunit/extensions/TestSuiteBuilderContext.h:45:33: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase const &) = default;
                                ^
external/cppunit/1.40.1-pafccj/include/cppunit/extensions/TestSuiteBuilderContext.h:106:14: note: copy assignment operator of 'TestSuiteBuilderContextBase' is implicitly deleted because field 'm_suite' is of reference type 'CppUnit::TestSuite &'
  TestSuite &m_suite;
             ^
  cppunit/1.40.1-pafccj/include/cppunit/extensions/TestSuiteBuilderContext.h:46:33: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase &&) = default;
                                ^
cppunit/1.40.1-pafccj/include/cppunit/extensions/TestSuiteBuilderContext.h:106:14: note: move assignment operator of 'TestSuiteBuilderContextBase' is implicitly deleted because field 'm_suite' is of reference type 'CppUnit::TestSuite &'
  TestSuite &m_suite;
```