### PR TITLE
Update LLVM to version 10.0.0 (plus bugfixes)

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -8,10 +8,10 @@ Requires: gcc zlib python python3
 Requires: cuda
 AutoReq: no
 
-%define llvmCommit 379a43bc841451feccf78db64f2ed5c9e62c7de8
-%define llvmBranch cms/release/9.x/c1a0a21
-%define iwyuCommit 06e88efada2ff6dbccee3bbb1279c10439daa4d2
-%define iwyuBranch clang_9.0
+%define llvmCommit 80c6853a9ea2d6b142111a4177f94fb8b39ba2cf
+%define llvmBranch cms/release/10.x/92d5c1b
+%define iwyuCommit a40a28740c963636d8d41e75f297e8e078302d70
+%define iwyuBranch clang_10
 
 Source0: git+https://github.com/cms-externals/llvm-project.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz
 Source1: git+https://github.com/include-what-you-use/include-what-you-use.git?obj=%{iwyuBranch}/%{iwyuCommit}&export=iwyu-%{realversion}-%{iwyuCommit}&module=iwyu-%{realversion}-%{iwyuCommit}&output=/iwyu-%{realversion}-%{iwyuCommit}.tgz


### PR DESCRIPTION
Update LLVM to version 10.0.0, plus
  - [ELF] Fix a null pointer dereference when --emit-relocs and --strip-debug are used together
  - [llvm-objcopy] Improve tool selection logic to recognize llvm-strip-$major as strip
  - Bump version to 10.0.1
  - Add yaml defintions for CI tests with GitHub Actions
  - Use FinishThunk to finish musttail thunks
  - [CodeGen] Fix sinking local values in lpads with phis
  - [COFF] Don't treat DWARF sections as GC roots
  - [DAGCombine] Fix splitting indexed loads in ForwardStoreValueToDirectLoad()
  - Teach TreeTransform to substitute into resolved TemplateArguments.
  - [ELF][test] Rename SHF_LINK_ORDER related "metadata" to "linkorder"
  - [ELF][test] Improve linkerscript/linkorder.s
  - [ELF] Allow SHF_LINK_ORDER and non-SHF_LINK_ORDER to be mixed
  - [SimplifyCFG]  Skip merging return blocks if it would break a CallBr.
  - [X86][SSE] combineX86ShufflesConstants - early out for zeroable vectors (PR45443)
  - add release notes for ffp-model and ffp-exception-behavior
  - [CodeView] Align type records on 4-bytes when emitting PDBs
  - [PowerPC] Update alignment for ReuseLoadInfo in LowerFP_TO_INTForReuse

Cherry-pick CMS specific changes:
  - Skip calling the gcc compiler.
  - Update scan-build to always remove working dir from path
  - Add CMS custom c++11 attributes

Update IWYU accordingly.
