### PR TITLE
[BuildRile] Do not process fortran files for code-checks

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-77
+%define configtag       V05-08-78
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
https://github.com/cms-sw/cmssw-config/commit/26e8be06d8006319b6a832f4aee051c1d4db7270 should not include fortran files in LLVM CCDB which means scram should not then process fortrans files for code-checks. This should resolve th issue https://github.com/cms-sw/cmssw/issues/29860 .