### PR TITLE
[GCC10] distcc - add flag for gcc10

### DIFF
--- a/distcc.spec
+++ b/distcc.spec
@@ -20,7 +20,7 @@ chmod +x ./config.{sub,guess}
   --without-gtk \
   --without-gnome \
   --without-avahi \
-  CFLAGS="-O2 -Wno-error=format-overflow -Wno-unused-but-set-variable -Wno-unused-local-typedefs -Wno-unused-parameter -Wno-unused-const-variable" \
+  CFLAGS="-O2 -Wno-error=format-overflow -Wno-unused-but-set-variable -Wno-unused-local-typedefs -Wno-unused-parameter -Wno-unused-const-variable -fcommon -Wno-error=stringop-truncation" \
   CC="$(which gcc)" \
   PYTHON=${PYTHON_ROOT}/bin/python
 


### PR DESCRIPTION
this flag is suggested as easy way for porting code to gcc10
https://gcc.gnu.org/gcc-10/porting_to.html
the proper way is also described , add `extern` for global variables
this explains other link failures we have with gcc10, at least in frontier_client