### PR TITLE
update cmsswdata to RecoBTag-Combined to V01-06-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -5,7 +5,7 @@
 [default]
 CalibPPS-ESProducers=V01-02-00
 RecoMET-METPUSubtraction=V01-01-00
-RecoBTag-Combined=V01-04-00
+RecoBTag-Combined=V01-06-00
 RecoJets-JetProducers=V05-12-00
 FWCore-Modules=V00-01-00
 IOPool-Input=V00-01-00


### PR DESCRIPTION
backport of #6156

it looks like it's most direct to just advance to the master version instead of making a targeted split tag
https://github.com/cms-data/RecoBTag-Combined/compare/V01-04-00...V01-06-00

