### PR TITLE
Enable building externals with multi-vectorization

### DIFF
--- a/OpenBLAS-toolfile.spec
+++ b/OpenBLAS-toolfile.spec
@@ -1,5 +1,8 @@
-### RPM external OpenBLAS-toolfile 1.0
-Requires: OpenBLAS
+### RPM external OpenBLAS-toolfile 2.0
+%define base_package %(echo %{n} | sed 's|-toolfile||')
+%define base_package_uc %(echo %{base_package} | tr '[a-z-]' '[A-Z_]')
+%{expand:%(for v in %{package_vectorization}; do echo Requires: %{base_package}_$v; done)}
+Requires: %{base_package}
 %prep
 
 %build
@@ -7,7 +10,7 @@ Requires: OpenBLAS
 %install
 
 mkdir -p %i/etc/scram.d
-cat << \EOF_TOOLFILE >%i/etc/scram.d/OpenBLAS.xml
+cat << \EOF_TOOLFILE >%i/etc/scram.d/%{base_package}.xml
 <tool name="OpenBLAS" version="@TOOL_VERSION@">
   <lib name="openblas"/>
   <client>
@@ -15,6 +18,12 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/OpenBLAS.xml
     <environment name="INCLUDE" default="$OPENBLAS_BASE/include"/>
     <environment name="LIBDIR" default="$OPENBLAS_BASE/lib"/>
     <environment name="BINDIR" default="$OPENBLAS_BASE/bin"/>
+EOF_TOOLFILE
+for v in $(echo %{package_vectorization} | tr '[a-z-]' '[A-Z_]')  ; do
+  r=`eval echo \\$%{base_package_uc}_${v}_ROOT`
+  echo "    <environment name=\"${v}_LIBDIR\" default=\"${r}/lib\" type=\"path\"/>" >> %i/etc/scram.d/%{base_package}.xml
+done
+cat << \EOF_TOOLFILE >>%i/etc/scram.d/%{base_package}.xml
   </client>
   <runtime name="OPENBLAS_NUM_THREADS" value="1"/>
 </tool>

--- a/fastjet-toolfile.spec
+++ b/fastjet-toolfile.spec
@@ -1,5 +1,8 @@
-### RPM external fastjet-toolfile 1.0
-Requires: fastjet
+### RPM external fastjet-toolfile 2.0
+%define base_package %(echo %{n} | sed 's|-toolfile||')
+%define base_package_uc %(echo %{base_package} | tr '[a-z-]' '[A-Z_]')
+%{expand:%(for v in %{package_vectorization}; do echo Requires: %{base_package}_$v; done)}
+Requires: %{base_package}
 %prep
 
 %build
@@ -7,8 +10,8 @@ Requires: fastjet
 %install
 
 mkdir -p %i/etc/scram.d
-cat << \EOF_TOOLFILE >%i/etc/scram.d/fastjet.xml
-  <tool name="fastjet" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/%{base_package}.xml
+  <tool name="%{base_package}" version="@TOOL_VERSION@">
     <info url="http://fastjet.fr"/>
     <lib name="fastjetplugins"/>
     <lib name="fastjettools"/>
@@ -19,6 +22,12 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/fastjet.xml
       <environment name="FASTJET_BASE" default="@TOOL_ROOT@"/>
       <environment name="LIBDIR" default="$FASTJET_BASE/lib"/>
       <environment name="INCLUDE" default="$FASTJET_BASE/include"/>
+EOF_TOOLFILE
+for v in $(echo %{package_vectorization} | tr '[a-z-]' '[A-Z_]')  ; do
+  r=`eval echo \\$%{base_package_uc}_${v}_ROOT`
+  echo "    <environment name=\"${v}_LIBDIR\" default=\"${r}/lib\" type=\"path\"/>" >> %i/etc/scram.d/%{base_package}.xml
+done
+cat << \EOF_TOOLFILE >>%i/etc/scram.d/%{base_package}.xml
     </client>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <runtime name="PYTHON27PATH" value="$FASTJET_BASE/lib/python@PYTHONV@/site-packages" type="path"/>

