### PR TITLE
Move back to ROOT 6.18 (11_1)

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,9 +1,9 @@
-### RPM lcg root 6.20.06
+### RPM lcg root 6.18.04
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag ff0d0942d42220f5f4bb3c92acde27a3373aea80
-%define branch cms/v6-20-00-patches/6781331
+%define tag c31b69b812b85090946497b46da9f01ab89e00f8
+%define branch cms/v6-18-00-patches/v6-18-04
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
@@ -12,7 +12,7 @@ Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 
-Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python fftw3 xz xrootd libxml2 openssl zlib davix tbb OpenBLAS py2-numpy lz4 freetype zstd
+Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python fftw3 xz xrootd libxml2 openssl zlib davix tbb OpenBLAS py2-numpy lz4 freetype
 
 %if %islinux
 Requires: dcap
@@ -54,7 +54,129 @@ cmake ../%{n}-%{realversion} \
   -Dvdt=OFF \
   -Dhdfs=OFF \
   -Dqt=OFF \
-  -Dtmva=ON \
+  -Dqtgsi=OFF \
+  -Dpgsql=OFF \
+  -Dsqlite=OFF \
+  -Dmysql=OFF \
+  -Doracle=OFF \
+  -Dldap=OFF \
+  -Dkrb5=OFF \
+  -Dftgl=OFF \
+  -Dfftw3=ON \
+  -Dtbb=ON \
+  -Dimt=ON \
+  -DFFTW_INCLUDE_DIR="${FFTW3_ROOT}/include" \
+  -DFFTW_LIBRARY="${FFTW3_ROOT}/lib/libfftw3.%{soext}" \
+  -Dminuit2=ON \
+  -Dmathmore=ON \
+  -Dexplicitlink=ON \
+  -Dtable=OFF \
+  -Dbuiltin_tbb=OFF \
+  -Dbuiltin_pcre=OFF \
+  -Dbuiltin_freetype=OFF \
+  -Dbuiltin_zlib=OFF \
+  -Dbuiltin_lzma=OFF \
+  -Dbuiltin_gsl=OFF \
+  -Dbuiltin_xxhash=ON \
+  -Darrow=OFF \
+  -DGSL_ROOT_DIR="${GSL_ROOT}" \
+  -DGSL_CBLAS_LIBRARY="${OPENBLAS_ROOT}/lib/libopenblas.%{soext}" \
+  -DGSL_CBLAS_LIBRARY_DEBUG="${OPENBLAS_ROOT}/lib/libopenblas.%{soext}" \
+  -DCMAKE_CXX_STANDARD=17 \
+  -Dssl=ON \
+  -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT}" \
+  -DOPENSSL_INCLUDE_DIR="${OPENSSL_ROOT}/include" \
+  -Dpython=ON \
+  -Dxrootd=ON \
+  -Dbuiltin_xrootd=OFF \
+  -DXROOTD_INCLUDE_DIR="${XROOTD_ROOT}/include/xrootd" \
+  -DXROOTD_ROOT_DIR="${XROOTD_ROOT}" \
+%if %islinux
+  -Drfio=OFF \
+  -Dcastor=OFF \
+  -Ddcache=ON \
+  -DDCAP_INCLUDE_DIR="${DCAP_ROOT}/include" \
+  -DDCAP_DIR="${DCAP_ROOT}" \
+%endif
+  -DCMAKE_C_FLAGS="-D__ROOFIT_NOBANNER" \
+  -DCMAKE_C_FLAGS="-D__ROOFIT_NOBANNER" \
+  -Dgviz=OFF \
+  -Dbonjour=OFF \
+  -Dodbc=OFF \
+  -Dpythia6=OFF \
+  -Dpythia8=OFF \
+  -Dfitsio=OFF \
+  -Dgfal=OFF \
+  -Dchirp=OFF \
+  -Dsrp=OFF \
+  -Ddavix=ON \
+  -Dglite=OFF \
+  -Dsapdb=OFF \
+  -Dalien=OFF \
+  -Dmonalisa=OFF \
+%if %isdarwin
+  -Dbuiltin_afterimage=OFF \
+  -Dcocoa=OFF \
+  -Dx11=ON \
+  -Dcastor=OFF \
+  -Drfio=OFF \
+  -Ddcache=OFF \
+%endif
+  -DJPEG_INCLUDE_DIR="${LIBJPEG_TURBO_ROOT}/include" \
+  -DJPEG_LIBRARY="${LIBJPEG_TURBO_ROOT}/lib64/libjpeg.%{soext}" \
+  -DPNG_INCLUDE_DIRS="${LIBPNG_ROOT}/include" \
+  -DPNG_LIBRARY="${LIBPNG_ROOT}/lib/libpng.%{soext}" \
+  -Dastiff=ON \
+  -DTIFF_INCLUDE_DIR="${LIBTIFF_ROOT}/include" \
+  -DTIFF_LIBRARY="${LIBTIFF_ROOT}/lib/libtiff.%{soext}" \
+  -DLIBLZMA_INCLUDE_DIR="${XZ_ROOT}/include" \
+  -DLIBLZMA_LIBRARY="${XZ_ROOT}/lib/liblzma.%{soext}" \
+  -DLIBLZ4_INCLUDE_DIR="${LZ4_ROOT}/include" \
+  -DLIBLZ4_LIBRARY="${LZ4_ROOT}/lib/liblz4.%{soext}" \
+  -DZLIB_ROOT="${ZLIB_ROOT}" \
+  -DZLIB_INCLUDE_DIR="${ZLIB_ROOT}/include" \
+  -DCMAKE_PREFIX_PATH="${GSL_ROOT}:${XZ_ROOT};${OPENSSL_ROOT};${GIFLIB_ROOT};${FREETYPE_ROOT};${PYTHON_ROOT};${LIBPNG_ROOT};${PCRE_ROOT};${TBB_ROOT};${OPENBLAS_ROOT};${DAVIX_ROOT};${LZ4_ROOT};${LIBXML2_ROOT}"
+
+# For CMake cache variables: http://www.cmake.org/cmake/help/v3.2/manual/cmake-language.7.html#lists
+# For environment variables it's OS specific: http://www.cmake.org/Wiki/CMake_Useful_Variables
+
+#  Required for generated dictionaries during ROOT6 compile/install
+ROOT_INCLUDE_PATH=
+for DEP in %requiredtools; do
+  ROOT_INCLUDE_PATH=$(eval echo $(printf "\${%%s_ROOT}/include" $(echo $DEP | tr "[a-z]-" "[A-Z]_"))):$ROOT_INCLUDE_PATH
+done
+
+export ROOT_INCLUDE_PATH
+export ROOTSYS="%{i}"
+
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN)
+
+%install
+cd ../build
+
+# Required for generated dictionaries during ROOT6 compile/install
+ROOT_INCLUDE_PATH=
+for DEP in %requiredtools; do
+  ROOT_INCLUDE_PATH=$(eval echo $(printf "\${%%s_ROOT}/include" $(echo $DEP | tr "[a-z]-" "[A-Z]_"))):$ROOT_INCLUDE_PATH
+done
+
+export ROOT_INCLUDE_PATH
+export ROOTSYS="%{i}"
+
+ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
+
+find %{i} -type f -name '*.py' | xargs chmod -x
+grep -R -l '#!.*python' %{i} | xargs chmod +x
+perl -p -i -e "s|#!/bin/perl|#!/usr/bin/env perl|" %{i}/bin/memprobe
+
+#Make sure root build directory is not available after the root install is done
+#This will catch errors if root remembers the build paths.
+cd ..
+rm -rf build
+
+%post
+%{relocateConfig}etc/cling/llvm/Config/llvm-config.h
+
   -Dqtgsi=OFF \
   -Dpgsql=OFF \
   -Dsqlite=OFF \

--- a/root.spec
+++ b/root.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag c31b69b812b85090946497b46da9f01ab89e00f8
+%define tag 2b91a0f8b8a094137a90fed9b340d99a3108c2d4
 %define branch cms/v6-18-00-patches/v6-18-04
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Revert of #5942 and #5951.
Request from PPD to move back to ROOT 6.18 for the 11_1_0 reReco production in order to fix a PSS memory jump in DQM merge (@srimanob)

See: https://sft.its.cern.ch/jira/browse/ROOT-10927
