### PR TITLE
Upgrade Herwig to v7.2.1, and add patch to fix crash when reading lhe…

### DIFF
--- a/FxFxFileReader.patch
+++ b/FxFxFileReader.patch
@@ -1,0 +1,63 @@
+--- Herwig-7.2.1/MatrixElement/FxFx/FxFxFileReader.cc	2020-10-11 13:40:21.000000000 +0300
++++ FxFxFileReader_fix.cc	2020-10-11 17:02:37.000000000 +0300
+@@ -527,6 +527,14 @@
+        */
+       if(readingInitWeights_sc && !cfile.find("</weightgroup") && !cfile.find("<weightgroup")) {
+ 	hs = cfile.getline();
++	//cout << "hs=" << hs << endl;
++	//cout << "weightinfo= " << weightinfo << endl;
++	//fix for potential new lines:
++	if(!cfile.find("<weight") and !cfile.find("</weightgroup")) {
++	  weightinfo = weightinfo + hs;
++	  //cout << "weightinfo fixed= " << weightinfo << endl;
++	  continue;
++	}
+ 	istringstream isc(hs);
+ 	int ws = 0;
+ 	/* get the name that will be used to identify the scale 
+@@ -544,10 +552,10 @@
+ 	unsigned firstLim = hs.find(startDEL); //find start of delimiter
+ //	unsigned lastLim = hs.find(stopDEL); //find end of delimitr
+ 	string scinfo = hs.substr(firstLim); //define the information for the scale
+-
+ 	erase_substr(scinfo,stopDEL);
+ 	erase_substr(scinfo,startDEL);
+         scinfo = StringUtils::stripws(scinfo);
++	//cout << "scinfo = " << scinfo << endl;
+ 	/* fill in the map 
+ 	 * indicating the information to be appended to each scale
+ 	 * i.e. scinfo for each scalname
+@@ -562,7 +570,6 @@
+     }
+    
+     if ( cfile.find("<header") ) {
+-      // We have hit the header block, so we should dump this and all
+       // following lines to headerBlock until we hit the end of it.
+       readingHeader = true;
+       headerBlock = cfile.getline() + "\n";
+@@ -725,6 +732,7 @@
+ 	++wi;
+       } while (iss);
+       // store the optional weights found in the temporary map
++      //cout << "weightName, weightValue= " << weightName << ", " << weightValue << endl;
+       optionalWeightsTemp[weightName] = weightValue; 
+     }
+     
+@@ -786,9 +794,16 @@
+   }
+   // loop over the optional weights and add the extra information as found in the init
+   for (map<string,double>::const_iterator it=optionalWeightsTemp.begin(); it!=optionalWeightsTemp.end(); ++it){
++    string itfirst = it->first;
++    erase_substr(itfirst, "'");
++    erase_substr(itfirst, "\"");
+     for (map<string,string>::const_iterator it2=scalemap.begin(); it2!=scalemap.end(); ++it2){
+       //find the scale id in the scale information and add this information
+-      if(it->first==it2->first) { 
++      string it2first = it2->first;
++      erase_substr(it2first, "'");
++      erase_substr(it2first, "\"");
++      //cout << "itfirst, it2first = " << itfirst << "\t" << it2first << endl;
++      if(itfirst==it2first) { 
+         string info = it2->second;
+ 	string str_newline = "\n";
+ 	erase_substr(info, str_newline);

--- a/herwigpp.spec
+++ b/herwigpp.spec
@@ -1,4 +1,4 @@
-### RPM external herwigpp 7.2.0
+### RPM external herwigpp 7.2.1
 Source: https://www.hepforge.org/archive/herwig/Herwig-%{realversion}.tar.bz2
 
 Requires: lhapdf
@@ -15,8 +15,12 @@ Requires: openloops
 %endif
 BuildRequires: autotools
 
+Patch0: FxFxFileReader
+
 %prep
 %setup -q -n Herwig-%{realversion}
+
+%patch0 -p1
 
 # Regenerate build scripts
 autoreconf -fiv

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -1,4 +1,4 @@
-### RPM external thepeg 2.2.0
+### RPM external thepeg 2.2.1
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib/ThePEG
 ## INITENV +PATH DYLD_LIBRARY_PATH %{i}/lib/ThePEG
 


### PR DESCRIPTION
Update Herwig v7.2.0->v7.2.1, and add patch which fixes crash when reading LHE files with comments in weight groups.

Tested by checking read-in of LHE files with problematic comments from Madgraph now runs without problems, and using runTheMatrix workflow 535 and Matchbox test command from the Herwig twiki