### PR TITLE
Update rucio-clients to 1.23.0, and bring all its dependencies

### DIFF
--- a/py2-attrs.spec
+++ b/py2-attrs.spec
@@ -1,0 +1,2 @@
+### RPM external py2-attrs 19.3.0
+## IMPORT build-with-pip

--- a/py2-importlib-metadata.spec
+++ b/py2-importlib-metadata.spec
@@ -1,0 +1,4 @@
+### RPM external py2-importlib-metadata 1.7.0
+## IMPORT build-with-pip
+
+Requires: py2-zipp py2-pathlib2 py2-contextlib2 py2-configparser

--- a/py2-jsonschema.spec
+++ b/py2-jsonschema.spec
@@ -1,7 +1,5 @@
-### RPM external py2-jsonschema 2.6.0
+### RPM external py2-jsonschema 3.2.0
 ## IMPORT build-with-pip
 
-Requires: python py2-functools32
-#%define PipPostBuild \
-#   perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/*/*.py
+Requires: py2-functools32 py2-attrs py2-pyrsistent py2-six py2-importlib-metadata
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py2-pathlib2.spec
+++ b/py2-pathlib2.spec
@@ -1,0 +1,4 @@
+### RPM external py2-pathlib2 2.3.5
+## IMPORT build-with-pip
+
+Requires: py2-six py2-scandir

--- a/py2-pyrsistent.spec
+++ b/py2-pyrsistent.spec
@@ -1,0 +1,4 @@
+### RPM external py2-pyrsistent 0.16.0
+## IMPORT build-with-pip
+
+Requires: py2-six

--- a/py2-rucio-clients.spec
+++ b/py2-rucio-clients.spec
@@ -1,11 +1,11 @@
-### RPM external py2-rucio-clients 1.22.2
+### RPM external py2-rucio-clients 1.23.0
 ## IMPORT build-with-pip
 ## INITENV SET RUCIO_HOME %i/
 
 Source1: rucio-config
 Requires: py2-argcomplete py2-requests py2-urllib3 py2-dogpile-cache py2-nose py2-boto
 Requires: py2-tabulate py2-progressbar2 py2-bz2file py2-python-magic py2-six py2-futures
-Requires: py2-boto3 py2-pysftp
+Requires: py2-boto3 py2-pysftp py2-jsonschema
 
 # setup a CMS rucio configuration standard file
 %define PipPreBuild mkdir -p %i/etc/; cp -f %_sourcedir/rucio-config %i/etc/rucio.cfg

--- a/py2-scandir.spec
+++ b/py2-scandir.spec
@@ -1,0 +1,2 @@
+### RPM external py2-scandir 1.10.0
+## IMPORT build-with-pip

--- a/py2-six.spec
+++ b/py2-six.spec
@@ -1,2 +1,2 @@
-### RPM external py2-six 1.12.0
+### RPM external py2-six 1.14.0
 ## IMPORT build-with-pip

--- a/py2-zipp.spec
+++ b/py2-zipp.spec
@@ -1,0 +1,4 @@
+### RPM external py2-zipp 1.2.0
+## IMPORT build-with-pip
+
+Requires: py2-contextlib2


### PR DESCRIPTION
The new rucio-clients (and 1.22.8) depends on `jsonschema`, which by itself depends on many other python packages.
Some of those python packages don't even seem to support python2 (by a quick look at their home page), even though rucio-clients is supposed to work on both py2 and py3 versions...

This PR also updates the py2-six spec, reason why it rebuilds most of our python-based applications.