### PR TITLE
[PYLint] fixed encoding issue with pylint 2.4.2

### DIFF
--- a/pip/py3-pylint.file
+++ b/pip/py3-pylint.file
@@ -1,2 +1,2 @@
+Patch0: pylint-2.4.2-encoding
 Requires: py3-astroid
-%define PipPreBuild export LC_ALL=C

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -182,7 +182,6 @@ pyflakes==2.1.1
 Pygments==2.4.2
 pylint==1.9.5 ; python_version<'3.0'
 pylint==2.4.2 ; python_version>'3.0'
-pylint==1.9.5 ; python_version>'3.0' ; platform_machine=='aarch64'
 pymongo==3.9.0
 pyOpenSSL==19.0.0
 pyparsing==2.4.2

--- a/pylint-2.4.2-encoding.patch
+++ b/pylint-2.4.2-encoding.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 4d16b79..107b72f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -56,7 +56,7 @@ extras_require = __pkginfo__.get("extras_require", {})
+ 
+ readme_path = join(base_dir, "README.rst")
+ if exists(readme_path):
+-    with open(readme_path) as stream:
++    with open(readme_path, encoding='utf8', errors='ignore') as stream:
+         long_description = stream.read()
+ else:
+     long_description = ""


### PR DESCRIPTION
pylint 2.4.2 failed to build for python3 due to encding issues [a]. We patch it to avoid ignore special characters in README.rst file.

[a]
```
      File "/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/pip-2z0c36hw-build/setup.py", line 60, in <module>
        long_description = stream.read()
      File "/build/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/python3/3.6.4-pafccj/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 4020: ordinal not in range(128)
```