### PR TITLE
bump py2/py3 versions of tools with updates in pypi

### DIFF
--- a/pip/jsonschema.file
+++ b/pip/jsonschema.file
@@ -1,4 +1,4 @@
-Requires: py2-functools32 py2-repoze-lru py2-argparse
-Requires: py2-attrs py2-pyrsistent py2-six py2-importlib-metadata
+Requires: py2-functools32 py2-repoze-lru py2-argparse py2-pyrsistent py3-pyrsistent
+Requires: py2-attrs py2-six py2-importlib-metadata
 %define RelocatePython %{i}/bin/jsonschema
 

--- a/pip/prettytable.file
+++ b/pip/prettytable.file
@@ -1,0 +1,1 @@
+Requires: py2-wcwidth

--- a/pip/py3-numpy.file
+++ b/pip/py3-numpy.file
@@ -1,0 +1,2 @@
+Requires: py2-cython
+

--- a/pip/py3-pylint.file
+++ b/pip/py3-pylint.file
@@ -1,2 +1,1 @@
-Patch0: pylint-2.4.2-encoding
-Requires: py3-astroid
+Requires: py3-astroid py2-toml

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -158,7 +158,8 @@ notebook==6.1.4 ; python_version>'3.0'
 numba==0.51.2 ; python_version>'3.0'
 numexpr==2.7.1
 numpy==1.16.6 ; python_version<'3.0'
-numpy==1.19.2 ; python_version>'3.0'
+#numpy 1.19 needs an updated tensorflow
+numpy==1.17.5 ; python_version>'3.0'
 #NO_AUTO_UPDATE:2: numpy versions >1.15.1 fail on aarch64
 numpy==1.16.4 ; python_version>'3.0' ; platform_machine=='aarch64'
 onnx==1.7.0

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -185,7 +185,7 @@ ply==3.11
 prettytable==1.0.0
 prometheus_client==0.8.0
 prompt_toolkit==1.0.18 ; python_version<'3.0'
-prompt_toolkit==3.0.0 ; python_version>'3.0'
+prompt_toolkit==2.0.10 ; python_version>'3.0'
 protobuf==3.10.0
 prwlock==0.4.1
 psutil==5.7.2

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -22,7 +22,7 @@ argparse==1.4.0
 asn1crypto==1.4.0
 astor==0.8.1
 astroid==1.6.6 ; python_version<'3.0'
-astroid==2.3.3 ; python_version>'3.0'
+astroid==2.4.2 ; python_version>'3.0'
 async-lru==1.0.2 ; python_version>'3.0'
 async-timeout==3.0.1 ; python_version>'3.0'
 atomicwrites==1.4.0
@@ -40,7 +40,7 @@ backports-shutil_which==3.5.2
 backports-ssl_match_hostname==3.7.0.1
 backports-weakref==1.0.post1
 backports-os==0.1.1
-beautifulsoup4==4.9.1
+beautifulsoup4==4.9.3
 bleach==3.2.1
 bokeh==1.4.0
 Bottleneck==1.3.2
@@ -70,7 +70,7 @@ downhill==0.4.0
 entrypoints==0.3
 enum34==1.1.10;python_version<'3.0'
 filelock==3.0.12
-flake8==3.8.3
+flake8==3.8.4
 flawfinder==2.0.11
 fs==2.4.11
 funcsigs==1.0.2
@@ -81,11 +81,11 @@ gast==0.4.0
 gitdb2==2.0.6 ; python_version<'3.0'
 gitdb==4.0.2 ; python_version>'3.0'
 GitPython==2.1.15 ; python_version<'3.0'
-GitPython==3.1.0 ; python_version>'3.0'
+GitPython==3.1.9 ; python_version>'3.0'
 google-common==0.0.1
 google-pasta==0.2.0
-grpcio==1.31.0
-grpcio-tools==1.31.0
+grpcio==1.32.0
+grpcio-tools==1.32.0
 #1.0.1 doesn't download (wheel only?)
 h5py-cache==1.0
 h5py==2.10.0
@@ -95,16 +95,16 @@ histogrammar==1.0.9 ; python_version<'3.0'
 histogrammar==1.0.10 ; python_version>'3.0'
 html5lib==1.1
 hyperas==0.4.1
-hyperopt==0.2.4
+hyperopt==0.2.5
 idna==2.10
-importlib-metadata==1.7.0
-importlib-resources==1.4.0
+importlib-metadata==2.0.0
+importlib-resources==3.0.0
 ipaddress==1.0.23
 ipykernel==4.10.1 ; python_version<'3.0'
 ipykernel==5.3.4 ; python_version>'3.0'
 ipython_genutils==0.2.0
 ipython==5.10.0 ; python_version<'3.0'
-ipython==7.17.0 ; python_version>'3.0'
+ipython==7.18.1 ; python_version>'3.0'
 ipywidgets==7.5.1
 isort==4.3.21
 jedi==0.17.2
@@ -113,9 +113,9 @@ joblib==0.14.1
 jsonpickle==1.4.1
 jsonschema==3.2.0
 jupyter_client==5.3.5 ; python_version<'3.0'
-jupyter_client==6.1.6 ; python_version>'3.0'
+jupyter_client==6.1.7 ; python_version>'3.0'
 jupyter_console==5.2.0 ; python_version<'3.0'
