### PR TITLE
HepPDT version 3.04.01

### DIFF
--- a/heppdt.spec
+++ b/heppdt.spec
@@ -1,6 +1,6 @@
-### RPM external heppdt 3.03.00
-%define tag ad5bd2d96ca39491a5c0f729c9ebbec9a36b85bf
-%define branch cms/3.03.00
+### RPM external heppdt 3.04.01
+%define tag d17b18f5865e00fb0b548485a5fb8a633b3b25eb
+%define branch cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/heppdt.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
@@ -13,7 +13,7 @@ Requires: tbb
 %endif
 
 %if "%{?cms_cxxflags:set}" != "set"
-%define cms_cxxflags -O2 -std=c++14
+%define cms_cxxflags -O2 -std=c++17
 %endif
 
 %prep


### PR DESCRIPTION
This is still based on TBB 2020. To update to oneAPI TBB 2021 we need to update https://github.com/cms-externals/heppdt/commit/d17b18f5865e00fb0b548485a5fb8a633b3b25eb patch 