### PR TITLE
Remove page size flag for non intel archs

### DIFF
--- a/jemalloc.spec
+++ b/jemalloc.spec
@@ -11,14 +11,8 @@ BuildRequires: autotools
 %setup -n %{n}-%{realversion}
 
 %build
-XOPTS=""
-case %{cmsplatf} in
-  # set the page size to 64k on ARMv8 and PowerPC
-  *_aarch64_*|*_ppc64le_*|*_ppc64_*) XOPTS="--with-lg-page=16" ;;
-esac
 
-./autogen.sh ${XOPTS} \
-  --enable-shared \
+./autogen.sh --enable-shared \
   --disable-static \
   --disable-doc \
   --enable-stats \


### PR DESCRIPTION
The jemalloc manual says for this option: 
"this option need not be specified unless the system page size may change between configuration and execution, e.g. when cross compiling"
https://github.com/jemalloc/jemalloc/blob/5.2.1/INSTALL.md
The last tests we were running showed 20 to 30 % improvement in max virtual memory used, and we are using 2^16 which is the default for our arm and ppc distros and it doesn't have to be specified. 
Also after few IBs we don't have to run relvals by hand for comparisons :)