### PR TITLE
[CRAB] By default make crab complete to use crab-prob

### DIFF
--- a/crab-build.file
+++ b/crab-build.file
@@ -72,6 +72,9 @@ rsync -a %{_builddir}/DBS/Client/utils/ %{i}/examples/
 
 if [ $(grep '_UseCrab' %{i}/etc/crab-bash-completion.sh | wc -l) -gt 0 ] && [ $(grep ' filenames  *crab' %{i}/etc/crab-bash-completion.sh |wc -l) -gt 0 ] ; then
   sed -i -e 's|_UseCrab|_UseCrab_%{crab_type}|g;s| filenames  *crab| filenames crab-%{crab_type}|' %{i}/etc/crab-bash-completion.sh
+  if [ "%{crab_type}" = "prod" ] ; then
+    echo "complete -F _UseCrab_prod -o filenames crab" >> %{i}/etc/crab-bash-completion.sh
+  fi
 else
   echo "ERROR: Unable to fix crab use function _UseCrab"
   exit 1

--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.200531
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.3

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version 3.3.2004
 ### RPM cms crab-pre v3.2004.%{version_suffix}
 %define wmcore_version     1.3.2

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version 3.3.2005
 ### RPM cms crab-prod v3.2005.%{version_suffix}
 %define wmcore_version     1.3.3


### PR DESCRIPTION
- fix autocomplete for crab
- increment version_suffix for all `crab-*` due to indirect changes in crab-build
Resolves https://github.com/cms-sw/cmsdist/issues/5916