### PR TITLE
crab-pre to 2002.rc3

### DIFF
--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -1,6 +1,6 @@
-### RPM cms crab-pre 3.3.2001
-%define wmcore_version     1.2.8
-%define crabserver_version 3.3.2001.rc1
+### RPM cms crab-pre 3.3.2002.rc3
+%define wmcore_version     1.2.9
+%define crabserver_version 3.3.2002.rc1
 %define dbs_version        3.10.0
 
 ## IMPORT crab-build


### PR DESCRIPTION
uses WMCore 1.2.9 and dasgoclient (align with crab-dev)
automaticaly compares dasgoclient with DBS API output for crab report