### PR TITLE
[Vincia] Updates to version 2.3.02 which addresses compiler warnings

### DIFF
--- a/vincia.spec
+++ b/vincia.spec
@@ -1,4 +1,4 @@
-### RPM external vincia 2.3.01
+### RPM external vincia 2.3.02
 
 Requires: pythia8
 


### PR DESCRIPTION
We have many warnings in cmssw which are coming from vincia. The new version 2.3.02 addresses these warnings.

[a]
```
  vincia/2.3.01/include/Pythia8/VinciaCommon.h:183:7: warning: 'class Pythia8::TFunctor' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TFunctor {
       ^~~~~~~~
  vincia/2.3.01/include/Pythia8/VinciaCommon.h:188:7: warning: base class 'class Pythia8::TFunctor' has accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TXiFunctor : public TFunctor {
       ^~~~~~~~~~
  vincia/2.3.01/include/Pythia8/VinciaCommon.h:188:7: warning: 'class Pythia8::TXiFunctor' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
   vincia/2.3.01/include/Pythia8/VinciaCommon.h:199:7: warning: base class 'class Pythia8::TFunctor' has accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TPtrFunctor : public TFunctor {
       ^~~~~~~~~~~
  vincia/2.3.01/include/Pythia8/VinciaCommon.h:199:7: warning: 'class Pythia8::TPtrFunctor' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
 In file included from vincia/2.3.01/include/Pythia8/VinciaFSR.h:15,
                 from vincia/2.3.01/include/Pythia8/Vincia.h:25,
                 from GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc:14:
  vincia/2.3.01/include/Pythia8/VinciaISR.h:36:7: warning: 'class Pythia8::TrialGeneratorISR' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TrialGeneratorISR {
       ^~~~~~~~~~~~~~~~~
  vincia/2.3.01/include/Pythia8/VinciaISR.h:163:7: warning: base class 'class Pythia8::TrialGeneratorISR' has accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TrialIISoft : public TrialGeneratorISR {

```