### PR TITLE
Rename herwigpp tool to herwig7

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -41,7 +41,7 @@ Requires: hector-toolfile
 Requires: hepmc-toolfile
 Requires: heppdt-toolfile
 Requires: herwig-toolfile
-Requires: herwigpp-toolfile
+Requires: herwig7-toolfile
 Requires: hydjet-toolfile
 Requires: ittnotify-toolfile
 Requires: jemalloc-toolfile

--- a/herwig7-toolfile.spec
+++ b/herwig7-toolfile.spec
@@ -1,5 +1,5 @@
-### RPM external herwigpp-toolfile 1.0
-Requires: herwigpp
+### RPM external herwig7-toolfile 1.0
+Requires: herwig7
 %prep
 
 %build
@@ -7,8 +7,8 @@ Requires: herwigpp
 %install
 
 mkdir -p %i/etc/scram.d
-cat << \EOF_TOOLFILE >%i/etc/scram.d/herwigpp.xml
-<tool name="herwigpp" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/herwig7.xml
+<tool name="herwig7" version="@TOOL_VERSION@">
   <lib name="HerwigAPI"/>
   <client>
     <environment name="HERWIGPP_BASE" default="@TOOL_ROOT@"/>

--- a/herwig7.spec
+++ b/herwig7.spec
@@ -1,4 +1,4 @@
-### RPM external herwigpp 7.2.1
+### RPM external herwig7 7.2.1
 Source: https://www.hepforge.org/archive/herwig/Herwig-%{realversion}.tar.bz2
 
 Requires: lhapdf
@@ -69,7 +69,7 @@ chmod +x %{i}/bin/Herwig
 
 %post
 %{relocateConfig}bin/herwig-config
-%{relocateConfig}bin/Herwig++
+%{relocateConfig}bin/Herwig7
 %{relocateConfig}bin/Herwig-cms
 %{relocateConfig}bin/ufo2herwig
 %{relocateConfig}lib/Herwig/*.la


### PR DESCRIPTION
Rename herwigpp.spec to herwig7.spec and similarly change the tool name so that it can be found by "scram tool info herwig7" and gen checking script. Tested with runTheMatrix workflow 535 and test command from Herwig twiki.