### PR TITLE
updated vecgeom patch for arm64: remove mm_free from test

### DIFF
--- a/vecgeom-fix-for-arm64.patch
+++ b/vecgeom-fix-for-arm64.patch
@@ -11,3 +11,22 @@ index b3014e9..f10fae0 100644
      else()
        message(FATAL_ERROR "Unsupported C++ standard requested")
      endif()
+diff --git a/test/core/testVectorSafety.cpp b/test/core/testVectorSafety.cpp
+index 4ef8146..30f6d71 100644
+--- a/test/core/testVectorSafety.cpp
++++ b/test/core/testVectorSafety.cpp
+@@ -152,10 +152,10 @@ void testVectorNavigator(VPlacedVolume const *world)
+   }
+ 
+   // cleanup
+-  _mm_free(steps);
+-  _mm_free(pSteps);
+-  _mm_free(safeties);
+-  _mm_free(calcSafeties);
++  //_mm_free(steps);
++  //_mm_free(pSteps);
++  //_mm_free(safeties);
++  //_mm_free(calcSafeties);
+ }
+ 
+ int main()


### PR DESCRIPTION
VecGeom 1.1.6 fails to build on aarch64 due to build error[a]. For now we propose to patch it  by removing the usage of _mm_free for non x86_64 archs. We have open a JIRA issue https://sft.its.cern.ch/jira/browse/VECGEOM-545 .

This change only effects non x86_64 archs, so it is safe to include it once it builds.