### PR TITLE
[Rivet][OpenMP] Disable OpenMP for aarch64

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -38,6 +38,12 @@ case %{cmsplatf} in
 esac
 
 autoreconf -fiv
+
+#disable building Rivet with OpenMP as it crash executables due to static TLS blocks
+%ifarch aarch64
+sed -i -e 's|^ax_openmp_flags=".*"|ax_openmp_flags="none"|' ./configure
+%endif
+
 ./configure --disable-silent-rules --prefix=%{i} --with-hepmc=${HEPMC_ROOT} \
             --with-fastjet=${FASTJET_ROOT} --with-fjcontrib=${FASTJET_CONTRIB_ROOT} --with-yoda=${YODA_ROOT} \
             --disable-doxygen --disable-pdfmanual --with-pic \


### PR DESCRIPTION
We noticed many Relvals fails for aarch64 due to OpenMP cannot allocate memory in static TLS block. This is happening as Rivet library is dynamically linked to gomp which CMSSW plugin manager loads using dlopen. We only see such crashes for aarch64 releases, so this PR suggests to disable openmp for aarch64.