### PR TITLE
[clhep] fix CLHEP_PARAM_PATH path

### DIFF
--- a/clhep-toolfile.spec
+++ b/clhep-toolfile.spec
@@ -27,7 +27,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/clhepheader.xml
     <environment name="INCLUDE"    default="$CLHEPHEADER_BASE/include"/>
   </client>
   <flags ROOTCLING_ARGS="-moduleMapFile=$(CLHEP_BASE)/include/module.modulemap"/>
-  <runtime name="CLHEP_PARAM_PATH" value="$CLHEP_BASE"/>
+  <runtime name="CLHEP_PARAM_PATH" value="$CLHEPHEADER_BASE"/>
   <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>


### PR DESCRIPTION
bug fix: https://github.com/cms-sw/cmsdist/pull/5879 wrong used CLHEP_BASE instead of CLHEPHEADER_BASE