### PR TITLE
Add externals for Alpaka and Cupla

### DIFF
--- a/alpaka-toolfile.spec
+++ b/alpaka-toolfile.spec
@@ -1,0 +1,44 @@
+### RPM external alpaka-toolfile 1.0
+Requires: alpaka
+
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/alpaka.xml
+<tool name="alpaka" version="@TOOL_VERSION@">
+  <use name="boost"/>
+  <client>
+    <environment name="ALPAKA_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"     default="$ALPAKA_BASE/include"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/alpaka-serial.xml
+<tool name="alpaka-serial" version="@TOOL_VERSION@">
+  <use name="alpaka"/>
+  <flags CXXFLAGS="-DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/alpaka-tbb.xml
+<tool name="alpaka-tbb" version="@TOOL_VERSION@">
+  <use name="alpaka"/>
+  <use name="tbb"/>
+  <flags CXXFLAGS="-DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/alpaka-cuda.xml
+<tool name="alpaka-cuda" version="@TOOL_VERSION@">
+  <use name="alpaka"/>
+  <use name="cuda"/>
+  <flags CXXFLAGS="-DALPAKA_ACC_GPU_CUDA_ENABLED"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,0 +1,15 @@
+### RPM external alpaka 0.4.0
+## NOCOMPILER
+
+Source: https://github.com/ComputationalRadiationPhysics/%{n}/archive/%{realversion}.tar.gz
+Requires: boost
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+
+%install
+cp -ar include %{i}/include
+
+%post

--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -1,0 +1,34 @@
+### FILE cuda-flags
+# define the CUDA compilation flags in a way that can be shared by SCRAM-based and regular tools
+
+# generate debugging information for device code
+%define cuda_flags_0 --generate-line-info --source-in-ptx
+
+# imply __host__, __device__ attributes in constexpr functions
+%define cuda_flags_1 --expt-relaxed-constexpr
+
+# allow __host__, __device__ attributes in lambda declaration
+%define cuda_flags_2 --expt-extended-lambda
+
+# on X86 and Power, build support for Kepler, Pascal and Volta/Turing
+%ifarch x86_64 ppc64le
+%define cuda_flags_3 -gencode arch=compute_35,code=sm_35
+%define cuda_flags_4 -gencode arch=compute_60,code=sm_60
+%define cuda_flags_5 -gencode arch=compute_70,code=sm_70
+%endif
+
+# on ARM, build Volta/Turing and the Xavier SoC
+%ifarch aarch64
+%define cuda_flags_3 -gencode arch=compute_70,code=sm_70
+%define cuda_flags_4 -gencode arch=compute_72,code=sm_72
+%define cuda_flags_5
+%endif
+
+# link the CUDA runtime shared library
+%define cuda_flags_6 --cudart shared
+
+# disable warnings about attributes on defaulted methods
+%define cuda_flags_7 -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+
+# collect all CUDA flags
+%define cuda_flags %{cuda_flags_0} %{cuda_flags_1} %{cuda_flags_2} %{cuda_flags_3} %{cuda_flags_4} %{cuda_flags_5} %{cuda_flags_6} %{cuda_flags_7}

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -5,6 +5,8 @@ Requires: cuda
 %build
 
 %install
+## INCLUDE cuda-flags
+# this defines cuda_flags, used below
 
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-stubs.xml
@@ -34,18 +36,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
-%ifarch x86_64 ppc64le
-  <flags CUDA_FLAGS="-gencode arch=compute_35,code=sm_35"/>
-  <flags CUDA_FLAGS="-gencode arch=compute_60,code=sm_60"/>
-  <flags CUDA_FLAGS="-gencode arch=compute_70,code=sm_70"/>
-%endif
-%ifarch aarch64
-  <flags CUDA_FLAGS="-gencode arch=compute_70,code=sm_70"/>
-  <flags CUDA_FLAGS="-gencode arch=compute_72,code=sm_72"/>
-%endif
-  <flags CUDA_FLAGS="-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda"/>
-  <flags CUDA_FLAGS="--generate-line-info --source-in-ptx"/>
-  <flags CUDA_FLAGS="--cudart=shared"/>
+  <flags CUDA_FLAGS="%{cuda_flags}"/>
   <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
   <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>
   <flags CUDA_HOST_CXXFLAGS="-std=c++14"/>

