### PR TITLE
[CC8] Use default zlib for non-x86_64 archs

### DIFF
--- a/zlib.spec
+++ b/zlib.spec
@@ -1,5 +1,5 @@
 ### RPM external zlib 1.2.11
-+%ifarch x86_64
+%ifarch x86_64
 %define git_repo cms-externals
 %define git_branch cms/v%{realversion}
 %define git_commit 822f7f5a8c57802faf8bbfe16266be02eff8c2e2

--- a/zlib.spec
+++ b/zlib.spec
@@ -1,7 +1,13 @@
 ### RPM external zlib 1.2.11
++%ifarch x86_64
 %define git_repo cms-externals
-%define git_branch cms/v1.2.11
+%define git_branch cms/v%{realversion}
 %define git_commit 822f7f5a8c57802faf8bbfe16266be02eff8c2e2
+%else
+%define git_repo madler
+%define git_branch master
+%define git_commit v%{realversion}
+%endif
 Source0: git://github.com/%{git_repo}/zlib.git?obj=%{git_branch}/%{git_commit}&export=zlib-%{realversion}&output=/zlib-%{realversion}.tgz
 
 %prep


### PR DESCRIPTION
zlib failed to build for Centos8 AARCH64. For CC7, we use official zlib sources for non-x86_64 so we propose to do the same for CC8