### PR TITLE
move forward to 0812 tag to fix httplib import

### DIFF
--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.200531
+%define crabclient_version v3.200812
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.3
 %define crabserver_version v3.200531


### PR DESCRIPTION
rolling back was not a good idea (see https://github.com/cms-sw/cmsdist/pull/6167#issuecomment-673645488  )
so move forward to tag with fix and align with current crab-prod