### PR TITLE
use current cx-oracle

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -11,7 +11,7 @@
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle51
+Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle
 Requires: py2-pyOpenSSL condor py2-mysqldb dbs3-pycurl-client dbs-client dbs3-client py2-retry
 Requires: jemalloc
 BuildRequires: py2-sphinx


### PR DESCRIPTION
No idea why it was locked to 5.1. in https://github.com/cms-sw/cmsdist/commit/276421ac450b4e5d1042cc5d111a899b197c3f22
Maybe it was meant as a temporary thing, currently crabserver would be the only app in cmsweb using py2-cx-oracle51 instead of py2-cx-oracle 
Anyhow 5.1 does not work anymore with sqlplus creating problems in building/changing the DB
