### PR TITLE
Add data-SimPPS-PPSPixelDigiProducer to cmsswdata.spec

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -62,6 +62,7 @@ Requires: data-RecoCTPPS-TotemRPLocal
 Requires: data-IOPool-Input
 Requires: data-RecoHGCal-TICL
 Requires: data-SimG4CMS-HGCalTestBeam
+Requires: data-SimPPS-PPSPixelDigiProducer
 
 %if %isnotonline
 # extra data dependencies for standard builds


### PR DESCRIPTION
The recent integration of #5262 has missed the update of cmsswdata.spec (it was the first addition, I believe that was the reason). As a result in CMSSW_11_0_X_2019-10-09-1100 there is no data file in ```$CMSSW_DATA_PATH/```. This PR is meant to fix this

@mundim FYI