### PR TITLE
[Geant4]Update geant4 10.6.1

### DIFF
--- a/clhep.spec
+++ b/clhep.spec
@@ -1,6 +1,6 @@
-### RPM external clhep 2.4.0.0
+### RPM external clhep 2.4.1.3
 
-%define tag 4b23da33f4607fde6f47c864871972558aa75c39
+%define tag bf87ac557a7be3a8a2ead6b27fbbc89dd7ed4c0b
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz

--- a/geant4-G4ABLA.spec
+++ b/geant4-G4ABLA.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4ABLA 3.0
+### RPM external geant4-G4ABLA 3.1
 %define G4RunTime G4ABLADATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4EMLOW.spec
+++ b/geant4-G4EMLOW.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4EMLOW 7.3
+### RPM external geant4-G4EMLOW 7.9.1
 %define G4RunTime G4LEDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4INCL.spec
+++ b/geant4-G4INCL.spec
@@ -1,0 +1,4 @@
+### RPM external geant4-G4INCL 1.0
+%define G4RunTime G4INCLDATA
+
+## IMPORT geant4-data-rpm

--- a/geant4-G4NDL.spec
+++ b/geant4-G4NDL.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4NDL 4.5
+### RPM external geant4-G4NDL 4.6
 %define G4RunTime G4NEUTRONHPDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4NEUTRONXS.spec
+++ b/geant4-G4NEUTRONXS.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4NEUTRONXS 1.4
+### RPM external geant4-G4NEUTRONXS 2.0
 %define G4RunTime G4NEUTRONXSDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4PARTICLEXS.spec
+++ b/geant4-G4PARTICLEXS.spec
@@ -1,0 +1,4 @@
+### RPM external geant4-G4PARTICLEXS 2.1
+%define G4RunTime G4PARTICLEXSDATA
+
+## IMPORT geant4-data-rpm

--- a/geant4-G4PhotonEvaporation.spec
+++ b/geant4-G4PhotonEvaporation.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4PhotonEvaporation 5.2
+### RPM external geant4-G4PhotonEvaporation 5.5
 %define G4RunTime G4LEVELGAMMADATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4RadioactiveDecay.spec
+++ b/geant4-G4RadioactiveDecay.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4RadioactiveDecay 5.2
+### RPM external geant4-G4RadioactiveDecay 5.4
 %define G4RunTime G4RADIOACTIVEDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-G4RealSurface.spec
+++ b/geant4-G4RealSurface.spec
@@ -1,0 +1,4 @@
+### RPM external geant4-G4RealSurface 2.1.1
+%define G4RunTime G4REALSURFACEDATA
+
+## IMPORT geant4-data-rpm

--- a/geant4-G4SAIDDATA.spec
+++ b/geant4-G4SAIDDATA.spec
@@ -1,4 +1,4 @@
-### RPM external geant4-G4SAIDDATA 1.1
+### RPM external geant4-G4SAIDDATA 2.0
 %define G4RunTime G4SAIDXSDATA
 
 ## IMPORT geant4-data-rpm

--- a/geant4-toolfile.spec
+++ b/geant4-toolfile.spec
@@ -10,7 +10,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4.xml
   <info url="http://geant4.web.cern.ch/geant4/"/>
   <use name="geant4core"/>
   <use name="geant4vis"/>
-  <use name="xerces-c"/>
 </tool>
 EOF_TOOLFILE
 
@@ -36,7 +35,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4core.xml
   <lib name="G4tracking"/>
   <lib name="G4track"/>
   <lib name="G4analysis"/>
-  <flags CXXFLAGS="-DG4MULTITHREADED -DG4USE_STD11 -DG4GEOM_USE_USOLIDS -ftls-model=global-dynamic -pthread"/>
+  <flags CXXFLAGS="-ftls-model=global-dynamic -pthread"/>
   <client>
     <environment name="GEANT4CORE_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$GEANT4CORE_BASE/lib"/>
@@ -47,6 +46,9 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4core.xml
   <flags cppdefines="GNU_GCC G4V9"/>
   <use name="clhep"/>
   <use name="vecgeom"/>
