### PR TITLE
[BuildRuiel] Do not drop optimization flags for header checks

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -62,7 +62,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-01-08
+%define configtag       V06-01-09
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
GCC seems to work with optimization flags for header checks