### PR TITLE
[TF] updated to version 2.3.1

### DIFF
--- a/bazel-3.7.0-patches.patch
+++ b/bazel-3.7.0-patches.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+index 0ea30a9..8df189f 100644
+--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
++++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+@@ -359,7 +359,7 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
+         @Param(
+             name = "use_default_shell_env",
+             type = Boolean.class,
+-            defaultValue = "False",
++            defaultValue = "True",
+             named = true,
+             positional = false,
+             doc = "Whether the action should use the built in shell environment or not."),

--- a/bazel.spec
+++ b/bazel.spec
@@ -1,4 +1,4 @@
-### RPM external bazel 0.29.1
+### RPM external bazel 3.7.0
 
 Source: https://github.com/bazelbuild/bazel/releases/download/%{realversion}/bazel-%{realversion}-dist.zip
 
@@ -16,7 +16,7 @@ BuildRequires: java-env python3
 
 # configuration issue
 # https://github.com/bazelbuild/bazel/issues/9392
-Patch0: bazel-0.29.1-patches
+Patch0: bazel-3.7.0-patches
 
 %prep
 

--- a/pip/astunparse.file
+++ b/pip/astunparse.file
@@ -1,0 +1,1 @@
+Requires: py2-wheel py2-six

--- a/pip/py2-tensorflow.file
+++ b/pip/py2-tensorflow.file
@@ -1,4 +1,5 @@
 Requires: py2-enum34 py2-tensorboard py2-wrapt py2-functools32 py2-google-pasta py2-opt-einsum py2-tensorflow-estimator py2-scipy