+  <use name="zlib"/>
+  <use name="expat"/>
+  <use name="xerces-c"/>
   <use name="root_cxxdefaults"/>
 </tool>
 EOF_TOOLFILE
@@ -55,13 +57,15 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4static.xml
 <tool name="geant4static" version="@TOOL_VERSION@">
   <info url="http://geant4.web.cern.ch/geant4/"/>
   <lib name="geant4-static"/>
-  <flags CXXFLAGS="-DG4MULTITHREADED -DG4USE_STD11  -ftls-model=global-dynamic -pthread"/>
+  <flags CXXFLAGS="-ftls-model=global-dynamic -pthread"/>
   <client>
     <environment name="GEANT4STATIC_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$GEANT4STATIC_BASE/lib/archive"/>
   </client>
-  <use name="vecgeom"/>
   <use name="clhep"/>
+  <use name="vecgeom"/>
+  <use name="zlib"/>
+  <use name="expat"/>
   <use name="xerces-c"/>
 </tool>
 EOF_TOOLFILE
@@ -78,7 +82,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4vis.xml
   <lib name="G4visXXX"/>
   <lib name="G4VRML"/>
   <lib name="G4GMocren"/>
-  <lib name="G4zlib"/>
   <use name="geant4core"/>
 </tool>
 EOF_TOOLFILE

--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
-### RPM external geant4 10.4.3
-%define tag 922600305b80a2b23e97abd352b68508cf419540
+### RPM external geant4 10.6.1
+%define tag b14d73978beaee6f5b6694ddbfe0dd54c7cdcf19
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz
@@ -10,6 +10,7 @@ Requires: clhep
 Requires: expat
 Requires: xerces-c
 Requires: vecgeom
+Requires: zlib
 
 %define keep_archives true
 
@@ -26,7 +27,6 @@ fi
 rm -rf ../build
 mkdir ../build
 cd ../build
-export Usolids_DIR=${VECGEOM_ROOT}/lib/cmake/Usolids
 export VecGeom_DIR=${VECGEOM_ROOT}/lib/cmake/VecGeom
 
 cmake ../%{n}.%{realversion} \
@@ -50,13 +50,12 @@ cmake ../%{n}.%{realversion} \
   -DGEANT4_BUILD_VERBOSE_CODE=OFF \
   -DGEANT4_USE_USOLIDS="all" \
   -DBUILD_SHARED_LIBS=ON \
-  -DXERCESC_ROOT_DIR:PATH="${XERCES_C_ROOT}" \
-  -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT" \
-  -DEXPAT_INCLUDE_DIR:PATH="$EXPAT_ROOT/include" \
-  -DEXPAT_LIBRARY:FILEPATH="$EXPAT_ROOT/lib/libexpat.$SOEXT" \
   -DBUILD_STATIC_LIBS=ON \
   -DGEANT4_INSTALL_EXAMPLES=OFF \
   -DGEANT4_USE_SYSTEM_CLHEP=ON \
+  -DGEANT4_USE_SYSTEM_EXPAT=ON \
+  -DCMAKE_PREFIX_PATH="${XERCES_C_ROOT};${CLHEP_ROOT};${EXPAT_ROOT};${VECGEOM_ROOT};${ZLIB_ROOT}" \
+  -DGEANT4_USE_SYSTEM_ZLIB=ON \
   -DGEANT4_BUILD_MULTITHREADED=ON
 
 make %makeprocesses VERBOSE=1
@@ -73,8 +72,7 @@ ar rcs libgeant4-static.a *.o
 find . -name "*.o" -delete
 
 %post
-%{relocateConfig}lib/Geant4-*/Geant4Config.cmake
+%{relocateConfig}lib/Geant4-*/*.cmake
 %{relocateConfig}bin/geant4-config
 %{relocateConfig}bin/geant4.*
 %{relocateConfig}share/Geant4-*/geant4make/geant4make.*
-%{relocateConfig}lib/Geant4-*/Geant4LibraryDepends.cmake

