### PR TITLE
[OpenLoops][ARM64] build loop with -Os optimization

### DIFF
--- a/openloops.spec
+++ b/openloops.spec
@@ -18,7 +18,7 @@ fortran_compiler = gfortran
 gfortran_f90_flags = -ffixed-line-length-0 -ffree-line-length-0
 generic_optimisation = -O2
 born_optimisation = -O2
-loop_optimisation = -O0
+loop_optimisation = -Os
 link_optimisation = -O2
 EOF
 export SCONSFLAGS="-j %{compiling_processes}"


### PR DESCRIPTION
Openloops failed[a] to build on ARM64. Looks like we had such issue in past https://sourceware.org/bugzilla/show_bug.cgi?id=18668 
May be size of openloops v2.1.0 is again causing this issue. For now we try to use `-Os` optimization

```
process_obj/ppaajjj/virtual_225_ppaajjj_ddxaaggg_1.os: In function `__ol_vamp_225_ppaajjj_ddxaaggg_1_dp_MOD_vamp_225':
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x170): relocation truncated to fit: R_AARCH64_CALL26 against symbol `malloc@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x244): relocation truncated to fit: R_AARCH64_CALL26 against symbol `memcpy@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x2b4): relocation truncated to fit: R_AARCH64_CALL26 against symbol `memcpy@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x310): relocation truncated to fit: R_AARCH64_CALL26 against symbol `malloc@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x35c): relocation truncated to fit: R_AARCH64_CALL26 against symbol `memcpy@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x3c4): relocation truncated to fit: R_AARCH64_CALL26 against symbol `malloc@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x410): relocation truncated to fit: R_AARCH64_CALL26 against symbol `memcpy@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x44c): relocation truncated to fit: R_AARCH64_CALL26 against symbol `__ol_merging_dp_MOD_ol_merge_tensors' defined in .text section in lib/libopenloops.so
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x4ac): relocation truncated to fit: R_AARCH64_CALL26 against symbol `free@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
virtual_225_ppaajjj_ddxaaggg_1.f90:(.text+0x4e8): relocation truncated to fit: R_AARCH64_CALL26 against symbol `free@@GLIBC_2.17' defined in .text section in /lib64/libc.so.6
```