### PR TITLE
[11.0.X] Added Lz4 in to cmssw-tool-conf

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -112,6 +112,7 @@ Requires: pyminuit2-toolfile
 Requires: professor-toolfile
 Requires: professor2-toolfile
 Requires: xz-toolfile
+Requires: lz4-toolfile
 Requires: protobuf-toolfile
 Requires: lcov-toolfile
 Requires: llvm-gcc-toolfile


### PR DESCRIPTION
backport of #6227

LZ4 dependency was added (https://github.com/cms-sw/cmsdist/pull/4103 )  but its toolfile was not part of cmssw that is why at runtime we pick lz4 from system. 

This should be backported to 10.2 and above