### PR TITLE
Bump python psutil to 5.6.6

### DIFF
--- a/py3-psutil.spec
+++ b/py3-psutil.spec
@@ -1,5 +1,5 @@
-### RPM external py2-psutil 5.6.6
-## IMPORT build-with-pip
+### RPM external py3-psutil 5.6.6
+## IMPORT build-with-pip3
 
 %define find %i -name '*.egg-info' -delete; \
     find %i -name '.package-checksum' -delete


### PR DESCRIPTION
Bump psutil in order to fix the following moderate severity vulnerability:
```
CVE-2019-18874
Vulnerable versions: <= 5.6.5
Patched version: 5.6.6

psutil (aka python-psutil) through 5.6.5 can have a double free. This occurs because of refcount mishandling within a while or for loop that converts system data into a Python object.
```

Also created a python3 spec file.

Not tested in my private VM.