### PR TITLE
[G4] Updated to version 10.06cand00 and its required datasets

### DIFF
--- a/geant4-G4EMLOW.spec
+++ b/geant4-G4EMLOW.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4EMLOW 7.7
+### RPM external geant4-G4EMLOW 7.9
 %define G4RunTime G4LEDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4NDL.spec
+++ b/geant4-G4NDL.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4NDL 4.5
+### RPM external geant4-G4NDL 4.6
 %define G4RunTime G4NEUTRONHPDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4PhotonEvaporation.spec
+++ b/geant4-G4PhotonEvaporation.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4PhotonEvaporation 5.3
+### RPM external geant4-G4PhotonEvaporation 5.4
 %define G4RunTime G4LEVELGAMMADATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4RadioactiveDecay.spec
+++ b/geant4-G4RadioactiveDecay.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4RadioactiveDecay 5.3
+### RPM external geant4-G4RadioactiveDecay 5.4
 %define G4RunTime G4RADIOACTIVEDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
-### RPM external geant4 10.05ref08
-%define tag 75b49238f83f0b1426124c52609dd8911d9f3ffd
+### RPM external geant4 10.06cand00
+%define tag 43b0c3184c0cc42865c8a3c9168e5817b47ed0e2
 %define branch cms/4.%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
As requested here https://github.com/cms-externals/geant4/issues/41 , this PR includes
- geant4: 10.06.cand00
- G4EMLOW: 7.9
- RadioactiveDecay: 5.4
- PhotonEvaporation: 5.4
- G4NDL: 4.6

FYI @civanch 