--- a/geant4data.spec
+++ b/geant4data.spec
@@ -5,10 +5,12 @@ Requires: geant4-G4NDL
 Requires: geant4-G4EMLOW
 Requires: geant4-G4PhotonEvaporation
 Requires: geant4-G4RadioactiveDecay
-Requires: geant4-G4NEUTRONXS
+Requires: geant4-G4PARTICLEXS
 Requires: geant4-G4SAIDDATA
 Requires: geant4-G4ABLA
 Requires: geant4-G4ENSDFSTATE
+Requires: geant4-G4RealSurface
+Requires: geant4-G4INCL
 
 %prep
 %build

--- a/vecgeom-fix-for-arm64.patch
+++ b/vecgeom-fix-for-arm64.patch
@@ -11,26 +11,3 @@ index b3014e9..f10fae0 100644
      else()
        message(FATAL_ERROR "Unsupported C++ standard requested")
      endif()
-diff --git a/base/Global.h b/base/Global.h
-index 9856628..d90b1f8 100644
---- a/base/Global.h
-+++ b/base/Global.h
-@@ -31,7 +31,18 @@ using uint = unsigned int;
- #endif
- #else
- // Functionality of <mm_malloc.h> is automatically included in icc
-+#if defined(__i386__) || defined(__x86_64__)
- #include <mm_malloc.h>
-+#else
-+#if __cplusplus >= 201703L
-+#include <cstdlib>
-+#define _mm_malloc(a, b) ::aligned_alloc(b, a)
-+#define _mm_free(p) ::free(p)
-+#else
-+#define _mm_malloc(a, b) malloc(a)
-+#define _mm_free(p) free(p)
-+#endif
-+#endif
- #if (defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)) && !defined(__NO_INLINE__) && \
-     !defined(VECGEOM_NOINLINE)
- #define VECGEOM_FORCE_INLINE inline __attribute__((always_inline))

--- a/vecgeom-toolfile.spec
+++ b/vecgeom-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external vecgeom-toolfile 1.0
+### RPM external vecgeom-toolfile 2.0
 Requires: vecgeom
 %prep
 
@@ -13,6 +13,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/vecgeom_interface.xml
   <client>
     <environment name="VECGEOM_INTERFACE_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$VECGEOM_INTERFACE_BASE/include"/>
+    <environment name="INCLUDE" default="$VECGEOM_INTERFACE_BASE/include/VecGeom"/>
   </client>
   <flags CPPDEFINES="VECGEOM_SCALAR"/>
   <flags CPPDEFINES="VECGEOM_REPLACE_USOLIDS"/>
@@ -20,7 +21,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/vecgeom_interface.xml
   <flags CPPDEFINES="VECGEOM_USOLIDS"/>
   <flags CPPDEFINES="VECGEOM_INPLACE_TRANSFORMATIONS"/>
   <flags CPPDEFINES="VECGEOM_USE_INDEXEDNAVSTATES"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$VECGEOM_INTERFACE_BASE/include" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$VECGEOM_INTERFACE_BASE/include/VecGeom" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>
 EOF_TOOLFILE
@@ -30,7 +32,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/vecgeom.xml
 <tool name="vecgeom" version="@TOOL_VERSION@">
   <info url="https://gitlab.cern.ch/VecGeom/VecGeom"/>
   <lib name="vecgeom"/>
-  <lib name="usolids"/>
   <client>
     <environment name="VECGEOM_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$VECGEOM_BASE/lib"/>

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,20 +1,14 @@
-### RPM external vecgeom v00.05.00
+### RPM external vecgeom v1.1.6
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake gmake
 %define keep_archives true
 
 Patch0: vecgeom-fix-for-arm64
-Patch1: vecgeom-uninit-fix
-Patch2: vecgeom-add-ppc64-cmake-fix
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %patch0 -p1
-%patch1 -p1
-%ifarch ppc64le
-%patch2 -p1
-%endif
 
 %build
 rm -rf ../build


### PR DESCRIPTION
Update Geant4 10.6.1 plus
- clhep: 2.4.1.3
- vecgeom: 1.1.6
- geant4 data needed by new version

This is backport from Geant4 branch and should be tested with https://github.com/cms-sw/cmssw/pull/29442 