--- a/gcc-toolfile.spec
+++ b/gcc-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM cms gcc-toolfile 14.0
+### RPM cms gcc-toolfile 15.0
 
 # gcc has a separate spec file for the generating a 
 # toolfile because gcc.spec could be not build because of the 
@@ -63,12 +63,14 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/gcc-cxxcompiler.xml
     <flags CXXFLAGS="-Werror=return-local-addr -Wnon-virtual-dtor"/>
     <flags CXXFLAGS="-Werror=switch -fdiagnostics-show-option"/>
     <flags CXXFLAGS="-Wno-unused-local-typedefs -Wno-attributes -Wno-psabi"/>
+EOF_TOOLFILE
 %ifarch x86_64
-    <flags CXXFLAGS_VECTORIZE_AVX512F="-mavx512f -mfma"/>
-    <flags CXXFLAGS_VECTORIZE_AVX2="-mavx2"/>
-    <flags CXXFLAGS_VECTORIZE_FMA="-mfma"/>
-    <flags CXXFLAGS_VECTORIZE_SSE4_2="-msse4.2"/>
+for v in %{package_vectorization} ; do
+  uv=$(echo $v | tr '[a-z-]' '[A-Z_]')
+  echo "    <flags CXXFLAGS_VECTORIZE_${uv}=\"$(%{cmsdist_directory}/vectorization/cmsdist_packages.py $v)\"/>" >> %i/etc/scram.d/gcc-cxxcompiler.xml
+done
 %endif
+cat << \EOF_TOOLFILE >>%i/etc/scram.d/gcc-cxxcompiler.xml
     <flags LDFLAGS="@OS_LDFLAGS@ @ARCH_LDFLAGS@ @COMPILER_LDFLAGS@"/>
     <flags CXXSHAREDFLAGS="@OS_SHAREDFLAGS@ @ARCH_SHAREDFLAGS@ @COMPILER_SHAREDFLAGS@"/>
     <flags LD_UNIT="@OS_LD_UNIT@ @ARCH_LD_UNIT@ @COMPILER_LD_UNIT@"/>
@@ -195,7 +197,7 @@ COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fno-math-errno --param vect-max-version-f
 COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -Xassembler --compress-debug-sections"
 
 %ifarch x86_64
-     COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -msse3"
+     COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS $(%{cmsdist_directory}/vectorization/cmsdist_packages.py)"
 %endif
 %ifarch aarch64
     COMPILER_CXXFLAGS="$COMPILER_CXXFLAGS -fsigned-char -fsigned-bitfields"

--- a/mkfit-toolfile.spec
+++ b/mkfit-toolfile.spec
@@ -1,6 +1,8 @@
-### RPM external mkfit-toolfile 2.0.0
-Requires: mkfit
-
+### RPM external mkfit-toolfile 3.0
+%define base_package %(echo %{n} | sed 's|-toolfile||')
+%define base_package_uc %(echo %{base_package} | tr '[a-z-]' '[A-Z_]')
+%{expand:%(for v in %{package_vectorization}; do echo Requires: %{base_package}_$v; done)}
+Requires: %{base_package}
 %prep
 
 %build
@@ -8,14 +10,20 @@ Requires: mkfit
 %install
 
 mkdir -p %i/etc/scram.d
-cat << \EOF_TOOLFILE >%i/etc/scram.d/mkfit.xml
-<tool name="mkfit" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/%{base_package}.xml
+<tool name="%{base_package}" version="@TOOL_VERSION@">
   <lib name="MicCore"/>
   <lib name="MkFit"/>
   <client>
     <environment name="MKFITBASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$MKFITBASE/include"/>
     <environment name="LIBDIR" default="$MKFITBASE/lib"/>
