### PR TITLE
[10.2.X] Update MXNet to 1.5.0

### DIFF
--- a/mxnet-predict-toolfile.spec
+++ b/mxnet-predict-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external mxnet-predict-toolfile 1.2.1.mod3
+### RPM external mxnet-predict-toolfile 1.5.0
 Requires: mxnet-predict
 %prep
 
@@ -9,11 +9,11 @@ Requires: mxnet-predict
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/mxnet-predict.xml
 <tool name="mxnet-predict" version="@TOOL_VERSION@">
-  <lib name="mxnetpredict"/>
+  <lib name="mxnet"/>
   <client>
     <environment name="MXNET_PREDICT_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$MXNET_PREDICT_BASE/include"/>
-    <environment name="LIBDIR" default="$MXNET_PREDICT_BASE/lib"/>
+    <environment name="LIBDIR" default="$MXNET_PREDICT_BASE/lib64"/>
   </client>
   <use name="openblas"/>
 </tool>

--- a/mxnet-predict.spec
+++ b/mxnet-predict.spec
@@ -1,8 +1,10 @@
-### RPM external mxnet-predict 1.2.1
-%define tag 97171b96b2b7efc78eccfbe0a0c2561a377ce153
-%define branch 1.2.1.mod3
+### RPM external mxnet-predict 1.5.0
+%define tag 337cf1b54cc02bde94f459c89863a18187b0aada
+%define branch 1.5.0-cms-mod
 %define github_user cms-externals
-Source: git+https://github.com/%{github_user}/incubator-mxnet.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: git+https://github.com/%{github_user}/incubator-mxnet.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}-%{tag}.tgz
+
+BuildRequires: cmake ninja ccache
 
 Requires: OpenBLAS
 
@@ -10,16 +12,34 @@ Requires: OpenBLAS
 %setup -q -n %{n}-%{realversion}
 
 %build
-make %{makeprocesses} USE_OPENCV=0 USE_OPENMP=0 USE_BLAS=openblas USE_CPP_PACKAGE=1 USE_F16C=0 \
-    ADD_LDFLAGS="-L$OPENBLAS_ROOT/lib" \
-    ADD_CFLAGS="-I$OPENBLAS_ROOT/include -DDISABLE_OPENMP=1 -DMSHADOW_RABIT_PS=0 -DMSHADOW_DIST_PS=0 -DMXNET_PREDICT_ONLY=1 -DMXNET_THREAD_LOCAL_ENGINE=1"
+rm -rf ../build; mkdir ../build; cd ../build
+
+# use LAPACK functions in OpenBLAS:
+# manually set MXNET_USE_LAPACK=1 and turn off USE_LAPACK in cmake
+export CFLAGS="-DMXNET_USE_LAPACK=1 -DMXNET_THREAD_LOCAL_ENGINE=1"
+
+cmake ../%{n}-%{realversion} -GNinja \
+    -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_INSTALL_PREFIX="%{i}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DUSE_CUDA=OFF \
+    -DUSE_OPENCV=OFF \
+    -DUSE_OPENMP=OFF \
+    -DUSE_BLAS=open \
+    -DUSE_LAPACK=OFF \
+    -DUSE_MKL_IF_AVAILABLE=OFF \
+    -USE_MKLDNN=OFF \
+    -DUSE_F16C=OFF \
+    -DUSE_CPP_PACKAGE=ON \
+    -DBUILD_CPP_EXAMPLES=OFF \
+    -DCMAKE_PREFIX_PATH="${OPENBLAS_ROOT}"
+
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 
 %install
-mkdir -p %{i}/{lib,include}
-mv lib/libmxnet.so                  %{i}/lib/libmxnetpredict.so
-mv include/*                        %{i}/include
-mv 3rdparty/dmlc-core/include/*     %{i}/include
-mv 3rdparty/tvm/nnvm/include/*      %{i}/include
-mv cpp-package/include/*            %{i}/include
-
+cd ../build
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
+rm %{i}/lib64/*.a
 


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/5148 to 10_2_X. 

This will be needed for the backport of https://github.com/cms-sw/cmssw/pull/28902.