### PR TITLE
Update py3-nootbook to version 6.1.5

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -158,7 +158,7 @@ neurolab==0.3.5
 nose-parameterized==0.6.0
 nose==1.3.7
 notebook==5.7.10 ; python_version<'3.0'
-notebook==6.1.4 ; python_version>'3.0'
+notebook==6.1.5 ; python_version>'3.0'
 numba==0.51.2 ; python_version>'3.0'
 numexpr==2.7.1
 numpy==1.16.6 ; python_version<'3.0'


### PR DESCRIPTION
Github checks suggest to update to fix the vulnerability 
https://github.com/cms-sw/cmsdist/network/alert/pip/requirements.txt/notebook/open