### PR TITLE
Add phedex specs back to the list of comp dependencies

### DIFF
--- a/comp.spec
+++ b/comp.spec
@@ -10,6 +10,8 @@ Requires: acdcserver
 Requires: t0wmadatasvc dbs3-migration t0_reqmon reqmgr2 reqmgr2ms
 Requires: cmsweb-analytics
 Requires: confdb exporters exitcodes
+# FIXME: remove these 3 PhEDEx specs from the building list for January/2021
+Requires: PHEDEX-combined-web PHEDEX-combined-agents PHEDEX-lifecycle
 # Common
 Requires: rotatelogs pystack wmcore-devtools
 # Other


### PR DESCRIPTION
@muhammadimranfarooqi as we discussed over google talk, I added back all the PhEDEx specs that I had removed in:
https://github.com/cms-sw/cmsdist/pull/6405

Unless we get ourselves in BIG trouble with the migration away of PhEDEx, it should be fine to remove them again in December/2020.