### PR TITLE
Fix 8_0 slc7 IB

### DIFF
--- a/data-Configuration-Generator.spec
+++ b/data-Configuration-Generator.spec
@@ -1,5 +1,5 @@
 ### RPM cms data-Configuration-Generator V01-02-00
-
+BuildRequires: curl
 %prep
 
 ## IMPORT data-build-github


### PR DESCRIPTION
Currently the 8_0_X IB of slc7 is failing because of curl library that needs to be updated in the 
bootstrap-bundle, and I still don't know how.
adding curl in build require is working hack to stitch it until I find how to fix the lib in the bundle. 