### PR TITLE
[LLVM] Add C++11 attribute [[cms::sa_allow]]

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -11,7 +11,7 @@ Requires: cuda
 %endif
 AutoReq: no
 
-%define llvmCommit 27c041cfa5e06380fbdfc971172581c07778a1c4
+%define llvmCommit a73e620a17c0734e33d1e0137765688833713ce8
 %define llvmBranch cms/release/8.x/635f8ff
 %define iwyuCommit 4d2bbcc0d98faccfc51d15c6f6a573ec78d7751d
 %define iwyuBranch master


### PR DESCRIPTION
As requested https://github.com/cms-externals/llvm-project/pull/3. This is needed by cms-sw/cmssw#28554 but can be merge independently