### PR TITLE
Update to CUDA 11.0.2 (11.0.207)

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,4 +1,4 @@
-### RPM external alpaka 0.4.0
+### RPM external alpaka 0.5.0
 ## NOCOMPILER
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,6 +1,6 @@
-### RPM external cuda 11.0.1
+### RPM external cuda 11.0.2
 
-%define driversversion 450.36.06
+%define driversversion 450.51.05
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/cupla.spec
+++ b/cupla.spec
@@ -1,12 +1,15 @@
-### RPM external cupla 0.2.0
+### RPM external cupla 0.3.0-dev
 
-Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz
+#%define tag %{realversion}
+%define tag ac24b2e0d906652054b1473635f9e1f98b2d31af
+
+Source: https://github.com/alpaka-group/%{n}/archive/%{tag}.tar.gz
 Requires: alpaka
 Requires: cuda
 Requires: tbb
 
 %prep
-%setup -n %{n}-%{realversion}
+%setup -n %{n}-%{tag}
 
 %build
 ## INCLUDE cuda-flags


### PR DESCRIPTION
Update to CUDA 11.0.2:
  - CUDA version 11.0.207
  - NVIDIA drivers version 450.51.05

Various bug fixes.

See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#title-new-features .