### PR TITLE
Update root to 6.22 for CMSSW_11_2_X

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -226,8 +226,8 @@ repoze-lru==0.7
 rep==0.6.6
 requests==2.24.0
 root_numpy==4.8.0
-root_pandas==0.7.0;python_version<'3.0'
-rootpy==1.0.1;python_version<'3.0'
+root_pandas==0.7.0
+rootpy==1.0.1
 scandir==1.10.0
 schema==0.7.3
 scikit-learn==0.20.4 ; python_version<'3.0'
@@ -289,7 +289,6 @@ xgboost==0.82 ; python_version<'3.0'
 xgboost==0.90 ; python_version>'3.0'
 #bumping this pulls in xrootd - which looks like it needs some understanding
 xrootdpyfs==0.2.1
-hepdata-lib==0.4.1;python_version<'3.0'
-yarl==1.5.1 ;python_version>'3.0'
+hepdata-lib==0.4.1
 zipp==1.2.0 ; python_version<'3.0'
 zipp==3.1.0 ; python_version>'3.0'

--- a/pip/root_numpy.file
+++ b/pip/root_numpy.file
@@ -1,2 +1,1 @@
-%define   doPython3 no
 Requires: py2-numpy root

--- a/pip/root_pandas.file
+++ b/pip/root_pandas.file
@@ -1,0 +1,1 @@
+Requires: py3-pandas py2-pandas py2-root_numpy

