### PR TITLE
remove dependancy from CRABServer/PandaServiceInterface

### DIFF
--- a/crab-build.file
+++ b/crab-build.file
@@ -5,7 +5,7 @@
   %define wmcore_packages PSetTweaks Utils WMCore
 %endif
 %if "%{?crabserver_packages:set}" != "set"
-  %define crabserver_packages PandaServerInterface.py RESTInteractions.py ServerUtilities.py
+  %define crabserver_packages RESTInteractions.py ServerUtilities.py
 %endif
 %if "%{?dbs_packages:set}" != "set"
   %define dbs_packages Client/src/python/dbs PycurlClient/src/python/RestClient


### PR DESCRIPTION
may make crab-prod and crab-pre fail, but I guss it is the only way to test.
Is there a way to mark this as "do in IB only and do not update master release in standard CVMFS" ?