### PR TITLE
[ROOT master] Root update master

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,9 +1,9 @@
-### RPM lcg root 6.19.01
+### RPM lcg root 6.21.01
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag fe010b579e40a65db15d0d9fd76b9d661db9d348
-%define branch cms/master/243541b
+%define tag 83199012fe44af9d7a8edfb0329e265fdfbdaf51
+%define branch cms/master/a98c539
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
@@ -140,7 +140,7 @@ cmake ../%{n}-%{realversion} \
   -DZLIB_INCLUDE_DIR="${ZLIB_ROOT}/include" \
   -DZSTD_ROOT="${ZSTD_ROOT}" \
   -DCMAKE_PREFIX_PATH="${LZ4_ROOT}/include;${LZ4_ROOT}/lib;${GSL_ROOT};${XZ_ROOT};${OPENSSL_ROOT};${GIFLIB_ROOT};${FREETYPE_ROOT};${PYTHON_ROOT};${LIBPNG_ROOT};${PCRE_ROOT};${TBB_ROOT};${OPENBLAS_ROOT};${DAVIX_ROOT};${LZ4_ROOT/usr/local};${LIBXML2_ROOT};${ZSTD_ROOT}" \
-  -Dexperimental_pyroot=ON
+  -Dpyroot_experimental=OFF
 
 
 # For CMake cache variables: http://www.cmake.org/cmake/help/v3.2/manual/cmake-language.7.html#lists


### PR DESCRIPTION
please test
keep experimental pyroot OFF to update ROOT6
We have https://github.com/cms-sw/cmsdist/pull/5531 dedicated on enabling the new pyroot