### PR TITLE
Bump gperftools to 2.7

### DIFF
--- a/gperftools.spec
+++ b/gperftools.spec
@@ -1,4 +1,4 @@
-### RPM external gperftools 2.6.1
+### RPM external gperftools 2.7
 Source: https://github.com/gperftools/gperftools/archive/gperftools-%{realversion}.tar.gz
 
 BuildRequires: autotools


### PR DESCRIPTION
please test
get the last release, 2.6.1 doesn't build on ppc cc8