### PR TITLE
Add initial tag reference for RecoMTD-TimingIDTools

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -64,6 +64,7 @@ Requires: data-IOPool-Input
 Requires: data-RecoHGCal-TICL
 Requires: data-SimG4CMS-HGCalTestBeam
 Requires: data-SimPPS-PPSPixelDigiProducer
+Requires: data-RecoMTD-TimingIDTools
 
 %if %isnotonline
 # extra data dependencies for standard builds

--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -30,6 +30,7 @@ SimTransport-PPSProtonTransport=V00-01-00
 SimTransport-TotemRPProtonTransportParametrization=V00-01-00
 RecoHGCal-TICL=V00-01-00
 SimG4CMS-HGCalTestBeam=V01-00-00
+RecoMTD-TimingIDTools=V00-00-00
 
 #Never update any package here. Always move it to default section.
 [cmssw-xmldata-build]


### PR DESCRIPTION
This is needed for https://github.com/cms-sw/cmssw/pull/28815
It adds reference to init release https://github.com/cms-data/RecoMTD-TimingIDTools/releases
