### PR TITLE
Revert "[ROOT] Testing latest root v6.22 for 11.2.X master  IBS"

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
 
-%define tag 61481a1f4cbdfc5a7124bff2a4a61be4d5c69235
-%define branch cms/v6-22-00-patches/2c44aae445
+%define tag 32198727e17368de837d36212d5a4cbb4da6a247
+%define branch cms/v6-22-00-patches/d6156de
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 


### PR DESCRIPTION
Reverts cms-sw/cmsdist#6404
Back to working commit of root 6.22 patches branch with following fixes
- Fix for Aarch64: https://github.com/cms-sw/root/commit/b9adbfff1b6caf1c1513284fb7c7a4275864ed7c:  [cling] Force char-signedness of host. Fixes root-projectroot/#6465
- DD4Hep  https://github.com/cms-sw/root/commit/76b0e9d16e71f7636b0503c68c289982c5205a58 : Fix for copying title to cloned volumes and nodes.
- DD4Hep https://github.com/cms-sw/root/commit/32198727e17368de837d36212d5a4cbb4da6a247 : Clone also name in the reflected shape.