### PR TITLE
add lzma and xz dependencies as their python interface is now in python3 itself

### DIFF
--- a/python3.spec
+++ b/python3.spec
@@ -25,7 +25,7 @@ export LIBFFI_ROOT
 # Python's configure parses LDFLAGS and CPPFLAGS to look for aditional library and include directories
 LDFLAGS=""
 CPPFLAGS=""
-for d in ${EXPAT_ROOT} ${BZ2LIB_ROOT} ${DB6_ROOT} ${GDBM_ROOT} ${OPENSSL_ROOT} ${LIBFFI_ROOT} ${ZLIB_ROOT} ${SQLITE_ROOT}; do
+for d in ${EXPAT_ROOT} ${BZ2LIB_ROOT} ${DB6_ROOT} ${GDBM_ROOT} ${OPENSSL_ROOT} ${LIBFFI_ROOT} ${ZLIB_ROOT} ${SQLITE_ROOT} ${XZ_ROOT}; do
   LDFLAGS="$LDFLAGS -L$d/lib -L$d/lib64"
   CPPFLAGS="$CPPFLAGS -I$d/include"
 done

--- a/python3.spec
+++ b/python3.spec
@@ -7,7 +7,7 @@
 %define pythonv %(echo %realversion | cut -d. -f 1,2)
 %define python_major %(echo %realversion | cut -d. -f 1)
 
-Requires: expat bz2lib db6 gdbm openssl libffi zlib sqlite
+Requires: expat bz2lib db6 gdbm openssl libffi zlib sqlite lzma xz
 
 Source: https://www.python.org/ftp/python/%realversion/Python-%realversion.tgz
 

--- a/python3.spec
+++ b/python3.spec
@@ -7,7 +7,7 @@
 %define pythonv %(echo %realversion | cut -d. -f 1,2)
 %define python_major %(echo %realversion | cut -d. -f 1)
 
-Requires: expat bz2lib db6 gdbm openssl libffi zlib sqlite lzma xz
+Requires: expat bz2lib db6 gdbm openssl libffi zlib sqlite xz
 
 Source: https://www.python.org/ftp/python/%realversion/Python-%realversion.tgz
 


### PR DESCRIPTION
should fix unit tests failure in PhysicsTools/PythonAnalysis (but I didn't check it)