### PR TITLE
[BuildRules] Updated build rules for 11.2.X

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -64,7 +64,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V05-10-13
+%define configtag       V05-10-14
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
remove the extra newline for `performance-inefficient-vector-operation` clang tidy check