### PR TITLE
added python packages needed by DQM GUI; enabled onnxruntime pycuda for ppc64

### DIFF
--- a/pip/aiohttp.file
+++ b/pip/aiohttp.file
@@ -1,0 +1,1 @@
+Requires: py2-attrs py2-chardet py3-multidict py3-yarl py3-async-timeout

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -13,8 +13,9 @@
 #To customize a package build e.g. providing extra Requirements, build, install
 #flags or patching, please use either py{2,3}-package_name.file or package_name.file
 #############################################################################
-
 absl-py==0.9.0
+aiohttp==3.6.2 ;python_version>'3.0'
+aiosqlite==0.13.0 ;python_version>'3.0'
 appdirs==1.4.4
 argon2-cffi==20.1.0
 argparse==1.4.0
@@ -22,6 +23,8 @@ asn1crypto==1.4.0
 astor==0.8.1
 astroid==1.6.6 ; python_version<'3.0'
 astroid==2.3.3 ; python_version>'3.0'
+async-lru==1.0.2 ; python_version>'3.0'
+async-timeout==3.0.1 ; python_version>'3.0'
 atomicwrites==1.4.0
 attrs==19.3.0
 autopep8==1.5.4
@@ -138,6 +141,7 @@ more-itertools==5.0.0 ; python_version<'3.0'
 more-itertools==7.2.0 ; python_version>'3.0'
 mpld3==0.5.1
 mpmath==1.1.0
+multidict==4.7.6 ; python_version>'3.0'
 nbconvert==5.6.1
 nbdime==1.1.0
 #5.0.3 does not support python2.7 even if pip thinks so
@@ -285,6 +289,6 @@ xgboost==0.90 ; python_version>'3.0'
 #bumping this pulls in xrootd - which looks like it needs some understanding
 xrootdpyfs==0.2.1
 hepdata-lib==0.4.1;python_version<'3.0'
+yarl==1.5.1 ;python_version>'3.0'
 zipp==1.2.0 ; python_version<'3.0'
 zipp==3.1.0 ; python_version>'3.0'
-

--- a/pip/yarl.file
+++ b/pip/yarl.file
@@ -1,0 +1,1 @@
+Requires: py3-multidict py2-idna

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -223,14 +223,6 @@ Requires: py2-importlib-resources
 Requires: py2-smmap
 Requires: py2-zipp py3-zipp
 
-#Needed by DQM GUI
-Requires: py3-aiohttp
-Requires: py3-aiosqlite
-Requires: py3-async-lru
-Requires: py3-async-timeout
-Requires: py3-multidict
-Requires: py3-yarl
-
 Requires: py2-pycuda
 Requires: onnxruntime
 

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -223,11 +223,16 @@ Requires: py2-importlib-resources
 Requires: py2-smmap
 Requires: py2-zipp py3-zipp
 
+#Needed by DQM GUI
+Requires: aiohttp
+Requires: aiosqlite
+Requires: async-lru
+Requires: async-timeout
+Requires: multidict
+Requires: yarl
 
-%ifnarch ppc64le
 Requires: py2-pycuda
 Requires: onnxruntime
-%endif
 
 %prep
 

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -224,12 +224,12 @@ Requires: py2-smmap
 Requires: py2-zipp py3-zipp
 
 #Needed by DQM GUI
-Requires: aiohttp
-Requires: aiosqlite
-Requires: async-lru
-Requires: async-timeout
-Requires: multidict
-Requires: yarl
+Requires: py3-aiohttp
+Requires: py3-aiosqlite
+Requires: py3-async-lru
+Requires: py3-async-timeout
+Requires: py3-multidict
+Requires: py3-yarl
 
 Requires: py2-pycuda
 Requires: onnxruntime


### PR DESCRIPTION
- Added python packages needed by new DQM GUI
  - As these packages are only available for Python3, so we only build and distribute it for python3

- Added onnxruntime and pycuda for ppc64le too (initially it was disabled as we did not have cuda and onnxruntime for power)