### PR TITLE
Update HTCondor to 8.9.6.a1

### DIFF
--- a/cms-htcondor-build.patch
+++ b/cms-htcondor-build.patch
@@ -1,6 +1,6 @@
 --- a/build/cmake/CondorConfigure.cmake
 +++ b/build/cmake/CondorConfigure.cmake
-@@ -501,7 +501,7 @@ endif()
+@@ -813,7 +813,7 @@
  #####################################
  # RPATH option
  if (LINUX AND NOT PROPER)
@@ -9,7 +9,7 @@
  else()
  	option(CMAKE_SKIP_RPATH "Skip RPATH on executables" ON)
  endif()
-@@ -967,7 +967,7 @@ else(MSVC)
+@@ -1328,7 +1328,7 @@
  	endif()
  
  	if (LINUX)
@@ -18,44 +18,44 @@
  		if ( "${LINUX_NAME}" STREQUAL "Ubuntu" )
  			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
  		endif()
+@@ -1339,9 +1339,9 @@
+ 		endif()
+ 	endif(LINUX)
+ 
+-	if (LINUX)
+-		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--enable-new-dtags")
+-	endif(LINUX)
++	#if (LINUX)
++		#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--enable-new-dtags")
++	#endif(LINUX)
+ 
+ 	if (AIX)
+ 		# specifically ask for the C++ libraries to be statically linked
 --- a/build/cmake/CondorPackageConfig.cmake
 +++ b/build/cmake/CondorPackageConfig.cmake
-@@ -168,9 +168,9 @@
+@@ -168,14 +168,14 @@
+ 		set( CONDOR_RPATH "$ORIGIN/../lib:/lib:/usr/lib:$ORIGIN/../lib/condor:/usr/lib/condor" )
  		set( EXTERNALS_RPATH "$ORIGIN/../lib:/lib:/usr/lib:$ORIGIN/../lib/condor:/usr/lib/condor" )
- 		set( PYTHON_RPATH "$ORIGIN/../:/lib:/usr/lib:$ORIGIN/../condor" )
- 	else()
+ 		set( PYTHON_RPATH "$ORIGIN/../../:/lib:/usr/lib:$ORIGIN/../../condor" )
+-	else()
 -		set( CONDOR_RPATH "$ORIGIN/../lib:/lib64:/usr/lib64:$ORIGIN/../lib/condor:/usr/lib64/condor" )
 -		set( EXTERNALS_RPATH "$ORIGIN/../lib:/lib64:/usr/lib64:$ORIGIN/../lib/condor:/usr/lib64/condor" )
--		set( PYTHON_RPATH "$ORIGIN/../:/lib64:/usr/lib64:$ORIGIN/../condor" )
+-        if ( ${SYSTEM_NAME} MATCHES "rhel7" OR ${SYSTEM_NAME} MATCHES "centos7" OR ${SYSTEM_NAME} MATCHES "sl7")
+-            set( PYTHON_RPATH "$ORIGIN/../../:/usr/lib64/boost169:/lib64:/usr/lib64:$ORIGIN/../../condor" )
+-        else()
+-            set( PYTHON_RPATH "$ORIGIN/../../:/lib64:/usr/lib64:$ORIGIN/../../condor" )
+-        endif()
++	#else()
 +		#set( CONDOR_RPATH "$ORIGIN/../lib:/lib64:/usr/lib64:$ORIGIN/../lib/condor:/usr/lib64/condor" )
 +		#set( EXTERNALS_RPATH "$ORIGIN/../lib:/lib64:/usr/lib64:$ORIGIN/../lib/condor:/usr/lib64/condor" )
