### PR TITLE
[Sonic] Add grpc recipe

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -87,6 +87,7 @@ Requires: valgrind-toolfile
 Requires: cmsswdata-toolfile
 Requires: zstd-toolfile
 Requires: hls-toolfile
+Requires: grpc-toolfile
 %ifnarch ppc64le
 Requires: onnxruntime-toolfile
 %endif

--- a/grpc-toolfile.spec
+++ b/grpc-toolfile.spec
@@ -46,8 +46,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
   <lib name="absl_utility"/>
   <lib name="absl_meta"/>
   <lib name="cares"/>
-  <lib name="ssl"/>
-  <lib name="crypto"/>
   <lib name="address_sorting"/>
   <client>
     <environment name="GRPC_BASE" default="@TOOL_ROOT@"/>
@@ -55,6 +53,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
     <environment name="LIBDIR" default="$GRPC_BASE/lib"/>
   </client>
   <use name="protobuf"/>
+  <use name="openssl"/>
 </tool>
 EOF_TOOLFILE
 

--- a/grpc-toolfile.spec
+++ b/grpc-toolfile.spec
@@ -1,0 +1,61 @@
+### RPM external grpc-toolfile 1.0
+Requires: grpc
+
+%prep
+
+%build
+
+%install
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
+<tool name="grpc" version="@TOOL_VERSION@">
+  <info url="https://github.com/grpc/grpc"/>
+  <lib name="grpc"/>
+  <lib name="grpc++"/>
+  <lib name="grpc++_reflection"/>
+  <lib name="absl_algorithm"/>
+  <lib name="absl_atomic_hook"/>
+  <lib name="absl_bad_optional_access"/>
+  <lib name="absl_base"/>
+  <lib name="absl_base_internal"/>
+  <lib name="absl_bits"/>
+  <lib name="absl_civil_time"/>
+  <lib name="absl_compressed_tuple"/>
+  <lib name="absl_config"/>
+  <lib name="absl_core_headers"/>
+  <lib name="absl_dynamic_annotations"/>
+  <lib name="absl_endian"/>
+  <lib name="absl_errno_saver"/>
+  <lib name="absl_inlined_vector"/>
+  <lib name="absl_inlined_vector_internal"/>
+  <lib name="absl_int128"/>
+  <lib name="absl_log_severity"/>
+  <lib name="absl_memory"/>
+  <lib name="absl_optional"/>
+  <lib name="absl_raw_logging_internal"/>
+  <lib name="absl_span"/>
+  <lib name="absl_spinlock_wait"/>
+  <lib name="absl_str_format"/>
+  <lib name="absl_str_format_internal"/>
+  <lib name="absl_strings"/>
+  <lib name="absl_strings_internal"/>
+  <lib name="absl_throw_delegate"/>
+  <lib name="absl_time"/>
+  <lib name="absl_time_zone"/>
+  <lib name="absl_type_traits"/>
+  <lib name="absl_utility"/>
+  <lib name="absl_meta"/>
+  <lib name="cares"/>
+  <lib name="ssl"/>
+  <lib name="crypto"/>
+  <lib name="address_sorting"/>
+  <client>
+    <environment name="GRPC_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$GRPC_BASE/include"/>
+    <environment name="LIBDIR" default="$GRPC_BASE/lib"/>
+  </client>
+  <use name="protobuf"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/grpc-toolfile.spec
+++ b/grpc-toolfile.spec
@@ -7,12 +7,20 @@ Requires: grpc
 
 %install
 mkdir -p %i/etc/scram.d
+
 cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
 <tool name="grpc" version="@TOOL_VERSION@">
   <info url="https://github.com/grpc/grpc"/>
-  <lib name="grpc"/>
-  <lib name="grpc++"/>
-  <lib name="grpc++_reflection"/>
+  <client>
+    <environment name="GRPC_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$GRPC_BASE/include"/>
+    <environment name="LIBDIR" default="$GRPC_BASE/lib"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc-absl.xml
+<tool name="grpc-absl" version="@TOOL_VERSION@">
   <lib name="absl_algorithm"/>
   <lib name="absl_atomic_hook"/>
   <lib name="absl_bad_optional_access"/>
