### PR TITLE
Update to pyinit interface in HepMC to turn int into size_t for string length

### DIFF
--- a/HepMC-2.06.07-pyinit.patch
+++ b/HepMC-2.06.07-pyinit.patch
@@ -1,0 +1,11 @@
+--- HepMC-2.06.07.orig/HepMC/PythiaWrapper6_4.h	2019-10-11 16:52:08.917366436 +0200
++++ HepMC-2.06.07/HepMC/PythiaWrapper6_4.h	2019-10-11 17:04:01.614803379 +0200
+@@ -247,7 +247,7 @@
+ #define upevnt upevnt_
+     extern "C" {
+ 	void pyhepc(int*);
+-	void pyinit(const char*,const char*,const char*,double*,int,int,int);
++        void pyinit(const char*,const char*,const char*,double*,std::size_t,std::size_t,std::size_t);
+ 	void pylist(int*);
+ 	void pystat(int*);
+ 	void pyevnt();

--- a/hepmc.spec
+++ b/hepmc.spec
@@ -3,6 +3,7 @@ Source: http://lcgapp.cern.ch/project/simu/HepMC/download/HepMC-%realversion.tar
 Patch0: hepmc-2.03.06-reflex
 Patch1: hepmc-2.06.07-WeightContainer-fix-size_type
 Patch2: HepMC-2.06.07-nodoc
+Patch3: HepMC-2.06.07-pyinit
 
 Requires: autotools
 
@@ -14,6 +15,7 @@ Requires: autotools
 %patch0 -p0
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 
 F77="$(which gfortran) -fPIC"
 CXX="$(which g++) -fPIC"


### PR DESCRIPTION
This PR addresses the issue cms-sw/cmssw#28149 by @Dr15Jones .

The ```pyinit``` arguments in the pythia6 wrapper interface describing the length of a string are moved from ```int``` to ```std::size_t```. As we are using a very outdated version of HepMC, the simplest solution is to patch the original code.

The HepMC build works smoothly, to be tested with the CLANG CMSSW build.