### PR TITLE
[GCC10] classlib - turn error to warning

### DIFF
--- a/classlib.spec
+++ b/classlib.spec
@@ -28,7 +28,7 @@ perl -p -i -e '
   !/^\S+: / && s{\S+LZO((C|Dec)ompressor|Constants|Error)\S+}{}g' \
  Makefile
 
-make %makeprocesses CXXFLAGS="-Wno-error=extra -ansi -pedantic -W -Wall -Wno-long-long -Werror"
+make %makeprocesses CXXFLAGS="-Wno-error=extra -ansi -pedantic -W -Wall -Wno-long-long -Werror -Wno-cast-function-type"
 
 %install
 make %makeprocesses install


### PR DESCRIPTION
please test
seems
`-Werror=cast-function-type`
is default for gcc10 resulting in an error, that's the fastest trick to avoid it. 