### PR TITLE
[PIP] force install pip packages even if there are already installed

### DIFF
--- a/build-with-pip.file
+++ b/build-with-pip.file
@@ -111,7 +111,7 @@ if [ $(cat files.list | wc -l) -eq 1 ] ; then
    %if "%{doPython3}" == "yes"
       pip3 list --disable-pip-version-check
       %{?PipPreBuildPy3:%PipPreBuildPy3}
-      pip3 install --no-cache-dir --disable-pip-version-check --user -v %{PipInstallOptions} %{PipBuildOptions} %{?PipBuildOptionsPy3:%PipBuildOptionsPy3} $PIPFILE
+      pip3 install  --no-cache-dir --disable-pip-version-check --user -v %{PipInstallOptions} %{PipBuildOptions} %{?PipBuildOptionsPy3:%PipBuildOptionsPy3} $PIPFILE
       PKG_NAME=$(pip3 show %{pip_name} --disable-pip-version-check | grep '^Name:' | sed 's|^Name: *||;s| ||g')
       DEPS=$(pip3 check --disable-pip-version-check | grep "^${PKG_NAME}  *%{realversion}  *requires " | sed 's|,.*||;s|.* |py2-|' | tr '\n' ' ')
       if [ "$DEPS" != "" ] ; then
@@ -124,7 +124,7 @@ if [ $(cat files.list | wc -l) -eq 1 ] ; then
    %if "%{doPython2}" == "yes"
       pip2 list  --disable-pip-version-check
       %{?PipPreBuildPy2:%PipPreBuildPy2}
-      pip2 install --no-cache-dir --disable-pip-version-check --user -v %{PipInstallOptions} %{PipBuildOptions} %{?PipBuildOptionsPy2:%PipBuildOptionsPy2}  $PIPFILE
+      pip2 install  --no-cache-dir --disable-pip-version-check --user -v %{PipInstallOptions} %{PipBuildOptions} %{?PipBuildOptionsPy2:%PipBuildOptionsPy2}  $PIPFILE
       PKG_NAME=$(pip2 show %{pip_name} --disable-pip-version-check | grep '^Name:' | sed 's|^Name: *||;s| ||g')
       DEPS=$(pip2 check --disable-pip-version-check | grep "^${PKG_NAME}  *%{realversion}  *requires " | sed 's|,.*||;s|.* |py2-|' | tr '\n' ' ')
       if [ "$DEPS" != "" ] ; then

--- a/py2-matplotlib.spec
+++ b/py2-matplotlib.spec
@@ -33,8 +33,8 @@ export MPLCONFIGDIR=$PWD/no-pkg-config
 PATH=$PWD/no-pkg-config:$PATH \
 export CPLUS_INCLUDE_PATH=${FREETYPE_ROOT}/include/freetype2:${LIBPNG_ROOT}/include/libpng16
 export PYTHONUSERBASE=%i
-pip install . --user
-pip3 install . --user
+pip  install   --no-cache-dir --disable-pip-version-check --no-deps --no-clean -v . --user
+pip3 install   --no-cache-dir --disable-pip-version-check --no-deps --no-clean -v . --user
 
 #python setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null
 

--- a/py2-numpy.spec
+++ b/py2-numpy.spec
@@ -45,8 +45,8 @@ EOF
 mkdir -p %i/${PYTHON_LIB_SITE_PACKAGES}
 
 export PYTHONUSERBASE=%i
-pip2 install . --user 
-pip3 install . --user
+pip2 install   --no-cache-dir --disable-pip-version-check --no-deps --no-clean -v . --user
+pip3 install   --no-cache-dir --disable-pip-version-check --no-deps --no-clean -v . --user
 %{relocatePy3SitePackages}
 %{relocatePy2SitePackages}
 perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py2-tensorflow.spec
+++ b/py2-tensorflow.spec
@@ -20,9 +20,9 @@ Requires: py2-funcsigs py2-protobuf py2-pbr py2-six py2-packaging py2-appdirs py
 mkdir -p %{i}
 export PYTHONUSERBASE=%i
 pip list
-pip install --user -v ${TENSORFLOW_SOURCES_ROOT}/tensorflow-%{realversion}-%{tensor_build}.whl
+pip install   --no-cache-dir --disable-pip-version-check --no-deps --no-clean --user -v ${TENSORFLOW_SOURCES_ROOT}/tensorflow-%{realversion}-%{tensor_build}.whl
 pip3 list
-pip3 install --user -v ${TENSORFLOW_PYTHON3_SOURCES_ROOT}/tensorflow-%{realversion}-%{tensor_python3_build}.whl
+pip3 install   --no-cache-dir --disable-pip-version-check --no-deps --no-clean --user -v ${TENSORFLOW_PYTHON3_SOURCES_ROOT}/tensorflow-%{realversion}-%{tensor_python3_build}.whl
 %{relocatePy3SitePackages}
 %{relocatePy2SitePackages}
 


### PR DESCRIPTION
CMS docker container has some pip packages already installed [a] which causes some of these packages to be picked up from system instead of building and distributing them in cmssw env. This change should force build/install these packages.

[a]
```
bash-4.2$ pip list
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Package                      Version
---------------------------- -------
backports.ssl-match-hostname 3.5.0.1
chardet                      2.2.1
iniparse                     0.4
ipaddress                    1.0.16
javapackages                 1.0.0
kerberos                     1.1
kitchen                      1.1.1
lxml                         3.2.1
pip                          19.2.1
pycurl                       7.19.0
pygobject                    3.22.0
pygpgme                      0.3
pyliblzma                    0.5.3
pyparsing                    1.5.6
python-dateutil              1.5
pyxattr                      0.5.1
requests                     2.6.0
requests-kerberos            0.7.0
setuptools                   0.9.8
six                          1.9.0
urlgrabber                   3.10
urllib3                      1.10.2
yum-metadata-parser          1.1.4
```