### PR TITLE
[TBB][BOOST] Treat includes as system includes to avoid warnings

### DIFF
--- a/boost-toolfile.spec
+++ b/boost-toolfile.spec
@@ -16,16 +16,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost.xml
   <client>
     <environment name="BOOST_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$BOOST_BASE/lib"/>
-    <environment name="INCLUDE" default="$BOOST_BASE/include"/>
   </client>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$BOOST_BASE/include" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <use name="root_cxxdefaults"/>
-  <flags CPPDEFINES="BOOST_SPIRIT_THREADSAFE PHOENIX_THREADSAFE"/>
-  <flags CPPDEFINES="BOOST_MATH_DISABLE_STD_FPCLASSIFY"/>
-  <flags CPPDEFINES="BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX"/>
-  <flags CXXFLAGS="-Wno-error=unused-variable"/>
-  <use name="sockets"/>
+  <use name="boost_header"/>
 </tool>
 EOF_TOOLFILE
 
@@ -75,10 +67,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_python.xml
   <client>
     <environment name="BOOST_PYTHON_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$BOOST_PYTHON_BASE/lib"/>
-    <environment name="INCLUDE" default="$BOOST_PYTHON_BASE/include"/>
   </client>
-  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <use name="root_cxxdefaults"/>
+  <use name="boost_header"/>
   <use name="python"/>
 </tool>
 EOF_TOOLFILE
@@ -134,8 +124,15 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/boost_header.xml
     <environment name="BOOSTHEADER_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$BOOSTHEADER_BASE/include"/>
   </client>
-  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <use name="sockets"/>
   <use name="root_cxxdefaults"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <flags CPPDEFINES="BOOST_SPIRIT_THREADSAFE PHOENIX_THREADSAFE"/>
+  <flags CPPDEFINES="BOOST_MATH_DISABLE_STD_FPCLASSIFY"/>
+  <flags CPPDEFINES="BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX"/>
+  <flags CXXFLAGS="-Wno-error=unused-variable"/>
+  <flags SYSTEM_INCLUDE="1"/>
 </tool>
 EOF_TOOLFILE
 

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-10-14
+%define configtag       V05-10-14-01
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/tbb-toolfile.spec
+++ b/tbb-toolfile.spec
@@ -19,6 +19,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/tbb.xml
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <flags CPPDEFINES="TBB_USE_GLIBCXX_VERSION=@GCC_GLIBCXX_VERSION@"/>
+  <flags CPPDEFINES="TBB_SUPPRESS_DEPRECATED_MESSAGES"/>
+  <flags SYSTEM_INCLUDE="1"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
To avoid warnings coming from TBB headers and boost headers, we mark these tools are system tools so that scram can use `-isystem /include/dir` instead of `-I/include/dir`. This will instruct the compiler to ignore the warnings coming from the headers in `/include/dir`