### PR TITLE
remove cmssw/bin/arch from PYTHONPATH

### DIFF
--- a/cmssw-toolfile.spec
+++ b/cmssw-toolfile.spec
@@ -19,9 +19,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/cmssw.xml
   <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/biglib/$SCRAM_ARCH" type="path"/>
   <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
-  <runtime name="PYTHON27PATH" value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHON27PATH" value="$LIBDIR" type="path"/>
-  <runtime name="PYTHON3PATH" value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHON3PATH" value="$LIBDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$CMSSW_BASE/src" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$CMSSW_BASE/include/$SCRAM_ARCH/include" type="path" handler="warn"/>


### PR DESCRIPTION
There is no need to hadd CMSSW/bin/arch in PYTHONPATH for patch releases. If it is not needed for Full cmssw releases then there is no need to have it for cmssw patch releases, Side effect of this is  reported https://github.com/cms-sw/cmssw/issues/17200 .
Resolves https://github.com/cms-sw/cmssw/issues/17200