### PR TITLE
Update OpenMPI to 4.1.0, and add extra support libraries

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -68,6 +68,7 @@ Requires: python-toolfile
 Requires: python3-toolfile
 Requires: root-toolfile
 Requires: sherpa-toolfile
+Requires: libpciaccess-toolfile
 Requires: openmpi-toolfile
 Requires: sigcpp-toolfile
 Requires: sqlite-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -70,6 +70,7 @@ Requires: root-toolfile
 Requires: sherpa-toolfile
 Requires: libpciaccess-toolfile
 Requires: numactl-toolfile
+Requires: hwloc-toolfile
 Requires: openmpi-toolfile
 Requires: sigcpp-toolfile
 Requires: sqlite-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -71,6 +71,9 @@ Requires: sherpa-toolfile
 Requires: libpciaccess-toolfile
 Requires: numactl-toolfile
 Requires: hwloc-toolfile
+%ifnarch aarch64
+Requires: gdrcopy-toolfile
+%endif
 Requires: openmpi-toolfile
 Requires: sigcpp-toolfile
 Requires: sqlite-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -74,6 +74,7 @@ Requires: hwloc-toolfile
 %ifnarch aarch64
 Requires: gdrcopy-toolfile
 %endif
+Requires: ucx-toolfile
 Requires: openmpi-toolfile
 Requires: sigcpp-toolfile
 Requires: sqlite-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -69,6 +69,7 @@ Requires: python3-toolfile
 Requires: root-toolfile
 Requires: sherpa-toolfile
 Requires: libpciaccess-toolfile
+Requires: numactl-toolfile
 Requires: openmpi-toolfile
 Requires: sigcpp-toolfile
 Requires: sqlite-toolfile

--- a/gdrcopy-toolfile.spec
+++ b/gdrcopy-toolfile.spec
@@ -1,0 +1,21 @@
+### RPM external gdrcopy-toolfile 1.0
+Requires: gdrcopy
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/gdrcopy.xml
+<tool name="gdrcopy" version="@TOOL_VERSION@">
+  <lib name="gdrapi"/>
+  <client>
+    <environment name="GDRCOPY_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$GDRCOPY_BASE/include"/>
+    <environment name="LIBDIR"       default="$GDRCOPY_BASE/lib64"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,0 +1,15 @@
+### RPM external gdrcopy 2.1
+## INITENV +PATH LD_LIBRARY_PATH %i/lib64
+Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
+Requires: cuda
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+make %{makeprocesses} PREFIX=%{i} CUDA=$CUDA_ROOT lib
+
+%install
+make %{makeprocesses} PREFIX=%{i} CUDA=$CUDA_ROOT lib_install
+
+%post

