### PR TITLE
Backports of phase-2 L1T cms-data externals to 11_1_X

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -43,6 +43,10 @@ Requires: data-RecoBTag-CTagging
 Requires: data-L1Trigger-L1TMuon
 Requires: data-L1Trigger-L1TGlobal
 Requires: data-L1Trigger-L1THGCal
+Requires: data-L1Trigger-Phase2L1ParticleFlow
+Requires: data-L1Trigger-DTTriggerPhase2
+Requires: data-L1Trigger-TrackFindingTracklet
+Requires: data-L1Trigger-TrackFindingTMTT
 Requires: data-SLHCUpgradeSimulations-Geometry
 Requires: data-CalibTracker-SiStripDCS
 Requires: data-SimTracker-SiStripDigitizer

--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,9 +3,15 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+L1Trigger-Phase2L1ParticleFlow=V00-02-00
+L1Trigger-L1THGCal=V01-03-00
+L1Trigger-L1TMuon=V01-02-00
+L1Trigger-DTTriggerPhase2=V00-01-00
+L1Trigger-L1TCalorimeter=V01-01-00
+L1Trigger-TrackFindingTracklet=V00-01-00
+L1Trigger-TrackFindingTMTT=V00-01-00
 RecoMET-METPUSubtraction=V01-01-00
 EgammaAnalysis-ElectronTools=V00-02-00
-L1Trigger-L1THGCal=V01-02-00
 PhysicsTools-NanoAOD=V01-01-00
 RecoBTag-Combined=V01-03-00
 RecoTauTag-TrainingFiles=V00-02-00
@@ -26,7 +32,6 @@ RecoCTPPS-TotemRPLocal=V00-02-00
 RecoMuon-MuonIdentification=V01-12-05
 RecoTracker-FinalTrackSelectors=V01-00-07
 SLHCUpgradeSimulations-Geometry=V01-00-10
-L1Trigger-L1TMuon=V01-01-04
 CondTools-SiPhase2Tracker=V00-01-00
 PhysicsTools-PatUtils=V00-01-00
 SimTransport-PPSProtonTransport=V00-01-00
@@ -75,7 +80,6 @@ EventFilter-L1TRawToDigi=V01-00-00
 FastSimulation-TrackingRecHitProducer=V01-00-03
 GeneratorInterface-EvtGenInterface=V02-00-11
 HLTrigger-JetMET=V01-00-00
-L1Trigger-L1TCalorimeter=V01-00-22
 L1Trigger-L1TGlobal=V00-00-07
 RecoBTag-CTagging=V01-00-03
 RecoBTag-SecondaryVertex=V02-00-04


### PR DESCRIPTION
Backports of phase-2 L1T cms-data to 11_1_X .

They are either new packages or update of packages adding new files.
So I expect they can be safetly merged, but let's wait for the PR tests.

@smuzaffar @mrodozov please double check if the PR looks ok.