### PR TITLE
[Geant4] Update Geant4 branch to use 10.7.0 Beta

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,7 +1,7 @@
-### RPM external geant4 10.6.2
-%define tag 2d174b7a10d70c0bc257ede0554bfcab14e75db5
-%define branch cms/v%{realversion}
-%define github_user cms-externals
+### RPM external geant4 10.7.0.beta
+%define tag 67ba86d073ec6366df0de75a0f5b5d57920d0b7e
+%define branch master
+%define github_user Geant4
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz
 
 BuildRequires: cmake gmake

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,4 +1,4 @@
-### RPM external vecgeom v1.1.6
+### RPM external vecgeom v1.1.7
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake gmake
 %define keep_archives true
@@ -17,6 +17,7 @@ cd ../build
 
 cmake ../%{n}-%{realversion} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_INSTALL_LIBDIR=%{i}/lib \
   -DROOT=OFF \
   -DCMAKE_BUILD_TYPE=Release \
   -DNO_SPECIALIZATION=ON \
@@ -43,7 +44,5 @@ perl -p -i -e 's|set\(VECGEOM_EXTERNAL_INCLUDES .*|set(VECGEOM_EXTERNAL_INCLUDES
   $(grep -R 'set(VECGEOM_EXTERNAL_INCLUDES ' %{i}/lib/cmake | sed 's|:.*||' | sort | uniq)
 
 %post
-%{relocateConfig}lib/cmake/USolids/*.cmake
-%{relocateConfig}lib/cmake/VecCore/*.cmake
 %{relocateConfig}lib/cmake/VecGeom/*.cmake
 


### PR DESCRIPTION
please test
Resolves: https://github.com/cms-externals/geant4/issues/47
both are building but that wasn't enough the last time, lets see
change the geant repo to their official github (they have one now)
The tag 10.7.0.beta was tagged from master, should be fine