### PR TITLE
Bump rucio client to 1.20.5; update rucio testbed url

### DIFF
--- a/py2-bcrypt.spec
+++ b/py2-bcrypt.spec
@@ -1,0 +1,3 @@
+### RPM external py2-bcrypt 3.1.7
+## IMPORT build-with-pip
+Requires: py2-cffi py2-six

--- a/py2-boto3.spec
+++ b/py2-boto3.spec
@@ -1,0 +1,3 @@
+### RPM external py2-boto3 1.9.229
+## IMPORT build-with-pip
+Requires: py2-botocore py2-jmespath py2-s3transfer 

--- a/py2-botocore.spec
+++ b/py2-botocore.spec
@@ -1,0 +1,3 @@
+### RPM external py2-botocore 1.12.229
+## IMPORT build-with-pip
+Requires: py2-jmespath py2-docutils py2-python-dateutil py2-urllib3

--- a/py2-jmespath.spec
+++ b/py2-jmespath.spec
@@ -1,0 +1,4 @@
+### RPM external py2-jmespath 0.9.4
+## IMPORT build-with-pip
+
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py2-paramiko.spec
+++ b/py2-paramiko.spec
@@ -1,0 +1,3 @@
+### RPM external py2-paramiko 2.6.0
+## IMPORT build-with-pip
+Requires: py2-bcrypt py2-cryptography py2-pynacl 

--- a/py2-pynacl.spec
+++ b/py2-pynacl.spec
@@ -1,0 +1,4 @@
+### RPM external py2-pynacl 1.3.0
+## IMPORT build-with-pip
+Requires: py2-six py2-cffi
+%define pip_name PyNaCl

--- a/py2-pysftp.spec
+++ b/py2-pysftp.spec
@@ -1,0 +1,3 @@
+### RPM external py2-pysftp 0.2.9
+## IMPORT build-with-pip
+Requires: py2-paramiko

--- a/py2-rucio-clients.spec
+++ b/py2-rucio-clients.spec
@@ -1,10 +1,11 @@
-### RPM external py2-rucio-clients 1.19.3
+### RPM external py2-rucio-clients 1.20.5
 ## IMPORT build-with-pip
 ## INITENV SET RUCIO_HOME %i/
 
 Source1: rucio-config
 Requires: py2-argcomplete py2-requests py2-urllib3 py2-dogpile-cache py2-nose py2-boto
 Requires: py2-tabulate py2-progressbar2 py2-bz2file py2-python-magic py2-six py2-futures
+Requires: py2-boto3 py2-pysftp
 
 # setup a CMS rucio configuration standard file
 %define PipPreBuild mkdir -p %i/etc/; cp -f %_sourcedir/rucio-config %i/etc/rucio.cfg

--- a/py2-s3transfer.spec
+++ b/py2-s3transfer.spec
@@ -1,0 +1,3 @@
+### RPM external py2-s3transfer 0.2.1
+## IMPORT build-with-pip
+Requires: py2-botocore py2-futures

--- a/rucio-config.file
+++ b/rucio-config.file
@@ -11,7 +11,7 @@
 [common]
 [client]
 rucio_host = http://cms-rucio-testbed.cern.ch
-auth_host = https://cms-rucio-tb-authz.cern.ch
+auth_host = https://cms-rucio-auth-testbed.cern.ch
 auth_type = x509
 ca_cert = /etc/grid-security/certificates/
 client_cert = $X509_USER_CERT


### PR DESCRIPTION
Hoping this client release is stable (it's supposed to be, given that it's a patch release...)
And bring a whole new set of dependencies in (libraries for AWS interaction, cryptography, and other stuff)