### PR TITLE
Build COMP packages with system-based openssl

### DIFF
--- a/apache2.spec
+++ b/apache2.spec
@@ -1,6 +1,6 @@
 ### RPM external apache2 2.2.31gsi
 %define apversion %(echo %realversion | sed 's/gsi.*$//')
-Requires: openssl zlib expat libuuid sqlite pcre
+Requires: zlib expat libuuid sqlite pcre
 BuildRequires: bison
 
 Source0: http://archive.apache.org/dist/httpd/httpd-%apversion.tar.gz
@@ -30,7 +30,6 @@ perl -p -i -e 's/-no-cpp-precomp//' srclib/apr/configure
                         --enable-rewrite \
                         --enable-ssl \
                         --with-pcre=$PCRE_ROOT \
-                        --with-ssl=$OPENSSL_ROOT \
                         --with-z=$ZLIB_ROOT \
 			--with-expat=$EXPAT_ROOT \
 			--with-sqlite3=$SQLITE_ROOT \

--- a/apache24.spec
+++ b/apache24.spec
@@ -1,6 +1,6 @@
 ### RPM external apache24 2.4.18gsi
 %define apversion %(echo %realversion | sed 's/gsi.*$//')
-Requires: openssl zlib expat libuuid sqlite pcre
+Requires: zlib expat libuuid sqlite pcre
 
 Source0: http://archive.apache.org/dist/httpd/httpd-%apversion.tar.gz
 Source1: http://archive.apache.org/dist/apr/apr-1.5.2.tar.gz
@@ -21,11 +21,6 @@ Patch3: apache24-status-maxline
 cp -rp ../apr-1.5.2/ ./srclib/apr/
 cp -rp ../apr-util-1.5.4 ./srclib/apr-util/
 
-# INCLUDES is needed otherwise apache will use the system openssl
-# despite the with-ssl below.
-
-export LDFLAGS="-L${OPENSSL_ROOT}/lib"
-export INCLUDES="-I${OPENSSL_ROOT}/include"
 ./configure --prefix=%i --with-mpm=prefork \
                         --enable-mods-shared=all \
                         --enable-so \
@@ -40,7 +35,6 @@ export INCLUDES="-I${OPENSSL_ROOT}/include"
                         --enable-rewrite \
                         --enable-ssl \
                         --with-pcre=$PCRE_ROOT \
-                        --with-ssl=$OPENSSL_ROOT \
                         --with-z=$ZLIB_ROOT \
 			--with-expat=$EXPAT_ROOT \
 			--with-sqlite3=$SQLITE_ROOT \

--- a/cherrypy.spec
+++ b/cherrypy.spec
@@ -13,6 +13,9 @@ perl -p -i -e 's/import profile/import cProfile as profile/' cherrypy/lib/profil
 python setup.py build
 
 %install
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python setup.py install --prefix=%i
-find %i -name '*.egg-info' -exec rm {} \;
-for f in %i/bin/cherryd; do perl -p -i -e 's{.*}{#!/usr/bin/env python} if $. == 1 && m{#!.*/bin/python}' $f; done
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/cherryd
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/CherryPy-5.4.0.post20201110-py2.7.egg/EGG-INFO/scripts/cherryd
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/CherryPy-5.4.0.post20201110-py2.7.egg/cherrypy/cherryd

--- a/cherrypy.spec
+++ b/cherrypy.spec
@@ -17,5 +17,5 @@ mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
 PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python setup.py install --prefix=%i
 perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/cherryd
-perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/CherryPy-5.4.0.post20201110-py2.7.egg/EGG-INFO/scripts/cherryd
-perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/CherryPy-5.4.0.post20201110-py2.7.egg/cherrypy/cherryd
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/CherryPy-5.4.0.post*/EGG-INFO/scripts/cherryd
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/CherryPy-5.4.0.post*/cherrypy/cherryd

--- a/classlib.spec
+++ b/classlib.spec
@@ -10,7 +10,6 @@ Patch5: classlib-3.1.3-fix-obsolete-CLK_TCK
 Requires: bz2lib 
 Requires: pcre 
 Requires: xz
-Requires: openssl
 Requires: zlib 
 
 %prep
@@ -36,8 +35,6 @@ chmod +x ./cfg/config.{sub,guess}
   --with-bz2lib-libraries=$BZ2LIB_ROOT/lib      \
   --with-pcre-includes=$PCRE_ROOT/include       \
   --with-pcre-libraries=$PCRE_ROOT/lib          \
-  --with-openssl-includes=$OPENSSL_ROOT/include \
-  --with-openssl-libraries=$OPENSSL_ROOT/lib	\
   --with-lzma-includes=$XZ_ROOT/include         \
   --with-lzma-libraries=$XZ_ROOT/lib
 

--- a/compsec.spec
+++ b/compsec.spec
@@ -1,5 +1,5 @@
 ### RPM cms compsec 1.0
-Requires: openssl python
+Requires: python
 Requires: skipfish pcre libidn
 Requires: openldap python-ldap py2-prettytable
 Requires: nmap py2-libnmap

--- a/condor.spec
+++ b/condor.spec
@@ -7,33 +7,20 @@ Source: git://github.com/htcondor/htcondor.git?obj=master/%{condortag}&export=co
 Patch0: cms-htcondor-build
 Patch1: condor-vomsapi-static
 
-Requires: openssl zlib expat pcre libtool python boost172 p5-archive-tar curl libxml2 p5-time-hires libuuid sqlite py2-setuptools
-BuildRequires: cmake gcc openssl
+Requires: zlib expat pcre libtool python boost172 p5-archive-tar curl libxml2 p5-time-hires libuuid sqlite py2-setuptools
+BuildRequires: cmake gcc
 
 %prep
 %setup -n %n-%{realversion}
 %patch0 -p1
 %patch1 -p1
 