-+		#set( PYTHON_RPATH "$ORIGIN/../:/lib64:/usr/lib64:$ORIGIN/../condor" )
++        #if ( ${SYSTEM_NAME} MATCHES "rhel7" OR ${SYSTEM_NAME} MATCHES "centos7" OR ${SYSTEM_NAME} MATCHES "sl7")
++            #set( PYTHON_RPATH "$ORIGIN/../../:/usr/lib64/boost169:/lib64:/usr/lib64:$ORIGIN/../../condor" )
++        #else()
++            #set( PYTHON_RPATH "$ORIGIN/../../:/lib64:/usr/lib64:$ORIGIN/../../condor" )
++        #endif()
  	endif()
  elseif( ${OS_NAME} STREQUAL "DARWIN" )
  	set( EXTERNALS_LIB "${C_LIB}/condor" )
---- a/build/cmake/macros/CondorSetLinkLibs.cmake
-+++ b/build/cmake/macros/CondorSetLinkLibs.cmake
-@@ -32,7 +32,8 @@ if (${_CNDR_TARGET}LinkLibs)
- 		if (DARWIN OR AIX OR SOLARIS)
- 			target_link_libraries( ${_CNDR_TARGET} ${${_CNDR_TARGET}LinkLibs} ${${_CNDR_TARGET}LinkLibs}  )
- 		else()
--	 		target_link_libraries( ${_CNDR_TARGET} -Wl,--start-group ${${_CNDR_TARGET}LinkLibs} -Wl,--end-group -Wl,--enable-new-dtags )
-+	 		#target_link_libraries( ${_CNDR_TARGET} -Wl,--start-group ${${_CNDR_TARGET}LinkLibs} -Wl,--end-group -Wl,--enable-new-dtags )
-+	 		target_link_libraries( ${_CNDR_TARGET} ${${_CNDR_TARGET}LinkLibs} ${${_CNDR_TARGET}LinkLibs} )
- 		endif()
- 	 else()
- 	 	target_link_libraries( ${_CNDR_TARGET} ${${_CNDR_TARGET}LinkLibs};${CONDOR_WIN_LIBS} )
---- a/externals/bundles/glibc/CMakeLists.txt
-+++ b/externals/bundles/glibc/CMakeLists.txt
-@@ -31,7 +31,7 @@ if (NOT CLIPPED)
- 	# check only the major and minor bits of gcc version.
- 	string(SUBSTRING ${CMAKE_C_COMPILER_VERSION} 0 2 GCC_VER_CHECK)
- 	# corner off glibc b/c it effect  
--	set(GLIBC_DETECTED ON)
-+	#set(GLIBC_DETECTED ON)
-         set(GLIBC_BUILD_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/glibc-prefix/src/glibc)
- 
- 	# By default, we don't need to set any flag environment variables
 --- a/src/nordugrid_gahp/CMakeLists.txt
 +++ b/src/nordugrid_gahp/CMakeLists.txt
 @@ -16,12 +16,7 @@

--- a/condor.spec
+++ b/condor.spec
@@ -1,4 +1,4 @@
-### RPM external condor 8.8.3
+### RPM external condor 8.9.6.a1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib/condor
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 %define condortag %(echo V%realversion | tr "." "_")


### PR DESCRIPTION
This updates HTCondor to the latest development version 8.9.6.a1

This is currently failing because it cannot find systemd dev dependencies:`sd-daemon.h`. Can we fake this dependency?

```
condor-8.9.6.a1/CMakeFiles/CMakeTmp/CheckIncludeFiles.c
/build/khurtado/w/BUILD/slc7_amd64_gcc630/external/condor/8.9.6.a1/condor-8.9.6.a1/CMakeFiles/CMakeTmp/CheckIncludeFiles.c:2:31: fatal error: systemd/sd-daemon.h: No such file or directory
 #include <systemd/sd-daemon.h>
                               ^
compilation terminated.
gmake[1]: *** [CMakeFiles/cmTC_f792c.dir/CheckIncludeFiles.c.o] Error 1
gmake[1]: Leaving directory `/build/khurtado/w/BUILD/slc7_amd64_gcc630/external/condor/8.9.6.a1/condor-8.9.6.a1/CMakeFiles/CMakeTmp'
gmake: *** [cmTC_f792c/fast] Error 2

Source:
/* */
#include <systemd/sd-daemon.h>
```