### PR TITLE
[OpenLoops] do not build pplljj_ew  for aarch64 as it again fails to build

### DIFF
--- a/openloops.spec
+++ b/openloops.spec
@@ -24,9 +24,16 @@ born_optimisation = -O2
 loop_optimisation = -O0
 link_optimisation = -O2
 EOF
+
+%ifarch aarch64
+grep -v '^pplljj_ew$' %{_sourcedir}/openloops-user.coll > openloops-user.coll
+%else
+cp %{_sourcedir}/openloops-user.coll openloops-user.coll
+%endif
+
 export SCONSFLAGS="-j %{compiling_processes}"
 ./openloops update --processes generator=0
-./openloops libinstall %{_sourcedir}/openloops-user.coll
+./openloops libinstall openloops-user.coll
 
 %install
 mkdir %i/{lib,proclib}


### PR DESCRIPTION
With GCC9 on aarch64, we again have openloops failing to build due to large function size. Removing another big object for aarch64 allow us to build