--- a/cupla-toolfile.spec
+++ b/cupla-toolfile.spec
@@ -1,0 +1,49 @@
+### RPM external cupla-toolfile 1.0
+Requires: cupla
+
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/cupla.xml
+<tool name="cupla" version="@TOOL_VERSION@">
+  <info url="https://github.com/ComputationalRadiationPhysics/cupla"/>
+  <use name="boost"/>
+  <client>
+    <environment name="CUPLA_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"    default="$CUPLA_BASE/include"/>
+    <environment name="LIBDIR"     default="$CUPLA_BASE/lib"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/cupla-serial.xml
+<tool name="cupla-serial" version="@TOOL_VERSION@">
+  <use name="cupla"/>
+  <lib name="cupla-serial"/>
+  <flags CXXFLAGS="-DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=0"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/cupla-tbb.xml
+<tool name="cupla-tbb" version="@TOOL_VERSION@">
+  <use name="cupla"/>
+  <use name="tbb"/>
+  <lib name="cupla-tbb"/>
+  <flags CXXFLAGS="-DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/cupla-cuda.xml
+<tool name="cupla-cuda" version="@TOOL_VERSION@">
+  <use name="cupla"/>
+  <use name="cuda"/>
+  <lib name="cupla-cuda"/>
+  <flags CXXFLAGS="-DALPAKA_ACC_GPU_CUDA_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/cupla.spec
+++ b/cupla.spec
@@ -1,0 +1,51 @@
+### RPM external cupla 0.2.0
+
+Source: https://github.com/ComputationalRadiationPhysics/%{n}/archive/%{realversion}.tar.gz
+Requires: alpaka
+Requires: cuda
+Requires: tbb
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+## INCLUDE cuda-flags
+# this defines cuda_flags, used below
+
+mkdir build lib
+
+# remove the version of Alpaka bundled with Cupla
+rm -rf alpaka
+
+CXXFLAGS="-std=c++14 -O2 -g -DALPAKA_DEBUG=0 -I$CUDA_ROOT/include -I$TBB_ROOT/include -I$BOOST_ROOT/include -I$ALPAKA_ROOT/include -Iinclude"
+HOST_FLAGS="-pthread -fPIC -Wall -Wextra"
+NVCC_FLAGS="%{cuda_flags}"
+FILES=$(find src -type f -name *.cpp)
+
+# build the serial CPU backend
+mkdir build/serial
+for FILE in $FILES; do
+  g++ -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=0 $CXXFLAGS $HOST_FLAGS -c $FILE -o build/serial/$(basename $FILE).o
+done
+g++ $CXXFLAGS $HOST_FLAGS build/serial/*.o -shared -o lib/libcupla-serial.so
+
+# build the TBB CPU backend
+mkdir build/tbb
+for FILE in $FILES; do
+  g++ -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1 $CXXFLAGS $HOST_FLAGS -c $FILE -o build/tbb/$(basename $FILE).o
+done
+g++ $CXXFLAGS $HOST_FLAGS build/tbb/*.o -L$TBB_ROOT/lib -ltbb -shared -o lib/libcupla-tbb.so
+
+# build the CUDA GPU backend
+mkdir build/cuda
+for FILE in $FILES; do
+  nvcc -DALPAKA_ACC_GPU_CUDA_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1 $CXXFLAGS $NVCC_FLAGS -Xcompiler "$HOST_FLAGS" -x cu -c $FILE -o build/cuda/$(basename $FILE).o
+done
+g++ $CXXFLAGS $HOST_FLAGS build/cuda/*.o -L$CUDA_ROOT/lib64 -lcudart -shared -o lib/libcupla-cuda.so
+
+
+%install
+cp -ar include %{i}/include
+cp -ar lib %{i}/lib
+
+%post


### PR DESCRIPTION
The alpaka library is a header-only C++14 abstraction library for accelerator development. Its aim is to provide performance portability across accelerators through the abstraction of the underlying levels of parallelism.

Cupla is a simple user interface for the platform independent parallel kernel acceleration library alpaka.

Add externals and scram tools for alpaka 0.4.0 and cupla 0.2.0.