### PR TITLE
Revert "Revert "added back cmsLHEtoEOSManager gcc-fixincludes install deps""

### DIFF
--- a/cmssw-patch-tool-conf.spec
+++ b/cmssw-patch-tool-conf.spec
@@ -3,6 +3,7 @@
 # tool is added
 
 ## NOCOMPILER
+## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes
 
 Requires: cmssw-toolfile
 

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -2,6 +2,7 @@
 # With cmsBuild, change the above version only when a new tool is added
 
 ## NOCOMPILER
+## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes
 
 Requires: crab
 Requires: cmssw-wm-tools


### PR DESCRIPTION
Reverts cms-sw/cmsdist#6298
This should work now. It was issue with cmsBuild where it failed when a reference repository is used