### PR TITLE
Add py2-opt-einsum to python_tools

### DIFF
--- a/python_tools.spec
+++ b/python_tools.spec
@@ -35,6 +35,7 @@ Requires: py2-h5py
 Requires: py2-h5py-cache
 Requires: py2-root_pandas
 Requires: py2-uproot
+Requires: py2-opt-einsum
 
 #this DOES NOT depend on numpy..
 Requires: py2-xrootdpyfs


### PR DESCRIPTION
please test
gcc10 IB fails because of missing  opt-einsum