### PR TITLE
remove ldscript from triton build to keep typeinfo

### DIFF
--- a/triton-inference-server.spec
+++ b/triton-inference-server.spec
@@ -20,6 +20,8 @@ sed -i '/triton-json-library/d' ../%{n}-%{realversion}/src/clients/c++/library/C
 sed -i 's~add_subdirectory(../../src/clients/python src/clients/python)~~' ../%{n}-%{realversion}/build/client/CMakeLists.txt
 # remove attempts to install external libs
 sed -i '\~../../../../..~d' ../%{n}-%{realversion}/src/clients/c++/library/CMakeLists.txt
+# keep typeinfo in .so by removing ldscript from properties
+sed -i '/set_target_properties/,+5d' ../%{n}-%{realversion}/src/clients/c++/library/CMakeLists.txt
 #change flag due to bug in gcc10 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95148
 if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then 
     sed -i -e "s|Werror|Wtype-limits|g" ../%{n}-%{realversion}/build/client/CMakeLists.txt


### PR DESCRIPTION
Thanks to the quick response from the Triton team (https://github.com/triton-inference-server/server/issues/2404), a minor modification to the `CMakeLists.txt` to remove lines relating to an `ldscript` restores the `typeinfo` in the shared library. (It increases the shared library size by 25%, but it's still only 4MB, so I don't think we care very much.)