### PR TITLE
use -msse3 in mkfit.spec to match gcc-toolfile.spec

### DIFF
--- a/mkfit.spec
+++ b/mkfit.spec
@@ -19,7 +19,7 @@ sed -i -e 's|-std=c++14|-std=c++1z|' Makefile.config
 
 %build
 %ifarch x86_64
-BUILD_ARGS=VEC_GCC="-march=core2"
+BUILD_ARGS=VEC_GCC="-msse3"
 %endif
 %ifarch aarch64
 BUILD_ARGS=VEC_GCC="-march=native"


### PR DESCRIPTION
This is a followup to tests and discussion in https://github.com/cms-sw/cmssw/pull/27895#issuecomment-530019102

@makortel @osschar
