### PR TITLE
Triton inference server

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -90,7 +90,7 @@ Requires: hls-toolfile
 Requires: opencv-toolfile
 Requires: grpc-toolfile
 Requires: onnxruntime-toolfile
-
+Requires: triton-inference-server-toolfile
 Requires: hdf5-toolfile
 Requires: rivet-toolfile
 Requires: cascade-toolfile

--- a/curl.spec
+++ b/curl.spec
@@ -1,4 +1,4 @@
-### RPM external curl 7.59.0
+### RPM external curl 7.62.0
 Source: http://curl.haxx.se/download/%{n}-%{realversion}.tar.gz
 Requires: openssl
 Requires: zlib

--- a/curl.spec
+++ b/curl.spec
@@ -1,4 +1,4 @@
-### RPM external curl 7.62.0
+### RPM external curl 7.70.0
 Source: http://curl.haxx.se/download/%{n}-%{realversion}.tar.gz
 Requires: openssl
 Requires: zlib

--- a/triton-inference-server-toolfile.spec
+++ b/triton-inference-server-toolfile.spec
@@ -1,0 +1,25 @@
+### RPM external triton-inference-server-toolfile 1.0
+Requires: triton-inference-server
+
+%prep
+
+%build
+
+%install
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/triton-inference-server.xml
+<tool name="triton-inference-server" version="@TOOL_VERSION@">
+  <info url="https://github.com/NVIDIA/triton-inference-server"/>
+  <lib name="request"/> 
+  <client>
+    <environment name="TRITON_INFERENCE_SERVER_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$TRITON_INFERENCE_SERVER_BASE/include"/>
+    <environment name="LIBDIR"  default="$TRITON_INFERENCE_SERVER_BASE/lib"/>
+  </client>
+  <use name="protobuf"/>
+  <use name="opencv"/>
+  <use name="grpc"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/triton-inference-server.spec
+++ b/triton-inference-server.spec
@@ -21,7 +21,6 @@ rm -rf ../build
 mkdir ../build
 cd ../build
 
-# -Wno-deprecated-declarations because of https://github.com/grpc/grpc/issues/21603
 cmake ../%{n}-%{realversion}/build/trtis-clients \
     -DCMAKE_INSTALL_PREFIX="%{i}" \
     -DCMAKE_INSTALL_LIBDIR=lib \

--- a/triton-inference-server.spec
+++ b/triton-inference-server.spec
@@ -13,9 +13,9 @@ Requires: openssl opencv protobuf grpc curl python py2-wheel py2-setuptools py2-
 %build
 
 # remove config required in cmake
-sed -i 's/find_package(CURL CONFIG REQUIRED)/find_package(CURL REQUIRED)/' ../triton-inference-server-1.12.0/src/clients/c++/library/CMakeLists.txt
+sed -i 's/find_package(CURL CONFIG REQUIRED)/find_package(CURL REQUIRED)/' ../%{n}-%{realversion}/src/clients/c++/library/CMakeLists.txt
 # remove perf_client which requires rapidjson
-sed -i 's/add_subdirectory(perf_client)//' ../triton-inference-server-1.12.0/src/clients/c++/CMakeLists.txt
+sed -i 's/add_subdirectory(perf_client)//' ../%{n}-%{realversion}/src/clients/c++/CMakeLists.txt
 
 rm -rf ../build
 mkdir ../build

--- a/triton-inference-server.spec
+++ b/triton-inference-server.spec
@@ -1,0 +1,44 @@
+### RPM external triton-inference-server 1.12.0
+%define branch master
+%define github_user NVIDIA
+
+Source: git+https://github.com/%{github_user}/triton-inference-server.git?obj=%{branch}/v%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+BuildRequires: cmake
+Requires: openssl opencv protobuf grpc curl python py2-wheel py2-setuptools py2-grpcio-tools
+
+%prep
+
+%setup -n %{n}-%{realversion}
+
+%build
+
+# remove config required in cmake
+sed -i 's/find_package(CURL CONFIG REQUIRED)/find_package(CURL REQUIRED)/' ../triton-inference-server-1.12.0/src/clients/c++/library/CMakeLists.txt
+# remove perf_client which requires rapidjson
+sed -i 's/add_subdirectory(perf_client)//' ../triton-inference-server-1.12.0/src/clients/c++/CMakeLists.txt
+
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+# -Wno-deprecated-declarations because of https://github.com/grpc/grpc/issues/21603
+cmake ../%{n}-%{realversion}/build/trtis-clients \
+    -DCMAKE_INSTALL_PREFIX="%{i}" \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DTRTIS_ENABLE_GPU=OFF \
+    -DCURL_LIBRARY=${CURL_ROOT}/lib/libcurl.so \
+    -DCURL_INCLUDE_DIR=${CURL_ROOT}/include \
+    -DTRTIS_ENABLE_METRICS=OFF \
+    -DTRTIS_ENABLE_HTTP_V2=OFF \
+    -DTRTIS_ENABLE_GRPC_V2=OFF \
+    -DTRTIS_VERSION=%{realversion} \
+    -DZLIB_ROOT=${ZLIB_ROOT} \
+    -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT} \
+    -DCMAKE_PREFIX_PATH="${ZLIB_ROOT}"
+make %{makeprocesses}
+
+%install
+cd ../build
+make install
+


### PR DESCRIPTION
This PR is the next step after #5744 and #5747 for fast inference as a service.

Notes:
* The spec file does *not* use the top-level CMakeLists.txt in the Triton repository, because this sets up a lot of unneeded external projects. Instead, it uses the CMakeLists.txt for the client package, which is the only part that is needed for CMSSW.
* A few of the tweaks to the CMake setup, currently implemented using `sed`, will hopefully be imported to the official repository at some point (work in progress).
* the curl version is upgraded because of a missing def in the old version, needed by Triton.