### PR TITLE
Bump python future for slc6 to 0.18.2

### DIFF
--- a/py2-future.spec
+++ b/py2-future.spec
@@ -1,4 +1,4 @@
-### RPM external py2-future 0.15.0
+### RPM external py2-future 0.18.2
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 Source: https://pypi.python.org/packages/source/f/future/future-%realversion.tar.gz
 Requires: python py2-setuptools py2-argparse


### PR DESCRIPTION
Same change as done for comp_gcc630: https://github.com/cms-sw/cmsdist/pull/6056

Not tested, I don't even know anymore which slc6 node can be used to build these packages