### PR TITLE
use -mlong-double-64 to avoid link error on ppc64le

### DIFF
--- a/fftjet.spec
+++ b/fftjet.spec
@@ -24,7 +24,11 @@ chmod +x ./config.{sub,guess}
 touch pkg-config ; chmod +x pkg-config
 ./configure $PLATF_CONF_OPTS --disable-dependency-tracking --enable-threads \
             --prefix=%i F77="$F77" CXX="$CXX" DEPS_CFLAGS=-I$FFTW3_ROOT/include \
+%ifarch ppc64le
             CXXFLAGS="-O2 -mlong-double-64" \
+%else
+            CXXFLAGS="-O2" \
+%endif
             DEPS_LIBS="-L$FFTW3_ROOT/lib -lfftw3" PKG_CONFIG=$PWD/pkg-config
 make %makeprocesses
 

--- a/fftjet.spec
+++ b/fftjet.spec
@@ -14,8 +14,8 @@ CXX="$(which g++) -fPIC"
 
 # Update to detect aarch64 and ppc64le
 rm -f ./config.{sub,guess}
-curl -L -k -s -o ./config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
-curl -L -k -s -o ./config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+curl -L -k -s -o ./config.sub http://cmsrep.cern.ch/cmssw/download/config/config.sub
+curl -L -k -s -o ./config.guess http://cmsrep.cern.ch/cmssw/download/config/config.guess
 chmod +x ./config.{sub,guess}
 
 # Fake the existance of pkg-config on systems which dont have it.
@@ -24,6 +24,7 @@ chmod +x ./config.{sub,guess}
 touch pkg-config ; chmod +x pkg-config
 ./configure $PLATF_CONF_OPTS --disable-dependency-tracking --enable-threads \
             --prefix=%i F77="$F77" CXX="$CXX" DEPS_CFLAGS=-I$FFTW3_ROOT/include \
+            CXXFLAGS="-O2 -mlong-double-64" \
             DEPS_LIBS="-L$FFTW3_ROOT/lib -lfftw3" PKG_CONFIG=$PWD/pkg-config
 make %makeprocesses
 


### PR DESCRIPTION
For `ppc64le`, we use  `-mlong-double-64` ( https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_11_1_X/master/gcc-toolfile.spec#L191 ) to compile cmssw. `fftjet` also uses long double but with 128 bits. That causes link error for `ppc64le` IBs [a]

By default fftjey is build in debug mode (`-g -O2`), we explicitly set CXXFLAGS to `-O2` to avoid debug build.

[a]

```
ld: RecoJets/FFTJetAlgorithms/src/EtaDependentPileup.cc.o uses 64-bit long double, libfftjet.a(libfftjet_la-LinearInterpolator2d.o) uses 128-bit long double
ld: failed to merge target specific data of file libfftjet.a(libfftjet_la-LinearInterpolator2d.o)
```