### PR TITLE
Updated BuildRules tag to fix cuda compilation

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-76
+%define configtag       V05-08-77
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
New tag makes sure that we always use gcc flags for CUDA. With old build rules cuda was using CXXFLAGS of default compiler. So it was working for gcc based IBs but for CLANG based IBs it uses llvm CXXFLAGS (as llvm is default compiler in CLANG IBs). cms-sw/cmssw-config@1c35b87 makes sure that we always use gcc for cuda.