### PR TITLE
cms monitoring tools spec

### DIFF
--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -1,11 +1,11 @@
-### RPM cms cmsmon-tools 0.3.8
+### RPM cms cmsmon-tools 0.3.9
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
 %define pkg CMSMonitoring
 %define ver %realversion
 Source0: https://github.com/dmwm/%pkg/archive/%ver.tar.gz
 
-#Requires: go
+Requires: go
 
 # RPM macros documentation
 # http://www.rpm.org/max-rpm/s1-rpm-inside-macros.html
@@ -13,6 +13,7 @@ Source0: https://github.com/dmwm/%pkg/archive/%ver.tar.gz
 %setup -D -T -b 0 -n %pkg-%ver
 
 %build
+export GOCACHE=%{_builddir}/gocache
 cd ..
 cd %pkg-%ver
 echo "build $PWD"
@@ -46,13 +47,11 @@ cd ../%pkg-%ver
 echo "### current dir: $PWD"
 cp src/go/MONIT/monit %i/
 cp src/go/NATS/nats-sub %i/
-
-# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-%addDependency
+cp src/wrappers/cms-monit %i/
+cp src/wrappers/cms-nats-sub %i/
 
 %post
-%{relocateConfig}etc/profile.d/dependencies-setup.*sh
-
-%files
-%{installroot}/%{pkgrel}/monit
-%{installroot}/%{pkgrel}/nats-sub
+cp $RPM_INSTALL_PREFIX/%{pkgrel}/cms-monit $RPM_INSTALL_PREFIX/common
+ln -sf $RPM_INSTALL_PREFIX/common/cms-monit cms-monit
+cp $RPM_INSTALL_PREFIX/%{pkgrel}/cms-nats-sub $RPM_INSTALL_PREFIX/common
+ln -sf $RPM_INSTALL_PREFIX/common/cms-nats-sub cms-nats-sub

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -1,5 +1,6 @@
 ### RPM cms cmsmon-tools 0.3.8
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
+## NOCOMPILER
 
 %define pkg CMSMonitoring
 %define ver %realversion
@@ -13,6 +14,7 @@ Source0: https://github.com/dmwm/%pkg/archive/%ver.tar.gz
 %setup -D -T -b 0 -n %pkg-%ver
 
 %build
+export GOCACHE=%{_builddir}/gocache
 cd ..
 cd %pkg-%ver
 echo "build $PWD"
@@ -46,13 +48,3 @@ cd ../%pkg-%ver
 echo "### current dir: $PWD"
 cp src/go/MONIT/monit %i/
 cp src/go/NATS/nats-sub %i/
-
-# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-%addDependency
-
-%post
-%{relocateConfig}etc/profile.d/dependencies-setup.*sh
-
-%files
-%{installroot}/%{pkgrel}/monit
-%{installroot}/%{pkgrel}/nats-sub

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -15,10 +15,7 @@ BuildRequires: go
 %setup -D -T -b 0 -n %pkg-%ver
 
 %build
-cd ..
-cd %pkg-%ver
-echo "build $PWD"
-ls
+cd ../%pkg-%ver
 mkdir -p gopath/bin
 export GOPATH=$PWD/gopath
 export GOCACHE=%{_builddir}/gocache
@@ -37,26 +34,22 @@ go get github.com/nats-io/nats.go
 go get github.com/gizak/termui/v3
 
 # build monit tools
-cd src/go/MONIT
-go build %flags monit.go
-cd -
+pushd src/go/MONIT
+  go build %flags monit.go
+popd
+
 # build NATS tools
-cd src/go/NATS
-for cmd in %cmsmon_commands; do
-if [ -f $cmd.go ]; then
-go build %flags $cmd.go
-fi
-done
-cd -
+pushd src/go/NATS
+  for cmd in %cmsmon_commands; do
+    go build %flags $cmd.go
+  done
+popd
 
 %install
 cd ../%pkg-%ver
-echo "### current dir: $PWD"
 cp src/go/MONIT/monit %i/
 for cmd in %cmsmon_commands; do
-if [ -f src/go/NATS/$cmd ]; then
-cp src/go/NATS/$cmd %i/
-fi
+  cp src/go/NATS/$cmd %i/
 done
 
 #####################################################

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -48,3 +48,18 @@ cd ../%pkg-%ver
 echo "### current dir: $PWD"
 cp src/go/MONIT/monit %i/
 cp src/go/NATS/nats-sub %i/
