### PR TITLE
Include the Alpaka and Cupla externals with CMSSW

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -172,6 +172,8 @@ Requires: gperftools-toolfile
 Requires: cuda-toolfile
 Requires: cub-toolfile
 Requires: cuda-api-wrappers-toolfile
+Requires: alpaka-toolfile
+Requires: cupla-toolfile
 
 %if %isnotppc64le_be
 Requires: libunwind-toolfile


### PR DESCRIPTION
#5568 added the externals for Alpaka and Cupla to CMSDIST, but they were not included in the dependencies of CMSSW, so are not part of any IB or release.