### PR TITLE
Update mkFit to 2.0.1

### DIFF
--- a/mkfit-toolfile.spec
+++ b/mkfit-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external mkfit-toolfile 2.0.1
+### RPM external mkfit-toolfile 2.0.0
 Requires: mkfit
 
 %prep

--- a/mkfit-toolfile.spec
+++ b/mkfit-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external mkfit-toolfile 2.0.0
+### RPM external mkfit-toolfile 2.0.1
 Requires: mkfit
 
 %prep

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,5 +1,5 @@
-### RPM external mkfit 2.0.0
-%define tag V2.0.0-1+pr237
+### RPM external mkfit 2.0.1
+%define tag V2.0.1-0+pr241
 %define branch devel
 %define github_user trackreco
 


### PR DESCRIPTION
This PR updates mkFit to 2.0.1, which itself is a code-wise small update to have the same version whose performance will be presented on TRK POG meeting next Monday (Sep 9).

FYI @slava77 @mtosi @JanFSchulte 