### PR TITLE
COMP: remove bootstrap bin and lib paths during the build stage

### DIFF
--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -195,12 +195,17 @@
 # packages.  This allows cross-package environment setup to work while
 # building.  See above how we determine the list by parsing the spec
 # itself.
+%{expand:%%define rpmbuild_libdir  %(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep '/external/bootstrap-bundle/')}
+%define rpmbuild_env LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:%{rpmbuild_libdir}
+%define drop_bootstrap_path export             PATH=$(echo           $PATH | tr ':' '\\n' | grep -v '/external/bootstrap-bundle/' | tr '\\n' ':' | sed 's|:*$||')
+%define drop_bootstrap_lib  export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ':' '\\n' | grep -v '/external/bootstrap-bundle/' | tr '\\n' ':' | sed 's|:*$||')
+%define drop_bootstrap_env %{drop_bootstrap_path}; %{drop_bootstrap_lib}
 %if "%archfirst" == "yes"
-%define initenv_all	for x in %{allpkgreqs}                          .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
-%define initenv_direct	for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_all	%{drop_bootstrap_env} ; for x in %{allpkgreqs}                          .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_direct	%{drop_bootstrap_env} ; for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/%{cmsplatf}/$x/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %else
-%define initenv_all	for x in %{allpkgreqs}                          .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
-%define initenv_direct	for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_all	%{drop_bootstrap_env} ;	for x in %{allpkgreqs}                          .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
+%define initenv_direct	%{drop_bootstrap_env} ;for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %endif
 %define initenv		%initenv_all
 


### PR DESCRIPTION
This change reflects what Shahzad provided to the CMSSW branches, under:
https://github.com/cms-sw/cmsdist/pull/6420

which is well explained on his PR. My understanding is that this change is required to avoid mixing up system with boostrap-bundle libraries that could be linked when building some RPMs.

@smuzaffar thank you very much for providing this fix!

PS.: I guess it won't build anything, but I'm manually building specs with this change and things seem to work fine.