### PR TITLE
[CXXMODULE] Build rules updated

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-09-17
+%define configtag       V05-09-18
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Set CLING_MODULEMAP_PATH environment variable to point to either one of the following
  - $CMSSW_BASE/tmp/$SCRAM_ARCH/cxxmodules
  - $CMSSW_BASE/include/$SCRAM_ARCH/cxxmodules
  - $CMSSW_RELEASE_BASE/include/$SCRAM_ARCH/cxxmodules

- Pass module.modulemap file path via -moduleMapFile command-line option to rootcling