### PR TITLE
roll back to PREvious CRAB client version.

### DIFF
--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.200719
+%define crabclient_version v3.200531
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.3
 %define crabserver_version v3.200531


### PR DESCRIPTION
@mrodozov this will allow users to run crab client on older CMSSW w/o the hack described in
https://hypernews.cern.ch/HyperNews/CMS/get/cernCompAnnounce/1444/1/1/2/1/1.html
they will have to use crab from IB, but that's rather straightforward
https://twiki.cern.ch/twiki/bin/view/CMSPublic/CMSCrabClient#Using_CRABClient_from_nightly_CM

For crab-prod I will rather change the code to have both this fix and the fixes from current (alas broken) version.

Sorry for the extra work,