### PR TITLE
Update tensorflow to 2.1.2 to fix multiple vulnerabilities

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -254,8 +254,8 @@ tables==3.6.1 ; python_version>'3.0'
 #tensorboard: Need separate packages for py2 and py3 to properly get the correct sources
 tensorboard==2.0.0 ; python_version<'3.0'
 tensorboard==2.0.0 ; python_version>'3.0'
-tensorflow==2.1.0 ; python_version<'3.0'
-tensorflow==2.1.0 ; python_version>'3.0'
+tensorflow==2.1.2 ; python_version<'3.0'
+tensorflow==2.1.2 ; python_version>'3.0'
 tensorflow-estimator==2.1.0
 termcolor==1.1.0
 terminado==0.8.3

--- a/tensorflow-python3-sources.spec
+++ b/tensorflow-python3-sources.spec
@@ -1,4 +1,4 @@
-### RPM external tensorflow-python3-sources 2.1.0
+### RPM external tensorflow-python3-sources 2.1.2
 %define python_cmd python3
 %define python_env PYTHON3PATH
 %define build_type opt

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -13,8 +13,8 @@ BuildRequires: bazel swig java-env git
 #Keep all requires in separate file, so that can be included in py-tensorflow too
 ## INCLUDE tensorflow-requires
 
-%define tag         441193ae4b89fd8784a3ea0a5dfd8700018980da
-%define branch      cms/v%{realversion}
+%define tag         63c7b8aabb9f882ec827a15ffe80aac17e14a021
+%define branch      cms/v2.1.2
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}.tgz
 

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,4 +1,4 @@
-### RPM external tensorflow-sources 2.1.0
+### RPM external tensorflow-sources 2.1.2
 %define python_cmd python
 %define python_env PYTHON27PATH
 %define build_type opt

--- a/tensorflow-toolfile.spec
+++ b/tensorflow-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external tensorflow-toolfile 2.1.0
+### RPM external tensorflow-toolfile 2.1.2
 
 Requires: tensorflow
 

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -1,4 +1,4 @@
-### RPM external tensorflow 2.1.0
+### RPM external tensorflow 2.1.2
 
 Provides: libtensorflow_cc.so(tensorflow)(64bit)
 Source: none


### PR DESCRIPTION
please test
externals are the same, no nee to update protobuf for this version
see https://github.com/tensorflow/tensorflow/releases/tag/v2.1.2