### PR TITLE
remove jemalloc lib condition

### DIFF
--- a/jemalloc-debug-toolfile.spec
+++ b/jemalloc-debug-toolfile.spec
@@ -10,9 +10,7 @@ Requires: jemalloc-debug
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/jemalloc-debug.xml
 <tool name="jemalloc-debug" version="@TOOL_VERSION@">
-  <architecture name="slc.*|fc.*|cc*">
-    <lib name="jemalloc"/>
-  </architecture>
+  <lib name="jemalloc"/>
   <client>
     <environment name="JEMALLOC_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"        default="$JEMALLOC_BASE/lib"/>

--- a/jemalloc-debug-toolfile.spec
+++ b/jemalloc-debug-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external jemalloc-debug-toolfile 1.0
+### RPM external jemalloc-debug-toolfile 2.0
 Requires: jemalloc-debug
 
 %prep

--- a/jemalloc-toolfile.spec
+++ b/jemalloc-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external jemalloc-toolfile 2.0
+### RPM external jemalloc-toolfile 3.0
 Requires: jemalloc 
 
 %prep
@@ -10,9 +10,7 @@ Requires: jemalloc
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/jemalloc.xml
 <tool name="jemalloc" version="@TOOL_VERSION@">
-  <architecture name="slc.*|fc.*">
-    <lib name="jemalloc"/>
-  </architecture>
+  <lib name="jemalloc"/>
   <client>
     <environment name="JEMALLOC_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"        default="$JEMALLOC_BASE/lib"/>


### PR DESCRIPTION
We have noticed that cmsRun is not linked against jemalloc library for `cc8_amd64_*` build. The reason is that the toolfile was only conditionally adding the `jemalloc` lib for only `slc*` and `fc*` archs.

This change should allow to properly link against `jemalloc` libs if one dependson it.

FYI, @silviodonato @makortel 