### PR TITLE
[BuildRules] Fix SimDataFormatsValidationFormats_xr_rdict issue

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-69
+%define configtag       V05-08-72
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Fix SimDataFormatsValidationFormats_xr_rdict issue
- copy only scripts with execution permission in to bin directory