-jupyter_console==6.1.0 ; python_version>'3.0'
+jupyter_console==6.2.0 ; python_version>'3.0'
 jupyter_core==4.6.3
 jupyter==1.0.0
 Keras==2.3.1
@@ -154,21 +154,21 @@ neurolab==0.3.5
 nose-parameterized==0.6.0
 nose==1.3.7
 notebook==5.7.10 ; python_version<'3.0'
-notebook==6.1.3 ; python_version>'3.0'
-numba==0.51 ; python_version>'3.0'
+notebook==6.1.4 ; python_version>'3.0'
+numba==0.51.2 ; python_version>'3.0'
 numexpr==2.7.1
 numpy==1.16.6 ; python_version<'3.0'
-numpy==1.17.5 ; python_version>'3.0'
+numpy==1.19.2 ; python_version>'3.0'
 #NO_AUTO_UPDATE:2: numpy versions >1.15.1 fail on aarch64
 numpy==1.16.4 ; python_version>'3.0' ; platform_machine=='aarch64'
 onnx==1.7.0
-onnxruntime==1.2.0 ; python_version>'3.0'
+onnxruntime==1.3.0 ; python_version>'3.0'
 opt-einsum==2.3.2 ; python_version<'3.0'
-opt-einsum==3.1.0 ; python_version>'3.0'
+opt-einsum==3.3.0 ; python_version>'3.0'
 ordereddict==1.1
 packaging==20.4
 pandas==0.24.2 ; python_version<'3.0'
-pandas==1.1.0 ; python_version>'3.0'
+pandas==1.1.3 ; python_version>'3.0'
 pandocfilters==1.4.2
 parsimonious==0.8.1
 parso==0.7.1
@@ -182,10 +182,10 @@ pkgconfig==1.5.1
 plac==1.2.0
 pluggy==0.13.1
 ply==3.11
-prettytable==0.7.2
+prettytable==1.0.0
 prometheus_client==0.8.0
 prompt_toolkit==1.0.18 ; python_version<'3.0'
-prompt_toolkit==2.0.10 ; python_version>'3.0'
+prompt_toolkit==3.0.0 ; python_version>'3.0'
 protobuf==3.10.0
 prwlock==0.4.1
 psutil==5.7.2
@@ -202,15 +202,16 @@ pydot==1.4.1
 pyflakes==2.2.0
 Pygments==2.5.2
 pylint==1.9.5 ; python_version<'3.0'
-pylint==2.4.3 ; python_version>'3.0'
+pylint==2.6.0 ; python_version>'3.0'
 pymongo==3.11.0
 pyOpenSSL==19.1.0
 pyparsing==2.4.7
-pyrsistent==0.16.0
+pyrsistent==0.16.0 ; python_version<'3.0'
+pyrsistent==0.17.2 ; python_version>'3.0'
 py==1.9.0
 pysqlite==2.8.3; python_version<'3.0'
 pytest==4.6.11 ; python_version<'3.0'
-pytest==5.2.2 ; python_version>'3.0'
+pytest==6.1.1 ; python_version>'3.0'
 pytest-cov==2.10.1
 pytest-runner==5.2
 python-cjson==1.2.2;python_version<'3.0'
@@ -265,7 +266,7 @@ Theano==1.0.5
 toml==0.10.1
 tornado==5.1.1 ; python_version<'3.0'
 tornado==6.0.4 ; python_version>'3.0'
-tqdm==4.49.0
+tqdm==4.50.1
 traitlets==4.3.3
 typed-ast==1.4.1 ; python_version>'3.0'
 typing_extensions==3.7.4.3
@@ -276,7 +277,7 @@ uproot-methods==0.7.4
 uproot4==0.0.27
 urllib3==1.25.10
 virtualenv-clone==0.5.4
-virtualenv==20.0.31
+virtualenv==20.0.33
 virtualenvwrapper==4.8.4
 wcwidth==0.2.5
 webencodings==0.5.1
@@ -290,6 +291,6 @@ xgboost==0.90 ; python_version>'3.0'
 #bumping this pulls in xrootd - which looks like it needs some understanding
 xrootdpyfs==0.2.1
 hepdata-lib==0.4.1;python_version<'3.0'
-yarl==1.5.1 ;python_version>'3.0'
+yarl==1.6.0 ;python_version>'3.0'
 zipp==1.2.0 ; python_version<'3.0'
-zipp==3.1.0 ; python_version>'3.0'
+zipp==3.3.0 ; python_version>'3.0'

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -162,7 +162,6 @@ numpy==1.19.2 ; python_version>'3.0'
 #NO_AUTO_UPDATE:2: numpy versions >1.15.1 fail on aarch64
 numpy==1.16.4 ; python_version>'3.0' ; platform_machine=='aarch64'
 onnx==1.7.0
-onnxruntime==1.3.0 ; python_version>'3.0'
 opt-einsum==2.3.2 ; python_version<'3.0'
 opt-einsum==3.3.0 ; python_version>'3.0'
 ordereddict==1.1


### PR DESCRIPTION
Hopefully I got the various .file additions correct. 

Otherwise, onnxruntime has dropped slc6 support in versions newer than 1.3.0. Either our spec files or our pip do not deal nicely with manylinux2014 wheels. [it seems our pip needs to be 19.3, so likely "just" pip that needs to be updated]
@smuzaffar 