### PR TITLE
python tool updates

### DIFF
--- a/pip/GitPython.file
+++ b/pip/GitPython.file
@@ -1,1 +1,1 @@
-Requires: py2-gitdb2 py2-smmap2
+Requires: py2-gitdb2 py2-smmap2 py3-gitdb

--- a/pip/importlib-metadata.file
+++ b/pip/importlib-metadata.file
@@ -1,1 +1,1 @@
-Requires: py2-zipp py2-contextlib2 py2-configparser py2-pathlib2
+Requires: py2-zipp py2-contextlib2 py2-configparser py2-pathlib2 py3-zipp

--- a/pip/importlib-resources.file
+++ b/pip/importlib-resources.file
@@ -1,0 +1,2 @@
+Requires: py2-pathlib2 py2-contextlib2 py2-singledispatch py2-typing py2-zipp py2-importlib-metadata py3-zipp
+

--- a/pip/py3-gitdb.file
+++ b/pip/py3-gitdb.file
@@ -1,0 +1,1 @@
+Requires: py2-smmap

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -266,7 +266,7 @@ webencodings==0.5.1
 Werkzeug==1.0.0
 wheel==0.33.6
 widgetsnbextension==3.5.1
-wrapt==1.12.1
+wrapt==1.11.2 #cannot update before astroid is
 xgboost==0.82 ; python_version<'3.0'
 xgboost==0.90 ; python_version>'3.0'
 xrootdpyfs==0.1.6

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -78,7 +78,7 @@ GitPython==2.1.15 ; python_version<'3.0'
 GitPython==3.1.0 ; python_version>'3.0'
 google-common==0.0.1
 google-pasta==0.2.0
-grpcio==1.25.0
+grpcio==1.27.2
 h5py-cache==1.0
 h5py==2.10.0
 hep_ml==0.6.1
@@ -90,7 +90,7 @@ hyperas==0.4.1
 hyperopt==0.2.3
 idna==2.9
 importlib-metadata==1.5.0
-importlib-resources==1.3.1
+importlib-resources==1.4.0
 ipaddress==1.0.23
 ipykernel==4.10.1 ; python_version<'3.0'
 ipykernel==5.1.3 ; python_version>'3.0'
@@ -200,12 +200,12 @@ pytest==4.6.9 ; python_version<'3.0'
 pytest==5.2.2 ; python_version>'3.0'
 pytest-cov==2.8.1
 pytest-runner==5.2
-python-cjson==1.2.1;python_version<'3.0'
+python-cjson==1.2.2;python_version<'3.0'
 python-dateutil==2.8.1
 python-ldap==3.2.0
 pytools==2020.1
 pytz==2019.3
-PyYAML==5.3
+PyYAML==5.3.1
 pyzmq==19.0.0
 qtconsole==4.5.5
 repoze-lru==0.7
@@ -259,7 +259,7 @@ uproot==3.11.3
 uproot-methods==0.7.3
 urllib3==1.25.8
 virtualenv-clone==0.5.3
-virtualenv==20.0.10
+virtualenv==20.0.13
 virtualenvwrapper==4.8.4
 wcwidth==0.1.8
 webencodings==0.5.1

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -36,7 +36,7 @@ backports-ssl_match_hostname==3.7.0.1
 backports-weakref==1.0.post1
 backports-os==0.1.1
 beautifulsoup4==4.8.2
-bleach==3.1.1
+bleach==3.1.3
 bokeh==1.4.0
 Bottleneck==1.3.2
 cachetools==3.1.1
@@ -51,17 +51,19 @@ cloudpickle==1.3.0
 colorama==0.4.3
 configparser==4.0.2
 contextlib2==0.6.0.post1
-coverage==4.5.4
+coverage==5.0.4
 cryptography==2.8
 cx-Oracle==7.3.0
 cycler==0.10.0
 cython==0.29.15
 decorator==4.4.2
 defusedxml==0.6.0
+distlib==0.3.0
 docopt==0.6.2
 downhill==0.4.0
 entrypoints==0.3
 enum34==1.1.10;python_version<'3.0'
+filelock==3.0.12
 flake8==3.7.9
 flawfinder==2.0.11
 fs==2.4.11
@@ -70,11 +72,12 @@ functools32==3.2.3-2;python_version<'3.0'
 future==0.18.2
 futures==3.3.0;python_version<'3.0'
 gast==0.3.3
-gitdb2==2.0.6
+gitdb2==2.0.6 ; python_version<'3.0'
+gitdb==4.0.2 ; python_version>'3.0'
 GitPython==2.1.15 ; python_version<'3.0'
-GitPython==3.0.4 ; python_version>'3.0'
+GitPython==3.1.0 ; python_version>'3.0'
 google-common==0.0.1
-google-pasta==0.1.8
+google-pasta==0.2.0
 grpcio==1.25.0
 h5py-cache==1.0
 h5py==2.10.0
@@ -86,7 +89,8 @@ html5lib==1.0.1
 hyperas==0.4.1
 hyperopt==0.2.3
 idna==2.9
