### PR TITLE
Update CXXModules.mk.file

### DIFF
--- a/CXXModules.mk.file
+++ b/CXXModules.mk.file
@@ -77,7 +77,9 @@ DataFormatsL1CaloTrigger_CXXMODULES:=1
 DataFormatsL1DTTrackFinder_CXXMODULES:=1
 DataFormatsL1GlobalCaloTrigger_CXXMODULES:=1
 DataFormatsL1GlobalMuonTrigger_CXXMODULES:=1
-DataFormatsL1GlobalTrigger_CXXMODULES:=1
+#DL this creates and error that we do not currently understand 
+#I will disable this module for now.
+DataFormatsL1GlobalTrigger_CXXMODULES:=0
 DataFormatsL1Trigger_CXXMODULES:=1
 DataFormatsLTCDigi_CXXMODULES:=1
 DataFormatsMath_CXXMODULES:=1


### PR DESCRIPTION
turn off module for DataFormats/L1GlobalTrigger. This appears to fix the build error in today's IB. I'm not sure why I didn't see this locally last week.. 