### PR TITLE
Remove bootstrap bin and lib paths during the build stage

### DIFF
--- a/dpm.spec
+++ b/dpm.spec
@@ -22,7 +22,7 @@ Provides: libdpm.so%{libsuffix}
 
 %prep
 rm -f %_builddir/DPM-%{downloadv}.src.tar.gz
-rpm2cpio %{_sourcedir}/DPM-mysql-%{downloadv}sec.%{dpmarch}.src.rpm | cpio -ivd LCG-DM-%{baseVersion}.tar.gz
+%{rpmbuild_env} rpm2cpio %{_sourcedir}/DPM-mysql-%{downloadv}sec.%{dpmarch}.src.rpm | cpio -ivd LCG-DM-%{baseVersion}.tar.gz
 cd %_builddir ; rm -rf LCG-DM-%{baseVersion}; tar -xzvf LCG-DM-%{baseVersion}.tar.gz
 
 perl -p -i -e 's|SHLIBREQLIBS = -lc|SHLIBREQLIBS = -lc /usr/lib/dylib1.o|' LCG-DM-%{baseVersion}/config/darwin.cf

--- a/gcc.spec
+++ b/gcc.spec
@@ -1,5 +1,4 @@
 ### RPM external gcc 8.4.0
-#Force rebuild; remove this after the tests
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 # Use the git repository for fetching the sources. This gives us more control while developing
 # a new platform so that we can compile yet to be released versions of the compiler.

--- a/gcc.spec
+++ b/gcc.spec
@@ -1,4 +1,5 @@
 ### RPM external gcc 8.4.0
+#Force rebuild; remove this after the tests
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 # Use the git repository for fetching the sources. This gives us more control while developing
 # a new platform so that we can compile yet to be released versions of the compiler.

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -201,6 +201,8 @@
 # packages.  This allows cross-package environment setup to work while
 # building.  See above how we determine the list by parsing the spec
 # itself.
+%{expand:%%define rpmbuild_libdir  %(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep '/external/bootstrap-bundle/')}
+%define rpmbuild_env LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:%{rpmbuild_libdir}
 %define drop_bootstrap_path export             PATH=$(echo           $PATH | tr ':' '\\n' | grep -v '/external/bootstrap-bundle/' | tr '\\n' ':' | sed 's|:*$||')
 %define drop_bootstrap_lib  export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ':' '\\n' | grep -v '/external/bootstrap-bundle/' | tr '\\n' ':' | sed 's|:*$||')
 %define drop_bootstrap_env %{drop_bootstrap_path}; %{drop_bootstrap_lib}

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -201,13 +201,16 @@
 # packages.  This allows cross-package environment setup to work while
 # building.  See above how we determine the list by parsing the spec
 # itself.
+%define drop_bootstrap_path export             PATH=$(echo           $PATH | tr ':' '\\n' | grep -v '/external/bootstrap-bundle/' | tr '\\n' ':' | sed 's|:*$||')
+%define drop_bootstrap_lib  export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ':' '\\n' | grep -v '/external/bootstrap-bundle/' | tr '\\n' ':' | sed 's|:*$||')
+%define drop_bootstrap_env %{drop_bootstrap_path}; %{drop_bootstrap_lib}
 %if "%archfirst" == "yes"
-%define initenv_all	for x in %{allpkgreqs}                          .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
-%define initenv_direct	for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_all	%{drop_bootstrap_env} ; for x in %{allpkgreqs}                          .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_direct	%{drop_bootstrap_env} ; for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %define post_initenv unset %{dynamic_path_var}; for x in %{allpkgreqs} %{pkgdir} ; do i=$RPM_INSTALL_PREFIX/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %else
-%define initenv_all	for x in %{allpkgreqs}                          .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
-%define initenv_direct	for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_all	%{drop_bootstrap_env} ; for x in %{allpkgreqs}                          .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_direct	%{drop_bootstrap_env} ; for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %define post_initenv unset %{dynamic_path_var}; for x in %{allpkgreqs} %{pkgdir} ; do i=$RPM_INSTALL_PREFIX/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %endif
 %define initenv		%initenv_all


### PR DESCRIPTION
We noticed that during the build of a package, `cmsBuild` source the env of rpm (so that it can run `rpmbuild` commands). One side effect of this is that it sets `PATH` and `LD_LIBRARY_PATH` of `bootstrap-bundle` package. Libraries (e.g openssl , xml2, zma etc) and binaries from these paths can be picked up by the up stream packages and can override system libs. For example , if one wants to use `openssl` from system then `openssl` library from bootstrap bundle will hide it.

The change in rpm-preamble.file does not re-build any thing. It will be only use when a package (for some other reason) needs a rebuilt. In orde rto test this fully, I have changed gcc.spec to re-build all packages to see if this has any side effects,