### PR TITLE
Update TBB to the master branch

### DIFF
--- a/tbb-toolfile.spec
+++ b/tbb-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external tbb-toolfile 1.0
+### RPM external tbb-toolfile 2.0
 Requires: tbb 
 %prep
 
@@ -13,13 +13,27 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/tbb.xml
   <lib name="tbb"/>
   <client>
     <environment name="TBB_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$TBB_BASE/lib"/>
-    <environment name="INCLUDE" default="$TBB_BASE/include"/>
+    <environment name="LIBDIR"   default="$TBB_BASE/lib"/>
+    <environment name="INCLUDE"  default="$TBB_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <flags CPPDEFINES="TBB_USE_GLIBCXX_VERSION=@GCC_GLIBCXX_VERSION@"/>
   <flags CPPDEFINES="TBB_SUPPRESS_DEPRECATED_MESSAGES"/>
+  <flags SYSTEM_INCLUDE="1"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/tbbbind.xml
+<tool name="tbbbind" version="@TOOL_VERSION@">
+  <info url="http://threadingbuildingblocks.org"/>
+  <use name="tbb"/>
+  <lib name="tbbbind_2_0"/>
+  <client>
+    <environment name="TBBBIND_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$TBBBIND_BASE/lib"/>
+    <environment name="INCLUDE"      default="$TBBBIND_BASE/include"/>
+  </client>
   <flags SYSTEM_INCLUDE="1"/>
 </tool>
 EOF_TOOLFILE


### PR DESCRIPTION
Update TBB to the HEAD of the master branch as of 2021.01.12 (oneapi-src/oneTBB@d86ed7fb).
This branch is newer than `v2021.1.1`, and fixes compilation warnings with GCC 9.

Building with the HEAD version of TBB is currently know to fail.
We can use this PR to check for progress as more packages support it.