### PR TITLE
Update rivet-toolfile.spec

### DIFF
--- a/rivet-toolfile.spec
+++ b/rivet-toolfile.spec
@@ -16,7 +16,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/rivet.xml
 <environment name="INCLUDE" default="$RIVET_BASE/include"/>
 </client>
 <runtime name="PATH" value="$RIVET_BASE/bin" type="path"/>
-<runtime name="RIVET_ANALYSIS_PATH" value="$RIVET_BASE/lib" type="path"/>
+<runtime name="RIVET_ANALYSIS_PATH" value="$RIVET_BASE/lib/Rivet" type="path"/>
+<runtime name="RIVET_DATA_PATH" value="$RIVET_BASE/share/Rivet" type="path"/>
 <runtime name="PDFPATH" default="$RIVET_BASE/share" type="path"/>
 <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 <runtime name="TEXMFHOME" value="$RIVET_BASE/share/Rivet/texmf" type="path"/>


### PR DESCRIPTION
For unknown reason, the Rivet paths need to be set more carefully now.

Fixes the following problem:
```
cmsRun: RivetYODA.cc:52: typename T::Ptr Rivet::Wrapper<T>::active() const [with T = YODA::Counter; typename T::Ptr = std::shared_ptr<YODA::Counter>]: Assertion `false && "No activ e pointer set. Was this object booked in init()?"' failed.
```

How to reproduce the problem:
CMSSW_11_0_0_pre7/gcc700 -> `rivet --list-analyses` working
CMSSW_11_0_0_pre7/gcc820 (and newer) -> not working