### PR TITLE
[10.3.X] Added Lz4 in to cmssw-tool-conf

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -107,6 +107,7 @@ Requires: pyminuit2-toolfile
 Requires: professor-toolfile
 Requires: professor2-toolfile
 Requires: xz-toolfile
+Requires: lz4-toolfile
 Requires: protobuf-toolfile
 Requires: lcov-toolfile
 Requires: llvm-gcc-toolfile

--- a/lz4.spec
+++ b/lz4.spec
@@ -1,19 +1,14 @@
-### RPM external lz4 1.8.2
+### RPM external lz4 1.9.2
 
-%define tag %{realversion}
-%define branch tbb_2018
 %define github_user lz4
-Source: https://github.com/%{github_user}/lz4/archive/v%{realversion}.tar.gz
+Source: https://github.com/%{github_user}/%{n}/archive/v%{realversion}.tar.gz
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
-
 make %{makeprocesses} 
 
 %install
-
-
-make DESTDIR=%i install
+make PREFIX=%{i} install
 


### PR DESCRIPTION
backport of #6227

LZ4 dependency was added (https://github.com/cms-sw/cmsdist/pull/4103 )  but its toolfile was not part of cmssw that is why at runtime we pick lz4 from system. 

This should be backported to 10.2 and above