### PR TITLE
use buildLogAnalyzer.py as RPM source

### DIFF
--- a/cmssw-ib.spec
+++ b/cmssw-ib.spec
@@ -2,7 +2,7 @@
 BuildRequires: cmssw SCRAMV1 python
 %define initenv	        %initenv_direct
 %define scram $SCRAMV1_ROOT/bin/scram --arch %cmsplatf
-Source: none
+Source: https://raw.githubusercontent.com/cms-sw/cms-bot/1df3f150585134b850610df53863fd712e5fac20/buildLogAnalyzer.py
 
 %prep
 cd ..
@@ -25,7 +25,7 @@ pushd %cmsroot/WEB/build-logs/%cmsplatf/$CMSSW_VERSION/logs/src
   cp -f src-logs.tgz $(echo $CMSSW_ROOT | sed 's|%cmsroot/|%cmsroot/BUILD/|')/src-logs.tgz
   tar xzf src-logs.tgz
 popd
-curl -L -k -s -o $CMSSW_ROOT/buildLogAnalyzer.py https://raw.githubusercontent.com/cms-sw/cms-bot/master/buildLogAnalyzer.py
+cp %{_sourcedir}/buildLogAnalyzer.py $CMSSW_ROOT/buildLogAnalyzer.py
 $PYTHON_CMD $CMSSW_ROOT//buildLogAnalyzer.py \
             -r $CMSSW_VERSION \
             -p $CMSSW_ROOT/src/PackageList.cmssw \


### PR DESCRIPTION
in 53x and 71x, curl is not able to download this source due to SSL issue

```
+ curl -L -k -o /data/cmsbld/x/w/slc6_amd64_gcc472/cms/cmssw/CMSSW_5_3_X_2021-01-17-2300/buildLogAnalyzer.py https://raw.githubusercontent.com/cms-sw/cms-bot/master/buildLogAnalyzer.py
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (35) Unknown SSL protocol error in connection to raw.githubusercontent.com:443
error: Bad exit status from /data/cmsbld/x/w/tmp/rpm-tmp.pKfNdB (%build)

```