### PR TITLE
update cms-common and cmssw-osenv

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1203
+## REVISION 1204
 ## NOCOMPILER
 
-%define tag 9e258c4a2ee83eec18e35e3eae190350d15ff983
+%define tag c9de2de0531eaa36246c630c2b20bd1d0471e3c7
 
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 

--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,9 +1,9 @@
-### RPM cms cmssw-osenv 191120.0
+### RPM cms cmssw-osenv 191121.0
 ## NOCOMPILER
 
 # ***Do not change minor number of the above version. ***
 
-%define commit 770ffef0c116e4d97c8d40bbddb4a20eaf1ae3d8
+%define commit 5a0d707f6bdfc9966a0ac32f00125e6862eb63fc
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.


### PR DESCRIPTION
cms-common: https://github.com/cms-sw/cms-common/commit/c9de2de0531eaa36246c630c2b20bd1d0471e3c7
  - clean cmsos unused defaultCompiler section
  - updated default compiler to match the latest release archs

cmssw-osenv: https://github.com/cms-sw/cmssw-osenv/commit/5a0d707f6bdfc9966a0ac32f00125e6862eb63fc
  - added cmssw-env script to run any unpacked image
  - Improved the logic o properly set SCRM_ARCH for new env