-# create OpenSSL pkginfo file for build (Globus needs it)
-mkdir -p ${OPENSSL_ROOT}/lib/pkgconfig
-echo "
-Name: OpenSSL
-Description: Secure Sockets Layer and cryptography libraries and tools
-Version: 1.0.1r
-Requires:
-Libs: -L${OPENSSL_ROOT}/lib -lssl -lcrypto
-Libs.private: -Wl,-z,relro -ldl -lz -L/usr/lib -lgssapi_krb5 -lkrb5 -lcom_err -lk5crypto
-Cflags: -I${OPENSSL_ROOT}/include -I/usr/include
-" > ${OPENSSL_ROOT}/lib/pkgconfig/openssl.pc
-
 %build
-export CMAKE_INCLUDE_PATH=${OPENSSL_ROOT}/include:${LIBTOOL_ROOT}/include:${ZLIB_ROOT}/include:${PCRE_ROOT}/include:${BOOST172_ROOT}/include:${EXPAT_ROOT}/include:${CURL_ROOT}/include:${LIBXML2_ROOT}/include:${LIBUUID_ROOT}/include:${SQLITE_ROOT}/include
-export CMAKE_LIBRARY_PATH=${OPENSSL_ROOT}/lib:${LIBTOOL_ROOT}/lib:${ZLIB_ROOT}/lib:${PCRE_ROOT}/lib:${BOOST172_ROOT}/lib:${EXPAT_ROOT}/lib:${CURL_ROOT}/lib:${LIBXML2_ROOT}/lib:${LIBUUID_ROOT}/lib:${SQLITE_ROOT}/lib
-export CXXFLAGS="-I${OPENSSL_ROOT}/include -I${LIBTOOL_ROOT}/include -I$ZLIB_ROOT/include -I$PCRE_ROOT/include -I$BOOST172_ROOT/include -I$EXPAT_ROOT/include -I$CURL_ROOT/include -I$LIBXML2_ROOT/include -I${LIBUUID_ROOT}/include -I${SQLITE_ROOT}/include"
-export LDFLAGS="-L${OPENSSL_ROOT}/lib -L${LIBTOOL_ROOT}/lib -L$ZLIB_ROOT/lib -L$PCRE_ROOT/lib -L$BOOST172_ROOT/lib -L$EXPAT_ROOT/lib -L$CURL_ROOT/lib -L$LIBXML2_ROOT/lib -L${LIBUUID_ROOT}/lib -L${SQLITE_ROOT}/lib"
+export CMAKE_INCLUDE_PATH=${LIBTOOL_ROOT}/include:${ZLIB_ROOT}/include:${PCRE_ROOT}/include:${BOOST172_ROOT}/include:${EXPAT_ROOT}/include:${CURL_ROOT}/include:${LIBXML2_ROOT}/include:${LIBUUID_ROOT}/include:${SQLITE_ROOT}/include
+export CMAKE_LIBRARY_PATH=${LIBTOOL_ROOT}/lib:${ZLIB_ROOT}/lib:${PCRE_ROOT}/lib:${BOOST172_ROOT}/lib:${EXPAT_ROOT}/lib:${CURL_ROOT}/lib:${LIBXML2_ROOT}/lib:${LIBUUID_ROOT}/lib:${SQLITE_ROOT}/lib
+export CXXFLAGS="-I${LIBTOOL_ROOT}/include -I$ZLIB_ROOT/include -I$PCRE_ROOT/include -I$BOOST172_ROOT/include -I$EXPAT_ROOT/include -I$CURL_ROOT/include -I$LIBXML2_ROOT/include -I${LIBUUID_ROOT}/include -I${SQLITE_ROOT}/include"
+export LDFLAGS="-L${LIBTOOL_ROOT}/lib -L$ZLIB_ROOT/lib -L$PCRE_ROOT/lib -L$BOOST172_ROOT/lib -L$EXPAT_ROOT/lib -L$CURL_ROOT/lib -L$LIBXML2_ROOT/lib -L${LIBUUID_ROOT}/lib -L${SQLITE_ROOT}/lib"
 export CFLAGS="$CXXFLAGS"
-export PKG_CONFIG_PATH=${OPENSSL_ROOT}/lib/pkgconfig
 cmake \
   -DCMAKE_INSTALL_PREFIX=%i \
   -DPROPER:BOOL=OFF \
@@ -55,7 +42,6 @@ cmake \
   -DWITH_GSOAP:BOOL=OFF \
   -DWITH_BLAHP:BOOL=OFF \
   -DWITH_KRB5:BOOL=OFF \
-  -DWITH_OPENSSL:BOOL=ON \
   -DWITH_LIBCGROUP:BOOL=OFF \
   -DWITH_LIBVIRT:BOOL=OFF \
   -DLDAP_FOUND_SEARCH_lber:PATH=LDAP_FOUND_SEARCH_lber-NOTFOUND \
@@ -110,5 +96,3 @@ done
 
 %post
 %{relocateConfig}etc/profile.d/dependencies-setup.*sh
-# Remove OpenSSL pkginfo only used for build
-rm -rf ${OPENSSL_ROOT}/lib/pkgconfig

