### PR TITLE
Updates SCRAM to version SCRAMV1 V2_2_9_pre05

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_9_pre04
+### RPM lcg SCRAMV1 V2_2_9_pre05
 ## NOCOMPILER
 
 BuildRequires: gmake


### PR DESCRIPTION
New version allows to create a project area with in another project area ( e.g. when cmssw runs grid-packs) for different OS.