### PR TITLE
Fix dasgoclient suffixes for Arm and PPC

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -28,12 +28,7 @@ EOF
 chmod +x %i/etc/dasgoclient
 
 suffix="_linux"
-case %{cmsos} in
-  *_aarch64 ) suffix="_arm64"  ;;
-  *_ppc64*  ) suffix="_power8" ;;
-  osx*      ) suffix="_osx"    ;;
-  *_amd64   ) suffix="_linux"  ;;
-esac
+
 cp -r ./opt/cmssw/%{dasgoclient_arch}/$(echo %{dasgoclient_pkg} | tr '+' '/')/bin/dasgoclient${suffix} %{i}/bin/dasgoclient
 %post
 %{relocateConfig}etc/dasgoclient


### PR DESCRIPTION
The suffix is always _linux on all archs. Thats why it failed on arm and ppc
This needs another commit to fix the following:

```
RpmInstallFailed: Failed to install package dasgoclient. Reason:
error: Failed dependencies:
	/bin/sh is needed by cms+dasgoclient+v02.04.02-1-1.aarch64
	libc.so.6()(64bit) is needed by cms+dasgoclient+v02.04.02-1-1.aarch64
	libc.so.6(GLIBC_2.2.5)(64bit) is needed by cms+dasgoclient+v02.04.02-1-1.aarch64
	libpthread.so.0()(64bit) is needed by cms+dasgoclient+v02.04.02-1-1.aarch64
	libpthread.so.0(GLIBC_2.2.5)(64bit) is needed by cms+dasgoclient+v02.04.02-1-1.aarch64
	libpthread.so.0(GLIBC_2.3.2)(64bit) is needed by cms+dasgoclient+v02.04.02-1-1.aarch64
```