### PR TITLE
Triton v2.3

### DIFF
--- a/triton-inference-server-toolfile.spec
+++ b/triton-inference-server-toolfile.spec
@@ -9,7 +9,7 @@ Requires: triton-inference-server
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/triton-inference-server.xml
 <tool name="triton-inference-server" version="@TOOL_VERSION@">
-  <info url="https://github.com/NVIDIA/triton-inference-server"/>
+  <info url="https://github.com/triton-inference-server/server"/>
   <lib name="request"/> 
   <client>
     <environment name="TRITON_INFERENCE_SERVER_BASE" default="@TOOL_ROOT@"/>

--- a/triton-inference-server-toolfile.spec
+++ b/triton-inference-server-toolfile.spec
@@ -10,7 +10,7 @@ mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/triton-inference-server.xml
 <tool name="triton-inference-server" version="@TOOL_VERSION@">
   <info url="https://github.com/triton-inference-server/server"/>
-  <lib name="request"/> 
+  <lib name="grpcclient"/> 
   <client>
     <environment name="TRITON_INFERENCE_SERVER_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$TRITON_INFERENCE_SERVER_BASE/include"/>

--- a/triton-inference-server.spec
+++ b/triton-inference-server.spec
@@ -12,6 +12,9 @@ Requires: openssl opencv protobuf grpc curl python py2-wheel py2-setuptools py2-
 
 %build
 
+# remove rapidjson dependence
+sed -i '/RapidJSON/,+9d;' ../%{n}-%{realversion}/src/core/CMakeLists.txt
+sed -i '/triton-json-library/d' ../%{n}-%{realversion}/src/clients/c++/library/CMakeLists.txt
 # remove python client because it requires perf_client which is disabled when examples skipped
 # if this were enabled, `export PYVER=3` would be needed for build_wheel.sh
 sed -i 's~add_subdirectory(../../src/clients/python src/clients/python)~~' ../%{n}-%{realversion}/build/client/CMakeLists.txt

--- a/triton-inference-server.spec
+++ b/triton-inference-server.spec
@@ -49,3 +49,7 @@ make %{makeprocesses}
 cd ../build
 make install
 
+# extra headers needed
+cp src/core/model_config.pb.h %{i}/include/
+cp src/core/grpc_service.grpc.pb.h %{i}/include/
+cp src/core/grpc_service.pb.h %{i}/include/


### PR DESCRIPTION
This PR upgrades the Triton inference server (client) to the latest version 2.3.

Some of the previous cmake modifications are now included in the upstream repository. There are still some other custom modifications needed:
* disable http client (currently not used, depends on rapidjson in a way that isn't fully consistent in the cmake setup)
* disable python client (requires perf_client, which is part of the examples that are disabled)
* prevent trying to copy nonexistent external library files
* install some additional headers

In one of the next triton versions, the client installation should become simpler.

This requires https://github.com/cms-sw/cmssw/pull/31715.