### PR TITLE
Update tag for DQM-SiStripMonitorClient to V01-01-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+DQM-SiStripMonitorClient=V01-01-00
 L1Trigger-TrackFindingTracklet=V00-01-00
 L1Trigger-TrackFindingTMTT=V00-01-00
 Geometry-TestReference=V00-02-00
@@ -73,7 +74,6 @@ CondFormats-JetMETObjects=V01-00-03
 DataFormats-PatCandidates=V01-00-01
 DQM-DTMonitorClient=V00-01-00
 DQM-PhysicsHWW=V01-00-00
-DQM-SiStripMonitorClient=V01-00-00
 EventFilter-L1TRawToDigi=V01-00-00
 FastSimulation-TrackingRecHitProducer=V01-00-03
 GeneratorInterface-EvtGenInterface=V02-00-11


### PR DESCRIPTION
Move DQM-SiStripMonitorClient data to new tag, see 
https://github.com/cms-data/DQM-SiStripMonitorClient/pull/1
