### PR TITLE
added cmsLHEtoEOSManager gcc-fixincludes install only deps for cmssw

### DIFF
--- a/cmsLHEtoEOSManager.tmpl
+++ b/cmsLHEtoEOSManager.tmpl
@@ -1,0 +1,30 @@
+### RPM cms cmsLHEtoEOSManager @VERSION@00
+## NOCOMPILER
+## NO_VERSION_SUFFIX
+
+%define commit @COMMIT@
+Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%{commit}/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+
+%prep
+%if "%{v}" != "%{realversion}"
+  echo "ERROR: %{v} does not match %{realversion}. Please update version number for %{n}."
+  exit 1
+%endif
+
+%build
+
+%install
+cp %{_sourcedir}/cmsLHEtoEOSManager.py %{i}
+chmod +x %{i}/cmsLHEtoEOSManager.py
+
+%post
+#Check if a newer revision is already installed
+if [ -f ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version ] ; then
+  if [ $(cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version) -ge %{realversion} ] ; then
+    exit 0
+  fi
+fi
+
+mkdir -p $RPM_INSTALL_PREFIX/share/overrides/bin ${RPM_INSTALL_PREFIX}/etc/%{pkgname}
+cp ${RPM_INSTALL_PREFIX}/%{pkgrel}/cmsLHEtoEOSManager.py $RPM_INSTALL_PREFIX/share/overrides/bin
+echo %{realversion} > ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version

--- a/cmssw-patch-tool-conf.spec
+++ b/cmssw-patch-tool-conf.spec
@@ -1,6 +1,9 @@
-### RPM cms cmssw-patch-tool-conf 2.0
+### RPM cms cmssw-patch-tool-conf 3.0
 # with cmsBuild, change the above version only when a new
 # tool is added
+
+## NOCOMPILER
+## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes
 
 Requires: cmssw-toolfile
 

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,6 +1,8 @@
-### RPM cms cmssw-tool-conf 45.0
-## NOCOMPILER
+### RPM cms cmssw-tool-conf 46.0
 # With cmsBuild, change the above version only when a new tool is added
+
+## NOCOMPILER
+## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes
 
 Requires: crab
 Requires: cmssw-wm-tools

--- a/extras/cmsdist_packages.py
+++ b/extras/cmsdist_packages.py
@@ -1,0 +1,8 @@
+from os.path import dirname, join
+from gen_package import package_names
+
+def packages(virtual_packages, opts):
+  pkg_dir = dirname(__file__)
+  for pkg in package_names:
+    virtual_packages[pkg] = "%s/gen_package.py %s %s %s" % (pkg_dir, pkg, opts.cmsdist, join(opts.workDir, opts.tempDirPrefix))
+  return

--- a/extras/gen_package.py
+++ b/extras/gen_package.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+package_names = {
+  "cmsLHEtoEOSManager" : "https://api.github.com/repos/cms-sw/cmssw/commits?path=GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py&page=0&per_page=1",
+}
+
+def main():
+  from os.path import dirname, join, exists
+  import os, sys, platform
+  from json import loads
+  from sys import version_info, argv
+  if version_info[0] == 2:
+    from urllib2 import urlopen
+    from md5 import new as md5adder
+  else:
+    from urllib.request import urlopen
+    from hashlib import md5 as md5adder
+
+  pkg = argv[1]
+  cmsdist = argv[2]
+  tmpdir = argv[3]
+
+  tmpl = join(cmsdist,  pkg+".tmpl")
+  md5str = ""
+  with open(tmpl) as ref:
+    m = md5adder(ref.read())
+    md5str = m.hexdigest()
+
+  sfile = join (tmpdir, pkg+"."+md5str)
+  if not exists(sfile):
+    data = loads(urlopen(package_names[pkg]).read())
+    commit = data[0]["sha"]
+    version = data[0]["commit"]["author"]["date"][0:10].replace("-","")
+    os.system("sed -e 's|@COMMIT@|%s|;s|@VERSION@|%s|' %s > %s" % (commit, version, tmpl, sfile))
+  os.system("cat %s" % sfile)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Added cmsLHEtoEOSManager package which should deploy latest `GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py` in to CMS-PATH/share/override/bin so that all releases can pick it up.
- Added support for virtual packages which can have dynamic version based on date of some file in git
- make use of `## INSTALL_DEPENDENCIES <deps>` feature of `cmsBuild` to add dependency on packages without rebuilt of package even if `<deps>` are re-build