### PR TITLE
[BuildRules] Support using -isystem instead of -I for system tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-10-09
+%define configtag       V05-10-10
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
We get a lot of warnings coming from externals e.g. tbb, boost. New build rules allows to use `-isystemINCLUDE_DIR` instead of -IINCLUDE_DIR` which can instruct compiler to ignore warnings coming from headers under INCLUDE_DIR.

An external tool can set following flag to declare its include as system includes.
```
<flags SYSTEM_INCLUDE="1"/>
```