### PR TITLE
Add spec and new tag for SimG4CMS-Forward big file

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -94,7 +94,6 @@ SimTransport-HectorProducer=V01-00-01
 
 #Never update any package here. Always move it to default section.
 [data-cmssw-package-build]
-SimG4CMS-Forward=V02-03-18
 GeneratorInterface-ReggeGribovPartonMCInterface=V00-00-02
 
 #Never update any package here. Always move it to default section.
@@ -105,3 +104,4 @@ L1Trigger-RPCTrigger=V00-15-00
 RecoParticleFlow-PFBlockProducer=V02-04-02
 SimG4CMS-Calo=V03-01-00
 Validation-Geometry=V00-07-00
+SimG4CMS-Forward=V02-03-19

--- a/data/data-SimG4CMS-Forward.spec
+++ b/data/data-SimG4CMS-Forward.spec
@@ -1,0 +1,12 @@
+### RPM cms data-SimG4CMS-Forward V02-03-19
+
+%prep
+
+# Base URL, where to find the files
+%define base_url "http://cmsdoc.cern.ch/cms/data/CMSSW"
+
+cat << CMS_EOF >> ./sources
+SimG4CMS/Forward/data/CastorShowerLibrary_CMSSW500_Standard.root
+CMS_EOF
+
+## IMPORT data-package-build


### PR DESCRIPTION
this adds the external without github repo because the file is too big (100mb max per file)
the other approach as with Fireworks-Geometry requires additionally to the .file in /data to have also a github repo with that name OR the distributed file to be a tar.gz archive. 
This one works the only problem is the tag needs to be updated in two files. With respect to having an empty github repo it's nearly the same 
Resolves: #6077 and needs https://github.com/cms-sw/cmssw/pull/30946 to be merged together