+EOF_TOOLFILE
+for v in $(echo %{package_vectorization} | tr '[a-z-]' '[A-Z_]')  ; do
+  r=`eval echo \\$%{base_package_uc}_${v}_ROOT`
+  echo "    <environment name=\"${v}_LIBDIR\" default=\"${r}/lib\" type=\"path\"/>" >> %i/etc/scram.d/%{base_package}.xml
+done
+cat << \EOF_TOOLFILE >>%i/etc/scram.d/%{base_package}.xml
   </client>
   <use name="tbb"/>
   <runtime name="MKFIT_BASE" value="$MKFITBASE"/>

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -27,7 +27,7 @@ BUILD_ARGS=VEC_GCC="-march=native"
 %ifarch ppc64le
 BUILD_ARGS=VEC_GCC="-mcpu=native"
 %endif
-make %{makeprocesses} TBB_PREFIX=$TBB_ROOT ${BUILD_ARGS}
+make %{makeprocesses} TBB_PREFIX=$TBB_ROOT "${BUILD_ARGS}"
 
 %install
 mkdir %{i}/include %{i}/include/mkFit %{i}/Geoms

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -32,10 +32,6 @@ Requires: glibc
 %define scramcmd        $SCRAMV1_ROOT/bin/scram --arch %cmsplatf
 %define srctree		src
 
-#config stuff moved to github!
-%define cvsconfig	config
-%define configtar	config.tar.gz
-%define configrepo	git://github.com/cms-sw/cmssw-config.git?protocol=https
 %if "%{?buildtarget:set}" != "set"
 %define buildtarget	release-build
 %endif
@@ -66,7 +62,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-01-06
+%define configtag       V06-01-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/tensorflow-python3-sources.spec
+++ b/tensorflow-python3-sources.spec
@@ -3,6 +3,7 @@
 %define python_env PYTHON3PATH
 %define build_type opt
 %define pythonOnly yes
+%define vectorize_flag -msse3
 #Just to make sure that only one tensorflow-source package built at a time
 BuildRequires: tensorflow-sources
 ## INCLUDE tensorflow-sources

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -37,11 +37,11 @@ export PYTHON_BIN_PATH="$(which %{python_cmd})"
 export USE_DEFAULT_PYTHON_LIB_PATH=1
 export GCC_HOST_COMPILER_PATH="$(which gcc)"
 %ifarch x86_64
-export CC_OPT_FLAGS=-msse3
+export CC_OPT_FLAGS="%{vectorize_flag}"
 %else
 export CC_OPT_FLAGS="-mcpu=native -mtune=native"
 %endif
-export CXX_OPT_FLAGS=-std=c++17
+export CXX_OPT_FLAGS="-std=c++17"
 export EIGEN_SOURCE=${EIGEN_SOURCE}
 export PROTOBUF_SOURCE=${PROTOBUF_SOURCE}
 export EIGEN_STRIP_PREFIX=${EIGEN_STRIP_PREFIX}

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -3,5 +3,6 @@
 %define python_env PYTHON27PATH
 %define build_type opt
 %define pythonOnly no
+%define vectorize_flag -msse3
 ## INCLUDE tensorflow-sources
 

--- a/tensorflow-toolfile.spec
+++ b/tensorflow-toolfile.spec
@@ -1,6 +1,8 @@
-### RPM external tensorflow-toolfile 2.1.2
-
-Requires: tensorflow
+### RPM external tensorflow-toolfile 3.0
+%define base_package %(echo %{n} | sed 's|-toolfile||')
+%define base_package_uc %(echo %{base_package} | tr '[a-z-]' '[A-Z_]')
+%{expand:%(for v in %{package_vectorization}; do echo Requires: %{base_package}_$v; done)}
+Requires: %{base_package}
 
 %prep
 
@@ -10,8 +12,8 @@ Requires: tensorflow
 
 mkdir -p %i/etc/scram.d
 
