### PR TITLE
[crab][dbs] expose dbs python api and examples via crab distribution

### DIFF
--- a/crab-build.file
+++ b/crab-build.file
@@ -34,6 +34,8 @@ rsync -a %{_builddir}/CRABClient/etc/  %{i}/etc/
 
 #List of CRAB python pakcages for which we need to create ProxyPackage symlink
 ls %{_builddir}/CRABClient/src/python/*/__init__.py | sed 's|/__init__.py$||;s|.*/||' > %{i}/etc/crab_py_pkgs.txt
+echo dbs >> %{i}/etc/crab_py_pkgs.txt
+echo RestClient >> %{i}/etc/crab_py_pkgs.txt
 
 #Copy WMCore
 for pkg in %{wmcore_packages} ; do
@@ -61,6 +63,7 @@ for pkg in %{dbs_packages} ; do
     cp %{_builddir}/DBS/${pkg} %{i}/lib/${pkg}
   fi
 done
+rsync -a %{_builddir}/DBS/Client/utils/ %{i}/examples/
 
 if [ $(grep '_UseCrab' %{i}/etc/crab-bash-completion.sh | wc -l) -gt 0 ] && [ $(grep ' filenames  *crab' %{i}/etc/crab-bash-completion.sh |wc -l) -gt 0 ] ; then
   sed -i -e 's|_UseCrab|_UseCrab_%{crab_type}|g;s| filenames  *crab| filenames crab-%{crab_type}|' %{i}/etc/crab-bash-completion.sh
@@ -72,6 +75,6 @@ fi
 %post
 cd ${RPM_INSTALL_PREFIX}
 mkdir -p share/%{pkgdir}
-for dir in bin lib etc ; do 
+for dir in bin lib etc examples; do
   rsync -a %{pkgrel}/${dir}/ share/%{pkgdir}/${dir}/
 done

--- a/crab/crab-proxy-package.file
+++ b/crab/crab-proxy-package.file
@@ -1,4 +1,4 @@
-#CMSDIST_FILE_REVISION=2
+#CMSDIST_FILE_REVISION=3
 import sys
 from os.path import join, exists
 CMSPath="@CMS_PATH@/share/cms"
@@ -6,7 +6,8 @@ _crab_type="crab-%s" % __file__.split("/")[-3]
 _crab_ver=None
 with open(join(CMSPath,"crab/@CRAB_COMMON_VERSION@/etc","%s.latest" % _crab_type)) as ref:
   _crab_ver = ref.readlines()[0].strip()
-_crablib = join(CMSPath,_crab_type,_crab_ver,"lib")
+CRABInstallationPath=join(CMSPath,_crab_type,_crab_ver)
+_crablib = join(CRABInstallationPath,"lib")
 sys.path.insert(0,_crablib)
 _crabpkg = join(_crablib, __name__)
 _pkg_init_file = join(_crabpkg, '__init__.py')

--- a/crab/crab-setup.csh.file
+++ b/crab/crab-setup.csh.file
@@ -1,5 +1,5 @@
 #!/bin/tcsh
-#CMSDIST_FILE_REVISION=1
+#CMSDIST_FILE_REVISION=2
 setenv CRABCLIENT_TYPE ""
 switch ("X$1Y")
   case XprodY:
@@ -24,3 +24,4 @@ if (${?CRABCLIENT_TYPE}) then
   endif
   unset crab_shared_dir
 endif
+setenv DBS3_CLIENT_ROOT `python -c 'from CRABClient import CRABInstallationPath as p; print(p)'`

--- a/crab/crab-setup.sh.file
+++ b/crab/crab-setup.sh.file
@@ -1,5 +1,5 @@
 #!/bin/bash
-#CMSDIST_FILE_REVISION=3
+#CMSDIST_FILE_REVISION=4
 case "X$1Y" in
   XprodY|XdevY|XpreY) CRABCLIENT_TYPE="$1" ;;
   XY ) CRABCLIENT_TYPE="prod" ;;
@@ -12,6 +12,7 @@ esac
 export CRABCLIENT_TYPE
 crab_shared_dir="@CMS_PATH@/share/cms/crab/@CRAB_COMMON_VERSION@"
 export PYTHONPATH="${crab_shared_dir}/lib/${CRABCLIENT_TYPE}${PYTHONPATH:+:$PYTHONPATH}"
+export DBS3_CLIENT_ROOT=$(python -c 'from CRABClient import CRABInstallationPath as p; print(p)')
 if [ "$(ps -p$$ -ocmd=)" = "zsh" ] ; then
   autoload -U +X compinit && compinit
   autoload -U +X bashcompinit && bashcompinit


### PR DESCRIPTION
- expose `dbs` and `RestClient` python api via crab distribution
- crab distribution to include `dbs/Client/utils` (as `examples`)
- `crab-setup.*sh` scripts to set `DBS3_CLIENT_ROOT` pointing to latest crab/dbs distribution  