### PR TITLE
Rename workqueue python build name to global-workqueue

### DIFF
--- a/workqueue.spec
+++ b/workqueue.spec
@@ -12,11 +12,11 @@ Requires: jemalloc cmsmonitoring
 %setup -b 0 -n %n
 
 %build
-python setup.py build_system -s workqueue
+python setup.py build_system -s global-workqueue
 
 %install
 mkdir -p %i/{x,}{bin,lib,data,doc} %i/{x,}$PYTHON_LIB_SITE_PACKAGES
-python setup.py install_system -s workqueue --prefix=%i
+python setup.py install_system -s global-workqueue --prefix=%i
 find %i -name '*.egg-info' -exec rm {} \;
 
 mkdir -p %i/bin


### PR DESCRIPTION
As part of the WMCore transition to PyPI packaging, we will update the WMCore internal naming of `workqueue` to `global-workqueue`. Workqueue was already taken as a PyPI package name, so WMCore code was updated to use `global-workqueue` to reference the set of code dependencies and build a `global-workqueue` pypi package.

This will not impact the name of the `workqueue` RPM. It will stay the same. The changes proposed in this PR just allow us to build both the RPM and PyPI based packages using the `global-workqueue` name. Additional details can be found in https://github.com/dmwm/WMCore/pull/10059 

This PR depends on merging https://github.com/dmwm/WMCore/pull/10059