### PR TITLE
[CXXMODULE] Build rules updated

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-10-06
+%define configtag       V05-10-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
For patch release build, use full cmssw base path to collect all the modulemaps.
FYI, @davidlange6 , @vgvassilev 