### PR TITLE
New go version

### DIFF
--- a/exporters.spec
+++ b/exporters.spec
@@ -49,7 +49,9 @@ go get github.com/shirou/gopsutil/process
 go get github.com/golang/dep/cmd/dep
 go get github.com/golang/glog
 go get github.com/namsral/flag
+
 #go get github.com/gesellix/couchdb-prometheus-exporter/glogadapt
+
 go get -d github.com/gesellix/couchdb-prometheus-exporter/lib
 go get -d github.com/gesellix/couchdb-prometheus-exporter
 go get github.com/prometheus/node_exporter

--- a/exporters.spec
+++ b/exporters.spec
@@ -1,10 +1,10 @@
-### RPM cms exporters 0.1.3
+### RPM cms exporters 0.1.4
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
 %define pkg cmsweb-exporters
 %define ver %realversion
 %define pkg1 glide
-%define ver1 0.13.2
+%define ver1 0.13.3
 %define dir1 linux-amd64
 %define pkg2 mongodb_exporter
 %define ver2 1.0.0
@@ -49,9 +49,9 @@ go get github.com/shirou/gopsutil/process
 go get github.com/golang/dep/cmd/dep
 go get github.com/golang/glog
 go get github.com/namsral/flag
-go get github.com/gesellix/couchdb-prometheus-exporter/glogadapt
-go get github.com/gesellix/couchdb-prometheus-exporter/lib
-go get github.com/gesellix/couchdb-prometheus-exporter
+#go get github.com/gesellix/couchdb-prometheus-exporter/glogadapt
+go get -d github.com/gesellix/couchdb-prometheus-exporter/lib
+go get -d github.com/gesellix/couchdb-prometheus-exporter
 go get github.com/prometheus/node_exporter
 
 go build process_exporter.go

--- a/go.spec
+++ b/go.spec
@@ -1,4 +1,4 @@
-### RPM external go 1.12.5
+### RPM external go 1.13.8
 
 Source: https://storage.googleapis.com/golang/go%{realversion}.linux-amd64.tar.gz
 


### PR DESCRIPTION
After several iterations I found that our stack of exporters (and DAS) works with Go version of 1.13.8, but does not yet work with 1.14. This PR updates go compiler to version 1.13.8 and adjust exporters spec accordingly. Please note that tfaas still fails with new Go compiler due to outdated list of dependencies of Go stack in TensorFlow. Therefore it should be removed from comp.spec and from repository for time being until I found a resolution.