### PR TITLE
Update tag for EgammaAnalysis-ElectronTools to V00-03-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+EgammaAnalysis-ElectronTools=V00-03-00
 CalibTracker-SiPixelESProducers=V02-02-00
 L1Trigger-CSCTriggerPrimitives=V00-03-00
 RecoBTag-Combined=V01-08-00
@@ -22,7 +23,6 @@ SimTransport-PPSProtonTransport=V00-02-00
 DQM-SiStripMonitorClient=V01-01-00
 L1Trigger-TrackFindingTracklet=V00-01-00
 RecoMET-METPUSubtraction=V01-01-00
-EgammaAnalysis-ElectronTools=V00-02-00
 PhysicsTools-NanoAOD=V01-01-00
 RecoTauTag-TrainingFiles=V00-02-00
 RecoMTD-TimingIDTools=V00-01-00


### PR DESCRIPTION
Move EgammaAnalysis-ElectronTools data to new tag, see 
https://github.com/cms-data/EgammaAnalysis-ElectronTools/pull/9
