### PR TITLE
CUPLA: check for cuda gcc support

### DIFF
--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -178,13 +178,11 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/nvidia-drivers.xml
 </tool>
 EOF_TOOLFILE
 
-touch cuda_gcc_supported.cu
-if [ $(nvcc -dc cuda_gcc_supported.cu -o cuda_gcc_supported.cu.o 2>&1 | grep 'unsupported GNU version' | wc -l) -eq 0 ] ; then
+if [ $(%{cuda_gcc_support}) = true ] ; then
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-gcc-support.xml
 <tool name="cuda-gcc-support" version="@TOOL_VERSION@">
 </tool>
 EOF_TOOLFILE
 fi
-rm -f cuda_gcc_supported.*
 
 ## IMPORT scram-tools-post

--- a/cupla.spec
+++ b/cupla.spec
@@ -37,12 +37,13 @@ done
 g++ $CXXFLAGS $HOST_FLAGS build/tbb/*.o -L$TBB_ROOT/lib -ltbb -shared -o lib/libcupla-tbb.so
 
 # build the CUDA GPU backend
-mkdir build/cuda
-for FILE in $FILES; do
-  nvcc -DALPAKA_ACC_GPU_CUDA_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1 $CXXFLAGS $NVCC_FLAGS -Xcompiler "$HOST_FLAGS" -x cu -c $FILE -o build/cuda/$(basename $FILE).o
-done
-g++ $CXXFLAGS $HOST_FLAGS build/cuda/*.o -L$CUDA_ROOT/lib64 -lcudart -shared -o lib/libcupla-cuda.so
-
+if [ $(%{cuda_gcc_support}) = true ] ; then
+  mkdir build/cuda
+  for FILE in $FILES; do
+    nvcc -DALPAKA_ACC_GPU_CUDA_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1 $CXXFLAGS $NVCC_FLAGS -Xcompiler "$HOST_FLAGS" -x cu -c $FILE -o build/cuda/$(basename $FILE).o
+  done
+  g++ $CXXFLAGS $HOST_FLAGS build/cuda/*.o -L$CUDA_ROOT/lib64 -lcudart -shared -o lib/libcupla-cuda.so
+fi
 
 %install
 cp -ar include %{i}/include

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -290,4 +290,4 @@ fi
 %define is_ncmsos   %(case %{cmsos} in (%1_*) echo 0 ;; (*) echo 1 ;; esac)
 %define is_cmsarch  %(case %{cmsos} in (*_%1) echo 1 ;; (*) echo 0 ;; esac)
 %define is_ncmsarch %(case %{cmsos} in (*_%1) echo 0 ;; (*) echo 1 ;; esac)
-%define cuda_gcc_support touch cuda_gcc_supported.cu; if [ $(nvcc -dc cuda_gcc_supported.cu -o cuda_gcc_supported.cu.o 2>&1 | grep 'unsupported GNU version' | wc -l) -eq 0 ] ; then echo true; else echo false; fi ; rm -f cuda_gcc_supported.cu
+%define cuda_gcc_support touch cuda_gcc_supported.cu; if [ $(nvcc -dc cuda_gcc_supported.cu -o cuda_gcc_supported.cu.o 2>&1 | grep 'unsupported GNU version' | wc -l) -eq 0 ] ; then echo true; else echo false; fi ; rm -f cuda_gcc_supported.cu*

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -290,3 +290,4 @@ fi
 %define is_ncmsos   %(case %{cmsos} in (%1_*) echo 0 ;; (*) echo 1 ;; esac)
 %define is_cmsarch  %(case %{cmsos} in (*_%1) echo 1 ;; (*) echo 0 ;; esac)
 %define is_ncmsarch %(case %{cmsos} in (*_%1) echo 0 ;; (*) echo 1 ;; esac)
+%define cuda_gcc_support touch cuda_gcc_supported.cu; if [ $(nvcc -dc cuda_gcc_supported.cu -o cuda_gcc_supported.cu.o 2>&1 | grep 'unsupported GNU version' | wc -l) -eq 0 ] ; then echo true; else echo false; fi ; rm -f cuda_gcc_supported.cu


### PR DESCRIPTION
- conditionally build cuda part of cupla if cuda supports our gcc. This should fix gcc9 IBs which are failing as cuda does not support gcc9 and cupla failed to build