### PR TITLE
Revert "[CXXMODULE] build cxxmodules for FWCore/Framework FWCore/ParameterSet"

### DIFF
--- a/cmssw-queue-override.file
+++ b/cmssw-queue-override.file
@@ -31,7 +31,7 @@
 Source20: CXXModules.mk
 %define patchsrc19     cp %{_sourcedir}/CXXModules.mk config/SCRAM/GMake/CXXModules.mk
 %define patchsrc20     \
-  for p in FWCore/Framework FWCore/ParameterSet FWCore/Reflection FWCore/Utilities  ; do \
+  for p in FWCore/Reflection FWCore/Utilities ; do \
     echo "${p}_CXXMODULES:=1" | sed 's|/||' >> config/SCRAM/GMake/CXXModules.mk ;\
     [ -d src/$p/src ] && touch src/$p/src/classes.h src/$p/src/classes_def.xml ;\
   done


### PR DESCRIPTION
Reverts cms-sw/cmsdist#5986
lets revert this, I think this break the IB