### PR TITLE
[ROOT6] Revert change for dd4hep ROOT master until fixed

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -1,6 +1,6 @@
 ### RPM external dd4hep v01-10x
 
-%define tag a2065d9461515873a6e37b099b6b06f3b9d7a81c
+%define tag e7882469767472c5d018b74fa13e600e9aba31d3
 %define branch master
 %define github_user AIDASoft
 %define keep_archives true


### PR DESCRIPTION
please test
for some reason in ROOT6 and ROOT620 branches DD4 cmake picks system python3 instead of the python2 given by the recipe