### PR TITLE
move latest version to prod

### DIFF
--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -3,10 +3,10 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.201026
+%define crabclient_version v3.201110
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
-%define wmcore_version     1.3.6.crab2
-%define crabserver_version v3.201026
+%define wmcore_version     1.3.6.crab4
+%define crabserver_version v3.201104
 %define dbs_version        3.14.0
 
 ## IMPORT crab-build


### PR DESCRIPTION
We managed to validate the latest crab client in dev. So this will move it to production and allow to remove all dependencies from PhEDEx in the next (Friday's ?) release build.