### PR TITLE
Add Niels Lohmann's JSON for Modern C++ header-only library

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -50,6 +50,7 @@ Requires: ittnotify-toolfile
 Requires: jemalloc-toolfile
 Requires: jemalloc-debug-toolfile
 Requires: jimmy-toolfile
+Requires: json-toolfile
 Requires: ktjet-toolfile
 Requires: lhapdf-toolfile
 Requires: libhepml-toolfile

--- a/json-toolfile.spec
+++ b/json-toolfile.spec
@@ -1,0 +1,19 @@
+### RPM external json-toolfile 1.0
+Requires: json
+
+%prep
+
+%build
+
+%install
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE > %i/etc/scram.d/json.xml
+<tool name="json" version="@TOOL_VERSION@">
+  <client>
+    <environment name="JSON_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"   default="$JSON_BASE/include"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/json.spec
+++ b/json.spec
@@ -1,0 +1,16 @@
+### RPM external json 3.7.3
+## NOCOMPILER
+
+Source: https://github.com/nlohmann/%{n}/releases/download/v%{realversion}/include.zip
+
+%prep
+%setup -c
+
+%build
+
+%install
+mkdir -p %{i}/include/nlohmann
+cp -a include/nlohmann/json_fwd.hpp     %{i}/include/nlohmann/
+cp -a single_include/nlohmann/json.hpp  %{i}/include/nlohmann/
+
+%post


### PR DESCRIPTION
Add an external and a tool file for  [Niels Lohmann's JSON for Modern C++](https://github.com/nlohmann/json) header-only library, from https://github.com/nlohmann/json .

Can be used in CMSSW by adding to a BuildFile.xml:
```xml
<use name="json"/>
```

and to a source or header file:
```c++
#include <nlohmann/json.hpp>
using json = nlohmann::json;
```

or, to include only the forward-declation:
```c++
#include <nlohmann/json_fwd.hpp>
using json = nlohmann::json;
```

See https://github.com/nlohmann/json/blob/develop/README.md for some documentation.