### PR TITLE
Backport OpenBLAS fixes [10_2_X]

### DIFF
--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -10,12 +10,12 @@ Source: https://github.com/xianyi/OpenBLAS/archive/v%{realversion}.tar.gz
 
 # PRESCOTT is a generic x86-64 target https://github.com/xianyi/OpenBLAS/issues/685 
 %ifarch x86_64
-make FC=gfortran BINARY=64 TARGET=PENRYN NUM_THREADS=256 DYNAMIC_ARCH=0
+make FC=gfortran BINARY=64 TARGET=PENRYN NUM_THREADS=256 DYNAMIC_ARCH=1
 %else
 %ifarch aarch64
-make FC=gfortran BINARY=64 TARGET=ARMV8 NUM_THREADS=256 DYNAMIC_ARCH=0
+make FC=gfortran BINARY=64 TARGET=ARMV8 NUM_THREADS=256 DYNAMIC_ARCH=1
 %else
-make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=0
+make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=1
 %endif # aarch64
 %endif # x86_64
 

--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -10,12 +10,12 @@ Source: https://github.com/xianyi/OpenBLAS/archive/v%{realversion}.tar.gz
 
 # PRESCOTT is a generic x86-64 target https://github.com/xianyi/OpenBLAS/issues/685 
 %ifarch x86_64
-make FC=gfortran BINARY=64 TARGET=PENRYN NUM_THREADS=256 DYNAMIC_ARCH=1
+make FC=gfortran BINARY=64 TARGET=CORE2 NUM_THREADS=256 DYNAMIC_ARCH=0
 %else
 %ifarch aarch64
-make FC=gfortran BINARY=64 TARGET=ARMV8 NUM_THREADS=256 DYNAMIC_ARCH=1
+make FC=gfortran BINARY=64 TARGET=ARMV8 NUM_THREADS=256 DYNAMIC_ARCH=0
 %else
-make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=1
+make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=0
 %endif # aarch64
 %endif # x86_64
 

--- a/gsl-toolfile.spec
+++ b/gsl-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external gsl-toolfile 1.0
+### RPM external gsl-toolfile 2.0
 Requires: gsl
 %prep
 
@@ -11,13 +11,13 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gsl.xml
 <tool name="gsl" version="@TOOL_VERSION@">
   <info url="http://www.gnu.org/software/gsl/gsl.html"/>
   <lib name="gsl"/>
-  <lib name="gslcblas"/>
   <client>
     <environment name="GSL_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$GSL_BASE/lib"/>
     <environment name="INCLUDE" default="$GSL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <use name="OpenBLAS"/>
   <use name="root_cxxdefaults"/>
 </tool>
 EOF_TOOLFILE

--- a/gsl.spec
+++ b/gsl.spec
@@ -1,5 +1,7 @@
 ### RPM external gsl 2.2.1
+## INITENV SET GSL_CBLAS_LIB -L${OPENBLAS_ROOT}/lib -lopenblas
 Source: ftp://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
+Requires: OpenBLAS
 
 %define keep_archives true
 

--- a/herwigpp.spec
+++ b/herwigpp.spec
@@ -9,7 +9,7 @@ Requires: boost
 Requires: hepmc
 Requires: yoda 
 Requires: thepeg
-Requires: gsl 
+Requires: gsl OpenBLAS
 Requires: fastjet
 Requires: gosamcontrib gosam
 Requires: madgraph5amcatnlo
@@ -35,6 +35,7 @@ CXX="$(which g++) -fPIC"
 CC="$(which gcc) -fPIC"
 PLATF_CONF_OPTS="--enable-shared --disable-static"
 
+sed -i -e "s|-lgslcblas|-lopenblas|" ./configure
 ./configure --prefix=%i \
             --with-thepeg=$THEPEG_ROOT \
             --with-fastjet=$FASTJET_ROOT \
@@ -51,7 +52,7 @@ PLATF_CONF_OPTS="--enable-shared --disable-static"
             FCFLAGS="-fno-range-check" \
 %endif
             $PLATF_CONF_OPTS \
-            CXX="$CXX" CC="$CC"
+            CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib"
 make %makeprocesses all
 
 %install

--- a/rivet.spec
+++ b/rivet.spec
@@ -29,6 +29,9 @@ do
   chmod +x $CONFIG_SUB_FILE
 done
 
+# fix regex to handle case with two -L statements (from gsl w/ openblas)
+sed -i 's/\.\*-L\\s\*(\\S+)\.\*/-L(\\S+)/' pyext/setup.py.in
+
 ./configure --disable-silent-rules --prefix=%{i} --with-hepmc=${HEPMC_ROOT} \
             --with-fastjet=${FASTJET_ROOT} --with-gsl=$GSL_ROOT --with-yoda=${YODA_ROOT} \
             --disable-doxygen --disable-pdfmanual --with-pic \

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -6,7 +6,7 @@
 Source: http://www.hepforge.org/archive/thepeg/ThePEG-%{realversion}.tar.bz2
 
 Requires: lhapdf
-Requires: gsl
+Requires: gsl OpenBLAS
 Requires: hepmc
 Requires: zlib
 Requires: fastjet
@@ -41,6 +41,7 @@ curl -L -k -s -o ./Config/config.sub 'http://git.savannah.gnu.org/gitweb/?p=conf
 curl -L -k -s -o ./Config/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
 chmod +x ./Config/config.{sub,guess}
 
+sed -i -e "s|-lgslcblas|-lopenblas|" ./configure
 ./configure $PLATF_CONF_OPTS \
             --with-lhapdf=$LHAPDF_ROOT \
             --with-boost=$BOOST_ROOT \
@@ -51,9 +52,7 @@ chmod +x ./Config/config.{sub,guess}
             --with-rivet=$RIVET_ROOT \
             --without-javagui \
             --prefix=%{i} \
-            --disable-readline CXX="$CXX" CC="$CC"  
-
-
+            --disable-readline CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib"
 
 make %{makeprocesses}
 
@@ -72,6 +71,3 @@ find %{i}/lib -name '*.la' -exec rm -f {} \;
 
 cd $RPM_INSTALL_PREFIX/%{pkgrel}/lib/ThePEG/
 ln -s LesHouches.so libLesHouches.so
-cd -
-
-


### PR DESCRIPTION
This is a combined backport of #5063 and #5091. The goal is to propagate the DeepAK8 speedup to the current analysis release. (Since ultra legacy production in 10_6_X will not finish for quite a while, 10_2_X will continue to see active use by analyzers.)

attn: @hqucms @smuzaffar @slava77 

A question for @davidlange6: would we gain anything by also backporting the OpenBLAS version update from #4897?