### PR TITLE
Tensorflow: export LD_LIBRARY_PATH so protoc.bin command works when generating C and C++ files from proto files.

### DIFF
--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -143,11 +143,11 @@ bazel $BAZEL_OPTS //tensorflow/core/profiler
 bazel $BAZEL_OPTS //tensorflow:install_headers
 
 # rebuild *.pb.{h|cc} files using the external protobuf compiler
-chmod -R a+rwX $PWD/bazel-bin/tensorflow/include
-for f in $(find tensorflow -name "*.proto")
-do
-    protoc --cpp_out=$PWD/bazel-bin/tensorflow/include $f
-done
+#chmod -R a+rwX $PWD/bazel-bin/tensorflow/include
+#for f in $(find tensorflow -name "*.proto")
+#do
+#    protoc --cpp_out=$PWD/bazel-bin/tensorflow/include $f
+#done
 %endif
 
 %install

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -73,6 +73,7 @@ export TF_NEED_ROCM=0
 export TF_NEED_TENSORRT=0
 export TEST_TMPDIR=%{_builddir}/build
 export TF_CMS_EXTERNALS="%{_builddir}/cms_externals.txt"
+export LD_LIBRARY_PATH
 
 echo "png:${LIBPNG_ROOT}"                   >  ${TF_CMS_EXTERNALS}
 echo "libjpeg_turbo:${LIBJPEG_TURBO_ROOT}"  >> ${TF_CMS_EXTERNALS}


### PR DESCRIPTION
Noticed the build of tensorflow:tensorflow would fail when invoking protoc because a newer libstdc++ was not found in the environment. Exporting LD_LIBRARY_PATH allowed the shell invoked by bazel to have the correct LD_LIBRARY_PATH set. 