### PR TITLE
march=core2 -> -msse3 for tensorflow x86_64 to keep old AMDs running

### DIFF
--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -37,7 +37,7 @@ export PYTHON_BIN_PATH="$(which %{python_cmd})"
 export USE_DEFAULT_PYTHON_LIB_PATH=1
 export GCC_HOST_COMPILER_PATH="$(which gcc)"
 %ifarch x86_64
-export CC_OPT_FLAGS=-march=core2
+export CC_OPT_FLAGS=-msse3
 %else
 export CC_OPT_FLAGS="-mcpu=native -mtune=native"
 %endif


### PR DESCRIPTION
based on observations summarized in https://github.com/cms-sw/cmsdist/pull/5525#issuecomment-594976041

Similar to  #5220 and to align with gcc.spec, switch to using msse3