### PR TITLE
Update ONNX Runtime to v1.0.0

### DIFF
--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -15,7 +15,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
     <environment name="INCLUDE" default="$ONNXRUNTIME_BASE/include"/>
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib64"/>
   </client>
-  <use name="eigen"/>
   <use name="protobuf"/>
   <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
 </tool>

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,11 +1,12 @@
-### RPM external onnxruntime 0.5.0
-%define tag 2824909ae569932d9aee1462049ff0da1e766989
-%define branch cms/master/9f633c5b
-%define github_user cms-externals
+### RPM external onnxruntime 1.0.0
+%define tag 12f9ce57d0b9cb82611284a435020de9b39e1107
+%define branch cms/v1.0.0
+#%define github_user cms-externals
+%define github_user hqucms
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja zlib python3
-Requires: eigen protobuf
+Requires: protobuf
 
 
 %prep
@@ -40,8 +41,6 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -Donnxruntime_USE_FULL_PROTOBUF=ON \
    -Donnxruntime_DISABLE_CONTRIB_OPS=OFF \
    -Donnxruntime_BUILD_UNIT_TESTS=OFF \
-   -Donnxruntime_USE_PREINSTALLED_EIGEN=ON \
-   -Deigen_SOURCE_PATH=$EIGEN_ROOT/include/eigen3 \
    -Donnxruntime_USE_PREINSTALLED_PROTOBUF=ON \
    -Dprotobuf_INSTALL_PATH=${PROTOBUF_ROOT}
 

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,5 +1,5 @@
 ### RPM external onnxruntime 1.0.0
-%define tag dfec41d1371a7b1233d25db55561ce4021fc7ceb
+%define tag eb635bfb66dae6cf414abfd1eb94c93842f1e66e
 %define branch cms/v1.0.0
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,8 +1,7 @@
 ### RPM external onnxruntime 1.0.0
-%define tag 12f9ce57d0b9cb82611284a435020de9b39e1107
+%define tag dfec41d1371a7b1233d25db55561ce4021fc7ceb
 %define branch cms/v1.0.0
-#%define github_user cms-externals
-%define github_user hqucms
+%define github_user cms-externals
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja zlib python3


### PR DESCRIPTION
Based on the [v1.0.0 release](https://github.com/microsoft/onnxruntime/releases/tag/v1.0.0), plus the modification in https://github.com/cms-sw/cmsdist/pull/5259.

v1.0.0 is not compatible with the eigen version we have -- given that eigen is a header-only library without any binaries, there is no runtime dependency on eigen, I think it should be fine to let ONNX Runtime use a different version (shipped as a git submodule). 

@smuzaffar Could you please create a new branch in https://github.com/cms-externals/onnxruntime/?