### PR TITLE
Revert to CUDA 10.1 Update 1 (10.1.168), add support for Power

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -169,13 +169,13 @@ Requires: codechecker-toolfile
 Requires: gcc-checker-plugin-toolfile
 Requires: openldap-toolfile
 Requires: gperftools-toolfile
+Requires: cuda-toolfile
+Requires: cub-toolfile
+Requires: cuda-api-wrappers-toolfile
 
 %if %isnotppc64le_be
 Requires: libunwind-toolfile
 Requires: igprof-toolfile
-Requires: cuda-toolfile
-Requires: cub-toolfile
-Requires: cuda-api-wrappers-toolfile
 Requires: openloops-toolfile
 %endif
 

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -86,9 +86,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cusolver.xml
   <info url="https://docs.nvidia.com/cuda/cusolver/index.html"/>
   <use name="cuda"/>
   <lib name="cusolver"/>
-%ifarch x86_64
-  <lib name="cusolverMg"/>
-%endif
 </tool>
 EOF_TOOLFILE
 

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -34,7 +34,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
-%ifarch x86_64
+%ifarch x86_64 ppc64le
   <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
   <flags CUDA_FLAGS="-gencode arch=compute_60,code=sm_60"/>
   <flags CUDA_FLAGS="-gencode arch=compute_70,code=sm_70"/>
@@ -58,7 +58,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cublas.xml
   <info url="https://docs.nvidia.com/cuda/cublas/index.html"/>
   <use name="cuda"/>
   <lib name="cublas"/>
-%ifarch x86_64
+%ifarch x86_64 ppc64le
   <lib name="cublasLt"/>
 %endif
 </tool>
@@ -132,7 +132,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvml.xml
 </tool>
 EOF_TOOLFILE
 
-%ifarch x86_64
+%ifarch x86_64 ppc64le
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvjpeg.xml
 <tool name="cuda-nvjpeg" version="@TOOL_VERSION@">
   <info url="https://docs.nvidia.com/cuda/nvjpeg/index.html"/>

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,6 +1,6 @@
 ### RPM external cuda %{fullversion}
 
-%ifarch x86_64
+%ifarch x86_64 ppc64le
 %define fullversion 10.1.168
 %define cudaversion %(echo %realversion | cut -d. -f 1,2)
 %define driversversion 418.67
@@ -15,6 +15,9 @@
 
 %ifarch x86_64
 Source0: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
+%endif
+%ifarch ppc64le
+Source0: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod/local_installers/%{n}_%{realversion}_%{driversversion}_linux_ppc64le.run
 %endif
 %ifarch aarch64
 Source0: https://patatrack.web.cern.ch/patatrack/files/cuda-repo-l4t-10-0-local-%{realversion}_1.0-1_arm64.deb
@@ -32,11 +35,11 @@ rm -rf %_builddir/build %_builddir/tmp
 mkdir %_builddir/build %_builddir/tmp
 
 # extract and repackage the CUDA runtime, tools and stubs
-%ifarch x86_64
+%ifarch x86_64 ppc64le
 /bin/sh %{SOURCE0} --silent --override --tmpdir %_builddir/tmp --extract=%_builddir/build
 # extracts:
 # %_builddir/build/EULA.txt
-# %_builddir/build/NVIDIA-Linux-x86_64-418.67.run       # linux drivers
+# %_builddir/build/NVIDIA-Linux-%{_arch}-418.67.run     # linux drivers
 # %_builddir/build/cublas/                              # standalone cuBLAS library, also included in cuda-toolkit
 # %_builddir/build/cuda-samples/                        # CUDA samples
 # %_builddir/build/cuda-toolkit/                        # CUDA runtime, tools and stubs
@@ -115,8 +118,8 @@ mv %_builddir/build/cuda-toolkit/nvvm %{i}/
 mv %_builddir/build/cuda-toolkit/version.txt %{i}/
 
 # extract and repackage the NVIDIA libraries needed by the CUDA runtime
-%ifarch x86_64
-/bin/sh %_builddir/build/NVIDIA-Linux-x86_64-%{driversversion}.run --silent --extract-only --tmpdir %_builddir/tmp --target %_builddir/build/drivers
+%ifarch x86_64 ppc64le
+/bin/sh %_builddir/build/NVIDIA-Linux-%{_arch}-%{driversversion}.run --silent --extract-only --tmpdir %_builddir/tmp --target %_builddir/build/drivers
 %endif
 %ifarch aarch64
 tar xaf %{SOURCE1} -C %_builddir/tmp Linux_for_Tegra/nv_tegra/nvidia_drivers.tbz2

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,9 +1,9 @@
 ### RPM external cuda %{fullversion}
 
 %ifarch x86_64
-%define fullversion 10.1.243
+%define fullversion 10.1.168
 %define cudaversion %(echo %realversion | cut -d. -f 1,2)
-%define driversversion 418.87.00
+%define driversversion 418.67
 %define cudasoversion %{driversversion}
 %endif
 %ifarch aarch64
@@ -14,7 +14,7 @@
 %endif
 
 %ifarch x86_64
-Source0: https://developer.download.nvidia.com/compute/cuda/%{cudaversion}/Prod/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
+Source0: https://developer.nvidia.com/compute/cuda/%{cudaversion}/Prod/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
 %endif
 %ifarch aarch64
 Source0: https://patatrack.web.cern.ch/patatrack/files/cuda-repo-l4t-10-0-local-%{realversion}_1.0-1_arm64.deb
