### PR TITLE
Update DWZ to version 0.13 plus recent bugfixes

### DIFF
--- a/dwz.spec
+++ b/dwz.spec
@@ -1,7 +1,7 @@
-### RPM external dwz 0.12
+### RPM external dwz 0.13
 
-%define dwz_branch master
-%define dwz_commit dwz-0.12
+%define dwz_branch %{n}-%{realversion}-branch
+%define dwz_commit 205663f31976
 
 Source: git://sourceware.org/git/dwz.git?obj=%{dwz_branch}/%{dwz_commit}&export=dwz-%{dwz_commit}&output=/dwz-%{dwz_commit}.tgz
 


### PR DESCRIPTION
When building CMSSW 11.0.0 with debug symbols I got
> dwz: libRecoEgammaEgammaIsolationAlgos.so: Unknown DWARF DW_OP_253
> dwz: plugintestGEMRecHittestGEMRecHitAnalyzer.so: Unknown DWARF DW_OP_253

Updating DWZ to version 0.13 is supposed to fix this issue.