### PR TITLE
Remove references to boost_signals library removed  in boost 1.69.0+

### DIFF
--- a/boost-toolfile.spec
+++ b/boost-toolfile.spec
@@ -22,6 +22,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost.xml
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <flags CPPDEFINES="BOOST_SPIRIT_THREADSAFE PHOENIX_THREADSAFE"/>
+  <flags CPPDEFINES="BOOST_MATH_DISABLE_STD_FPCLASSIFY"/>
   <flags CXXFLAGS="-Wno-error=unused-variable"/>
   <use name="sockets"/>
 </tool>
@@ -86,14 +87,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_regex.xml
 <tool name="boost_regex" version="@TOOL_VERSION@">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_REGEX_LIB@"/>
-  <use name="boost"/>
-</tool>
-EOF_TOOLFILE
-
-# boost_signals_toolfile
-cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_signals.xml
-<tool name="boost_signals" version="@TOOL_VERSION@">
-  <info url="http://www.boost.org"/>
   <use name="boost"/>
 </tool>
 EOF_TOOLFILE

--- a/boost-toolfile.spec
+++ b/boost-toolfile.spec
@@ -90,7 +90,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_regex.xml
 </tool>
 EOF_TOOLFILE
 
-# boost_toolfile
+# boost_signals_toolfile
 cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_signals.xml
 <tool name="boost_signals" version="@TOOL_VERSION@">
   <info url="http://www.boost.org"/>

--- a/boost-toolfile.spec
+++ b/boost-toolfile.spec
@@ -12,7 +12,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost.xml
 <tool name="boost" version="@TOOL_VERSION@">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_THREAD_LIB@"/>
-  <lib name="@BOOST_SIGNALS_LIB@"/>
   <lib name="@BOOST_DATE_TIME_LIB@"/>
   <client>
     <environment name="BOOST_BASE" default="@TOOL_ROOT@"/>
@@ -91,11 +90,10 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_regex.xml
 </tool>
 EOF_TOOLFILE
 
-# boost_signals toolfile
+# boost_toolfile
 cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_signals.xml
 <tool name="boost_signals" version="@TOOL_VERSION@">
   <info url="http://www.boost.org"/>
-  <lib name="@BOOST_SIGNALS_LIB@"/>
   <use name="boost"/>
 </tool>
 EOF_TOOLFILE
@@ -155,7 +153,6 @@ getLibName()
 }
 
 export BOOST_THREAD_LIB=`getLibName thread`
-export BOOST_SIGNALS_LIB=`getLibName signals`
 export BOOST_CHRONO_LIB=`getLibName chrono`
 export BOOST_FILESYSTEM_LIB=`getLibName filesystem`
 export BOOST_DATE_TIME_LIB=`getLibName date_time`


### PR DESCRIPTION
The boost signals library does not appear to be used anywhere in CMSSW. This library is removed in boost 1.69.0+. Keep the toolfile but remove references to libboost_signals.