### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient-binary.spec
+++ b/dasgoclient-binary.spec
@@ -1,12 +1,15 @@
-### RPM cms dasgoclient-binary v02.04.00
+### RPM cms dasgoclient-binary v02.04.02
 Source0: git+https://github.com/dmwm/dasgoclient?obj=master/%{realversion}&export=dasgoclient&output=/dasgoclient.tar.gz
 Source1: git+https://github.com/dmwm/cmsauth?obj=master/e9fca92e3335252a5f71d8e6d09c64012f7d3c0c&export=github.com/dmwm/cmsauth&output=/cmsauth.tar.gz
 Source2: git+https://github.com/vkuznet/x509proxy?obj=master/c93f6cae85114060b3b65861ea8436e4e14c54a6&export=github.com/vkuznet/x509proxy&output=/x509proxy.tar.gz
 Source3: git+https://github.com/buger/jsonparser?obj=master/6bd16707875b997f7a60327f888a28a3d28cf8c2&export=github.com/buger/jsonparser&output=/jsonparser.tar.gz
 Source4: git+https://github.com/go-mgo/mgo?obj=v2/3f83fa5005286a7fe593b055f0d7771a7dce4655&export=gopkg.in/mgo.v2&output=/mgo.v2.tar.gz
 Source5: git+https://github.com/pkg/profile?obj=master/3a8809bd8a80f8ecfe4ee1b34b3f37194968617c&export=github.com/pkg/profile&output=/profile.tar.gz
-Source6: git+https://github.com/dmwm/das2go?obj=master/77549fa70d07abbca64f9b438e5c9ae6d0469b3b&export=github.com/dmwm/das2go&output=/das2go.tar.gz
+Source6: git+https://github.com/dmwm/das2go?obj=master/d156472b03c144a71d62d7802b2dcd41e1c06151&export=github.com/dmwm/das2go&output=/das2go.tar.gz
 Source7: git+https://github.com/sirupsen/logrus?obj=master/a3f95b5c423586578a4e099b11a46c2479628cac&export=github.com/sirupsen/logrus&output=/logrus.tar.gz
+
+Requires: go
+
 %prep
 
 %setup -n dasgoclient
@@ -24,7 +27,8 @@ tar -xzf %{_sourcedir}/logrus.tar.gz
 %build
 export GOPATH=`pwd`/gopath
 sed -i -e "s,TAG :=,#TAG :=,g" -e "s,\$(TAG),%{realversion},g" Makefile
-make build_all
+make build_linux
+#make build_all
 
 %install
 mkdir -p %{i}/bin

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v02.04.00
+### RPM cms dasgoclient v02.04.02
 ## NOCOMPILER
 %define dasgoclient_arch     slc7_amd64_gcc820
 %define dasgoclient_pkg      cms+%{n}-binary+%{realversion}


### PR DESCRIPTION
This version includes switch to using machine based port (8443) on cmsweb services and bug fix for missing key values used in DAS filters