### PR TITLE
keep cmssw PYTHONPATH saved in CRAB_CMSSW_SITE_PACKAGES

### DIFF
--- a/_crab-startup.file
+++ b/_crab-startup.file
@@ -3,7 +3,7 @@
 # **************** IMPORTANT NOTE ***************** #
 # Increament Crab Startup Revision for every change #
 #####################################################
-CRAB_STARTUP_REVISION=1
+CRAB_STARTUP_REVISION=2
 
 #Check if we have not already found CRAB
 if [ -z "${CMS_CRAB_PATH}" ] ; then
@@ -23,8 +23,18 @@ if [ -z "${CMS_CRAB_PATH}" ] ; then
   export CMS_CRAB_PATH="${crab_dir}"
   export CRAB_VERSION=$(basename ${crab_dir})
 
-  #Save CMSSW_BASE in case we have to set its env later
-  export ORIGINAL_CMSSW_BASE="${CMSSW_BASE}"
+  #Save CMSSW_BASE, and PYTHONPATH in case we have to set its env later
+  ORIGINAL_CMSSW_BASE="${CMSSW_BASE}"
+  CRAB_CMSSW_SITE_PACKAGES=""
+  if [ "${SRT_PYTHON27PATH_SCRAMRTDEL}" != "" ] ; then
+    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON27PATH_SCRAMRTDEL}"
+  elif [ "${SRT_PYTHON27PATH_SCRAMRT}" != "" ] ; then
+    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON27PATH_SCRAMRT}"
+  elif [ "${SRT_PYTHON3PATH_SCRAMRTDEL}" != "" ] ; then
+    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON3PATH_SCRAMRTDEL}"
+  elif [ "${SRT_PYTHON3PATH_SCRAMRT}" != "" ] ; then
+    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON3PATH_SCRAMRT}"
+  fi
 
   #Unset cmssw env
   eval `scram unset -sh`
@@ -52,6 +62,7 @@ if [ -z "${CMS_CRAB_PATH}" ] ; then
     ## The submit command will know what to do if this variable is set!
     ## See TODO: add link to an hypothetical twiki
     export CRAB3_BOOTSTRAP_DIR="$BOOTSTRAP_OUT"
+    export CRAB_CMSSW_SITE_PACKAGES
   fi
 else
   CRAB3_BOOTSTRAP_DIR=""

--- a/_crab-startup.file
+++ b/_crab-startup.file
@@ -26,16 +26,14 @@ if [ -z "${CMS_CRAB_PATH}" ] ; then
   #Save CMSSW_BASE, and PYTHONPATH in case we have to set its env later
   ORIGINAL_CMSSW_BASE="${CMSSW_BASE}"
   CRAB_CMSSW_SITE_PACKAGES=""
-  if [ "${SRT_PYTHON27PATH_SCRAMRTDEL}" != "" ] ; then
-    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON27PATH_SCRAMRTDEL}"
-  elif [ "${SRT_PYTHON27PATH_SCRAMRT}" != "" ] ; then
-    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON27PATH_SCRAMRT}"
-  elif [ "${SRT_PYTHON3PATH_SCRAMRTDEL}" != "" ] ; then
-    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON3PATH_SCRAMRTDEL}"
-  elif [ "${SRT_PYTHON3PATH_SCRAMRT}" != "" ] ; then
-    CRAB_CMSSW_SITE_PACKAGES="${SRT_PYTHON3PATH_SCRAMRT}"
-  fi
-
+  for pyenv in PYTHONPATH PYTHON27PATH PYTHON3PATH ; do
+    for ext in DEL '' ; do
+      eval "CRAB_CMSSW_SITE_PACKAGES=\${SRT_${pyenv}_SCRAMRT${ext}}"
+      [ -z "${CRAB_CMSSW_SITE_PACKAGES}" ] || break
+    done
+    [ -z "${CRAB_CMSSW_SITE_PACKAGES}" ] || break
+  done
+  
   #Unset cmssw env
   eval `scram unset -sh`
 

--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -1,4 +1,4 @@
-### RPM cms crab-dev 3.3.1912.rc1
+### RPM cms crab-dev 3.3.1912.rc2
 %define wmcore_version     1.2.8
 %define crabserver_version 3.3.1912.rc4
 %define dbs_version        3.10.0

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -1,4 +1,4 @@
-### RPM cms crab-pre 3.3.1912.rc1
+### RPM cms crab-pre 3.3.1912.rc2
 %define wmcore_version     1.2.8
 %define crabserver_version 3.3.1912.rc4
 %define dbs_version        3.10.0

--- a/crab.spec
+++ b/crab.spec
@@ -1,4 +1,4 @@
-### RPM cms crab 3.3.1912.rc1
+### RPM cms crab 3.3.1912.rc2
 %define wmcore_version     1.2.8
 %define crabserver_version 3.3.1912.rc4
 %define dbs_version        3.10.0


### PR DESCRIPTION
crab submit needs to have CMSSW PYTHONPATH in order to process/load cmssw configuration. This change proposes to save CMSSW PYTHONPATH in CRAB_CMSSW_SITE_PACKAGES which `crab submit` can load before processing cmssw configurations