### PR TITLE
move back to pylint 1.9.5

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -181,7 +181,7 @@ pydot==1.4.1
 pyflakes==2.1.1
 Pygments==2.4.2
 pylint==1.9.5 ; python_version<'3.0'
-pylint==2.4.2 ; python_version>'3.0'
+pylint==1.9.5 ; python_version>'3.0'
 pylint==1.9.5 ; python_version>'3.0' ; platform_machine=='aarch64'
 pymongo==3.9.0
 pyOpenSSL==19.0.0


### PR DESCRIPTION
need to check why it is failing on aarch64