### PR TITLE
[BuildRules] Allow to use different python to compile package/python

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -66,7 +66,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-01-03
+%define configtag       V06-01-04
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
In order to suppot python3 only cmssw packages , now build rules allows to add  the following in package/python/BuildFile.xml to compile/test this package with python3 . Default is to test with python
```
<flags PYTHON_VERSION="3"/>
```