### PR TITLE
Remove dqmgui, it breaks cc8 builds

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -3,7 +3,6 @@
 
 ## NOCOMPILER
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cmssw-osenv cms-git-tools
-## UPLOAD_DEPENDENCIES dqmgui
 
 Requires: crab
 Requires: cmssw-wm-tools


### PR DESCRIPTION
@andrius-k and @jfernan2 , I integrated dqmgui ( https://github.com/cms-sw/cmsdist/pull/6371) for last night IBs but it broke our cc8 build. For now I am remove it from the stack. Once we have a fix for cc8 then we can add it back