--- a/condor.spec
+++ b/condor.spec
@@ -21,6 +21,7 @@ export CMAKE_LIBRARY_PATH=${LIBTOOL_ROOT}/lib:${ZLIB_ROOT}/lib:${PCRE_ROOT}/lib:
 export CXXFLAGS="-I${LIBTOOL_ROOT}/include -I$ZLIB_ROOT/include -I$PCRE_ROOT/include -I$BOOST172_ROOT/include -I$EXPAT_ROOT/include -I$CURL_ROOT/include -I$LIBXML2_ROOT/include -I${LIBUUID_ROOT}/include -I${SQLITE_ROOT}/include"
 export LDFLAGS="-L${LIBTOOL_ROOT}/lib -L$ZLIB_ROOT/lib -L$PCRE_ROOT/lib -L$BOOST172_ROOT/lib -L$EXPAT_ROOT/lib -L$CURL_ROOT/lib -L$LIBXML2_ROOT/lib -L${LIBUUID_ROOT}/lib -L${SQLITE_ROOT}/lib"
 export CFLAGS="$CXXFLAGS"
+
 cmake \
   -DCMAKE_INSTALL_PREFIX=%i \
   -DPROPER:BOOL=OFF \

--- a/couchdb15.spec
+++ b/couchdb15.spec
@@ -36,7 +36,7 @@ Patch4: couchdb15-heartbeat-timeout
 
 # Although there is no technical software dependency,
 # couchapp was included because all CMS applications will need it.
-Requires: curl spidermonkey openssl icu4c erlang couchapp
+Requires: curl spidermonkey icu4c erlang couchapp
 BuildRequires: autotools
 
 %prep
@@ -54,7 +54,7 @@ perl -p -i -e 's{-licuuc -licudt -licuin}{-licui18n -licuuc -licudata}g;' config
 %build
 # apache 1.5.1 does not have option to specify --with-icu4c, instead
 # they used --with-win32-icu-binaries which mostly the same
-export CURL_ROOT SPIDERMONKEY_ROOT OPENSSL_ROOT ICU4C_ROOT ERLANG_ROOT AUTOTOOLS_ROOT
+export CURL_ROOT SPIDERMONKEY_ROOT ICU4C_ROOT ERLANG_ROOT AUTOTOOLS_ROOT
 export PATH=$ERLANG_ROOT/bin:$AUTOTOOLS_ROOT/bin:$PATH
 ./configure --prefix=%i --with-js-lib=$SPIDERMONKEY_ROOT/lib --with-js-include=$SPIDERMONKEY_ROOT/include/js --with-erlang=$ERLANG_ROOT/lib/erlang/usr/include --with-win32-icu-binaries=$ICU4C_ROOT
 make %makeprocesses

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -9,7 +9,7 @@
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
-Patch0: crabtaskworker_cherrypy
+#Patch0: crabtaskworker_cherrypy
 
 #Patch0: crabserver3-setup
 
@@ -21,7 +21,7 @@ BuildRequires: py2-sphinx
 
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
-%patch0 -p0 -d bin
+#%patch0 -p0 -d bin
 %setup -T -b 0 -n WMCore-%{wmcver}
 #%patch0 -p1
 

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -9,6 +9,7 @@
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
+Patch0: crabtaskworker_cherrypy
 
 #Patch0: crabserver3-setup
 
@@ -20,6 +21,7 @@ BuildRequires: py2-sphinx
 
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
+%patch0 -p0 -d bin
 %setup -T -b 0 -n WMCore-%{wmcver}
 #%patch0 -p1
 

--- a/crabtaskworker_cherrypy.patch
+++ b/crabtaskworker_cherrypy.patch
@@ -1,0 +1,11 @@
+--- htcondor_make_runtime.sh.orig	2020-11-16 13:44:04.093228726 +0100
++++ htcondor_make_runtime.sh	2020-11-16 13:46:05.390384346 +0100
+@@ -56,7 +56,7 @@
+     zip -rq $STARTDIR/CRAB3.zip RESTInteractions.py HTCondorUtils.py HTCondorLocator.py TaskWorker CRABInterface  TransferInterface -x \*.pyc || exit 3
+     popd
+ 
+-    pushd $VO_CMS_SW_DIR/$SCRAM_ARCH/external/cherrypy/*/lib/python2.7/site-packages
++    pushd $VO_CMS_SW_DIR/$SCRAM_ARCH/external/cherrypy/*/lib/python2.7/site-packages/CherryPy-5.4.0.post*/
+     zip -rq $STARTDIR/CRAB3.zip cherrypy -x \*.pyc
+     popd
+ 

--- a/curl.spec
+++ b/curl.spec
@@ -1,6 +1,5 @@
 ### RPM external curl 7.59.0
 Source: http://curl.haxx.se/download/%{n}-%{realversion}.tar.gz
-Requires: openssl
 Requires: zlib
 
 %prep
@@ -19,7 +18,6 @@ esac
   --without-libidn \
   --disable-ldap \
   --with-zlib=${ZLIB_ROOT} \
-  --with-ssl=${OPENSSL_ROOT} \
   --without-nss \
   --without-libssh2 \
   --with-gssapi=${KERBEROS_ROOT}

--- a/davix.spec
+++ b/davix.spec
@@ -12,7 +12,7 @@ Source0: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&exp
 %endif
 
 BuildRequires: cmake gmake 
-Requires: openssl libxml2 libuuid
+Requires: libxml2 libuuid
 %prep
 %setup -n %{n}-%{realversion}
 
@@ -23,7 +23,6 @@ cmake -DCMAKE_INSTALL_PREFIX="%{i}" \
  -DLIBXML2_LIBRARIES="${LIBXML2_ROOT}/lib/libxml2.%{soext}" \
  -DUUID_INCLUDE_DIR="${LIBUUID_ROOT}/include" \
  -DUUID_LIBRARY="${LIBUUID_ROOT}/lib/libuuid.%{soext}" \
- -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT}" \
  ../
 
 make VERBOSE=1 %{makeprocesses}

--- a/erlang.spec
+++ b/erlang.spec
@@ -25,9 +25,9 @@ mv ../lib/{crypto,public_key} ./lib/
 %define flavour --enable-m64-build --disable-m32-build
 %endif
 
