### PR TITLE
Needs cx_oracle51 (old version!)

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -11,7 +11,7 @@
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle
+Requires: python cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle51
 Requires: py2-pyOpenSSL condor py2-mysqldb dbs3-pycurl-client dbs-client dbs3-client py2-retry
 Requires: jemalloc
 BuildRequires: py2-sphinx


### PR DESCRIPTION
somehow more recent versions of cx_oracle cause oracle error
when inserting long lists into CLOB vartype, leading to:
https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/5640/1/1/1/1/1/1/1.html