### PR TITLE
[ROOT modules] Fix yoda for ROOT python updates

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -142,7 +142,7 @@ cmake ../%{n}-%{realversion} \
   -DZLIB_INCLUDE_DIR="${ZLIB_ROOT}/include" \
   -DZSTD_ROOT="${ZSTD_ROOT}" \
   -DCMAKE_PREFIX_PATH="${LZ4_ROOT};${GSL_ROOT};${XZ_ROOT};${OPENSSL_ROOT};${GIFLIB_ROOT};${FREETYPE_ROOT};${PYTHON_ROOT};${PYTHON3_ROOT};${LIBPNG_ROOT};${PCRE_ROOT};${TBB_ROOT};${OPENBLAS_ROOT};${DAVIX_ROOT};${LIBXML2_ROOT};${ZSTD_ROOT}" \
-  -Dpyroot_experimental=OFF
+  -Dpyroot_experimental=ON
 # For CMake cache variables: http://www.cmake.org/cmake/help/v3.2/manual/cmake-language.7.html#lists
 # For environment variables it's OS specific: http://www.cmake.org/Wiki/CMake_Useful_Variables
 

--- a/yoda.spec
+++ b/yoda.spec
@@ -3,21 +3,39 @@
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 
 Source: git+https://gitlab.com/hepcedar/yoda.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Patch0: yoda_pyroot
 
-Requires: python root
+Requires: python python3 root
 BuildRequires: py2-cython autotools
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 autoreconf -fiv
-./configure --prefix=%i --enable-root
 
 %build
-make all
+
+sed -i -e "s|lPyROOT|lcppyyX.X|" ./pyext/setup.py.in
+
+#Build for Python3
+export PYTHON_VERSION=$(python3 --version 2>&1 | sed 's|.* ||' | cut -d. -f1,2)
+sed -i -e "s|lcppyy...|lcppyy$(echo ${PYTHON_VERSION} | tr . _)|" ./pyext/setup.py.in
+./configure --prefix=%i --enable-root
+make %{makeprocesses} all
+
+#Install Py3 Only
+mkdir -p %{i}/${PYTHON3_LIB_SITE_PACKAGES}
+mv pyext/build/lib*-${PYTHON_VERSION}/yoda* %{i}/${PYTHON3_LIB_SITE_PACKAGES}/
+
+#Build & install for Python2
+export PYTHON_VERSION=$(python2 --version 2>&1 | sed 's|.* ||' | cut -d. -f1,2)
+sed -i -e "s|lcppyy...|lcppyy$(echo ${PYTHON_VERSION} | tr . _)|" ./pyext/setup.py.in
+./configure --prefix=%i --enable-root
+make %{makeprocesses} all
+make install
 
 %install
-make install
 
 %post
 %{relocateConfig}bin/yoda-config

--- a/yoda_pyroot.patch
+++ b/yoda_pyroot.patch
@@ -1,0 +1,26 @@
+diff --git a/pyext/yoda/pyroot_helpers.hh b/pyext/yoda/pyroot_helpers.hh
+index b299a74..3e7f4d5 100644
+--- a/pyext/yoda/pyroot_helpers.hh
++++ b/pyext/yoda/pyroot_helpers.hh
+@@ -1,12 +1,12 @@
+ #include "YODA/ROOTCnv.h"
+ #include "Python.h"
+ #include "YODA/Profile1D.h"
+-#include "TPython.h"
++#include "CPyCppyy/API.h"
+ 
+ 
+ // Get a PyROOT object from a ROOT one
+ inline PyObject* root_to_py_owned(TObject* root_obj) {
+-  return TPython::ObjectProxy_FromVoidPtr(root_obj, root_obj->ClassName());
++  return CPyCppyy::Instance_FromVoidPtr(root_obj, root_obj->ClassName());
+   /// @todo Different signatures in different ROOT versions?
+   //return TPython::ObjectProxy_FromVoidPtr(root_obj, root_obj->ClassName(), kFALSE);
+ }
+@@ -14,5 +14,5 @@ inline PyObject* root_to_py_owned(TObject* root_obj) {
+ 
+ // Get the ROOT object in a PyROOT one
+ inline TObject* py_owned_to_root(PyObject* pyroot_obj) {
+-  return (TObject*) TPython::ObjectProxy_AsVoidPtr(pyroot_obj);
++  return (TObject*) CPyCppyy::Instance_AsVoidPtr(pyroot_obj);
+ }


### PR DESCRIPTION
yoda builds with this changes, I had to turn the 
`-Dpyroot_experimental=ON`
this yoda changes with the patch and all are requiring it