### PR TITLE
[BuildRule] Updates scram build rules

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -66,7 +66,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-01-04
+%define configtag       V06-01-06
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Use system cuda only if its version is >= to the version shipped with cmssw
- for PR tests also disable usage of release/externals/bin path