### PR TITLE
[GEANT4] Cleanup Geant4 G4GEOM_USE_USOLIDS macro

### DIFF
--- a/geant4-toolfile.spec
+++ b/geant4-toolfile.spec
@@ -35,7 +35,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4core.xml
   <lib name="G4tracking"/>
   <lib name="G4track"/>
   <lib name="G4analysis"/>
-  <flags CXXFLAGS="-DG4GEOM_USE_USOLIDS -ftls-model=global-dynamic -pthread"/>
+  <flags CXXFLAGS="-ftls-model=global-dynamic -pthread"/>
   <client>
     <environment name="GEANT4CORE_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$GEANT4CORE_BASE/lib"/>


### PR DESCRIPTION
Geant4 now keeps it in  G4GeomConfig.hh and causes warning about redifinition
CMSSW_11_1_GEANT4_X_2020-01-09-2300/src/SimG4Core/Application/src/RunManager.cc:10:
geant4/10.6.0/include/Geant4/G4GeomConfig.hh:34: 
warning: "G4GEOM_USE_USOLIDS" redefined
  #define G4GEOM_USE_USOLIDS

FYI @civanch 