-./configure CPPFLAGS=-I$ZLIB_ROOT/include LDFLAGS=-L$ZLIB_ROOT/lib \
+./configure CFLAGS="-DOPENSSL_NO_EC=1" CPPFLAGS=-I$ZLIB_ROOT/include LDFLAGS=-L$ZLIB_ROOT/lib \
   --prefix=%i %flavour --without-javac --enable-shared-zlib \
-  --enable-dynamic-ssl-lib --without-termcap
+  --with-ssl --enable-dynamic-ssl-lib --without-termcap
 make
 
 %install

--- a/erlang.spec
+++ b/erlang.spec
@@ -2,7 +2,7 @@
 Source0: http://erlang.org/download/otp_src_%{realversion}.tar.gz
 #Source1: git+https://github.com/erlang/otp.git?obj=master/OTP_R16B03-1&export=./&filter=*lib/*&output=/R16libs.tar.gz
 Source1: git+https://github.com/erlang/otp.git?obj=master/OTP_R16B03-1&export=./&output=/R16libs.tar.gz
-Requires: openssl zlib
+Requires: zlib
 
 # 32-bit
 Provides: libc.so.6(GLIBC_PRIVATE)
@@ -27,7 +27,7 @@ mv ../lib/{crypto,public_key} ./lib/
 
 ./configure CPPFLAGS=-I$ZLIB_ROOT/include LDFLAGS=-L$ZLIB_ROOT/lib \
   --prefix=%i %flavour --without-javac --enable-shared-zlib \
-  --with-ssl=$OPENSSL_ROOT --enable-dynamic-ssl-lib --without-termcap
+  --enable-dynamic-ssl-lib --without-termcap
 make
 
 %install

--- a/frontend.spec
+++ b/frontend.spec
@@ -17,7 +17,7 @@ Requires: py2-flask-sqlalchemy py2-flask-login py2-rauth py2-argparse py2-rauth
 
 %build
 gcc -o %_builddir/grid-proxy-verify %_sourcedir/grid-proxy-verify.c \
-  -I$OPENSSL_ROOT/include -L$OPENSSL_ROOT/lib -lssl -lcrypto -ldl
+  -lssl -lcrypto -ldl
 
 %install
 mkdir -p %i/{bin,etc/env.d,etc/profile.d}

--- a/libpq.spec
+++ b/libpq.spec
@@ -1,15 +1,12 @@
 ### RPM external libpq 9.4.5
 
 Source: https://ftp.postgresql.org/pub/source/v9.4.5/postgresql-%{realversion}.tar.gz
-Requires: openssl
 
 %prep
 %setup -n postgresql-%{realversion}
 
 %build
-export CFLAGS="-I${OPENSSL_ROOT}/include"
-export LDFLAGS="-L${OPENSSL_ROOT}/lib"
-./configure --prefix=%{i} --disable-static --with-openssl --without-readline
+./configure --prefix=%{i} --disable-static --without-readline
 
 #Build libpq
 cd src/interfaces/libpq/

--- a/mariadb.spec
+++ b/mariadb.spec
@@ -3,7 +3,7 @@
 ## INITENV +PATH PATH %i/scripts
 ## INITENV SET MYSQL_HOME $MYSQL_ROOT
 Source: https://downloads.mariadb.org/f/mariadb-%realversion/source/mariadb-%realversion.tar.gz/from/http%3A//ftp.hosteurope.de/mirror/archive.mariadb.org/?serve
-Requires: zlib openssl ncurses libxml2
+Requires: zlib ncurses libxml2
 BuildRequires: cmake
 Provides: perl(GD)
 Provides: perl(List::Util)
@@ -16,9 +16,6 @@ cmake .  -DCURSES_LIBRARY=${NCURSES_ROOT}/lib/libncurses.a \
          -DCURSES_INCLUDE_PATH=${NCURSES_ROOT}/include \
          -DZLIB_LIBRARY=${ZLIB_ROOT}/lib/libz.so \
          -DZLIB_INCLUDE_DIR=${ZLIB_ROOT}/include \
-         -DOPENSSL_LIBRARIES=${OPENSSL_ROOT}/lib/libssl.so \
-         -DOPENSSL_INCLUDE_DIR=${OPENSSL_ROOT}/include \
-         -DCRYPTO_LIBRARY=${OPENSSL_ROOT}/lib/libcrypto.so \
          -DLIBXML2_LIBRARIES=${LIBXML2_ROOT}/lib/libxml2.so \
          -DLIBXML2_INCLUDE_DIR=${LIBXML2_ROOT}/include/libxml2 \
          -DHAVE_VIDATTR:INTERNAL=0 \

--- a/mariadb.spec
+++ b/mariadb.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH %{dynamic_path_var} %i/lib/mysql
 ## INITENV +PATH PATH %i/scripts
 ## INITENV SET MYSQL_HOME $MYSQL_ROOT
-Source: https://downloads.mariadb.org/f/mariadb-%realversion/source/mariadb-%realversion.tar.gz/from/http%3A//ftp.hosteurope.de/mirror/archive.mariadb.org/?serve
+Source: https://ftp.igh.cnrs.fr/pub/archive.mariadb.org/mariadb-%{realversion}/source/mariadb-%{realversion}.tar.gz
 Requires: zlib ncurses libxml2
 BuildRequires: cmake
 Provides: perl(GD)

--- a/mod_gridsite24.spec
+++ b/mod_gridsite24.spec
@@ -1,7 +1,7 @@
 ### RPM external mod_gridsite24 2_3_4
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 Source0: https://github.com/CESNET/gridsite/archive/gridsite-core_R_%realversion.zip
-Requires: apache24 python libtool doxygen openssl libxml2
+Requires: apache24 python libtool doxygen libxml2
 
 Provides: libcanl_c.so.2()(64bit)
 
