### PR TITLE
Remove py3-onnxruntime as it does not build for aarch64

### DIFF
--- a/python_tools.spec
+++ b/python_tools.spec
@@ -219,7 +219,6 @@ Requires: py2-wrapt
 
 %ifnarch ppc64le
 Requires: py2-pycuda
-Requires: py3-onnxruntime
 %endif
 
 %prep


### PR DESCRIPTION
@mrodozov , please check if we can build it directly from sources