@@ -36,11 +36,10 @@ mkdir %_builddir/build %_builddir/tmp
 /bin/sh %{SOURCE0} --silent --override --tmpdir %_builddir/tmp --extract=%_builddir/build
 # extracts:
 # %_builddir/build/EULA.txt
-# %_builddir/build/NVIDIA-Linux-x86_64-418.87.00.run    # linux drivers
+# %_builddir/build/NVIDIA-Linux-x86_64-418.67.run       # linux drivers
 # %_builddir/build/cublas/                              # standalone cuBLAS library, also included in cuda-toolkit
 # %_builddir/build/cuda-samples/                        # CUDA samples
 # %_builddir/build/cuda-toolkit/                        # CUDA runtime, tools and stubs
-# %_builddir/build/integration/                         # Nsight Systems and Compute wrappers
 %endif
 %ifarch aarch64
 # extract the individual .deb archives from the repository into
@@ -74,7 +73,6 @@ rm -f %_builddir/build/cuda-toolkit/lib64/libcufft.so*
 rm -f %_builddir/build/cuda-toolkit/lib64/libcufftw.so*
 rm -f %_builddir/build/cuda-toolkit/lib64/libcurand.so*
 rm -f %_builddir/build/cuda-toolkit/lib64/libcusolver.so*
-rm -f %_builddir/build/cuda-toolkit/lib64/libcusolverMg.so*
 rm -f %_builddir/build/cuda-toolkit/lib64/libcusparse.so*
 rm -f %_builddir/build/cuda-toolkit/lib64/libnpp*.so*
 rm -f %_builddir/build/cuda-toolkit/lib64/libnvgraph.so*

--- a/cuda.spec
+++ b/cuda.spec
@@ -5,17 +5,12 @@
 %define cudaversion %(echo %realversion | cut -d. -f 1,2)
 %define driversversion 418.87.00
 %define cudasoversion %{driversversion}
-%define nsightarch linux-desktop-glibc_2_11_3-x64
-%define computeversion 2019.4.0
-%define systemsversion 2019.3.7.5
 %endif
 %ifarch aarch64
 %define fullversion 10.0.326
 %define cudaversion %(echo %realversion | cut -d. -f 1,2)
 %define driversversion 32.2.0
 %define cudasoversion 1.1
-%define nsightarch linux-v4l_l4t-glx-t210-a64
-%define computeversion 1.0
 %endif
 
 %ifarch x86_64
@@ -104,33 +99,6 @@ rm -f %_builddir/build/cuda-toolkit/bin/computeprof
 # leave out the CUDA samples
 rm -f %_builddir/build/cuda-toolkit/bin/cuda-install-samples-%{cudaversion}.sh
 
-# package the Nsight Compute command line tool
-mkdir %{i}/NsightCompute
-%ifarch x86_64
-mv %_builddir/build/cuda-toolkit/nsight-compute-%{computeversion}/target            %{i}/NsightCompute/
-mv %_builddir/build/cuda-toolkit/nsight-compute-%{computeversion}/sections          %{i}/NsightCompute/
-%endif
-%ifarch aarch64
-mv %_builddir/build/cuda-toolkit/NsightCompute-%{computeversion}/target             %{i}/NsightCompute/
-mv %_builddir/build/cuda-toolkit/NsightCompute-%{computeversion}/host               %{i}/NsightCompute/
-%endif
-cat > %{i}/bin/nv-nsight-cu-cli <<@EOF
-#! /bin/bash
-exec %{i}/NsightCompute/target/%{nsightarch}/nv-nsight-cu-cli "\$@"
-@EOF
-chmod a+x %{i}/bin/nv-nsight-cu-cli
-
-# package the Nsight Systems command line tool
-%ifarch x86_64
-mkdir %{i}/NsightSystems
-mv %_builddir/build/cuda-toolkit/nsight-systems-%{systemsversion}/Target-x86_64     %{i}/NsightSystems/
-cat > %{i}/bin/nsys <<@EOF
-#! /bin/bash
-exec %{i}/NsightSystems/Target-x86_64/x86_64/quadd_d --cli "\$@"
-@EOF
-chmod a+x %{i}/bin/nsys
-%endif
-
 # package the cuda-gdb support files, and rename the binary to use it via a wrapper
 mv %_builddir/build/cuda-toolkit/share/gdb/ %{i}/share/
 mv %_builddir/build/cuda-toolkit/bin/cuda-gdb %{i}/bin/cuda-gdb.real
@@ -181,9 +149,5 @@ sed \
   -e's|$(_TARGET_SIZE_)|64|g' \
   -i $RPM_INSTALL_PREFIX/%{pkgrel}/bin/nvcc.profile
 
-# relocate the paths inside bin/nv-nsight-cu-cli
-%{relocateConfig}bin/nv-nsight-cu-cli
-%ifarch x86_64
-%{relocateConfig}bin/nsys
-%endif
+# relocate the paths inside the scripts
 %{relocateConfig}bin/cuda-gdb


### PR DESCRIPTION
CUDA 10.1 Update 2 and later show a problem with running under MPS (NVIDIA Multi Process Server) or using CUDA Dynamic Parallelism within CMSSW.
While awaiting feedback from NVIDIA, the only solution seems to revert to the latest working version, which was 10.1 Update 1.

Drop the Nsight Compute and Nsigh System tools from the CUDA package, because they are released much more often as external packages.

Add support for CUDA on IBM Power architecture (ppc64le) on Linux.