### PR TITLE
[OpenLoops-2.1.0]Topping up Vtt+jets and Htt+jets libraries processes

### DIFF
--- a/openloops.spec
+++ b/openloops.spec
@@ -24,6 +24,7 @@ EOF
 export SCONSFLAGS="-j %{compiling_processes}"
 ./openloops update --processes generator=0
 ./openloops libinstall lhc.coll
+./openloops libinstall ppatt,ppatt_ew,ppattj,pplltt,pplltt_ew,ppllttj,ppllttj_ew,pplntt,pplnttj,ppwtt,ppwtt_ew,ppwttj,ppwttj_ew,ppztt,ppztt_ew,ppzttj,pphtt,pphtt_ew,pphttj
 
 %install
 mkdir %i/{lib,proclib}


### PR DESCRIPTION
lhc.coll does not contain all P-P collision processes. Topping up Vtt+Jets and Htt+jets loop processes.