### PR TITLE
Update TBB to version v2021.1.1

### DIFF
--- a/tbb-2021.1.1-cmake_policy-CMP0074.patch
+++ b/tbb-2021.1.1-cmake_policy-CMP0074.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f71eff1..d2370ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,6 +27,10 @@ elseif (DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+     message(FATAL_ERROR "CMAKE_MSVC_RUNTIME_LIBRARY was defined while policy CMP0091 is not available. Use CMake 3.15 or newer.")
+ endif()
+ 
++if (POLICY CMP0074)
++    cmake_policy(SET CMP0074 NEW)
++endif()
++
+ if (TBB_WINDOWS_DRIVER AND (NOT ("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL MultiThreaded OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL MultiThreadedDebug)))
+     message(FATAL_ERROR "Enabled TBB_WINDOWS_DRIVER requires CMAKE_MSVC_RUNTIME_LIBRARY to be set to MultiThreaded or MultiThreadedDebug.")
+ endif()

--- a/tbb-toolfile.spec
+++ b/tbb-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external tbb-toolfile 1.0
+### RPM external tbb-toolfile 2.0
 Requires: tbb 
 %prep
 
@@ -13,13 +13,27 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/tbb.xml
   <lib name="tbb"/>
   <client>
     <environment name="TBB_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$TBB_BASE/lib"/>
-    <environment name="INCLUDE" default="$TBB_BASE/include"/>
+    <environment name="LIBDIR"   default="$TBB_BASE/lib"/>
+    <environment name="INCLUDE"  default="$TBB_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <flags CPPDEFINES="TBB_USE_GLIBCXX_VERSION=@GCC_GLIBCXX_VERSION@"/>
   <flags CPPDEFINES="TBB_SUPPRESS_DEPRECATED_MESSAGES"/>
+  <flags SYSTEM_INCLUDE="1"/>
+</tool>
+EOF_TOOLFILE
+
+cat << \EOF_TOOLFILE >%i/etc/scram.d/tbbbind.xml
+<tool name="tbbbind" version="@TOOL_VERSION@">
+  <info url="http://threadingbuildingblocks.org"/>
+  <use name="tbb"/>
+  <lib name="tbbbind_2_0"/>
+  <client>
+    <environment name="TBBBIND_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$TBBBIND_BASE/lib"/>
+    <environment name="INCLUDE"      default="$TBBBIND_BASE/include"/>
+  </client>
   <flags SYSTEM_INCLUDE="1"/>
 </tool>
 EOF_TOOLFILE

--- a/tbb.spec
+++ b/tbb.spec
@@ -1,24 +1,34 @@
-### RPM external tbb 2020_U3
+### RPM external tbb v2021.1.1
 
-%define tag %{realversion}
-%define branch tbb_2020
+%define tag    %{realversion}
+%define branch onetbb_2021
 %define github_user oneapi-src
-Source: git+https://github.com/%{github_user}/oneTBB.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+%define github_repo oneTBB
+Source: git+https://github.com/%{github_user}/%{github_repo}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{branch}-%{tag}.tgz
+# Patch tbb v2021.1.1 CMake file to support $HWLOC_ROOT
+# not needed in the tbb master branch
+Patch: tbb-2021.1.1-cmake_policy-CMP0074
+Requires: hwloc
 BuildRequires: cmake
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch -p1
 
 %build
+rm -rf %{_builddir}/build
+mkdir %{_builddir}/build
 
-make %{makeprocesses} stdver=c++17
+cd %{_builddir}/build
+cmake ../%{n}-%{realversion} \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_CXX_FLAGS=-Wno-deprecated-copy \
+  -DHWLOC_ROOT=$HWLOC_ROOT
+
+make %{makeprocesses}
 
 %install
-install -d %i/lib
-cp -r include %i/include
-case %cmsplatf in 
-  osx*) SONAME=dylib ;;
-  *) SONAME=so ;;
-esac
-find build -name "*.$SONAME*" -exec cp {} %i/lib \; 
-cmake -DINSTALL_DIR=%{i}/cmake/TBB -DSYSTEM_NAME=Linux -DINC_PATH=%{i}/include -DLIB_PATH=%{i}/lib -P cmake/tbb_config_installer.cmake
+cd %{_builddir}/build
+make install


### PR DESCRIPTION
See the [release notes](https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html) for more information.

Issues in the v2021.1.1 release (alrady resolved in the master branch):
  - patch tbb's CMakeFile.txt to find the hwloc library and enable support for NUMA-aware task_arena.
  - disable the deprecated copy warning (-Wdeprecated-copy) from GCC 9.