### PR TITLE
Update to CUDA 11.0 RC (11.0.182)

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -17,7 +17,7 @@
 
 
 # enable C++17, and generate optimised code
-%define cuda_flags_0 -std=c++14 -O3
+%define cuda_flags_0 -std=c++17 -O3
 
 # generate debugging information for device code
 %define cuda_flags_1 --generate-line-info --source-in-ptx

--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -15,9 +15,11 @@
 # LLVM style for listing the supported CUDA compute architectures
 %define llvm_cuda_arch %(echo $(for ARCH in %cuda_arch; do echo "$ARCH"; done) | sed -e"s/ /,/g")
 
+# C++ standard to use for building host and device code with nvcc
+%define nvcc_stdcxx -std=c++17
 
-# enable C++17, and generate optimised code
-%define cuda_flags_0 -std=c++17 -O3
+# generate optimised code
+%define cuda_flags_0 -O3
 
 # generate debugging information for device code
 %define cuda_flags_1 --generate-line-info --source-in-ptx
@@ -38,4 +40,4 @@
 %define cuda_flags_6 --cudart shared
 
 # collect all CUDA flags
-%define cuda_flags %{cuda_flags_0} %{cuda_flags_1} %{cuda_flags_2} %{cuda_flags_3} %{cuda_flags_4} %{cuda_flags_5} %{cuda_flags_6}
+%define nvcc_cuda_flags %{nvcc_stdcxx} %{cuda_flags_0} %{cuda_flags_1} %{cuda_flags_2} %{cuda_flags_3} %{cuda_flags_4} %{cuda_flags_5} %{cuda_flags_6}

--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -16,7 +16,7 @@
 %define llvm_cuda_arch %(echo $(for ARCH in %cuda_arch; do echo "$ARCH"; done) | sed -e"s/ /,/g")
 
 
-# enable C++14, and generate optimised code
+# enable C++17, and generate optimised code
 %define cuda_flags_0 -std=c++14 -O3
 
 # generate debugging information for device code
@@ -29,7 +29,7 @@
 %define cuda_flags_3 --expt-extended-lambda
 
 # build support for the various compute architectures
-%define cuda_flags_4 %(echo $(for ARCH in %cuda_arch; do echo "-gencode arch=compute_$ARCH,code=sm_$ARCH"; done))
+%define cuda_flags_4 %(echo $(for ARCH in %cuda_arch; do echo "-gencode arch=compute_$ARCH,code=sm_$ARCH"; done)) -Wno-deprecated-gpu-targets
 
 # disable warnings about attributes on defaulted methods
 %define cuda_flags_5 -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -76,9 +76,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-cusolver.xml
   <info url="https://docs.nvidia.com/cuda/cusolver/index.html"/>
   <use name="cuda"/>
   <lib name="cusolver"/>
-%ifarch x86_64 ppc64le
   <lib name="cusolverMg"/>
-%endif
 </tool>
 EOF_TOOLFILE
 
@@ -96,7 +94,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-npp.xml
   <use name="cuda"/>
   <lib name="nppial"/>
   <lib name="nppicc"/>
-  <lib name="nppicom"/>
   <lib name="nppidei"/>
   <lib name="nppif"/>
   <lib name="nppig"/>
@@ -125,7 +122,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvml.xml
 </tool>
 EOF_TOOLFILE
 
-%ifarch x86_64 ppc64le
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvjpeg.xml
 <tool name="cuda-nvjpeg" version="@TOOL_VERSION@">
   <info url="https://docs.nvidia.com/cuda/nvjpeg/index.html"/>
@@ -133,7 +129,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvjpeg.xml
   <lib name="nvjpeg"/>
 </tool>
 EOF_TOOLFILE
-%endif
 
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvrtc.xml
 <tool name="cuda-nvrtc" version="@TOOL_VERSION@">

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -39,7 +39,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
   <flags CUDA_FLAGS="%{cuda_flags}"/>
   <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
   <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>
-  <flags CUDA_HOST_CXXFLAGS="-std=c++14"/>
+  <flags CUDA_HOST_CXXFLAGS="-std=c++17"/>
   <lib name="cudadevrt" type="cuda"/>
   <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>
 </tool>

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -6,7 +6,7 @@ Requires: cuda
 
 %install
 ## INCLUDE cuda-flags
-# defines cuda_flags
+# defines nvcc_cuda_flags and nvcc_stdcxx
 
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-stubs.xml
@@ -36,10 +36,10 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda.xml
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
-  <flags CUDA_FLAGS="%{cuda_flags}"/>
+  <flags CUDA_FLAGS="%{nvcc_cuda_flags}"/>
   <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
   <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>
-  <flags CUDA_HOST_CXXFLAGS="-std=c++17"/>
+  <flags CUDA_HOST_CXXFLAGS="%{nvcc_stdcxx}"/>
   <lib name="cudadevrt" type="cuda"/>
   <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>
 </tool>

--- a/cupla.spec
+++ b/cupla.spec
@@ -18,7 +18,7 @@ mkdir build lib
 rm -rf alpaka
 
 CXXFLAGS="-DALPAKA_DEBUG=0 -I$CUDA_ROOT/include -I$TBB_ROOT/include -I$BOOST_ROOT/include -I$ALPAKA_ROOT/include -Iinclude"
-HOST_FLAGS="-std=c++14 -O2 -pthread -fPIC -Wall -Wextra"
+HOST_FLAGS="-std=c++17 -O2 -pthread -fPIC -Wall -Wextra"
 NVCC_FLAGS="%{cuda_flags}"
 FILES=$(find src -type f -name *.cpp)
 

--- a/cupla.spec
+++ b/cupla.spec
@@ -10,7 +10,7 @@ Requires: tbb
 
 %build
 ## INCLUDE cuda-flags
-# defines cuda_flags
+# defines nvcc_cuda_flags and nvcc_stdcxx
 
 mkdir build lib
 
@@ -18,8 +18,8 @@ mkdir build lib
 rm -rf alpaka
 
 CXXFLAGS="-DALPAKA_DEBUG=0 -I$CUDA_ROOT/include -I$TBB_ROOT/include -I$BOOST_ROOT/include -I$ALPAKA_ROOT/include -Iinclude"
-HOST_FLAGS="-std=c++17 -O2 -pthread -fPIC -Wall -Wextra"
-NVCC_FLAGS="%{cuda_flags}"
+HOST_FLAGS="%{nvcc_stdcxx} -O2 -pthread -fPIC -Wall -Wextra"
+NVCC_FLAGS="%{nvcc_cuda_flags}"
 FILES=$(find src -type f -name *.cpp)
 
 # build the serial CPU backend


### PR DESCRIPTION
Update to CUDA 11.0 RC:
  * CUDA version 11.0.182
  * NVIDIA drivers version 450.36.06

Use the same package structure on Intel/AMD (x86_64), Power (ppc64le) and ARMv8/SBSA (aarch64).

Include support for c++17, gcc 9, clang 9.

See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#title-new-features .