### PR TITLE
Update tag for EgammaAnalysis-ElectronTools to V00-02-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+EgammaAnalysis-ElectronTools=V00-02-00
 L1Trigger-L1THGCal=V01-01-00
 PhysicsTools-NanoAOD=V01-01-00
 RecoBTag-Combined=V01-03-00
@@ -26,7 +27,6 @@ RecoTracker-FinalTrackSelectors=V01-00-07
 SLHCUpgradeSimulations-Geometry=V01-00-10
 L1Trigger-L1TMuon=V01-01-04
 CondTools-SiPhase2Tracker=V00-01-00
-EgammaAnalysis-ElectronTools=V00-01-04
 PhysicsTools-PatUtils=V00-01-00
 SimTransport-PPSProtonTransport=V00-01-00
 SimTransport-TotemRPProtonTransportParametrization=V00-01-00


### PR DESCRIPTION
Move EgammaAnalysis-ElectronTools data to new tag, see 
https://github.com/cms-data/EgammaAnalysis-ElectronTools/pull/8
