### PR TITLE
[CRAB] Created symlink crab pointing to crab-prod

### DIFF
--- a/crab.spec
+++ b/crab.spec
@@ -61,4 +61,4 @@ for pkg in $(echo %{directpkgreqs} | tr ' ' '\n' | grep '^cms/crab-') ; do
   rm -f common/_crab-startup common/${crab_name}
   ln -s ../${crab}/bin/crab.sh common/${crab_name}
 done
-ln -s crab-prod common/crab
+ln -sf crab-prod common/crab

--- a/crab.spec
+++ b/crab.spec
@@ -58,7 +58,6 @@ for pkg in $(echo %{directpkgreqs} | tr ' ' '\n' | grep '^cms/crab-') ; do
   done
   #Find latest version; extra .zzzz are added so that version 3.3.2001 becomes > 3.3.2001.rcX
   ls -d share/cms/${crab_name}/*/bin/crab | sed -e 's|/bin/crab$|.zzzz|;s|.*/||' | sort -n | sed -e 's|.zzzz$||' | tail -1 > ${crab}/etc/${crab_name}.latest
-  rm -f common/_crab-startup common/${crab_name}
-  ln -s ../${crab}/bin/crab.sh common/${crab_name}
+  ln -sf ../${crab}/bin/crab.sh common/${crab_name}
 done
 ln -sf crab-prod common/crab

--- a/crab.spec
+++ b/crab.spec
@@ -61,3 +61,4 @@ for pkg in $(echo %{directpkgreqs} | tr ' ' '\n' | grep '^cms/crab-') ; do
   rm -f common/_crab-startup common/${crab_name}
   ln -s ../${crab}/bin/crab.sh common/${crab_name}
 done
+ln -s crab-prod common/crab


### PR DESCRIPTION
@belforte , this change should make `crab` command available in cms environment. We can merge it for the integration build now so that you can run some test. Next CMSSW 11.1.X release might be around mid of April. In case we need it earlier then we can request Bockjoo to manually deploy it on /cvmfs/cms.cern.ch 