### PR TITLE
[GCC10][ROOT] disable runtime_cxxmodules for root 6.20

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -48,6 +48,7 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_LINKER=ld \
   -DCMAKE_VERBOSE_MAKEFILE=TRUE \
   -Droot7=ON \
+  -Druntime_cxxmodules=OFF \
   -Dfail-on-missing=ON \
   -Dgnuinstall=OFF \
   -Droofit=ON \


### PR DESCRIPTION
as it is not supported for gcc 10

https://sft.its.cern.ch/jira/browse/ROOT-10863
https://root-forum.cern.ch/t/error-compiling-root-6-20-04/39966/5?u=eguiraud