### PR TITLE
Update CLHEP to 2.4.4.0

### DIFF
--- a/clhep.spec
+++ b/clhep.spec
@@ -1,6 +1,6 @@
-### RPM external clhep 2.4.1.3
+### RPM external clhep 2.4.4.0
 
-%define tag bf87ac557a7be3a8a2ead6b27fbbc89dd7ed4c0b
+%define tag eb4138d955a4b923551fdd65788d9f48d8a57fbb
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
please test
the external builds with g4 and vecgeom 117, 
checking if this version will cause comparison differences etc.
it's the shortest way to get new geant4 branch changes, see
https://github.com/cms-sw/cmssw/pull/32420 