### PR TITLE
Update to CUDA 11.2

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -22,13 +22,13 @@
 %define cuda_flags_0 -O3
 
 # generate debugging information for device code
-%define cuda_flags_1 --generate-line-info --source-in-ptx
+%define cuda_flags_1 --generate-line-info --source-in-ptx --display-error-number
 
 # imply __host__, __device__ attributes in constexpr functions
 %define cuda_flags_2 --expt-relaxed-constexpr
 
 # allow __host__, __device__ attributes in lambda declaration
-%define cuda_flags_3 --expt-extended-lambda
+%define cuda_flags_3 --extended-lambda
 
 # build support for the various compute architectures
 %define cuda_flags_4 %(echo $(for ARCH in %cuda_arch; do echo "-gencode arch=compute_$ARCH,code=sm_$ARCH"; done)) -Wno-deprecated-gpu-targets

--- a/cuda-toolfile.spec
+++ b/cuda-toolfile.spec
@@ -117,7 +117,7 @@ EOF_TOOLFILE
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/cuda-nvml.xml
 <tool name="cuda-nvml" version="@TOOL_VERSION@">
   <info url="https://docs.nvidia.com/deploy/nvml-api/index.html"/>
-  <use name="cuda"/>
+  <use name="cuda-stubs"/>
   <lib name="nvidia-ml"/>
 </tool>
 EOF_TOOLFILE

--- a/cuda.spec
+++ b/cuda.spec
@@ -35,8 +35,9 @@ mkdir -p %{i}/lib64/stubs
 mv %_builddir/build/lib64/libcudadevrt.a %{i}/lib64/
 rm -f %_builddir/build/lib64/lib*.a
 
-# package only the CUDA driver library stub
+# package only the CUDA driver and NVML library stub
 mv %_builddir/build/lib64/stubs/libcuda.so %{i}/lib64/stubs/
+mv %_builddir/build/lib64/stubs/libnvidia-ml.so %{i}/lib64/stubs/
 rm -rf %_builddir/build/lib64/stubs/
 
 # do not package the OpenCL libraries

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,6 +1,6 @@
-### RPM external cuda 11.1.1
+### RPM external cuda 11.2.0
 
-%define driversversion 455.32.00
+%define driversversion 460.27.04
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,4 +1,5 @@
 ### RPM external cuda 11.2.0
+## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define driversversion 460.27.04
 


### PR DESCRIPTION
Update to CUDA 11.2 (11.2.0):
  * CUDA runtime version 11.2.72
  * NVIDIA drivers version 460.27.04

Various new fetures and bug fixes.

See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html .