### PR TITLE
Build py3-pylint package

### DIFF
--- a/py3-astroid.spec
+++ b/py3-astroid.spec
@@ -1,4 +1,4 @@
-### RPM external py3-astroid 1.6.6
+### RPM external py3-astroid 2.4.2
 ## IMPORT build-with-pip3
 
-Requires: py3-lazy-object-proxy py3-six py3-wrapt py3-singledispatch py3-backports-functools_lru_cache
+Requires: py3-typed-ast py3-lazy-object-proxy py3-six py3-wrapt

--- a/py3-configparser.spec
+++ b/py3-configparser.spec
@@ -1,2 +1,0 @@
-### RPM external py3-configparser 3.7.4
-## IMPORT build-with-pip3

--- a/py3-isort.spec
+++ b/py3-isort.spec
@@ -1,4 +1,4 @@
-### RPM external py3-isort 5.6.4
+### RPM external py3-isort 5.7.0
 ## IMPORT build-with-pip3
 
 Requires: py3-backports-functools_lru_cache

--- a/py3-lazy-object-proxy.spec
+++ b/py3-lazy-object-proxy.spec
@@ -1,3 +1,3 @@
-### RPM external py3-lazy-object-proxy 1.5.1
+### RPM external py3-lazy-object-proxy 1.4.3
 ## IMPORT build-with-pip3
 

--- a/py3-pylint.spec
+++ b/py3-pylint.spec
@@ -1,7 +1,7 @@
-### RPM external py3-pylint 1.9.4
+### RPM external py3-pylint 2.6.0
 ## IMPORT build-with-pip3
 
-Requires: py3-astroid py3-backports-functools_lru_cache py3-configparser py3-isort py3-mccabe py3-singledispatch py3-six
+Requires: py3-astroid py3-toml py3-isort py3-mccabe
 
 %define PipPostBuild \
     perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*; \

--- a/py3-singledispatch.spec
+++ b/py3-singledispatch.spec
@@ -1,4 +1,0 @@
-### RPM external py3-singledispatch 3.4.0.3
-## IMPORT build-with-pip3
-
-Requires: py3-six

--- a/py3-toml.spec
+++ b/py3-toml.spec
@@ -1,0 +1,4 @@
+### RPM external py3-toml 0.10.2
+## IMPORT build-with-pip3
+
+Requires: py3-astroid

--- a/py3-typed-ast.spec
+++ b/py3-typed-ast.spec
@@ -1,0 +1,2 @@
+### RPM external py3-typed-ast 1.4.1
+## IMPORT build-with-pip3

--- a/wmcorepy3-devtools.spec
+++ b/wmcorepy3-devtools.spec
@@ -1,7 +1,7 @@
 ### RPM cms wmcorepy3-devtools 0.1
 
 # This is a meta-package to group development tool dependencies
-Requires: python3 py3-mock py3-pep8 py3-mox3
+Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint
 
 %prep
 %build


### PR DESCRIPTION
This PR builds python3 pylint specs, all the other specs come together as dependencies.