### PR TITLE
Update upstream repositories for Alpaka and Cupla

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
 ### RPM external alpaka 0.4.0
 ## NOCOMPILER
 
-Source: https://github.com/ComputationalRadiationPhysics/%{n}/archive/%{realversion}.tar.gz
+Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz
 Requires: boost
 
 %prep

--- a/cupla.spec
+++ b/cupla.spec
@@ -1,6 +1,6 @@
 ### RPM external cupla 0.2.0
 
-Source: https://github.com/ComputationalRadiationPhysics/%{n}/archive/%{realversion}.tar.gz
+Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz
 Requires: alpaka
 Requires: cuda
 Requires: tbb


### PR DESCRIPTION
The Alpaka and Cupla libraries have been migrated the to a new GitHub group, to better reflect their open development model.

Update the upstream repositories for Alpaka and Cupla to
  - https://github.com/alpaka-group/alpaka
  - https://github.com/alpaka-group/cupla