--- a/pip/rootpy.file
+++ b/pip/rootpy.file
@@ -1,1 +1,2 @@
-Requires: root py2-matplotlib     
+Requires: root py2-matplotlib
+%define PipPostBuild perl -p -i -e "s|^#!.*python.*|#!/usr/bin/env python|" %{i}/bin/*

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -3,7 +3,7 @@
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 Source: none
  
-Requires: root curl python python3 xrootd llvm hdf5 mxnet-predict opencv
+Requires: root curl python python3 xrootd llvm hdf5 mxnet-predict yoda opencv
 
 Requires: py2-scipy
 Requires: py2-Keras

--- a/root.spec
+++ b/root.spec
@@ -1,9 +1,10 @@
-### RPM lcg root 6.20.06
+### RPM lcg root 6.22.03
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-%define tag 3cca992985710d719af0a31082c589cd996f7f43
-%define branch cms/v6-20-00-patches/6877628
+
+%define tag c8fedfbe7f2179e4bcccbc20be7bcdc1f49e2a8f
+%define branch cms/v6-22-00-patches/d6156de
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
@@ -12,7 +13,7 @@ Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 
-Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python fftw3 xz xrootd libxml2 openssl zlib davix tbb OpenBLAS py2-numpy lz4 freetype zstd
+Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python python3 fftw3 xz xrootd libxml2 openssl zlib davix tbb OpenBLAS py2-numpy py3-numpy lz4 freetype zstd
 
 %if %islinux
 Requires: dcap
@@ -55,6 +56,7 @@ cmake ../%{n}-%{realversion} \
   -Dhdfs=OFF \
   -Dqt=OFF \
   -Dtmva=ON \
+  -DPython3_EXECUTABLE="${PYTHON3_ROOT}/bin/python3" \
   -Dqtgsi=OFF \
   -Dpgsql=OFF \
   -Dsqlite=OFF \
@@ -90,7 +92,7 @@ cmake ../%{n}-%{realversion} \
   -Dssl=ON \
   -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT}" \
   -DOPENSSL_INCLUDE_DIR="${OPENSSL_ROOT}/include" \
-  -Dpython=ON \
+  -Dpyroot=ON \
   -Dxrootd=ON \
   -Dbuiltin_xrootd=OFF \
   -DXROOTD_INCLUDE_DIR="${XROOTD_ROOT}/include/xrootd" \
@@ -139,7 +141,7 @@ cmake ../%{n}-%{realversion} \
   -DZLIB_ROOT="${ZLIB_ROOT}" \
   -DZLIB_INCLUDE_DIR="${ZLIB_ROOT}/include" \
   -DZSTD_ROOT="${ZSTD_ROOT}" \
-  -DCMAKE_PREFIX_PATH="${LZ4_ROOT}/include;${LZ4_ROOT}/lib;${GSL_ROOT};${XZ_ROOT};${OPENSSL_ROOT};${GIFLIB_ROOT};${FREETYPE_ROOT};${PYTHON_ROOT};${LIBPNG_ROOT};${PCRE_ROOT};${TBB_ROOT};${OPENBLAS_ROOT};${DAVIX_ROOT};${LZ4_ROOT};${LIBXML2_ROOT};${ZSTD_ROOT}"
+  -DCMAKE_PREFIX_PATH="${LZ4_ROOT};${GSL_ROOT};${XZ_ROOT};${OPENSSL_ROOT};${GIFLIB_ROOT};${FREETYPE_ROOT};${PYTHON_ROOT};${PYTHON3_ROOT};${LIBPNG_ROOT};${PCRE_ROOT};${TBB_ROOT};${OPENBLAS_ROOT};${DAVIX_ROOT};${LIBXML2_ROOT};${ZSTD_ROOT}"
 
 # For CMake cache variables: http://www.cmake.org/cmake/help/v3.2/manual/cmake-language.7.html#lists
 # For environment variables it's OS specific: http://www.cmake.org/Wiki/CMake_Useful_Variables
@@ -170,8 +172,12 @@ export ROOTSYS="%{i}"
 ninja -v %{makeprocesses} -l $(getconf _NPROCESSORS_ONLN) install
 
 find %{i} -type f -name '*.py' | xargs chmod -x
-grep -R -l '#!.*python' %{i} | xargs chmod +x
+grep -rlI '#!.*python' %{i} | xargs chmod +x
 perl -p -i -e "s|#!/bin/perl|#!/usr/bin/env perl|" %{i}/bin/memprobe
+for p in $(grep -rlI -m1 '^#\!.*python' %i/bin) ; do
+  lnum=$(grep -n -m1 '^#\!.*python' $p | sed 's|:.*||')
+  sed -i -e "${lnum}c#!/usr/bin/env python" $p
+done
 
 #Make sure root build directory is not available after the root install is done
 #This will catch errors if root remembers the build paths.

--- a/yoda-toolfile.spec
+++ b/yoda-toolfile.spec
@@ -20,5 +20,4 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/yoda.xml
 </tool>
 EOF_TOOLFILE
 
-export PYTHONV=$(echo $PYTHON_VERSION | cut -f1,2 -d.)
 ## IMPORT scram-tools-post

--- a/yoda.spec
+++ b/yoda.spec
@@ -3,21 +3,39 @@
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 
 Source: git+https://gitlab.com/hepcedar/yoda.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Patch0: yoda_pyroot
 
-Requires: python root
+Requires: python python3 root
 BuildRequires: py2-cython autotools
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 autoreconf -fiv
-./configure --prefix=%i --enable-root
 
 %build
-make all
+
+sed -i -e "s|lPyROOT|lcppyyX.X|" ./pyext/setup.py.in
+
+#Build for Python3
+export PYTHON_VERSION=$(python3 --version 2>&1 | sed 's|.* ||' | cut -d. -f1,2)
+sed -i -e "s|lcppyy...|lcppyy$(echo ${PYTHON_VERSION} | tr . _)|" ./pyext/setup.py.in
+./configure --prefix=%i --enable-root
+make %{makeprocesses} all
+
+#Install Py3 Only
+mkdir -p %{i}/${PYTHON3_LIB_SITE_PACKAGES}
+mv pyext/build/lib*-${PYTHON_VERSION}/yoda* %{i}/${PYTHON3_LIB_SITE_PACKAGES}/
+
+#Build & install for Python2
+export PYTHON_VERSION=$(python2 --version 2>&1 | sed 's|.* ||' | cut -d. -f1,2)
+sed -i -e "s|lcppyy...|lcppyy$(echo ${PYTHON_VERSION} | tr . _)|" ./pyext/setup.py.in
+./configure --prefix=%i --enable-root
+make %{makeprocesses} all
+make install
 
 %install
-make install
 
 %post
 %{relocateConfig}bin/yoda-config

--- a/yoda_pyroot.patch
+++ b/yoda_pyroot.patch
@@ -1,0 +1,26 @@
+diff --git a/pyext/yoda/pyroot_helpers.hh b/pyext/yoda/pyroot_helpers.hh
+index b299a74..3e7f4d5 100644
+--- a/pyext/yoda/pyroot_helpers.hh
++++ b/pyext/yoda/pyroot_helpers.hh
+@@ -1,12 +1,12 @@
+ #include "YODA/ROOTCnv.h"
+ #include "Python.h"
+ #include "YODA/Profile1D.h"
+-#include "TPython.h"
++#include "CPyCppyy/API.h"
+ 
+ 
+ // Get a PyROOT object from a ROOT one
+ inline PyObject* root_to_py_owned(TObject* root_obj) {
+-  return TPython::ObjectProxy_FromVoidPtr(root_obj, root_obj->ClassName());
++  return CPyCppyy::Instance_FromVoidPtr(root_obj, root_obj->ClassName());
+   /// @todo Different signatures in different ROOT versions?
+   //return TPython::ObjectProxy_FromVoidPtr(root_obj, root_obj->ClassName(), kFALSE);
+ }
+@@ -14,5 +14,5 @@ inline PyObject* root_to_py_owned(TObject* root_obj) {
+ 
+ // Get the ROOT object in a PyROOT one
+ inline TObject* py_owned_to_root(PyObject* pyroot_obj) {
+-  return (TObject*) TPython::ObjectProxy_AsVoidPtr(pyroot_obj);
++  return (TObject*) CPyCppyy::Instance_AsVoidPtr(pyroot_obj);
+ }


### PR DESCRIPTION
Backport changes from IB/CMSSW_11_2_X/rootnext branch to get root version 6.22 in CMSSW_11_2_X IBs. Changes include
- Updating root version which is now build for both python2 and 3
- Build python packages for both py2/3 which were dependening on root python.
- Patches yoda to build against new ROOT Python module