### PR TITLE
[10.2.X][RecoBTag-Combined]DNN models for the ParticleNet tagger

### DIFF
--- a/data-RecoBTag-Combined.spec
+++ b/data-RecoBTag-Combined.spec
@@ -1,4 +1,4 @@
-### RPM cms data-RecoBTag-Combined V01-01-03
+### RPM cms data-RecoBTag-Combined V01-01-03-01
 
 %prep
 


### PR DESCRIPTION
back ported https://github.com/cms-data/RecoBTag-Combined/pull/26 for 10.2.X. Should be tested with https://github.com/cms-sw/cmssw/pull/29063