@@ -11,10 +11,9 @@ Provides: libcanl_c.so.2()(64bit)
 %build
 cd src
 sed -i \
-    -e "s,HTTPD_FLAGS=,HTTPD_FLAGS=-I${APACHE24_ROOT}/include -I${OPENSSL_ROOT}/include -I${LIBXML2_ROOT}/include/libxml2/,g" \
+    -e "s,HTTPD_FLAGS=,HTTPD_FLAGS=-I${APACHE24_ROOT}/include -I${LIBXML2_ROOT}/include/libxml2/,g" \
     -e "s,apidoc ,,g" \
     Makefile
-LDFLAGS="-L${OPENSSL_ROOT}/lib " \
 export PATH=$PATH:$DOXYGEN_ROOT/bin
 make %makeprocesses
 

--- a/nmap.spec
+++ b/nmap.spec
@@ -1,13 +1,13 @@
 ### RPM external nmap 6.49BETA4
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 Source: https://nmap.org/dist/%n-%realversion.tar.bz2
-Requires: openssl pcre
+Requires: pcre
 
 %prep
 %setup -n %n-%{realversion}
 
 %build
-./configure --prefix=%{i} --enable-static=no --without-zenmap --with-openssl=$OPENSSL_ROOT
+./configure --prefix=%{i} --enable-static=no --without-zenmap
 make %makeprocesses
 
 %install

--- a/openldap.spec
+++ b/openldap.spec
@@ -1,7 +1,7 @@
 ### RPM external openldap 2.4.44
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib
 Source: ftp://ftp.openldap.org/pub/OpenLDAP/%{n}-release/%{n}-%{realversion}.tgz
-Requires: openssl db6
+Requires: db6
 
 %prep
 %setup -q -n %{n}-%{realversion}
@@ -16,11 +16,11 @@ chmod +x ./build/config.{sub,guess}
 ./configure \
   --prefix=%{i} \
   --without-cyrus-sasl \
-  --with-tls=openssl \
+  --with-tls=openssl\
   --disable-static \
   --disable-slapd \
-  CPPFLAGS="-I${OPENSSL_ROOT}/include -I${DB6_ROOT}/include" \
-  LDFLAGS="-L${OPENSSL_ROOT}/lib -L${DB6_ROOT}/lib"
+  CPPFLAGS="-I${DB6_ROOT}/include" \
+  LDFLAGS="-L${DB6_ROOT}/lib"
 make depend
 make
 

--- a/p5-crypt-ssleay.spec
+++ b/p5-crypt-ssleay.spec
@@ -21,12 +21,4 @@ find %i -type f -name .packlist -exec rm -f {} ';'
 find %i -type f -name '*.bs' -a -size 0 -exec rm -f {} ';'
 find %i -type d -depth -exec rmdir {} 2>/dev/null ';'
 
-mkdir -p %{i}/etc/profile.d
-: > %{i}/etc/profile.d/dependencies-setup.sh
-: > %{i}/etc/profile.d/dependencies-setup.csh
-
-echo " . $r/etc/profile.d/init.sh" > %i/etc/profile.d/dependencies-setup.sh
-echo " source $r/etc/profile.d/init.csh" > %i/etc/profile.d/dependencies-setup.csh
-
 %post
-%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/p5-crypt-ssleay.spec
+++ b/p5-crypt-ssleay.spec
@@ -3,7 +3,7 @@
 ## NOCOMPILER
 %define downloadn Crypt-SSLeay
 Source: http://search.cpan.org/CPAN/authors/id/D/DL/DLAND/Crypt-SSLeay-0.57.tar.gz
-Requires: p5-extutils-makemaker openssl
+Requires: p5-extutils-makemaker
 # As of 0.57-17 Crypt-SSLeay no longer ships the ca certs and uses the system ones in:
 # Requires: /etc/pki/tls/certs/ca-bundle.crt
 
@@ -12,7 +12,7 @@ Requires: p5-extutils-makemaker openssl
 
 %build
 LC_ALL=C; export LC_ALL
-PERL_MM_USE_DEFAULT=1 perl Makefile.PL --lib=$OPENSSL_ROOT/lib INSTALL_BASE=%i
+PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALL_BASE=%i
 make pure_install
 
 %define drop_files %i/man
@@ -21,12 +21,10 @@ find %i -type f -name .packlist -exec rm -f {} ';'
 find %i -type f -name '*.bs' -a -size 0 -exec rm -f {} ';'
 find %i -type d -depth -exec rmdir {} 2>/dev/null ';'
 
-# Set environment for openssl libs needed at runtime: 
 mkdir -p %{i}/etc/profile.d
 : > %{i}/etc/profile.d/dependencies-setup.sh
 : > %{i}/etc/profile.d/dependencies-setup.csh
 
-eval r=\$OPENSSL_ROOT
 echo " . $r/etc/profile.d/init.sh" > %i/etc/profile.d/dependencies-setup.sh
 echo " source $r/etc/profile.d/init.csh" > %i/etc/profile.d/dependencies-setup.csh
 

--- a/py2-cheetah.spec
+++ b/py2-cheetah.spec
@@ -1,7 +1,7 @@
 ### RPM external py2-cheetah 2.4.0
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 Source: http://pypi.python.org/packages/source/C/Cheetah/Cheetah-%realversion.tar.gz
-Requires: python
+Requires: python py2-markdown
 
 %prep
 %setup -n Cheetah-%realversion
