### PR TITLE
Fix CUDA device code used in Eigen for compatibility with MPS

### DIFF
--- a/eigen.spec
+++ b/eigen.spec
@@ -1,14 +1,14 @@
-### RPM external eigen e4c107b451c52c9ab2d7b7fa4194ee35332916ec
+### RPM external eigen d812f411c3f9
 ## INITENV +PATH PKG_CONFIG_PATH %{i}/share/pkgconfig
 ## INITENV SETV EIGEN_SOURCE %{source0}
 ## INITENV SETV EIGEN_STRIP_PREFIX %{source_prefix}
 ## NOCOMPILER
-%define tag %{realversion}
+%define tag b20a61c3a0dc9a79790cd258130a99b574662272
 
 # These are needed by Tensorflow sources
 # NOTE: Never apply any patch in the spec file, this way tensorflow gets the exact same sources
 %define source0 https://github.com/cms-externals/eigen-git-mirror/archive/%{tag}.tar.gz
-%define source_prefix eigen-git-mirror-%{realversion}
+%define source_prefix eigen-git-mirror-%{tag}
 Source: %{source0}
 BuildRequires: cmake
 


### PR DESCRIPTION
Use hard-coded cache size parameters on CUDA devices, instead of trying to read
the L2 cache size at runtime, which is not supported under CUDA MPS.

Update the upstream repository to https://gitlab.com/libeigen/eigen.git .