-cat << \EOF_TOOLFILE > %i/etc/scram.d/tensorflow.xml
-<tool name="tensorflow" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE > %i/etc/scram.d/%{base_package}.xml
+<tool name="%{base_package}" version="@TOOL_VERSION@">
   <client>
     <environment name="TENSORFLOW_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$TENSORFLOW_BASE/lib"/>
@@ -19,6 +21,12 @@ cat << \EOF_TOOLFILE > %i/etc/scram.d/tensorflow.xml
 %ifnarch ppc64le
     <environment name="TFCOMPILE" default="$TENSORFLOW_BASE/bin/tfcompile"/>
 %endif
+EOF_TOOLFILE
+for v in $(echo %{package_vectorization} | tr '[a-z-]' '[A-Z_]')  ; do
+  r=`eval echo \\$%{base_package_uc}_${v}_ROOT`
+  echo "  <runtime name=\"${v}_LIBDIR\" value=\"${r}/lib\" type=\"path\"/>" >> %i/etc/scram.d/%{base_package}.xml
+done
+cat << \EOF_TOOLFILE >>%i/etc/scram.d/%{base_package}.xml
   </client>
   <runtime name="PATH" value="$TENSORFLOW_BASE/bin" type="path"/>
 </tool>

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -1,8 +1,14 @@
 ### RPM external tensorflow 2.1.2
-
+%define source_package tensorflow-sources
+%if "%{?vectorized_package:set}" != "set"
+BuildRequires: %{source_package}
+%define tf_root %(echo %{source_package}_ROOT | tr '[a-z-]' '[A-Z_]')
+%else
+BuildRequires: %{source_package}_%{vectorized_package}
+%define tf_root %(echo %{source_package}_%{vectorized_package}_ROOT | tr '[a-z-]' '[A-Z_]')
+%endif
 Provides: libtensorflow_cc.so(tensorflow)(64bit)
 Source: none
-BuildRequires: tensorflow-sources
 
 %prep
 
@@ -10,4 +16,4 @@ BuildRequires: tensorflow-sources
 
 %install
 
-tar xfz ${TENSORFLOW_SOURCES_ROOT}/libtensorflow_cc.tar.gz -C %{i}
+tar xfz ${%{tf_root}}/libtensorflow_cc.tar.gz -C %{i}