-importlib-metadata==0.23
+importlib-metadata==1.5.0
+importlib-resources==1.3.1
 ipaddress==1.0.23
 ipykernel==4.10.1 ; python_version<'3.0'
 ipykernel==5.1.3 ; python_version>'3.0'
@@ -150,7 +154,7 @@ onnxruntime==1.2.0 ; python_version>'3.0'
 opt-einsum==2.3.2 ; python_version<'3.0'
 opt-einsum==3.1.0 ; python_version>'3.0'
 ordereddict==1.1
-packaging==19.2
+packaging==20.3
 pandas==0.24.2 ; python_version<'3.0'
 pandas==0.25.3 ; python_version>'3.0'
 pandocfilters==1.4.2
@@ -158,7 +162,7 @@ parsimonious==0.8.1
 parso==0.5.2
 pathlib2==2.3.5
 pbr==5.4.4
-pexpect==4.7.0
+pexpect==4.8.0
 pickleshare==0.7.5
 pillow==6.2.2
 pkgconfig==1.5.1
@@ -199,7 +203,7 @@ pytest-runner==5.2
 python-cjson==1.2.1;python_version<'3.0'
 python-dateutil==2.8.1
 python-ldap==3.2.0
-pytools==2019.1.1
+pytools==2020.1
 pytz==2019.3
 PyYAML==5.3
 pyzmq==19.0.0
@@ -222,7 +226,8 @@ setuptools-scm==3.5.0
 simplegeneric==0.8.1
 singledispatch==3.4.0.3
 six==1.14.0
-smmap2==2.0.5
+smmap==3.0.1
+smmap2==3.0.1
 soupsieve==1.9.5
 sqlalchemy==1.3.11
 stevedore==1.32.0
@@ -254,16 +259,18 @@ uproot==3.11.3
 uproot-methods==0.7.3
 urllib3==1.25.8
 virtualenv-clone==0.5.3
-virtualenv==16.7.7
+virtualenv==20.0.10
 virtualenvwrapper==4.8.4
 wcwidth==0.1.8
 webencodings==0.5.1
-Werkzeug==0.16.0
+Werkzeug==1.0.0
 wheel==0.33.6
 widgetsnbextension==3.5.1
-wrapt==1.11.2
+wrapt==1.12.1
 xgboost==0.82 ; python_version<'3.0'
 xgboost==0.90 ; python_version>'3.0'
 xrootdpyfs==0.1.6
 hepdata-lib==0.3.0;python_version<'3.0'
-zipp==0.6.0
+zipp==1.2.0 ; python_version<'3.0'
+zipp==3.1.0 ; python_version>'3.0'
+

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -266,7 +266,8 @@ webencodings==0.5.1
 Werkzeug==1.0.0
 wheel==0.33.6
 widgetsnbextension==3.5.1
-wrapt==1.11.2 #cannot update before astroid is
+#cannot wrapt update before astroid is
+wrapt==1.11.2 
 xgboost==0.82 ; python_version<'3.0'
 xgboost==0.90 ; python_version>'3.0'
 xrootdpyfs==0.1.6

--- a/pip/smmap2.file
+++ b/pip/smmap2.file
@@ -1,0 +1,1 @@
+Requires: py2-smmap

--- a/pip/virtualenv.file
+++ b/pip/virtualenv.file
@@ -1,1 +1,2 @@
+Requires: py2-appdirs py2-distlib py2-filelock py2-six py2-importlib-metadata py2-importlib-resources
 %define RelocatePython %{i}/bin/*

--- a/pip/zipp.file
+++ b/pip/zipp.file
@@ -1,1 +1,1 @@
-Requires: py2-more-itertools py3-more-itertools py2-setuptools-scm
+Requires: py2-more-itertools py3-more-itertools py2-setuptools-scm  py2-contextlib2

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -164,7 +164,7 @@ Requires: py2-backports_abc
 Requires: py2-colorama
 Requires: py2-lxml
 Requires: py2-beautifulsoup4
-Requires: py2-GitPython
+Requires: py2-GitPython py3-GitPython
 Requires: py2-Send2Trash
 Requires: py2-gitdb2
 Requires: py2-ipaddress
@@ -213,6 +213,14 @@ Requires: py2-lazy-object-proxy
 Requires: py2-pylint
 Requires: py2-pytest-cov
 Requires: py2-wrapt
+
+Requires: py2-distlib
+Requires: py2-filelock
+Requires: py3-gitdb
+Requires: py2-importlib-resources
+Requires: py2-smmap
+Requires: py2-zipp py3-zipp
+
 
 %ifnarch ppc64le
 Requires: py2-pycuda


### PR DESCRIPTION
Additional python package updates - nearly caught up with what is in pypi now.

Not really for this PR - it seems we need to revisit what ends up in python_tools.spec. It doesn't seem we are maintaining the py3-*specs there.  Perhaps this file can be automatically derived from requirements.txt plus the list of exceptions?
