### PR TITLE
updated pip packages to fix build errors on aarch64

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -153,7 +153,7 @@ notebook==6.1.3 ; python_version>'3.0'
 numba==0.51 ; python_version>'3.0'
 numexpr==2.7.1
 numpy==1.16.6 ; python_version<'3.0'
-numpy==1.19.1 ; python_version>'3.0'
+numpy==1.17.5 ; python_version>'3.0'
 #NO_AUTO_UPDATE:2: numpy versions >1.15.1 fail on aarch64
 numpy==1.16.4 ; python_version>'3.0' ; platform_machine=='aarch64'
 onnx==1.7.0

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -153,10 +153,9 @@ notebook==6.1.3 ; python_version>'3.0'
 numba==0.51 ; python_version>'3.0'
 numexpr==2.7.1
 numpy==1.16.6 ; python_version<'3.0'
-numpy==1.17.5 ; python_version>'3.0'
+numpy==1.19.1 ; python_version>'3.0'
 #NO_AUTO_UPDATE:2: numpy versions >1.15.1 fail on aarch64
-numpy==1.15.1 ; python_version<'3.0' ; platform_machine=='aarch64'
-numpy==1.15.1 ; python_version>'3.0' ; platform_machine=='aarch64'
+numpy==1.16.4 ; python_version>'3.0' ; platform_machine=='aarch64'
 onnx==1.7.0
 onnxruntime==1.2.0 ; python_version>'3.0'
 opt-einsum==2.3.2 ; python_version<'3.0'


### PR DESCRIPTION
- updated py3-numy to 1.19.1
- py2-numpy 1.16.6 builds on aarch64
- py3-numpy 1.16.4 builds on aarch64