@@ -9,6 +9,9 @@ Requires: python
 python setup.py build
 
 %install
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
-for f in %i/bin/cheetah*; do perl -p -i -e 's{.*}{#!/usr/bin/env python} if $. == 1 && m{#!.*/bin/python}' $f; done
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/lib/python2.7/site-packages/Cheetah-2.4.0-py2.7-linux-x86_64.egg/EGG-INFO/scripts/*

--- a/py2-cryptography.spec
+++ b/py2-cryptography.spec
@@ -1,6 +1,4 @@
 ### RPM external py2-cryptography 2.4.2
 ## IMPORT build-with-pip
 
-Requires: openssl py2-cffi py2-asn1crypto py2-enum34 py2-idna py2-ipaddress py2-six
-%define PipPreBuild export LDFLAGS="-L${OPENSSL_ROOT}/lib"; \
-                    export CFLAGS="-I${OPENSSL_ROOT}/include"
+Requires: py2-cffi py2-asn1crypto py2-enum34 py2-idna py2-ipaddress py2-six

--- a/py2-lxml.spec
+++ b/py2-lxml.spec
@@ -12,5 +12,7 @@ export LDFLAGS="-L $ZLIB_ROOT/lib $LDFLAGS"
 python setup.py build
 
 %install
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python setup.py install --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;

--- a/py2-markdown.spec
+++ b/py2-markdown.spec
@@ -1,0 +1,6 @@
+### RPM external py2-markdown 3.1.1
+## IMPORT build-with-pip
+
+%define pip_name Markdown
+
+perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py2-markdown.spec
+++ b/py2-markdown.spec
@@ -3,4 +3,4 @@
 
 %define pip_name Markdown
 
-perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py2-mysqldb.spec
+++ b/py2-mysqldb.spec
@@ -3,15 +3,15 @@
 %define downloadn MySQL-python
 
 Source: https://pypi.python.org/packages/source/M/MySQL-python/%downloadn-%realversion.tar.gz
-Requires: python mariadb openssl
+Requires: python mariadb
 Patch0: py2-mysqldb-setup
 
 %prep
 %setup -n %downloadn-%realversion
 %patch0 -p0
 cat >> setup.cfg <<- EOF
-include_dirs = $MARIADB_ROOT/include:$OPENSSL_ROOT/include
-library_dirs = $MARIADB_ROOT/lib:$OPENSSL_ROOT/lib
+include_dirs = $MARIADB_ROOT/include
+library_dirs = $MARIADB_ROOT/lib
 EOF
 
 %build

--- a/py2-pycurl.spec
+++ b/py2-pycurl.spec
@@ -1,8 +1,8 @@
 ### RPM external py2-pycurl 7.43.0.3
 ## IMPORT build-with-pip
 
-%define PipBuildOptions --global-option="--with-openssl" --global-option="--openssl-dir=${OPENSSL_ROOT}"
+Requires: curl
+%define PipBuildOptions --global-option="--with-openssl"
 %define pip_name pycurl
 %define PipPreBuild export PYCURL_SSL_LIBRARY=openssl
 
-Requires: curl openssl

--- a/py2-pydoop.spec
+++ b/py2-pydoop.spec
@@ -3,7 +3,7 @@
 
 Source0: https://pypi.python.org/packages/source/p/pydoop/pydoop-%realversion.tar.gz
 Source1: http://www-eu.apache.org/dist/hadoop/common/hadoop-2.6.4/hadoop-2.6.4.tar.gz 
-Requires: zlib bz2lib openssl python py2-setuptools py2-avro
+Requires: zlib bz2lib python py2-setuptools py2-avro
 BuildRequires: java-jdk
 Provides: libjvm.so()(64bit)
 

--- a/py2-pyxml.spec
+++ b/py2-pyxml.spec
@@ -1,6 +1,6 @@
 ### RPM external py2-pyxml 0.8.4
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
-Source: http://switch.dl.sourceforge.net/sourceforge/pyxml/PyXML-%{realversion}.tar.gz
+Source: https://sourceforge.net/projects/pyxml/files/pyxml/%{realversion}/PyXML-%{realversion}.tar.gz/download
 Requires: python expat
 Patch0: py2-pyxml-fix-as-keyword-usage-as-variable
 

--- a/py3-pycurl.spec
+++ b/py3-pycurl.spec
@@ -1,8 +1,8 @@
 ### RPM external py3-pycurl 7.43.0.3
 ## IMPORT build-with-pip3
 
-%define PipBuildOptions --global-option="--with-openssl" --global-option="--openssl-dir=${OPENSSL_ROOT}"
+Requires: curl
+%define PipBuildOptions --global-option="--with-openssl"
 %define pip_name pycurl
 %define PipPreBuild export PYCURL_SSL_LIBRARY=openssl
 
-Requires: curl openssl

--- a/py3-pydoop.spec
+++ b/py3-pydoop.spec
@@ -3,7 +3,7 @@
 
 Source0: https://pypi.python.org/packages/source/p/pydoop/pydoop-%realversion.tar.gz
 Source1: http://www-eu.apache.org/dist/hadoop/common/hadoop-2.6.4/hadoop-2.6.4.tar.gz 
-Requires: zlib bz2lib openssl py3-setuptools py3-avro
+Requires: zlib bz2lib py3-setuptools py3-avro
 BuildRequires: java-jdk
 Provides: libjvm.so()(64bit)
 

--- a/python-ldap.spec
+++ b/python-ldap.spec
@@ -14,5 +14,8 @@ perl -p -i -e "s:(defines = )(.*):\1 HAVE_TLS HAVE_LIBLDAP_R:g" setup.cfg
 python setup.py build
 
 %install
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
 python setup.py install --prefix=%i 
 find %i -name '*.egg-info' -exec rm {} \;
+perl -p -i -e 's{^#!.*/python}{#!/usr/bin/env python}' %i/bin/*

--- a/python-ldap.spec
+++ b/python-ldap.spec
@@ -11,6 +11,8 @@ Requires: python openldap
 perl -p -i -e "s:(library_dirs =)(.*):\1 ${PYTHON_ROOT}/lib ${OPENLDAP_ROOT}/lib:g" setup.cfg
 perl -p -i -e "s:(include_dirs =)(.*):\1 ${PYTHON_ROOT}/include ${OPENLDAP_ROOT}/include:g" setup.cfg
 perl -p -i -e "s:(defines = )(.*):\1 HAVE_TLS HAVE_LIBLDAP_R:g" setup.cfg
+# to avoid a UnicodeDecodeError exception
+perl -p -i -e "s/Michael Ströder/Michael Stroder/g" setup.cfg
 python setup.py build
 
 %install

--- a/python-ldap.spec
+++ b/python-ldap.spec
@@ -2,14 +2,14 @@
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 
 Source: http://pypi.python.org/packages/source/p/%n/%n-%{realversion}.tar.gz
-Requires: python openssl openldap
+Requires: python openldap
 
 %prep
 %setup -q -n %n-%{realversion}
 
 %build
-perl -p -i -e "s:(library_dirs =)(.*):\1 ${OPENSSL_ROOT}/lib ${PYTHON_ROOT}/lib ${OPENLDAP_ROOT}/lib:g" setup.cfg
-perl -p -i -e "s:(include_dirs =)(.*):\1 ${OPENSSL_ROOT}/include ${PYTHON_ROOT}/include ${OPENLDAP_ROOT}/include:g" setup.cfg
+perl -p -i -e "s:(library_dirs =)(.*):\1 ${PYTHON_ROOT}/lib ${OPENLDAP_ROOT}/lib:g" setup.cfg
+perl -p -i -e "s:(include_dirs =)(.*):\1 ${PYTHON_ROOT}/include ${OPENLDAP_ROOT}/include:g" setup.cfg
 perl -p -i -e "s:(defines = )(.*):\1 HAVE_TLS HAVE_LIBLDAP_R:g" setup.cfg
 python setup.py build
 

--- a/python.spec
+++ b/python.spec
@@ -10,7 +10,7 @@
 Requires: expat bz2lib db4 gdbm
 
 %if "%online" != "true"
-Requires: zlib openssl sqlite readline ncurses
+Requires: zlib sqlite readline ncurses
 %endif
 
 # FIXME: crypt
@@ -49,7 +49,7 @@ done
 mkdir -p %i/include %i/lib %i/bin
 
 %if "%online" != "true"
-%define extradirs ${ZLIB_ROOT} ${OPENSSL_ROOT} ${SQLITE_ROOT}
+%define extradirs ${ZLIB_ROOT} ${SQLITE_ROOT}
 %else
 %define extradirs %{nil}
 %endif

--- a/python3.spec
+++ b/python3.spec
@@ -7,7 +7,7 @@
 %define pythonv %(echo %realversion | cut -d. -f 1,2)
 %define python_major %(echo %realversion | cut -d. -f 1)
 
-Requires: expat bz2lib db6 gdbm openssl libffi zlib sqlite xz libuuid
+Requires: expat bz2lib db6 gdbm libffi zlib sqlite xz libuuid
 
 Source: https://www.python.org/ftp/python/%realversion/Python-%realversion.tgz
 
@@ -25,7 +25,7 @@ export LIBFFI_ROOT
 # Python's configure parses LDFLAGS and CPPFLAGS to look for aditional library and include directories
 LDFLAGS=""
 CPPFLAGS=""
-for d in ${EXPAT_ROOT} ${BZ2LIB_ROOT} ${DB6_ROOT} ${GDBM_ROOT} ${OPENSSL_ROOT} ${LIBFFI_ROOT} ${ZLIB_ROOT} ${SQLITE_ROOT} ${XZ_ROOT} ${LIBUUID_ROOT}; do
+for d in ${EXPAT_ROOT} ${BZ2LIB_ROOT} ${DB6_ROOT} ${GDBM_ROOT} ${LIBFFI_ROOT} ${ZLIB_ROOT} ${SQLITE_ROOT} ${XZ_ROOT} ${LIBUUID_ROOT}; do
   [ -e $d/lib ]     && LDFLAGS="$LDFLAGS -L$d/lib"
   [ -e $d/lib64 ]   && LDFLAGS="$LDFLAGS -L$d/lib64"
   [ -e $d/include ] && CPPFLAGS="$CPPFLAGS -I$d/include"
@@ -35,7 +35,6 @@ done
   --prefix=%{i} \
   --enable-shared \
   --enable-ipv6 \
-  --with-openssl=${OPENSSL_ROOT} \
   --with-system-ffi \
   --without-ensurepip \
   --with-system-expat \

--- a/root.spec
+++ b/root.spec
@@ -11,7 +11,7 @@ Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 
-Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python fftw3 xz xrootd libxml2 openssl zlib davix tbb OpenBLAS py2-numpy lz4
+Requires: gsl libjpeg-turbo libpng libtiff giflib pcre python fftw3 xz xrootd libxml2 zlib davix tbb OpenBLAS py2-numpy lz4
 
 %if %islinux
 Requires: dcap
@@ -84,8 +84,6 @@ cmake ../%{n}-%{realversion} \
   -DGSL_CONFIG_EXECUTABLE="$(which gsl-config)" \
   -Dcxx17=ON \
   -Dssl=ON \
-  -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT}" \
-  -DOPENSSL_INCLUDE_DIR="${OPENSSL_ROOT}/include" \
   -Dpython=ON \
   -Dxrootd=ON \
   -Dbuiltin_xrootd=OFF \
@@ -135,7 +133,7 @@ cmake ../%{n}-%{realversion} \
   -DLIBLZ4_LIBRARY="${LZ4_ROOT}/lib/liblz4.%{soext}" \
   -DZLIB_ROOT="${ZLIB_ROOT}" \
   -DZLIB_INCLUDE_DIR="${ZLIB_ROOT}/include" \
-  -DCMAKE_PREFIX_PATH="${XZ_ROOT};${OPENSSL_ROOT};${GIFLIB_ROOT};${FREETYPE_ROOT};${PYTHON_ROOT};${LIBPNG_ROOT};${PCRE_ROOT};${TBB_ROOT};${OPENBLAS_ROOT};${DAVIX_ROOT};${LZ4_ROOT};${LIBXML2_ROOT}"
+  -DCMAKE_PREFIX_PATH="${XZ_ROOT};${GIFLIB_ROOT};${FREETYPE_ROOT};${PYTHON_ROOT};${LIBPNG_ROOT};${PCRE_ROOT};${TBB_ROOT};${OPENBLAS_ROOT};${DAVIX_ROOT};${LZ4_ROOT};${LIBXML2_ROOT}"
 
 # For CMake cache variables: http://www.cmake.org/cmake/help/v3.2/manual/cmake-language.7.html#lists
 # For environment variables it's OS specific: http://www.cmake.org/Wiki/CMake_Useful_Variables