+
+%post
+cat << \END_SCRIPT >$RPM_INSTALL_PREFIX/common/cms-monit
+#!/bin/bash -e
+eval $(scram unsetenv -sh)
+THISDIR=$(dirname $0)
+TOOLNAME=$(basename $0 | sed 's|^cms-||')
+SHARED_ARCH=$(cmsos)
+TOOL=$(ls -d ${THISDIR}/../${SHARED_ARCH}_*/%{pkgcategory}/%{pkgname}/*/$TOOLNAME 2>/dev/null | sort | tail -1)
+[ -z $TOOL ] && >&2 echo "ERROR: Unable to find command '$TOOLNAME' for '$SHARED_ARCH' architecture." && exit 1
+$TOOL "$@"
+END_SCRIPT
+
+chmod +x $RPM_INSTALL_PREFIX/common/cms-monit
+ln -sf cms-monit $RPM_INSTALL_PREFIX/common/cms-nats-sub

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -1,0 +1,58 @@
+### RPM cms cmsmon-tools 0.3.8
+## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
+
+%define pkg CMSMonitoring
+%define ver %realversion
+Source0: https://github.com/dmwm/%pkg/archive/%ver.tar.gz
+
+#Requires: go
+
+# RPM macros documentation
+# http://www.rpm.org/max-rpm/s1-rpm-inside-macros.html
+%prep
+%setup -D -T -b 0 -n %pkg-%ver
+
+%build
+cd ..
+cd %pkg-%ver
+echo "build $PWD"
+ls
+mkdir -p gopath/bin
+export GOPATH=$PWD/gopath
+go get github.com/dmwm/cmsauth
+go get github.com/vkuznet/x509proxy
+go get github.com/sirupsen/logrus
+go get github.com/prometheus/client_golang/prometheus
+go get github.com/prometheus/common/log
+go get github.com/prometheus/common/version
+go get github.com/shirou/gopsutil/cpu
+go get github.com/shirou/gopsutil/mem
+go get github.com/shirou/gopsutil/load
+go get github.com/shirou/gopsutil/process
+go get github.com/go-stomp/stomp
+go get github.com/nats-io/nats.go
+
+# build monit tools
+cd src/go/MONIT
+go build monit.go
+cd -
+# build NATS tools
+cd src/go/NATS
+go build nats-sub.go
+cd -
+
+%install
+cd ../%pkg-%ver
+echo "### current dir: $PWD"
+cp src/go/MONIT/monit %i/
+cp src/go/NATS/nats-sub %i/
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+%addDependency
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh
+
+%files
+%{installroot}/%{pkgrel}/monit
+%{installroot}/%{pkgrel}/nats-sub

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -61,6 +61,16 @@ fi
 done
 
 %post
+mkdir -p $RPM_INSTALL_PREFIX/cmsmon
 for cmd in %cmsmon_commands; do
-cp $RPM_INSTALL_PREFIX/%{pkgrel}/$cmd $RPM_INSTALL_PREFIX/common
+cat > $RPM_INSTALL_PREFIX/cmsmon/$cmd << EOF
+#!/bin/bash -e
+eval \$(scram unsetenv -sh)
+THISDIR=\$(dirname \$0)
+SHARED_ARCH=\$(cmsos)
+TOOL=\$(ls -d \${THISDIR}/../\${SHARED_ARCH}_*/cms/cmsmon-tools/*/$cmd 2>/dev/null | sort | tail -1)
+[ -z $TOOL ] && >&2 echo "ERROR: Unable to find command '$cmd' for '\$SHARED_ARCH' architecture." && exit 1
+\$TOOL "\$@"
+EOF
+chmod +x $RPM_INSTALL_PREFIX/cmsmon/$cmd
 done

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -5,6 +5,7 @@
 %define pkg CMSMonitoring
 %define ver %realversion
 %define cmsmon_commands nats-sub nats-pub nats-exitcodes-termui dbs_vm
+%define flags -ldflags="-s -w -extldflags -static"
 Source0: https://github.com/dmwm/%pkg/archive/%ver.tar.gz
 
 Requires: go
@@ -38,14 +39,15 @@ go get github.com/gizak/termui/v3
 
 # build monit tools
 cd src/go/MONIT
-go build monit.go
+go build %flags monit.go
 cd -
 # build NATS tools
 cd src/go/NATS
-go build nats-sub.go
-go build nats-pub.go
-go build dbs_vm.go
-go build nats-exitcodes-termui.go
+for cmd in %cmsmon_commands; do
+if [ -f $cmd.go ]; then
+go build %flags $cmd.go
+fi
+done
 cd -
 
 %install

--- a/go.spec
+++ b/go.spec
@@ -1,4 +1,5 @@
 ### RPM external go 1.13.8
+## NOCOMPILER
 
 Source: https://storage.googleapis.com/golang/go%{realversion}.linux-amd64.tar.gz
 
@@ -10,4 +11,4 @@ Provides: /bin/rc
 %build
 
 %install
-cp -r * %i
+rsync -a ./ %i/

--- a/go.spec
+++ b/go.spec
@@ -1,0 +1,13 @@
+### RPM external go 1.13.8
+
+Source: https://storage.googleapis.com/golang/go%{realversion}.linux-amd64.tar.gz
+
+Provides: /bin/rc
+
+%prep
+%setup -n go
+
+%build
+
+%install
+cp -r * %i


### PR DESCRIPTION
New spec for cms monitoring tools. So far I disabled `Requirements: go` because go spec only exists in comp branch, but since go is pre-installed on lxplus I think the build will be fine.

@smuzaffar please inspect the spec and make a suggestion on how to adjust it correctly If it will be required.