### PR TITLE
BuildRules: Included biglib path in to CLING_PREBUILT_MODULE_PATH env

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -65,7 +65,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-00-04
+%define configtag       V06-00-05
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This is needed by CXXMODULE Ibs