### PR TITLE
[10.6] Onnx runtime 1.3.0 in 10.6.X

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -97,6 +97,7 @@ Requires: graphviz-toolfile
 Requires: valgrind-toolfile
 Requires: cmsswdata-toolfile
 Requires: hls-toolfile
+Requires: onnxruntime-toolfile
 
 Requires: hdf5-toolfile
 Requires: rivet-toolfile

--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external onnxruntime-toolfile 1.0
+Requires: onnxruntime
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
+<tool name="onnxruntime" version="@TOOL_VERSION@">
+  <lib name="onnxruntime"/>
+  <client>
+    <environment name="ONNXRUNTIME_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$ONNXRUNTIME_BASE/include"/>
+    <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
+  </client>
+  <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,0 +1,49 @@
+### RPM external onnxruntime 1.3.0
+## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
+%define tag 9294d790219aa0d1007d918d7d736d7f5d3e82d8
+%define branch cms/v1.3.0
+%define github_user cms-externals
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
+
+BuildRequires: cmake ninja python3
+Requires: zlib libpng
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build; mkdir ../build; cd ../build
+
+cmake ../%{n}-%{realversion}/cmake -GNinja \
+   -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3 \
+   -DCMAKE_BUILD_TYPE=Release \
+   -DCMAKE_INSTALL_PREFIX="%{i}" \
+   -DCMAKE_INSTALL_LIBDIR=lib \
+   -Donnxruntime_ENABLE_PYTHON=OFF \
+   -Donnxruntime_BUILD_SHARED_LIB=ON \
+   -Donnxruntime_USE_CUDA=OFF \
+   -Donnxruntime_BUILD_CSHARP=OFF \
+   -Donnxruntime_USE_EIGEN_FOR_BLAS=ON \
+   -Donnxruntime_USE_OPENBLAS=OFF \
+   -Donnxruntime_USE_MKLML=OFF \
+   -Donnxruntime_USE_NGRAPH=OFF \
+   -Donnxruntime_USE_OPENMP=OFF \
+   -Donnxruntime_USE_TVM=OFF \
+   -Donnxruntime_USE_LLVM=OFF \
+   -Donnxruntime_ENABLE_MICROSOFT_INTERNAL=OFF \
+   -Donnxruntime_USE_BRAINSLICE=OFF \
+   -Donnxruntime_USE_NUPHAR=OFF \
+   -Donnxruntime_USE_TENSORRT=OFF \
+   -Donnxruntime_CROSS_COMPILING=OFF \
+   -Donnxruntime_USE_FULL_PROTOBUF=ON \
+   -Donnxruntime_DISABLE_CONTRIB_OPS=OFF \
+   -Donnxruntime_USE_PREINSTALLED_PROTOBUF=OFF \
+   -Donnxruntime_PREFER_SYSTEM_LIB=ON \
+   -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${LIBPNG_ROOT}"
+
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
+
+%install
+cd ../build
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
+


### PR DESCRIPTION
add onnxrt and toolfiles to substitute https://github.com/cms-sw/cmsdist/pull/5902 when #5925 is merged