+Requires: py2-futures
 BuildRequires: tensorflow-sources
 %define PipPreBuildPy2 PIPFILE=${TENSORFLOW_SOURCES_ROOT}/tensorflow-%{realversion}-cp27-cp27mu-linux_%{_arch}.whl
 %define PipPostBuild rm -f %{i}/bin/tensorboard* ; ls %{i}/bin/* | xargs -i cp '{}' '{}2'

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -23,6 +23,7 @@ asn1crypto==1.4.0
 astor==0.8.1
 astroid==1.6.6 ; python_version<'3.0'
 astroid==2.4.2 ; python_version>'3.0'
+astunparse==1.6.3
 async-lru==1.0.2 ; python_version>'3.0'
 async-timeout==3.0.1 ; python_version>'3.0'
 atomicwrites==1.4.0
@@ -258,8 +259,8 @@ tables==3.6.1 ; python_version>'3.0'
 #tensorboard: Need separate packages for py2 and py3 to properly get the correct sources
 tensorboard==2.0.0 ; python_version<'3.0'
 tensorboard==2.0.0 ; python_version>'3.0'
-tensorflow==2.1.2 ; python_version<'3.0'
-tensorflow==2.1.2 ; python_version>'3.0'
+tensorflow==2.3.1 ; python_version<'3.0'
+tensorflow==2.3.1 ; python_version>'3.0'
 tensorflow-estimator==2.1.0
 termcolor==1.1.0
 terminado==0.8.3

--- a/pip/tensorflow.file
+++ b/pip/tensorflow.file
@@ -1,5 +1,5 @@
 ## INCLUDE tensorflow-requires
 Requires: py2-funcsigs py2-pbr py2-packaging py2-appdirs py2-setuptools py2-pyparsing py2-mock py2-Werkzeug
-Requires: py2-grpcio
+Requires: py2-grpcio py2-astunparse
 %define source0 none
 %define source_file none

--- a/tensorflow-python3-sources.spec
+++ b/tensorflow-python3-sources.spec
@@ -1,4 +1,4 @@
-### RPM external tensorflow-python3-sources 2.1.2
+### RPM external tensorflow-python3-sources 2.3.1
 %define python_cmd python3
 %define python_env PYTHON3PATH
 %define build_type opt

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -14,8 +14,8 @@ BuildRequires: bazel swig java-env git
 ## INCLUDE tensorflow-requires
 ## INCLUDE compilation_flags
 
-%define tag         63c7b8aabb9f882ec827a15ffe80aac17e14a021
-%define branch      cms/v2.1.2
+%define tag         6108bcc3b760aed2d7eb5896e30a8cbd27750679
+%define branch      cms/v2.3.1
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}.tgz
 
@@ -76,7 +76,7 @@ export TF_CMS_EXTERNALS="%{_builddir}/cms_externals.txt"
 
 echo "png:${LIBPNG_ROOT}"                   >  ${TF_CMS_EXTERNALS}
 echo "libjpeg_turbo:${LIBJPEG_TURBO_ROOT}"  >> ${TF_CMS_EXTERNALS}
-echo "zlib_archive:${ZLIB_ROOT}"            >> ${TF_CMS_EXTERNALS}
+echo "zlib:${ZLIB_ROOT}"                    >> ${TF_CMS_EXTERNALS}
 echo "curl:${CURL_ROOT}"                    >> ${TF_CMS_EXTERNALS}
 echo "com_google_protobuf:${PROTOBUF_ROOT}" >> ${TF_CMS_EXTERNALS}
 echo "pcre:${PCRE_ROOT}"                    >> ${TF_CMS_EXTERNALS}
@@ -90,7 +90,6 @@ echo "astor_archive:"                       >> ${TF_CMS_EXTERNALS}
 echo "six_archive:"                         >> ${TF_CMS_EXTERNALS}
 echo "absl_py:"                             >> ${TF_CMS_EXTERNALS}
 echo "termcolor_archive:"                   >> ${TF_CMS_EXTERNALS}
-echo "keras_applications_archive:"          >> ${TF_CMS_EXTERNALS}
 echo "pasta:"                               >> ${TF_CMS_EXTERNALS}
 echo "wrapt:"                               >> ${TF_CMS_EXTERNALS}
 echo "gast_archive:"                        >> ${TF_CMS_EXTERNALS}
@@ -103,14 +102,32 @@ export TF_SYSTEM_LIBS=$(cat ${TF_CMS_EXTERNALS} | sed 's|:.*||' | tr "\n" "," | 
 rm -rf ../build
 ./configure
 
+#Generate Python wrappers so that we can use PYTHON*PATH env
+rm -rf %{_builddir}/cms-pytool ; mkdir %{_builddir}/cms-pytool
+echo '#!/bin/bash'                             > %{_builddir}/cms-pytool/python3
+echo "export PYTHON3PATH=\"${PYTHON3PATH}\""  >> %{_builddir}/cms-pytool/python3
+echo "$(which python3) \"\$@\""               >> %{_builddir}/cms-pytool/python3
+
+echo '#!/bin/bash'                             > %{_builddir}/cms-pytool/python2
+echo "export PYTHON27PATH=\"${PYTHON27PATH}\"" >> %{_builddir}/cms-pytool/python2
+echo "$(which python2) \"\$@\""                 >> %{_builddir}/cms-pytool/python2
+
+chmod +x %{_builddir}/cms-pytool/python2 %{_builddir}/cms-pytool/python3
+if [ "%{python_cmd}" = "python3" ] ; then
+  ln -s python3 %{_builddir}/cms-pytool/python
+else
+  ln -s python2 %{_builddir}/cms-pytool/python
+fi
+export PATH=%{_builddir}/cms-pytool:$PATH
+
 # define bazel options
 BAZEL_OPTS="--batch --output_user_root ../build build -s --verbose_failures --config=opt --cxxopt=$CXX_OPT_FLAGS %{makeprocesses}"
 BAZEL_OPTS="$BAZEL_OPTS --config=noaws --config=nogcp --config=nohdfs --config=nonccl"
-BAZEL_OPTS="$BAZEL_OPTS --action_env=SWIG_LIB=${SWIG_LIB} --action_env=PYTHONPATH=$%{python_env} --action_env=LD_LIBRARY_PATH"
-BAZEL_OPTS="$BAZEL_OPTS --distinct_host_configuration=false --incompatible_no_support_tools_in_action_inputs=false"
+BAZEL_OPTS="$BAZEL_OPTS --action_env=SWIG_LIB=${SWIG_LIB}"
+BAZEL_OPTS="$BAZEL_OPTS --distinct_host_configuration=false"
 
 # build tensorflow python targets
-bazel $BAZEL_OPTS $BAZEL_EXTRA_OPTS //tensorflow/tools/pip_package:build_pip_package
+bazel $BAZEL_OPTS //tensorflow/tools/pip_package:build_pip_package
 
 %if "%{pythonOnly}" == "no"
 bazel $BAZEL_OPTS //tensorflow:tensorflow
@@ -120,9 +137,9 @@ bazel $BAZEL_OPTS //tensorflow/compiler/tf2xla:tf2xla
 bazel $BAZEL_OPTS //tensorflow/compiler/xla:cpu_function_runtime
 bazel $BAZEL_OPTS //tensorflow/compiler/xla:executable_run_options
 bazel $BAZEL_OPTS //tensorflow/compiler/tf2xla:xla_compiled_cpu_function
-bazel $BAZEL_OPTS //tensorflow/compiler/aot:tfcompile
+#bazel $BAZEL_OPTS //tensorflow/compiler/aot:tfcompile
 bazel $BAZEL_OPTS //tensorflow/core/profiler
-bazel $BAZEL_OPTS $BAZEL_EXTRA_OPTS //tensorflow:install_headers
+bazel $BAZEL_OPTS //tensorflow:install_headers
 
 # rebuild *.pb.{h|cc} files using the external protobuf compiler
 chmod -R a+rwX $PWD/bazel-bin/tensorflow/include
@@ -164,7 +181,7 @@ for l in tensorflow_cc tensorflow_framework tensorflow ; do
   ln -s lib${l}.so.%{majorversion} $libdir/lib${l}.so
 done
 
-cp -p $srcdir/compiler/aot/tfcompile $bindir
+#cp -p $srcdir/compiler/aot/tfcompile $bindir
 for name in tensorflow absl re2 third_party ; do
     cp -r -p $srcdir/include/$name $incdir
 done

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -14,7 +14,7 @@ BuildRequires: bazel swig java-env git
 ## INCLUDE tensorflow-requires
 ## INCLUDE compilation_flags
 
-%define tag         6108bcc3b760aed2d7eb5896e30a8cbd27750679
+%define tag         77e1c215529a442d2c9268c62f010dcf30d90cc4
 %define branch      cms/v2.3.1
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}.tgz

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,8 +1,9 @@
-### RPM external tensorflow-sources 2.1.2
+### RPM external tensorflow-sources 2.3.1
 %define python_cmd python
 %define python_env PYTHON27PATH
 %define build_type opt
 %define pythonOnly no
 %define vectorize_flag -msse3
+Requires: py2-futures
 ## INCLUDE tensorflow-sources
 

--- a/tensorflow-toolfile.spec
+++ b/tensorflow-toolfile.spec
@@ -18,9 +18,6 @@ cat << \EOF_TOOLFILE > %i/etc/scram.d/%{base_package}.xml
     <environment name="TENSORFLOW_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$TENSORFLOW_BASE/lib"/>
     <environment name="INCLUDE" default="$TENSORFLOW_BASE/include"/>
-%ifnarch ppc64le
-    <environment name="TFCOMPILE" default="$TENSORFLOW_BASE/bin/tfcompile"/>
-%endif
 EOF_TOOLFILE
 for v in $(echo %{package_vectorization} | tr '[a-z-]' '[A-Z_]')  ; do
   r=`eval echo \\$%{base_package_uc}_${v}_ROOT`

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -1,4 +1,4 @@
-### RPM external tensorflow 2.1.2
+### RPM external tensorflow 2.3.1
 %define source_package tensorflow-sources
 %if "%{?vectorized_package:set}" != "set"
 BuildRequires: %{source_package}


### PR DESCRIPTION
This should update Tensorflow to verison 2.3.1. It builds for x86_64 arch. PR tests should run for aarch64 and ppc64le too to make sure that this works for other achs too.
Note that tfcompiler is failing in this due to internal compiler error. I will look in to it later to fix that.

New Bazel is not passing all the env to commands, specially our `PYTHON*PATH` variables. To work around this issue, I created wrapper python scripts ( https://github.com/cms-sw/cmsdist/pull/6410/files#diff-bc1e16af800e69ca55692be3a5bf4bc9dc9e80b2a4644b0b40ccfd8063e25067R105-R122 ) which sets the python env and then call the actual python binary