### PR TITLE
Do not allow to link agaisnt PyROOT library

### DIFF
--- a/root-toolfile.spec
+++ b/root-toolfile.spec
@@ -220,7 +220,6 @@ EOF_TOOLFILE
 cat << \EOF_TOOLFILE >%i/etc/scram.d/rootpy.xml
 <tool name="rootpy" version="@TOOL_VERSION@">
   <info url="http://root.cern.ch/root/"/>
-  <lib name="PyROOT"/>
   <use name="rootgraphics"/>
 </tool>
 EOF_TOOLFILE


### PR DESCRIPTION
This can bring in a different python version, so do not allow any product to link against it. We can drop the `rootpy.xml` all together.