--- a/vecgeom-fix-vector.patch
+++ b/vecgeom-fix-vector.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f5833f..d4bfd51 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -80,7 +80,7 @@ option(USE_CACHED_TRANSFORMATIONS "Use cached transformations in navigation stat
+ option(FAST_MATH "Enable the -ffast-math compiler option in Release builds" OFF)
+ 
+ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(i686|x86_64)")
+-  set(VECGEOM_ARCH sse2 sse3 ssse3 sse4.1 sse4.2 avx avx2 mic mic_avx512 native empty)
++  set(VECGEOM_ARCH sse2 sse3 ssse3 sse4.1 sse4.2 avx avx2 mic mic_avx512 native empty arch=nehalem arch=sandybridge  arch=haswell)
+ else()
+   set(VECGEOM_ARCH empty)
+ endif()

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -4,11 +4,13 @@ BuildRequires: cmake gmake
 %define keep_archives true
 
 Patch0: vecgeom-fix-for-arm64
+Patch1: vecgeom-fix-vector
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %patch0 -p1
+%patch1 -p1
 
 %build
 rm -rf ../build

--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+from platform import machine
+from sys import exit, argv
+
+DEFAULT_VECTORIZED_FLAG="-msse3"
+VECTORIZED_PACKAGES = []
+VALID_VECTORIZATION = {}
+if machine() == "x86_64":
+  VECTORIZED_PACKAGES = [
+    "zlib",
+    "fastjet",
+    "mkfit",
+    "vecgeom",
+    "tensorflow-sources",
+    "tensorflow",
+    "OpenBLAS",
+  ]
+  VALID_VECTORIZATION = {
+    "nehalem":     "-march=nehalem",
+    "sandybridge": "-march=sandybridge",
+    "haswell":     "-march=haswell",
+  }
+
+def fix_vecgeom(vec, value):
+  return [(DEFAULT_VECTORIZED_FLAG.replace("-m", ""), value.replace("-m", ""))]
+
+def fix_OpenBLAS(vec, value):
+  return [("TARGET=CORE2", "TARGET=%s" % vec.upper())]
+
+def packages(virtual_packages, *args):
+  opts = args[0].options
+  if not opts.vectorization: return
+  for pkg in VECTORIZED_PACKAGES:
+    err = False
+    for v in opts.vectorization:
+      if v not in  VALID_VECTORIZATION:
+        print("Vectorization instructions %s not supported. Please update %s to generate specs for this vectorized instructions set." % (v, __file__))
+        err = True
+      vpkg = "%s_%s" % (pkg, v)
+      rdata = [(DEFAULT_VECTORIZED_FLAG, VALID_VECTORIZATION[v])]
+      try:
+        rdata = eval('fix_%s' % pkg)(v, rdata[0][1])
+      except:
+        pass
+      xregexp = ""
+      for item in rdata:
+        xregexp = "s|%s|%s|g;" % (item[0], item[1])
+      spec = "echo -e '%%define vectorized_package %s\n%%define vectorized_flags  %s'; sed -e '%ss|\(^###  *RPM  *[^\s]*\)  *%s |\\1 %s |;s|%%{n}|%s|g;' %s/%s.spec"
+      virtual_packages[vpkg] = spec % (v, rdata[0][1], xregexp, pkg, vpkg, pkg, opts.cmsdist, pkg)
+    if err:
+      exit(1)
+  return
+
+if __name__ == '__main__':
+  if len(argv)==2:
+    if argv[1] in VALID_VECTORIZATION:
+      print (VALID_VECTORIZATION[argv[1]])
+  else:
+    print (DEFAULT_VECTORIZED_FLAG)

--- a/zlib-toolfile.spec
+++ b/zlib-toolfile.spec
@@ -1,5 +1,8 @@
-### RPM external zlib-toolfile 1.0
-Requires: zlib
+### RPM external zlib-toolfile 2.0
+%define base_package %(echo %{n} | sed 's|-toolfile||')
+%define base_package_uc %(echo %{base_package} | tr '[a-z-]' '[A-Z_]')
+%{expand:%(for v in %{package_vectorization}; do echo Requires: %{base_package}_$v; done)}
+Requires: %{base_package}
 %prep
 
 %build
@@ -7,13 +10,19 @@ Requires: zlib
 %install
 
 mkdir -p %i/etc/scram.d
-cat << \EOF_TOOLFILE >%i/etc/scram.d/zlib.xml
-<tool name="zlib" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/%{base_package}.xml
+<tool name="%{base_package}" version="@TOOL_VERSION@">
   <lib name="z"/>
   <client>
     <environment name="ZLIB_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$ZLIB_BASE/include"/>
     <environment name="LIBDIR" default="$ZLIB_BASE/lib"/>
+EOF_TOOLFILE
+for v in $(echo %{package_vectorization} | tr '[a-z-]' '[A-Z_]')  ; do
+  r=`eval echo \\$%{base_package_uc}_${v}_ROOT`
+  echo "    <environment name=\"${v}_LIBDIR\" default=\"${r}/lib\" type=\"path\"/>" >> %i/etc/scram.d/%{base_package}.xml
+done
+cat << \EOF_TOOLFILE >>%i/etc/scram.d/%{base_package}.xml
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>


### PR DESCRIPTION
Added support for building `zlib, mkfit, OpenBLAS, tensorflow, vecgeom and fastjet` with multi-vector support. Currently enable `haswell (avx2), sandybridge(avx) and nehalem(sse4.2)` vectorization for `x86_64` arch