### PR TITLE
Bump python future package from 0.16.0 to 0.18.2

### DIFF
--- a/py2-future.spec
+++ b/py2-future.spec
@@ -1,4 +1,4 @@
-### RPM external py2-future 0.16.0
+### RPM external py2-future 0.18.2
 ## IMPORT build-with-pip
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*


### PR DESCRIPTION
Many bugfixes have gone between these two releases, see full notes here:
https://github.com/PythonCharmers/python-future/releases

it's important to highlight: "Python 3.8 is not yet officially supported.", which means, we should keep python3.6 in COMP for a little longer.