@@ -45,16 +53,23 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
   <lib name="absl_type_traits"/>
   <lib name="absl_utility"/>
   <lib name="absl_meta"/>
+  <use name="grpc"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc-lib.xml
+<tool name="grpc-lib" version="@TOOL_VERSION@">
+  <lib name="grpc"/>
+  <lib name="grpc++"/>
+  <lib name="grpc++_reflection"/>
   <lib name="cares"/>
   <lib name="address_sorting"/>
-  <client>
-    <environment name="GRPC_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$GRPC_BASE/include"/>
-    <environment name="LIBDIR" default="$GRPC_BASE/lib"/>
-  </client>
+  <use name="grpc"/>
+  <use name="grpc-absl"/>
   <use name="protobuf"/>
   <use name="openssl"/>
   <use name="pcre"/>
+  <use name="grpc-absl"/>
 </tool>
 EOF_TOOLFILE
 

--- a/grpc-toolfile.spec
+++ b/grpc-toolfile.spec
@@ -54,6 +54,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
   </client>
   <use name="protobuf"/>
   <use name="openssl"/>
+  <use name="pcre"/>
 </tool>
 EOF_TOOLFILE
 

--- a/grpc-toolfile.spec
+++ b/grpc-toolfile.spec
@@ -11,65 +11,17 @@ mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
 <tool name="grpc" version="@TOOL_VERSION@">
   <info url="https://github.com/grpc/grpc"/>
+  <lib name="grpc"/>
+  <lib name="grpc++"/>
+  <lib name="grpc++_reflection"/>
   <client>
     <environment name="GRPC_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$GRPC_BASE/include"/>
     <environment name="LIBDIR" default="$GRPC_BASE/lib"/>
   </client>
-</tool>
-EOF_TOOLFILE
-
-cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc-absl.xml
-<tool name="grpc-absl" version="@TOOL_VERSION@">
-  <lib name="absl_algorithm"/>
-  <lib name="absl_atomic_hook"/>
-  <lib name="absl_bad_optional_access"/>
-  <lib name="absl_base"/>
-  <lib name="absl_base_internal"/>
-  <lib name="absl_bits"/>
-  <lib name="absl_civil_time"/>
-  <lib name="absl_compressed_tuple"/>
-  <lib name="absl_config"/>
-  <lib name="absl_core_headers"/>
-  <lib name="absl_dynamic_annotations"/>
-  <lib name="absl_endian"/>
-  <lib name="absl_errno_saver"/>
-  <lib name="absl_inlined_vector"/>
-  <lib name="absl_inlined_vector_internal"/>
-  <lib name="absl_int128"/>
-  <lib name="absl_log_severity"/>
-  <lib name="absl_memory"/>
-  <lib name="absl_optional"/>
-  <lib name="absl_raw_logging_internal"/>
-  <lib name="absl_span"/>
-  <lib name="absl_spinlock_wait"/>
-  <lib name="absl_str_format"/>
-  <lib name="absl_str_format_internal"/>
-  <lib name="absl_strings"/>
-  <lib name="absl_strings_internal"/>
-  <lib name="absl_throw_delegate"/>
-  <lib name="absl_time"/>
-  <lib name="absl_time_zone"/>
-  <lib name="absl_type_traits"/>
-  <lib name="absl_utility"/>
-  <lib name="absl_meta"/>
-  <use name="grpc"/>
-</tool>
-EOF_TOOLFILE
-
-cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc-lib.xml
-<tool name="grpc-lib" version="@TOOL_VERSION@">
-  <lib name="grpc"/>
-  <lib name="grpc++"/>
-  <lib name="grpc++_reflection"/>
-  <lib name="cares"/>
-  <lib name="address_sorting"/>
-  <use name="grpc"/>
-  <use name="grpc-absl"/>
   <use name="protobuf"/>
   <use name="openssl"/>
   <use name="pcre"/>
-  <use name="grpc-absl"/>
 </tool>
 EOF_TOOLFILE
 

--- a/grpc.spec
+++ b/grpc.spec
@@ -21,6 +21,7 @@ cmake ../%{n}-%{realversion} \
     -DgRPC_INSTALL=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_INSTALL_LIBDIR=lib \
     -DgRPC_ABSL_PROVIDER=module \
     -DgRPC_CARES_PROVIDER=module \
     -DgRPC_PROTOBUF_PROVIDER=package \
