### PR TITLE
Update Bottleneck to version 1.3.0rc1

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -38,7 +38,7 @@ backports-os==0.1.1
 beautifulsoup4==4.8.1
 bleach==3.1.0
 bokeh==1.4.0
-Bottleneck==1.2.1
+Bottleneck==1.3.0rc1
 cachetools==3.1.1
 certifi==2019.9.11
 cffi==1.13.2


### PR DESCRIPTION
This should fix the bottleneck unit test for PY3 IBs
https://github.com/pydata/bottleneck/issues/266