### PR TITLE
[BuildRule] disable vectorization support by default

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-10-04
+%define configtag       V05-10-05
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Disable vectorization by default.
- Added enable/disable/check-vectorize targets.
- Bug fix: create symlinks for r_dict.pcm for vectorize libs
- USER_VECTORIZE_ALL=1 to enable vectorization for all libs/plugins