### PR TITLE
upgrade DBS to 3.15.1.

### DIFF
--- a/dbs3-client.spec
+++ b/dbs3-client.spec
@@ -1,4 +1,4 @@
-### RPM cms dbs3-client 3.13.1
+### RPM cms dbs3-client 3.15.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV SET DBS3_CLIENT_ROOT %i/
@@ -9,7 +9,6 @@
 Source0: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&output=/%{n}.tar.gz
 Requires: python py2-cjson dbs3-pycurl-client
 BuildRequires: py2-sphinx
-
 
 %prep
 %setup -D -T -b 0 -n DBS

--- a/dbs3-combined.spec
+++ b/dbs3-combined.spec
@@ -1,4 +1,4 @@
-### RPM cms dbs3-combined 3.13.1
+### RPM cms dbs3-combined 3.15.1
 
 # This is a fake spec whose only job is to build and upload 
 # dbs3 and dbs3-client in one go

--- a/dbs3-migration.spec
+++ b/dbs3-migration.spec
@@ -1,4 +1,4 @@
-### RPM cms dbs3-migration 3.13.1
+### RPM cms dbs3-migration 3.15.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV SET DBS3_MIGRATION_ROOT %i/
@@ -10,7 +10,7 @@ Source1: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&outp
 Requires: python py2-simplejson py2-sqlalchemy096 py2-httplib2 cherrypy py2-cheetah yui
 Requires: py2-cjson py2-cx-oracle dbs3-pycurl-client rotatelogs pystack
 BuildRequires: py2-sphinx
-
+#
 %prep
 %setup -T -b 0 -n WMCore
 %setup -D -T -b 1 -n DBS

--- a/dbs3-pycurl-client.spec
+++ b/dbs3-pycurl-client.spec
@@ -1,4 +1,4 @@
-### RPM cms dbs3-pycurl-client 3.13.1
+### RPM cms dbs3-pycurl-client 3.15.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
@@ -6,7 +6,6 @@
 Source0: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&output=/%{n}.tar.gz
 Requires: python py2-cjson py2-pycurl curl
 BuildRequires: py2-sphinx
-
 
 %prep
 %setup -D -T -b 0 -n DBS

--- a/dbs3.spec
+++ b/dbs3.spec
@@ -1,10 +1,10 @@
-### RPM cms dbs3 3.13.1
+### RPM cms dbs3 3.15.1
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV SET DBS3_SERVER_ROOT %i/
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
 %define wmcver 1.3.2
-
+#
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore&output=/WMCore4%{n}.tar.gz
 Source1: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&output=/%{n}.tar.gz
 


### PR DESCRIPTION
This DBS release fixed a bug that allowed run_num=1 to pass in when the run range is used.  Add more unit tests and fixed some because of fixing the bug. This also removed phys01/02 in  the view_instances_mg.json so we no longer need a special k8s view.