### PR TITLE
move crab-prod to v3.201026

### DIFF
--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -3,10 +3,10 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.200818
+%define crabclient_version v3.201026
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
-%define wmcore_version     1.3.6.crab1
-%define crabserver_version v3.200816
+%define wmcore_version     1.3.6.crab2
+%define crabserver_version v3.201026
 %define dbs_version        3.14.0
 
 ## IMPORT crab-build


### PR DESCRIPTION
Makes crab getoutput and getlog work after PhEDEx is turned off.  Was tested as crab-dev in IB.
This will be a fall back in case I don't get a newer version (which also fixes crab checkwrite) working by Friday