@@ -28,7 +29,7 @@ cmake ../%{n}-%{realversion} \
     -DgRPC_ZLIB_PROVIDER=package \
     -DZLIB_ROOT=${ZLIB_ROOT} \
     -DCMAKE_INSTALL_PREFIX=%{i} \
-    -DCMAKE_PREFIX_PATH="${LIBUNWIND_ROOT};${PROTOBUF_ROOT};${ZLIB_ROOT};${OPENSSL_ROOT}"
+    -DCMAKE_PREFIX_PATH="${PCRE_ROOT};${PROTOBUF_ROOT};${ZLIB_ROOT};${OPENSSL_ROOT}"
 
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 

--- a/grpc.spec
+++ b/grpc.spec
@@ -3,7 +3,7 @@
 Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja go
-Requires: protobuf zlib libunwind
+Requires: protobuf zlib libunwind openssl
 %define keep_archives true
 
 %prep
@@ -24,11 +24,11 @@ cmake ../%{n}-%{realversion} \
     -DgRPC_ABSL_PROVIDER=module \
     -DgRPC_CARES_PROVIDER=module \
     -DgRPC_PROTOBUF_PROVIDER=package \
-    -DgRPC_SSL_PROVIDER=module \
+    -DgRPC_SSL_PROVIDER=package \
     -DgRPC_ZLIB_PROVIDER=package \
     -DZLIB_ROOT=${ZLIB_ROOT} \
     -DCMAKE_INSTALL_PREFIX=%{i} \
-    -DCMAKE_PREFIX_PATH="${LIBUNWIND_ROOT};${PROTOBUF_ROOT};${ZLIB_ROOT}"
+    -DCMAKE_PREFIX_PATH="${LIBUNWIND_ROOT};${PROTOBUF_ROOT};${ZLIB_ROOT};${OPENSSL_ROOT}"
 
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 

--- a/grpc.spec
+++ b/grpc.spec
@@ -3,7 +3,10 @@
 Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja go
-Requires: protobuf zlib openssl pcre
+Requires: protobuf zlib pcre
+%if 0%{?centos} == 7
+Requires: openssl
+%endif
 %define keep_archives true
 
 %prep

--- a/grpc.spec
+++ b/grpc.spec
@@ -3,7 +3,7 @@
 Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja go
-Requires: protobuf zlib libunwind openssl pcre
+Requires: protobuf zlib openssl pcre
 %define keep_archives true
 
 %prep

--- a/grpc.spec
+++ b/grpc.spec
@@ -1,0 +1,36 @@
+### RPM external grpc 1.27.3
+
+Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
+
+BuildRequires: cmake ninja
+Requires: protobuf zlib libunwind
+
+%prep
+
+%setup -n %{n}-%{realversion}
+
+%build
+
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+pwd
+
+cmake ../%{n}-%{realversion} \
+    -G Ninja \
+    -DgRPC_INSTALL=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DgRPC_ABSL_PROVIDER=module \
+    -DgRPC_CARES_PROVIDER=module \
+    -DgRPC_PROTOBUF_PROVIDER=package \
+    -DgRPC_SSL_PROVIDER=module \
+    -DgRPC_ZLIB_PROVIDER=package \
+    -DCMAKE_INSTALL_PREFIX=%{i} \
+    -DCMAKE_PREFIX_PATH="${LIBUNWIND_ROOT};{PROTOBUF_ROOT};{ZLIB_ROOT}"
+
+make %{makeprocesses}
+
+%install
+
+make install

--- a/grpc.spec
+++ b/grpc.spec
@@ -1,9 +1,10 @@
-### RPM external grpc 1.27.3
+### RPM external grpc 1.28.1
 
 Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
-BuildRequires: cmake ninja
+BuildRequires: cmake ninja go
 Requires: protobuf zlib libunwind
+%define keep_archives true
 
 %prep
 
@@ -15,22 +16,22 @@ rm -rf ../build
 mkdir ../build
 cd ../build
 
