### PR TITLE
Include Eigne include directory in ROOT_INCLUDE_PATH

### DIFF
--- a/eigen-toolfile.spec
+++ b/eigen-toolfile.spec
@@ -13,6 +13,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/eigen.xml
     <environment name="EIGEN_BASE"   default="@TOOL_ROOT@"/>
     <environment name="INCLUDE"      default="$EIGEN_BASE/include/eigen3"/>
   </client>
+  <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags CPPDEFINES="EIGEN_DONT_PARALLELIZE"/>
 </tool>
 EOF_TOOLFILE


### PR DESCRIPTION
As reported here https://github.com/cms-sw/cmssw/issues/29444 , now we have eigen dependency in dataformats and phase2 workflows workflows are failing as root is not able to find eigen headers. This PR propose to add eigen include directory in ROOT_INCLUDE_PATH which is used by root for finding headers at runtime.