### PR TITLE
Update to CUDA 11.1 (CMSSW_11_1_X branch)

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -1,14 +1,14 @@
 ### FILE cuda-flags
 # define the CUDA compilation flags in a way that can be shared by SCRAM-based and regular tools
 
-# on X86 and Power, build support for Kepler, Pascal and Volta/Turing
+# on X86 and Power, build support for Pascal, Volta and Turing
 %ifarch x86_64 ppc64le
-%define cuda_arch 35 60 70
+%define cuda_arch 60 70 75
 %endif
 
-# on ARM, build Volta/Turing and the Xavier SoC
+# on ARM, build support for Volta, Xavier SoC and Turing
 %ifarch aarch64
-%define cuda_arch 70 72
+%define cuda_arch 70 72 75
 %endif
 
 

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,6 +1,6 @@
-### RPM external cuda 11.0.1
+### RPM external cuda 11.1.0
 
-%define driversversion 450.36.06
+%define driversversion 455.23.05
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
@@ -59,7 +59,7 @@ mv %_builddir/build/extras/CUPTI/include/*.h %{i}/include/
 rm -f %_builddir/build/bin/computeprof
 rm -f %_builddir/build/bin/cuda-uninstaller
 rm -f %_builddir/build/bin/ncu*
-rm -f %_builddir/build/bin/nsyght*
+rm -f %_builddir/build/bin/nsight*
 rm -f %_builddir/build/bin/nsys*
 rm -f %_builddir/build/bin/nv-nsight*
 rm -f %_builddir/build/bin/nvvp
@@ -75,13 +75,13 @@ exec %{i}/bin/cuda-gdb.real "\$@"
 @EOF
 chmod a+x %{i}/bin/cuda-gdb
 
-# package the other binaries and tools
-mv %_builddir/build/nvvm %{i}/
-mv %_builddir/build/Sanitizer %{i}/
+# package the Compute Sanitizer, and replace the wrapper with a symlink
+mv %_builddir/build/compute-sanitizer %{i}/
+rm -f %{i}/bin/compute-sanitizer
+ln -s ../compute-sanitizer/compute-sanitizer %{i}/bin/compute-sanitizer
 
-# package the EULA and version file
-mv %_builddir/build/EULA.txt %{i}/
-mv %_builddir/build/version.txt %{i}/
+# package the NVVM compiler (cicc), library (libnvvm.so), device library (libdevice.10.bc) and samples
+mv %_builddir/build/nvvm %{i}/
 
 # extract and repackage the NVIDIA libraries needed by the CUDA runtime
 /bin/sh %_builddir/pkg/builds/NVIDIA-Linux-%{_arch}-%{driversversion}.run --silent --extract-only --tmpdir %_builddir/tmp --target %_builddir/build/drivers


### PR DESCRIPTION
Update to CUDA 11.1:
  * CUDA version 11.1.74
  * NVIDIA drivers version 455.23.05

From the release notes:
  - add support for GCC 10 and clang 10
  - support multi-threaded launch to different CUDA streams
  - improve MPS error handling when using multiple GPUs
  - various bug fixes

See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html .