### PR TITLE
update config tag; added multi-vec and root flags

### DIFF
--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -62,6 +62,12 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-cxxcompiler.xml
     <flags CXXFLAGS="-Werror=return-local-addr -Wnon-virtual-dtor"/>
     <flags CXXFLAGS="-Werror=switch -fdiagnostics-show-option"/>
     <flags CXXFLAGS="-Wno-unused-local-typedefs -Wno-attributes -Wno-psabi"/>
+%ifarch x86_64
+    <flags CXXFLAGS_VECTORIZE_AVX512F="-mavx512f -mfma"/>
+    <flags CXXFLAGS_VECTORIZE_AVX2="-mavx2"/>
+    <flags CXXFLAGS_VECTORIZE_FMA="-mfma"/>
+    <flags CXXFLAGS_VECTORIZE_SSE4_2="-msse4.2"/>
+%endif
     <flags LDFLAGS="@OS_LDFLAGS@ @ARCH_LDFLAGS@ @COMPILER_LDFLAGS@"/>
     <flags CXXSHAREDFLAGS="@OS_SHAREDFLAGS@ @ARCH_SHAREDFLAGS@ @COMPILER_SHAREDFLAGS@"/>
     <flags LD_UNIT="@OS_LD_UNIT@ @ARCH_LD_UNIT@ @COMPILER_LD_UNIT@"/>

--- a/root-toolfile.spec
+++ b/root-toolfile.spec
@@ -180,9 +180,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/root.xml
 <tool name="root" version="@TOOL_VERSION@">
   <info url="http://root.cern.ch/root/"/>
   <use name="rootphysics"/>
-  <ifversion name="^[6-9]\.">
-    <flags NO_CAPABILITIES="yes"/>
-  </ifversion>
+  <flags GENREFLEX_FAILES_ON_WARNS="--fail_on_warnings"/>
+  <flags CXXMODULES="0"/>
 </tool>
 EOF_TOOLFILE
 

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-08-78
+%define configtag       V05-10-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-10-00
+%define configtag       V05-10-01
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
backport of #5827

New build rules
- Drop Capabilities support
- Add vectorization support, one can set `SCRAM_VECTORIZE` in self.xml to add the supported vectorization builds. The compiler cxxcompiler tool `CXXFLAGS_VECTORIZE_<VEC_FLAG>` to provide the extra flags to be used for vectorizations.
- Merge cxxmodules changes from V05-09-XX tags
- Drop Python wrapper build rules (not used since many years)
- Allow to use different compiler to build a product. One can set
```
<flag COMPILER="llvm"/>
```
in the BuildFile.xml to use llvm compiler to build the product.