--- a/skipfish.spec
+++ b/skipfish.spec
@@ -1,13 +1,13 @@
 ### RPM external skipfish 2.10b
 Source: http://skipfish.googlecode.com/files/%n-%realversion.tgz
-Requires: openssl pcre libidn
+Requires: pcre libidn
 
 %prep
 %setup -q -n %n-%{realversion}
 
 %build
-export CFLAGS="-I${OPENSSL_ROOT}/include -I${PCRE_ROOT}/include -I${LIBIDN_ROOT}/include"
-export LDFLAGS="-L${OPENSSL_ROOT}/lib -L${PCRE_ROOT}/lib -L${LIBIDN_ROOT}/lib"
+export CFLAGS="-I${PCRE_ROOT}/include -I${LIBIDN_ROOT}/include"
+export LDFLAGS="-L${PCRE_ROOT}/lib -L${LIBIDN_ROOT}/lib"
 make %{makeprocesses}
 
 %install

--- a/spacemon-client.spec
+++ b/spacemon-client.spec
@@ -24,7 +24,7 @@ Provides: perl(LWP::UserAgent)
 mkdir -p %i/DMWMMON
 tar -c SpaceMon | tar -x -C %i/DMWMMON
 
-# Add p5-crypt-ssleay/openssl environment required at run time
+# Add p5-crypt-ssleay/environment required at run time
 mkdir -p %i/etc/profile.d
 : > %i/etc/profile.d/dependencies-setup.sh
 : > %i/etc/profile.d/dependencies-setup.csh