--- a/hwloc-toolfile.spec
+++ b/hwloc-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external hwloc-toolfile 1.0
+Requires: hwloc
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/hwloc.xml
+<tool name="hwloc" version="@TOOL_VERSION@">
+  <lib name="hwloc"/>
+  <client>
+    <environment name="HWLOC_BASE"  default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"     default="$HWLOC_BASE/include/hwloc"/>
+    <environment name="LIBDIR"      default="$HWLOC_BASE/lib"/>
+  </client>
+  <runtime name="PATH" value="$HWLOC_BASE/bin" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/hwloc.spec
+++ b/hwloc.spec
@@ -1,0 +1,52 @@
+### RPM external hwloc 2.4.0
+Source: https://download.open-mpi.org/release/%{n}/v2.4/%{n}-%{realversion}.tar.bz2
+
+BuildRequires: autotools
+Requires: cuda libpciaccess libxml2 numactl
+
+%prep
+%setup -n %{n}-%{realversion}
+
+./configure \
+  --prefix %{i} \
+  --enable-shared \
+  --disable-static \
+  --disable-dependency-tracking \
+  --enable-cpuid \
+  --enable-cuda \
+  --enable-nvml \
+  --enable-libxml2 \
+  --disable-cairo \
+  --disable-doxygen \
+  --enable-plugins=cuda,nvml \
+  --with-pic \
+  --with-gnu-ld \
+  --without-x \
+  CPPFLAGS="-I$CUDA_ROOT/include" \
+  LDFLAGS="-L$CUDA_ROOT/lib64 -L$CUDA_ROOT/lib64/stubs" \
+  HWLOC_PCIACCESS_CFLAGS="-I$LIBPCIACCESS_ROOT/include" \
+  HWLOC_PCIACCESS_LIBS="-L$LIBPCIACCESS_ROOT/lib -lpciaccess" \
+  HWLOC_LIBXML2_CFLAGS="-I$LIBXML2_ROOT/include/libxml2" \
+  HWLOC_LIBXML2_LIBS="-L$LIBXML2_ROOT/lib -lxml2" \
+  HWLOC_NUMA_CFLAGS="-I$NUMACTL_ROOT/include" \
+  HWLOC_NUMA_LIBS="-L$NUMACTL_ROOT/lib -lnuma"
+
+%build
+make %{makeprocesses} 
+
+%install
+make install
+
+# remove the libtool library files
+rm -f  %{i}/lib/lib*.la
+rm -f  %{i}/lib/hwloc/*.la
+
+# remove unnecessary or unwanted files
+rm -rf %{i}/sbin
+rm -rf %{i}/share/doc
+rm -rf %{i}/share/hwloc
+rm -f  %{i}/share/man/man1/hwloc-dump-hwdata.1
+
+%post
+%{relocateConfig}bin/hwloc-compress-dir
+%{relocateConfig}bin/hwloc-gather-topology

--- a/libpciaccess-toolfile.spec
+++ b/libpciaccess-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external libpciaccess-toolfile 1.0
+Requires: libpciaccess 
+
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/libpciaccess.xml
+<tool name="libpciaccess" version="@TOOL_VERSION@">
+  <lib name="libpciaccess"/>
+  <client>
+    <environment name="LIBPCIACCESS_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"            default="$LIBPCIACCESS_BASE/lib"/>
+    <environment name="INCLUDE"           default="$LIBPCIACCESS_BASE/include"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/libpciaccess.spec
+++ b/libpciaccess.spec
@@ -1,0 +1,24 @@
+### RPM external libpciaccess 0.16
+# use the packaged sources from Debian instead of the developer sources from Xorg gitlab
+# to avoid the dependency on the xorg-macros package
+Source: http://deb.debian.org/debian/pool/main/libp/%{n}/%{n}_%{realversion}.orig.tar.gz
+
+BuildRequires: autotools
+Requires: zlib
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+./configure \
+  --prefix %{i} \
+  --disable-dependency-tracking \
+  --enable-shared \
+  --disable-static \
+  --with-pic \
+  --with-gnu-ld \
+  --with-zlib \
+  CPPFLAGS="-I$ZLIB_ROOT/include" \
+  LDFLAGS="-L$ZLIB_ROOT/lib"
+
+%post

--- a/numactl-toolfile.spec
+++ b/numactl-toolfile.spec
@@ -1,0 +1,23 @@
+### RPM external numactl-toolfile 1.0
+Requires: numactl
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/numactl.xml
+<tool name="numactl" version="@TOOL_VERSION@">
+  <lib name="numa"/>
+  <client>
+    <environment name="NUMACTL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$NUMACTL_BASE/include"/>
+    <environment name="LIBDIR"       default="$NUMACTL_BASE/lib"/>
+  </client>
+  <runtime name="PATH" value="$NUMACTL_BASE/bin" type="path"/>
+  <runtime name="MANPATH" value="$NUMACTL_BASE/share/man" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/numactl.spec
+++ b/numactl.spec
@@ -1,0 +1,27 @@
+### RPM external numactl 2.0.14
+## INITENV +PATH MANPATH %i/share/man
+BuildRequires: autotools
+Source: https://github.com/%{n}/%{n}/archive/v%{realversion}.tar.gz
+
+%prep
+%setup -n %{n}-%{realversion}
+
+./autogen.sh
+./configure \
+  --prefix=%{i} \
+  --enable-shared \
+  --disable-static \
+  --disable-dependency-tracking \
+  --with-pic \
+  --with-gnu-ld
+
+%build
+make %{makeprocesses}
+
+%install
+make install
+
+# Remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
+rm -rf %{i}/lib/pkgconfig
+
+%post

--- a/openmpi-toolfile.spec
+++ b/openmpi-toolfile.spec
@@ -6,18 +6,19 @@ Requires: openmpi
 %build
 
 %install
+
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/openmpi.xml
 <tool name="openmpi" version="@TOOL_VERSION@">
-<lib name="mpi"/>
-<lib name="mpi_cxx"/>
-<client>
-<environment name="OPENMPI_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$OPENMPI_BASE/lib"/>
-<environment name="INCLUDE" default="$OPENMPI_BASE/include"/>
-</client>
-<runtime name="PATH" value="$OPENMPI_BASE/bin" type="path"/>
-<runtime name="OPAL_PREFIX" value="$OPENMPI_BASE"/>
+  <lib name="mpi"/>
+  <lib name="mpi_cxx"/>
+  <client>
+    <environment name="OPENMPI_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$OPENMPI_BASE/lib"/>
+    <environment name="INCLUDE"      default="$OPENMPI_BASE/include"/>
+  </client>
+  <runtime name="PATH" value="$OPENMPI_BASE/bin" type="path"/>
+  <runtime name="OPAL_PREFIX" value="$OPENMPI_BASE"/>
 </tool>
 EOF_TOOLFILE
 

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,16 +1,48 @@
-### RPM external openmpi 4.0.5
+### RPM external openmpi 4.1.0
 ## INITENV SET OPAL_PREFIX %{i}
-Source: http://download.open-mpi.org/release/open-mpi/v4.0/%{n}-%{realversion}.tar.gz
+Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools
+Requires: zlib cuda hwloc ucx
+# external libraries are needed for additional protocols:
+#   --with-ofi:         Open Fabric Interface's libfabric
+#   --with-mxm:         Mellanox Messaging
+#   --with-fca:         Mellanox Fabric Collective Accelerator
+#   --with-hcoll:       Mellanox Hierarchical Collectives
+#   --with-lsf:         LSF job scheduler
+#   --with-lustre:      Lustre filesystem
+# etc.
 
 %prep
 %setup -q -n %{n}-%{realversion}
 
-./autogen.pl --force
-./configure --prefix=%i --without-lsf --disable-libnuma --enable-mpi-cxx --enable-mpi-thread-multiple
+./configure \
+  --prefix=%i \
+  --disable-dependency-tracking \
+  --enable-ipv6 \
+  --enable-mpi-cxx \
+  --enable-shared \
+  --disable-static \
+  --enable-cxx-exceptions \
+  --disable-mpi-java \
+  --enable-openib-rdmacm-ibaddr \
+  --with-zlib=$ZLIB_ROOT \
+  --with-cuda=$CUDA_ROOT \
+  --with-hwloc=$HWLOC_ROOT \
+  --with-ucx=$UCX_ROOT \
+  --without-x \
+  --with-pic \
+  --with-gnu-ld
 
 %build
 make %{makeprocesses} 
 
 %install
 make install
+
+# remove the libtool library files
+rm -f %{i}/lib/lib*.la
+rm -f %{i}/lib/pmix/lib*.la
+rm -f %{i}/lib/openmpi/lib*.la
+
+%post
+%{relocateConfig}share/openmpi/*-wrapper-data.txt

--- a/ucx-toolfile.spec
+++ b/ucx-toolfile.spec
@@ -1,0 +1,25 @@
+### RPM external ucx-toolfile 1.0
+Requires: ucx
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/ucx.xml
+<tool name="ucx" version="@TOOL_VERSION@">
+  <lib name="ucp"/>
+  <lib name="uct"/>
+  <lib name="ucs"/>
+  <lib name="ucm"/>
+  <client>
+    <environment name="UCX_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"  default="$UCX_BASE/include"/>
+    <environment name="LIBDIR"   default="$UCX_BASE/lib"/>
+  </client>
+  <runtime name="PATH" value="$UCX_BASE/bin" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,0 +1,76 @@
+### RPM external ucx 1.9.0
+Source: https://github.com/openucx/%{n}/releases/download/v%{realversion}/%{n}-%{realversion}.tar.gz
+BuildRequires: autotools
+Requires: numactl cuda
+%ifnarch aarch64
+Requires: gdrcopy
+%endif
+AutoReq: no
+# external libraries are needed for additional protocols:
+#   --with-rocm:        AMD ROCm platform for accelerated compute
+#   --with-verbs:       Verbs library for direct userspace use of RDMA (InfiniBand/iWARP) hardware
+#   --with-cm:          Userspace InfiniBand Communication Managment library
+#   --with-rdmacm:      Userspace RDMA Connection Manager
+#   --with-knem:        KNEM High-Performance Intra-Node MPI Communication
+# etc.
+
+%prep
+%setup -q -n %{n}-%{realversion}
+
+./configure \
+  --prefix=%i \
+  --disable-dependency-tracking \
+  --enable-openmp \
+  --enable-shared \
+  --disable-static \
+  --enable-ucg \
+  --disable-doxygen-doc \
+  --disable-doxygen-man \
+  --disable-doxygen-html \
+  --enable-compiler-opt \
+  --enable-cma \
+  --enable-mt \
+  --with-pic \
+  --with-gnu-ld \
+  --with-avx \
+  --with-sse41 \
+  --with-sse42 \
+  --without-java \
+  --with-cuda=$CUDA_ROOT \
+  --without-rocm \
+%ifarch aarch64
+  --without-gdrcopy \
+%else
+  --with-gdrcopy=$GDRCOPY_ROOT \
+%endif
+  --without-verbs \
+  --with-rc \
+  --with-ud \
+  --with-dc \
+  --with-mlx5-dv \
+  --with-ib-hw-tm \
+  --with-dm \
+  --without-cm \
+  --without-rdmacm \
+  --without-knem \
+  --with-xpmem \
+  CPPFLAGS="-I$NUMACTL_ROOT/include" \
+  LDFLAGS="-L$NUMACTL_ROOT/lib"
+
+%build
+make %{makeprocesses} 
+
+%install
+make install
+
+# remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
+rm -rf %{i}/lib/pkgconfig
+
+# remove the libtool library files
+rm -f %{i}/lib/lib*.la
+rm -f %{i}/lib/ucx/lib*.la
+
+# remove the UCX examples
+rm -rf %{i}/share/ucx/examples
+
+%post


### PR DESCRIPTION
###  Update OpenMPI to version 4.1.0

See https://www.open-mpi.org/software/ompi/major-changes.php for major user-noticeable changes in the OpenMPI 4.1.x and 4.0.x series.
See https://raw.githubusercontent.com/open-mpi/ompi/v4.1.x/NEWS for a detailed list of changes in the OpenMPI 4.1.x and 4.0.x series.


### Add the UCX libraries version 1.9.0
    
Unified Communication X (UCX) provides an optimized communication layer for Message Passing (MPI), PGAS/OpenSHMEM libraries and RPC/data-centric applications.
UCX utilizes high-speed networks for inter-node communication, and shared memory mechanisms for efficient intra-node communication.

For more information see:
  - https://www.openucx.org/
  - https://github.com/openucx/ucx/tree/v1.9.0


### Add the NVIDIA GDRCopy library v2.1

GDRCopy is a low-latency GPU memory copy library based on NVIDIA GPUDirect RDMA technology.

For more details, see
  - https://github.com/NVIDIA/gdrcopy/blob/v2.1/README.md
  - https://docs.nvidia.com/cuda/gpudirect-rdma/
  - https://developer.nvidia.com/gpudirect


### Add the Portable Hardware Locality (hwloc) package

The Portable Hardware Locality (hwloc) software package provides a portable abstraction (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading.
It also gathers various system attributes such as cache and memory information as well as the locality of I/O devices such as network interfaces, InfiniBand HCAs or GPUs.

See https://www.open-mpi.org/projects/hwloc/ for more details.


### Add numactl utilities and libnuma library version 2.0.14

Simple NUMA policy support. It consists of a numactl program to run other programs with a specific NUMA policy and a libnuma shared library ("NUMA API") to set NUMA policy in applications.
See https://github.com/numactl/numactl/blob/v2.0.14/README.md for more information.


### Add libpciaccess, a generic PCI access library

libpciaccess is a generic PCI access library originally developed for the Xorg project; it is now used by various other projects, for example the hwloc library developed by the OpenMPI project.

The upstream git repository is at https://gitlab.freedesktop.org/xorg/lib/libpciaccess

To avoid the dependency on the "xorg-macros" autotool package, the CMSDIST package for libpciaccess is based on the Debian package (where the autogen step has already been performed) instead of the upstream git sources.