### PR TITLE
Add fmt flag for ppc

### DIFF
--- a/fmt.spec
+++ b/fmt.spec
@@ -14,6 +14,9 @@ rm -rf build && mkdir build && cd build
 cmake ../%{n}-%{realversion} \
     -DCMAKE_INSTALL_PREFIX:STRING=%{i} \
     -DCMAKE_INSTALL_LIBDIR:STRING=lib \
+%ifarch ppc64le
+    -DCMAKE_CXX_FLAGS="-mlong-double-64" \
+%endif
     -DBUILD_SHARED_LIBS=TRUE
 
 make %{makeprocesses}


### PR DESCRIPTION
please test
Unit test compilation is failing because of missing flag for ppc in
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_ppc64le_gcc820/CMSSW_11_2_X_2020-07-12-0000/FWCore/MessageService