### PR TITLE
[CXXModules] build rules; clhep modulemap; enable few cxxmodules

### DIFF
--- a/CXXModules.mk.file
+++ b/CXXModules.mk.file
@@ -62,7 +62,7 @@ CondFormatsPhysicsToolsObjects_CXXMODULES:=1
 CondFormatsRecoMuonObjects_CXXMODULES:=1
 CondFormatsRPCObjects_CXXMODULES:=1
 CondFormatsSiPhase2TrackerObjects_CXXMODULES:=1
-CondFormatsSiPixelObjects_CXXMODULES:=1
+CondFormatsSiPixelObjects_CXXMODULES:=0
 CondFormatsSerialization_CXXMODULES:=1
 #------------- CondTools
 CondToolsBTau_CXXMODULES:=0
@@ -212,7 +212,7 @@ DataFormatsV0Candidate_CXXMODULES:=1
 ###########################################################################
 # Invalid declaration chain: clang::Redeclarable<clang::FunctionDecl>::redecl_iterator::operator++()
 # (this will be fixed automatically when we upgrade llvm in root)
-DataFormatsParticleFlowReco_CXXMODULES:=0
+DataFormatsParticleFlowReco_CXXMODULES:=1
 # Disabling module because of error: CondFormatsL1TObjects_xr dictionary forward declarations' payload:16:192: error: enumeration previously declared with nonfixed underlying type
 # enum  __attribute__((annotate("$clingAutoload$CondFormats/L1TObjects/interface/L1GtDefinitions.h")))  __attribute__((annotate("$clingAutoload$CondFormats/L1TObjects/interface/L1GtBoard.h"))) L1GtPsbQuad : unsigned int;                                                                                                                                                                                             ^
 # ../src/CondFormats/L1TObjects/interface/L1GtDefinitions.h38:6: note: previous declaration is here
@@ -284,21 +284,21 @@ RecoTrackerTkTrackingRegions_CXXMODULES:=0
 #------------- SimDataFormats
 SimDataFormatsCaloHit_CXXMODULES:=0
 SimDataFormatsDigiSimLinks_CXXMODULES:=0
-SimDataFormatsEncodedEventId_CXXMODULES:=0
+SimDataFormatsEncodedEventId_CXXMODULES:=1
 SimDataFormatsForward_CXXMODULES:=0
 SimDataFormatsGEMDigiSimLink_CXXMODULES:=0
-SimDataFormatsGeneratorProducts_CXXMODULES:=0
+SimDataFormatsGeneratorProducts_CXXMODULES:=1
 SimDataFormatsHcalTestBeam_CXXMODULES:=0
 SimDataFormatsHTXS_CXXMODULES:=0
 SimDataFormatsPileupSummaryInfo_CXXMODULES:=0
 SimDataFormatsRandomEngine_CXXMODULES:=0
 SimDataFormatsRPCDigiSimLink_CXXMODULES:=0
 SimDataFormatsTrackerDigiSimLink_CXXMODULES:=0
-SimDataFormatsTrackingAnalysis_CXXMODULES:=0
+SimDataFormatsTrackingAnalysis_CXXMODULES:=1
 SimDataFormatsTrackingHit_CXXMODULES:=0
-SimDataFormatsTrack_CXXMODULES:=0
+SimDataFormatsTrack_CXXMODULES:=1
 SimDataFormatsValidationFormats_CXXMODULES:=0
-SimDataFormatsVertex_CXXMODULES:=0
+SimDataFormatsVertex_CXXMODULES:=1
 SimDataFormatsAssociations_CXXMODULES:=0
 SimDataFormatsCaloAnalysis_CXXMODULES:=0
 SimDataFormatsCaloTest_CXXMODULES:=0

--- a/clhep.spec
+++ b/clhep.spec
@@ -26,7 +26,7 @@ ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 %install
 cd ../build
 ninja install
-cp %{_sourcedir}/clhep.modulemap %(i}/include/
+cp %{_sourcedir}/clhep.modulemap %{i}/include/
 
 case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
 rm -f %i/lib/libCLHEP-[A-Z]*-%realversion.$so

--- a/clhep.spec
+++ b/clhep.spec
@@ -3,7 +3,8 @@
 %define tag bf87ac557a7be3a8a2ead6b27fbbc89dd7ed4c0b
 %define branch cms/v%{realversion}
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source0: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source1: modulemaps/clhep.modulemap
 
 BuildRequires: cmake ninja
 
@@ -25,6 +26,7 @@ ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
 %install
 cd ../build
 ninja install
+cp %{_sourcedir}/clhep.modulemap %(i}/include/
 
 case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
 rm -f %i/lib/libCLHEP-[A-Z]*-%realversion.$so

--- a/modulemaps/clhep.modulemap.file
+++ b/modulemaps/clhep.modulemap.file
@@ -1,0 +1,6 @@
+module clhep {
+  export *
+  requires cplusplus
+  umbrella "CLHEP"
+  module * { export *}
+}

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-09-27
+%define configtag       V05-09-28
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- New build rules to only pass `-m *rdict.pcm` for direct dependencies only. 
- Added clhep.modulemap ( see https://github.com/cms-externals/clhep/pull/5 )
- Enable few more CMSSW packages to build C++ Modules