### PR TITLE
OnnxRuntime: enable python bindings

### DIFF
--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -13,7 +13,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
   <client>
     <environment name="ONNXRUNTIME_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$ONNXRUNTIME_BASE/include"/>
-    <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib64"/>
+    <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
   </client>
   <use name="protobuf"/>
   <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,4 +1,5 @@
 ### RPM external onnxruntime 1.0.0
+## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 %define tag 0f048da7774428d5fb2c4c808fc5820809ab24b8
 %define branch cms/v1.0.0_pb380
 %define github_user cms-externals
@@ -17,6 +18,9 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3 \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="%{i}" \
+   -DCMAKE_INSTALL_LIBDIR=lib \
+   -Donnxruntime_BUILD_UNIT_TESTS=ON \
+   -Donnxruntime_ENABLE_PYTHON=ON \
    -Donnxruntime_BUILD_SHARED_LIB=ON \
    -Donnxruntime_USE_CUDA=OFF \
    -Donnxruntime_USE_NSYNC=OFF \
@@ -38,13 +42,15 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -Donnxruntime_CROSS_COMPILING=OFF \
    -Donnxruntime_USE_FULL_PROTOBUF=ON \
    -Donnxruntime_DISABLE_CONTRIB_OPS=OFF \
-   -Donnxruntime_BUILD_UNIT_TESTS=OFF \
    -Donnxruntime_USE_PREINSTALLED_PROTOBUF=ON \
    -Dprotobuf_INSTALL_PATH=${PROTOBUF_ROOT} \
    -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${LIBPNG_ROOT}"
 
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
+python3 ../%{n}-%{realversion}/setup.py build
 
 %install
 cd ../build
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
+mkdir -p %{i}/${PYTHON3_LIB_SITE_PACKAGES}
+mv build/lib/onnxruntime %{i}/${PYTHON3_LIB_SITE_PACKAGES}/

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -219,6 +219,7 @@ Requires: py2-wrapt
 
 %ifnarch ppc64le
 Requires: py2-pycuda
+Requires: onnxruntime
 %endif
 
 %prep


### PR DESCRIPTION
- Enable python bindings
- Due to bug in onnxruntime build, we need to enable unit tests to get the python build
- Use `lib` instead of lib64 so that shared lib and python bindings live in same path