--- a/webtools.spec
+++ b/webtools.spec
@@ -5,7 +5,7 @@
 %define gittag V01-03-48
 Source: git://github.com/geneguvo/webtools?obj=master/%gittag&export=%n&output=/%n.tar.gz
 
-Requires: python cherrypy py2-cheetah yui sqlite zlib py2-pysqlite expat openssl bz2lib db4 gdbm py2-cx-oracle py2-formencode py2-pycrypto oracle beautifulsoup py2-sqlalchemy oracle-env py2-pyOpenSSL
+Requires: python cherrypy py2-cheetah yui sqlite zlib py2-pysqlite expat bz2lib db4 gdbm py2-cx-oracle py2-formencode py2-pycrypto oracle beautifulsoup py2-sqlalchemy oracle-env py2-pyOpenSSL
 Requires: p5-crypt-cbc p5-crypt-blowfish
 
 Provides: perl(SecurityModule) 

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -9,7 +9,6 @@ Source: git+https://github.com/%github_user/xrootd.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake
 Requires: zlib
-Requires: openssl
 Requires: python
 
 %prep
@@ -32,7 +31,6 @@ cd build
 # libfuse and libperl are not produced by CMSDIST.
 cmake ../ \
   -DCMAKE_INSTALL_PREFIX=%{i} \
-  -DOPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT} \
   -DZLIB_ROOT:PATH=${ZLIB_ROOT} \
   -DENABLE_PYTHON=FALSE \
   -DENABLE_FUSE=FALSE \


### PR DESCRIPTION
This PR rebuilds the whole SLC7 COMP software stack, removing the dependency on our OpenSSL spec (even though the spec remains here) and relying on the system-based OpenSSL (apparently 1.0.2k-fips), thus requiring our nodes where we run those applications to have the following RPMs installed:
```
openssl openssl-devel openssl-libs
```

With the changes provided in this PR, I managed to build the whole stack of COMP packages, uploaded to my private repo (cmsrep.amaltaro) and successfully ran tests with WMCore/MongoDB/CouchDB central services and submitted/executed jobs with WMAgent as well. So everything seems to be working as expected, but further tests are likely required..

NOTE 1: when trying to build it myself, build of the `mod_gridsite24.spec` spec fails. If I remove its dependency from the `frontend.spec` everything goes fine. Central services deployed like that work, including the frontend/apache. Build bot does not complain about it though, so the requirement remains there.
NOTE 2: crabtaskworker also failed to be built on my private tests. Hence, I created that patch to manage to build it. Patch has been commented out in this PR because the build BOT does not complain about it
NOTE 3: for the erlang changes, here is one of the sources that had suggestions on how to fix that missing symbol: http://erlang.org/pipermail/erlang-questions/2014-February/076760.html