### PR TITLE
Add nose2 python dependency to wmcore-devtools package

### DIFF
--- a/py2-nose2.spec
+++ b/py2-nose2.spec
@@ -1,0 +1,5 @@
+### RPM external py2-nose2 0.9.2
+## IMPORT build-with-pip
+
+Requires: py2-six py2-coverage py2-mock
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/wmcore-devtools.spec
+++ b/wmcore-devtools.spec
@@ -1,7 +1,7 @@
 ### RPM cms wmcore-devtools 1.5
 
 # This is a meta-package to group development tool dependencies
-Requires: yuicompressor py2-coverage py2-pylint py2-nose py2-sphinx py2-cherrypy
+Requires: yuicompressor py2-coverage py2-pylint py2-nose py2-nose2 py2-sphinx py2-cherrypy
 Requires: py2-mox py2-future py2-mock py2-retry py2-pep8 py2-memory-profiler py2-pymongo
 
 %prep


### PR DESCRIPTION
This python dependency will then be available in the docker image used for unit tests (wmagent-dev), here:
https://github.com/dmwm/WMCore/blob/master/test/deploy/deploy_unittest.sh#L16