### PR TITLE
Added new cmssw-wm-tools tool

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -3,6 +3,7 @@
 # With cmsBuild, change the above version only when a new tool is added
 
 Requires: crab
+Requires: cmssw-wm-tools
 Requires: google-benchmark-toolfile
 Requires: catch2-toolfile
 Requires: starlight-toolfile

--- a/cmssw-wm-tools.spec
+++ b/cmssw-wm-tools.spec
@@ -3,6 +3,7 @@
 ################################################################
 ### RPM cms cmssw-wm-tools 200923
 ## NOCOMPILER
+## NO_VERSION_SUFFIX
 
 %define commit 656b9fea7da4a596bf688785741a2abcf80c071d
 %define branch master

--- a/cmssw-wm-tools.spec
+++ b/cmssw-wm-tools.spec
@@ -1,0 +1,35 @@
+################################################################
+####For any change, always update version number to latest date#
+################################################################
+### RPM cms cmssw-wm-tools 200923
+## NOCOMPILER
+
+%define commit 656b9fea7da4a596bf688785741a2abcf80c071d
+%define branch master
+Source0: git://github.com/cms-sw/%{n}.git?obj=%{branch}/%{commit}&export=%{n}&output=/%{n}-%{commit}.tgz
+
+%prep
+%if "%{v}" != "%{realversion}"
+  echo "ERROR: %{v} does not match %{realversion}. Please update version number for %{n}."
+  exit 1
+%endif
+%setup -n %{n}
+
+%build
+
+%install
+rsync -a ./ %{i}/
+
+%post
+#Check if a newer revision is already installed
+if [ -f ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version ] ; then
+  if [ $(cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version) -ge %{realversion} ] ; then
+    exit 0
+  fi
+fi
+
+mkdir -p $RPM_INSTALL_PREFIX/share/overrides ${RPM_INSTALL_PREFIX}/etc/%{pkgname}
+for d in bin python ; do
+  rsync -a ${RPM_INSTALL_PREFIX}/%{pkgrel}/$d/ $RPM_INSTALL_PREFIX/share/overrides/$d/
+done
+echo %{realversion} > ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version


### PR DESCRIPTION
New cmssw-wm-tools ( https://github.com/cms-sw/cmssw-wm-tools)  tool is added for tweaking CMSSW job configurations.
This will install `cmssw-wm-tools/bin` under `CMS_PATH/share/overrides/bin` and `cmssw-wm-tools/python` under `CMS_PATH/share/overrides/python` . SCRAM then adds these in PATH and PYTHON*PATH after `cmsenv`. This should work for all CMSSW releases (5.3X and above).

FYI @davidlange6   