### PR TITLE
Add missing libtensorflow*.so.MAJOR links.

### DIFF
--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -24,6 +24,8 @@ Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag
 %define pythonOnly no
 %endif
 
+%define majorversion %(echo %realversion | cut -d . -f 1)
+
 %prep
 
 %setup -q -n tensorflow-%{realversion}
@@ -118,9 +120,15 @@ cp -p $srcdir/compiler/tf2xla/lib*.so* $libdir/
 cp -p $srcdir/compiler/xla/lib*.so* $libdir/
 
 for l in tensorflow_cc tensorflow_framework tensorflow ; do
+  # link from realversion to majorversion
+  if [ ! -e $libdir/lib${l}.so.%{majorversion} ] ; then
+    [ -e $libdir/lib${l}.so.%{realversion} ] || exit 1
+    (cd $libdir && ln -s lib${l}.so.%{realversion} lib${l}.so.%{majorversion})
+  fi
+  # link from majorversion to default lib
   if [ ! -e $libdir/lib${l}.so ] ; then
-    [ -e  $libdir/lib${l}.so.%{realversion} ] || exit 1
-    ln -s lib${l}.so.%{realversion} $libdir/lib${l}.so
+    [ -e $libdir/lib${l}.so.%{majorversion} ] || exit 1
+    (cd $libdir && ln -s lib${l}.so.%{majorversion} lib${l}.so)
   fi
 done
 

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -120,6 +120,9 @@ cp -p $srcdir/compiler/tf2xla/lib*.so* $libdir/
 cp -p $srcdir/compiler/xla/lib*.so* $libdir/
 
 for l in tensorflow_cc tensorflow_framework tensorflow ; do
+  # check if the actual lib exists
+  [ -f $libdir/lib${l}.so.%{realversion} ] || exit 1
+
   # link from majorversion to realversion
   rm -f $libdir/lib${l}.so.%{majorversion}
   ln -s $libdir/lib${l}.so.%{realversion} $libdir/lib${l}.so.%{majorversion}

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -120,16 +120,13 @@ cp -p $srcdir/compiler/tf2xla/lib*.so* $libdir/
 cp -p $srcdir/compiler/xla/lib*.so* $libdir/
 
 for l in tensorflow_cc tensorflow_framework tensorflow ; do
-  # link from realversion to majorversion
-  if [ ! -e $libdir/lib${l}.so.%{majorversion} ] ; then
-    [ -e $libdir/lib${l}.so.%{realversion} ] || exit 1
-    (cd $libdir && ln -s lib${l}.so.%{realversion} lib${l}.so.%{majorversion})
-  fi
-  # link from majorversion to default lib
-  if [ ! -e $libdir/lib${l}.so ] ; then
-    [ -e $libdir/lib${l}.so.%{majorversion} ] || exit 1
-    (cd $libdir && ln -s lib${l}.so.%{majorversion} lib${l}.so)
-  fi
+  # link from majorversion to realversion
+  rm -f $libdir/lib${l}.so.%{majorversion}
+  ln -s $libdir/lib${l}.so.%{realversion} $libdir/lib${l}.so.%{majorversion}
+
+  # link from default lib to majorversion
+  rm -f $libdir/lib${l}.so
+  ln -s $libdir/lib${l}.so.%{majorversion} $libdir/lib${l}.so
 done
 
 cp -p $srcdir/compiler/aot/tfcompile $bindir


### PR DESCRIPTION
I noticed that the tests in PhysicsTools/TensorFlow are automatically linked to various libtensorflow*.so.MAJOR libs which appear to be missing in #5427 .
This PR adds them through new links, e.g.

```
libtensorflow_cc.so.2.0.0  # installed lib
libtensorflow_cc.so.2 -> libtensorflow_cc.so.2.0.0
libtensorflow_cc.so -> libtensorflow_cc.so.2
```