### PR TITLE
Update jemalloc to version 5.2.1

### DIFF
--- a/jemalloc.spec
+++ b/jemalloc.spec
@@ -1,4 +1,4 @@
-### RPM external jemalloc 5.2.0
+### RPM external jemalloc 5.2.1
 
 %define tag %{realversion}
 %define branch master


### PR DESCRIPTION
This release is primarily about Windows. A critical virtual memory leak is resolved on all Windows platforms.
The regression was present in all releases since 5.0.0.

Bug fixes:
  - Fix a severe virtual memory leak on Windows. This regression was first released in 5.0.0.
  - Fix size 0 handling in posix_memalign(). This regression was first released in 5.2.0.
  - Fix the prof_log unit test which may observe unexpected backtraces from compiler optimizations. The test was first added in 5.2.0.
  - Fix the declaration of the extent_avail tree. This regression was first released in 5.1.0.
  - Fix an incorrect reference in jeprof. This functionality was first released in 3.0.0.
  - Fix an assertion on the deallocation fast-path. This regression was first released in 5.2.0.
  - Fix the TLS_MODEL attribute in headers. This regression was first released in 5.0.0.

Optimizations and refactors:
  - Implement opt.retain on Windows and enable by default on 64-bit.
  - Optimize away a branch on the operator delete path.
  - Add format annotation to the format generator function.
  - Refactor and improve the size class header generation.
  - Remove best fit.
  - Avoid blocking on background thread locks for stats.