### PR TITLE
[CXXMODULE] Use new build rules

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-09-21
+%define configtag       V05-09-22
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
create module.modulemap directly in include/arch/cxxmodule directory.