### PR TITLE
[Geant4] Update to verion new patched version 10.6.2

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
-### RPM external geant4 10.6.1
-%define tag b14d73978beaee6f5b6694ddbfe0dd54c7cdcf19
+### RPM external geant4 10.6.2
+%define tag 0f6c7dd7bcf054e57fdc34da9b4696fce5c6ac90
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz

--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 10.6.2
-%define tag 0f6c7dd7bcf054e57fdc34da9b4696fce5c6ac90
+%define tag 2d174b7a10d70c0bc257ede0554bfcab14e75db5
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
New Geant4 patch02 version:  http://cern.ch/geant4-data/ReleaseNotes/Patch4.10.6-2.txt
FYI @civanch , let me know if we need any CMS patches to go with it or if any geant4 data needs to be updated. Do we need to build G4Py (only available for python3 with Boost.Python version 1.72)?