-pwd
-
 cmake ../%{n}-%{realversion} \
     -G Ninja \
     -DgRPC_INSTALL=ON \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
     -DgRPC_ABSL_PROVIDER=module \
     -DgRPC_CARES_PROVIDER=module \
     -DgRPC_PROTOBUF_PROVIDER=package \
     -DgRPC_SSL_PROVIDER=module \
     -DgRPC_ZLIB_PROVIDER=package \
+    -DZLIB_ROOT=${ZLIB_ROOT} \
     -DCMAKE_INSTALL_PREFIX=%{i} \
-    -DCMAKE_PREFIX_PATH="${LIBUNWIND_ROOT};{PROTOBUF_ROOT};{ZLIB_ROOT}"
+    -DCMAKE_PREFIX_PATH="${LIBUNWIND_ROOT};${PROTOBUF_ROOT};${ZLIB_ROOT}"
 
-make %{makeprocesses}
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 
 %install
-
-make install
+cd ../build
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install

--- a/grpc.spec
+++ b/grpc.spec
@@ -3,7 +3,7 @@
 Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja go
-Requires: protobuf zlib libunwind openssl
+Requires: protobuf zlib libunwind openssl pcre
 %define keep_archives true
 
 %prep

--- a/grpc.spec
+++ b/grpc.spec
@@ -4,9 +4,6 @@ Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%
 
 BuildRequires: cmake ninja go
 Requires: protobuf zlib pcre
-%if 0%{?centos} == 7
-Requires: openssl
-%endif
 %define keep_archives true
 
 %prep
@@ -18,6 +15,8 @@ Requires: openssl
 rm -rf ../build
 mkdir ../build
 cd ../build
+OPENSSLROOT=""
+if [[ ! -z "$OPENSSL_ROOT" ]]; then OPENSSLROOT=";${OPENSSL_ROOT}" ; fi
 
 cmake ../%{n}-%{realversion} \
     -G Ninja \
@@ -32,7 +31,7 @@ cmake ../%{n}-%{realversion} \
     -DgRPC_ZLIB_PROVIDER=package \
     -DZLIB_ROOT=${ZLIB_ROOT} \
     -DCMAKE_INSTALL_PREFIX=%{i} \
-    -DCMAKE_PREFIX_PATH="${PCRE_ROOT};${PROTOBUF_ROOT};${ZLIB_ROOT};${OPENSSL_ROOT}"
+    -DCMAKE_PREFIX_PATH="${PCRE_ROOT};${PROTOBUF_ROOT};${ZLIB_ROOT}${OPENSSLROOT}"
 
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 

--- a/pip/grpcio-tools.file
+++ b/pip/grpcio-tools.file
@@ -1,0 +1,1 @@
+Requires: py2-protobuf py2-grpcio

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -79,6 +79,7 @@ GitPython==3.1.0 ; python_version>'3.0'
 google-common==0.0.1
 google-pasta==0.2.0
 grpcio==1.27.2
+grpcio-tools==1.27.2
 h5py-cache==1.0
 h5py==2.10.0
 hep_ml==0.6.1

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -78,8 +78,8 @@ GitPython==2.1.15 ; python_version<'3.0'
 GitPython==3.1.0 ; python_version>'3.0'
 google-common==0.0.1
 google-pasta==0.2.0
-grpcio==1.27.2
-grpcio-tools==1.27.2
+grpcio==1.28.1
+grpcio-tools==1.28.1
 h5py-cache==1.0
 h5py==2.10.0
 hep_ml==0.6.1

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -190,6 +190,7 @@ Requires: py2-pycparser
 Requires: py2-absl-py
 Requires: py2-gast
 Requires: py2-grpcio
+Requires: py2-grpcio-tools
 Requires: py2-Markdown
 Requires: py2-subprocess32
 Requires: py2-kiwisolver


### PR DESCRIPTION
this recipe needs additional work.
the original recipe checks out git submodules and uses
`make `
but we need protobuf, zlib and libunwind from externals. 
problem is that
`-DgRPC_PROTOBUF_PROVIDER=package \`
for example is searching for cmake config in the protobuf install location, which doesn't exist. 
for onnxruntime we have the same problem which is solved like this:
https://github.com/cms-externals/onnxruntime/commit/dfec41d1371a7b1233d25db55561ce4021fc7ceb
same is (probably) true for libunwind. 
I'll try to get opencv and then return here.
@kpedro88 that's on your request. 
