### PR TITLE
include  py2-pycuda fir not ppc64

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -6,7 +6,7 @@
 
 BuildRequires: cmake ninja
 Requires: gcc zlib python python3
-%if %{isamd64}
+%ifnarch ppc64le
 Requires: cuda
 %endif
 AutoReq: no

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -216,9 +216,10 @@ Requires: py2-pylint
 Requires: py2-pytest-cov
 Requires: py2-wrapt
 
-%ifarch ppc64le
+%ifnarch ppc64le
 Requires: py2-pycuda
 %endif
+
 %prep
 
 %build

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -216,8 +216,9 @@ Requires: py2-pylint
 Requires: py2-pytest-cov
 Requires: py2-wrapt
 
+%ifarch ppc64le
 Requires: py2-pycuda
-
+%endif
 %prep
 
 %build


### PR DESCRIPTION
PowerPC Ibs are failing to due missing cuda. This PR include pycuda only for non ppc64le archs