### PR TITLE
Update ONNXRuntime to a custom version

### DIFF
--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -17,6 +17,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
   </client>
   <use name="eigen"/>
   <use name="protobuf"/>
+  <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
 </tool>
 EOF_TOOLFILE
 

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,8 +1,7 @@
-### RPM external onnxruntime 0.5.0.mod-from-9f633c5b
-%define tag 04f3c766dc4b0cba097ac48af9c8771beb37f3d8
-%define branch cms/v%{realversion}
-#%define github_user cms-externals
-%define github_user hqucms
+### RPM external onnxruntime 0.5.0
+%define tag 2824909ae569932d9aee1462049ff0da1e766989
+%define branch cms/master/9f633c5b
+%define github_user cms-externals
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja zlib python3

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,11 +1,13 @@
-### RPM external onnxruntime 0.5.0
-%define tag 2a8b02097514ca90ac7471054460dcdc47b69e1b
+### RPM external onnxruntime 0.5.0.mod-from-9f633c5b
+%define tag 04f3c766dc4b0cba097ac48af9c8771beb37f3d8
 %define branch cms/v%{realversion}
-%define github_user cms-externals
+#%define github_user cms-externals
+%define github_user hqucms
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja zlib python3
 Requires: eigen protobuf
+
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -21,6 +23,7 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -Donnxruntime_USE_CUDA=OFF \
    -Donnxruntime_USE_NSYNC=OFF \
    -Donnxruntime_BUILD_CSHARP=OFF \
+   -Donnxruntime_USE_AUTOML=OFF \
    -Donnxruntime_USE_EIGEN_FOR_BLAS=ON \
    -Donnxruntime_USE_OPENBLAS=OFF \
    -Donnxruntime_USE_MKLDNN=OFF \


### PR DESCRIPTION
Based on the master branch of the official repo @ https://github.com/microsoft/onnxruntime/tree/9f633c5bd9ecccdb0d02e0088d516d67a9dab7cb.

Changes on top of that:
 - Remove the hard-coded thread pool in LSTM: https://github.com/hqucms/onnxruntime/commit/04f3c766dc4b0cba097ac48af9c8771beb37f3d8
 - Control MLAS runtime kernel selection w/ an environment variable `MLAS_DYNAMIC_CPU_ARCH`: https://github.com/hqucms/onnxruntime/commit/7222aeadaa2731f858e18b555e23e464a6363645. We set `MLAS_DYNAMIC_CPU_ARCH=0` in the CMS build so it does not attempt to use AVX (or more advanced) instructions.
 - Propagate the cmake change from @smuzaffar to use pre-installed protobuf. 