### PR TITLE
Fix go.spec for  cc8 ppc64le to provide the missing deps

### DIFF
--- a/go.spec
+++ b/go.spec
@@ -5,6 +5,7 @@
 Source: https://storage.googleapis.com/golang/go%{realversion}.linux-amd64.tar.gz
 %endif
 %ifarch ppc64le
+Provides: libc.so.6(GLIBC_2.2.5)(64bit)
 Source: https://storage.googleapis.com/golang/go%{realversion}.linux-ppc64le.tar.gz
 %endif
 %ifarch aarch64


### PR DESCRIPTION
RPM failed to package `go` for `cc8/ppc64le` due to [a]. The change here provides the missing deps. On `cc8` for `amd64/aarch64` `glibc-2.28` provides  GLIBC_2.2.5 but not for ppc64le.

[a]
RpmInstallFailed: Failed to install package go. Reason:
error: Failed dependencies:
	libc.so.6(GLIBC_2.2.5)(64bit) is needed by external+go+1.15beta1-1-1.ppc64le
