### PR TITLE
[BuildRules] Fix clang-tidy script to work with LLVM 9.0.1 too

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-75
+%define configtag       V05-08-76
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This fixes the script with parses the yaml files generated by clang-tidy so that we only apply changes for the files changed by PR. In LLVM 9 they have changed the format of yaml thatis why clang-tidy is not suggesting any thing for PR.

This means once we have integrated this then we can ask to re-run code PR for open PRs.
For already mrged code with out clang-tidy we will open PR to get fix those. There are 800+ cmssw files which needed updates
 
FYI @makortel , @silviodonato 
