### PR TITLE
[CC8] Build Pycurl with OpenSSL backend

### DIFF
--- a/pip/pycurl.file
+++ b/pip/pycurl.file
@@ -1,2 +1,4 @@
 %define pip_name pycurl
+%define PipPreBuild export PYCURL_SSL_LIBRARY=openssl
+
 Requires: curl


### PR DESCRIPTION
This should fix mane unit tests in CC8 IBs which are failing with error
```
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/nweek-02600/cc8_amd64_gcc8/cms/cmssw/CMSSW_11_0_X_2019-10-29-2300/bin/cc8_amd64_gcc8/conddb", line 29, in &lt;module&gt;
    from CondCore.Utilities.tier0 import Tier0Handler, Tier0Error, tier0Url
  File "/cvmfs/cms-ib.cern.ch/nweek-02600/cc8_amd64_gcc8/cms/cmssw/CMSSW_11_0_X_2019-10-29-2300/python/CondCore/Utilities/tier0.py", line 12, in &lt;module&gt;
    import pycurl
ImportError: pycurl: libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (none/other)
return code is 65
```