### PR TITLE
Bump rucio-clients to 1.22.2; update production urls

### DIFF
--- a/py2-rucio-clients.spec
+++ b/py2-rucio-clients.spec
@@ -1,4 +1,4 @@
-### RPM external py2-rucio-clients 1.20.5
+### RPM external py2-rucio-clients 1.22.2
 ## IMPORT build-with-pip
 ## INITENV SET RUCIO_HOME %i/
 

--- a/rucio-config.file
+++ b/rucio-config.file
@@ -10,8 +10,8 @@
 
 [common]
 [client]
-rucio_host = http://cms-rucio-testbed.cern.ch
-auth_host = https://cms-rucio-auth-testbed.cern.ch
+rucio_host = http://cms-rucio.cern.ch
+auth_host = https://cms-rucio-auth.cern.ch
 auth_type = x509
 ca_cert = /etc/grid-security/certificates/
 client_cert = $X509_USER_CERT


### PR DESCRIPTION
Bump rucio client to the latest version: 1.22.2
and update the host_url and auth_url to the upcoming production instances, as a reference to: https://github.com/cms-sw/cmsdist/issues/5752