### PR TITLE
Bump httplib2 to 0.18.0

### DIFF
--- a/py3-httplib2.spec
+++ b/py3-httplib2.spec
@@ -1,2 +1,2 @@
 ### RPM external py2-httplib2 0.18.0
-## IMPORT build-with-pip
+## IMPORT build-with-pip3


### PR DESCRIPTION
Required to fix a low level security vulnerability. For further info, check:
https://github.com/advisories/GHSA-gg84-qgv9-w4pq

This change can potentially affect these services:
```
acdcserver.spec
asyncstageout.spec
crabcache.spec
crabclient.spec
crabserver.spec
crabtaskworker.spec
dbs3-migration.spec
dbs3.spec
filemover.spec
reqmgr2.spec
reqmgr2ms.spec
reqmon.spec
t0.spec
t0_reqmon.spec
wmagent.spec
workqueue.spec
```
I still have to test it for WMCore services, however, we still have almost 2 weeks for that ;)

FYI.: @belforte @yuyiguo