### PR TITLE
Update to CUDA 11.0 Update 1, and update the list of supported architectures

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -1,14 +1,14 @@
 ### FILE cuda-flags
 # define the CUDA compilation flags in a way that can be shared by SCRAM-based and regular tools
 
-# on X86 and Power, build support for Kepler, Pascal and Volta/Turing
+# on X86 and Power, build support for Pascal, Volta and Turing
 %ifarch x86_64 ppc64le
-%define cuda_arch 35 60 70
+%define cuda_arch 60 70 75
 %endif
 
-# on ARM, build Volta/Turing and the Xavier SoC
+# on ARM, build support for Volta, Xavier SoC and Turing
 %ifarch aarch64
-%define cuda_arch 70 72
+%define cuda_arch 70 72 75
 %endif
 
 

--- a/cuda.spec
+++ b/cuda.spec
@@ -75,9 +75,13 @@ exec %{i}/bin/cuda-gdb.real "\$@"
 @EOF
 chmod a+x %{i}/bin/cuda-gdb
 
-# package the other binaries and tools
-mv %_builddir/build/nvvm %{i}/
+# package the Compute Sanitizer, and replace the wrapper with a symlink
 mv %_builddir/build/Sanitizer %{i}/
+rm -f %{i}/bin/compute-sanitizer
+ln -s ../Sanitizer/compute-sanitizer %{i}/bin/compute-sanitizer
+
+# package the NVVM compiler (cicc), library (libnvvm.so), device library (libdevice.10.bc) and samples
+mv %_builddir/build/nvvm %{i}/
 
 # package the EULA and version file
 mv %_builddir/build/EULA.txt %{i}/

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,6 +1,6 @@
-### RPM external cuda 11.0.2
+### RPM external cuda 11.0.3
 
-%define driversversion 450.51.05
+%define driversversion 450.51.06
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run


### PR DESCRIPTION
Update CUDA to version 11.0 Update 1:
  * CUDA version 11.0.228
  * NVIDIA drivers version 450.51.06
    
See [What's New in CUDA 11.0 Update 1](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-whats-new-11Upd1).


Replace the Compute Sanitizer wrapper with a symlink, to work as a CMSSW external.


Drop support for Kepler, which is deprecated in CUDA 11, and add explicit support for Turing (e.g. Tesla T4).

Note that one can check the compute capabilities of the GPUs on the local machines with:
```bash
cudaComputeCapabilities
```
and re-build all CUDA code for the compute capabilities of the GPUs on the local machines with:
```
cmsCudaSetup.sh
cmsCudaRebuild.sh
```