### PR TITLE
rename pylint to pylint3 for python3

### DIFF
--- a/pip/pylint.file
+++ b/pip/pylint.file
@@ -1,2 +1,3 @@
 Requires: py2-astroid py2-six py2-isort py2-mccabe py2-configparser
 %define RelocatePython %{i}/bin/*
+%define PipPostBuildPy3 for x in $(ls %{i}/bin/*) ; do mv $x ${x}3; done


### PR DESCRIPTION
make sure that pylint from python and python3 have different name e.g. pylint and pylint3.