### PR TITLE
Upgrade Herwig7 from 7.1.4 to 7.2.0

### DIFF
--- a/herwigpp.spec
+++ b/herwigpp.spec
@@ -1,4 +1,4 @@
-### RPM external herwigpp 7.1.4
+### RPM external herwigpp 7.2.0
 Source: https://www.hepforge.org/archive/herwig/Herwig-%{realversion}.tar.bz2
 
 %define isamd64 %(case %{cmsplatf} in (*amd64*) echo 1 ;; (*) echo 0 ;; esac)
@@ -18,14 +18,9 @@ Requires: openloops
 %endif
 BuildRequires: autotools
 
-# Patch since otherwise Boost wants multithreaded lib, even though only single-threaded lib is installed
-# Problem exists since Herwig++3Beta
-Patch0: herwigpp-missingBoostMTLib
 
 %prep
 %setup -q -n Herwig-%{realversion}
-
-%patch0 -p1
 
 # Regenerate build scripts
 autoreconf -fiv
@@ -57,23 +52,6 @@ make %makeprocesses all
 
 %install
 make %makeprocesses install LHAPDF_DATA_PATH=$LHAPDF_ROOT/share/LHAPDF
-
-#FxFx.so needs to be build after herwigpp installation so that it can correctly pick up needed headers
-#FIX for 7.1.4: need to fix path in Makefile to build the FxFx.so library correctly
-#Maybe not needed for future versions.  Bug has been reported to the authors
-sed -i -e "s|UEBase.fh|Shower/UEBase.fh|g" Shower/UEBase.h
-sed -i -e "s|Herwig/Shower/Couplings/ShowerAlpha.h|Herwig/Shower/Core/Couplings/ShowerAlpha.h|g" Contrib/FxFx/FxFxHandler.h
-sed -i -e "s|^HERWIGINCLUDE.*|HERWIGINCLUDE = -I%{i}/include|g" Contrib/FxFx/Makefile
-sed -i -e "s|^RIVETINCLUDE.*|RIVETINCLUDE = -I${RIVET_ROOT}/include|g" Contrib/FxFx/Makefile
-sed -i -e "s|^HEPMCINCLUDE.*|HEPMCINCLUDE = -I${HEPMC_ROOT}/include|g" Contrib/FxFx/Makefile
-sed -i "/^FASTJETLIB.*/a YODAINCLUDE= -I${YODA_ROOT}/include" Contrib/FxFx/Makefile
-sed -i "/^YODAINCLUDE=.*/a BOOSTINCLUDE= -I${BOOST_ROOT}/include" Contrib/FxFx/Makefile
-sed -i -e "/^INCLUDE.*/s/$/ \$(YODAINCLUDE) \$(BOOSTINCLUDE)/" Contrib/FxFx/Makefile
-sed -i "/^FASTJETLIB.*/a HERWIGINSTALL = %{i}" Contrib/FxFx/Makefile
-sed -i -e '0,/\$(HERWIGINSTALL)\/lib\/Herwig/s//\$(HERWIGINSTALL)\/lib\/./' Contrib/FxFx/Makefile
-
-make -C Contrib/FxFx %makeprocesses FxFx.so FxFxHandler.so FxFxAnalysis.so
-cp Contrib/FxFx/*.so %{i}/lib/Herwig/.
 
 mv %{i}/bin/Herwig  %{i}/bin/Herwig-cms
 cat << \HERWIG_WRAPPER > %{i}/bin/Herwig

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -1,4 +1,4 @@
-### RPM external thepeg 2.1.4
+### RPM external thepeg 2.2.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib/ThePEG
 ## INITENV +PATH DYLD_LIBRARY_PATH %{i}/lib/ThePEG
 


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/5765 to upgrade Herwig7 from 7.1.4 to Herwig 7.2.0.
To be tested with: cms-sw/cmssw#29536

Kind regards,
Dominic