### PR TITLE
Update DBS specs to SQLAlchemy 1.1.13

### DIFF
--- a/dbs3-migration.spec
+++ b/dbs3-migration.spec
@@ -7,7 +7,7 @@
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore&output=/WMCore4%{n}.tar.gz
 Source1: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&output=/%{n}.tar.gz
-Requires: python py2-simplejson py2-sqlalchemy096 py2-httplib2 py2-cherrypy py2-cheetah yui
+Requires: python py2-simplejson py2-sqlalchemy11 py2-httplib2 py2-cherrypy py2-cheetah yui
 Requires: py2-cjson py2-cx-oracle dbs3-pycurl-client rotatelogs pystack
 BuildRequires: py2-sphinx
 #

--- a/dbs3.spec
+++ b/dbs3.spec
@@ -8,7 +8,7 @@
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore&output=/WMCore4%{n}.tar.gz
 Source1: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&output=/%{n}.tar.gz
 
-Requires: python py2-simplejson py2-sqlalchemy096 py2-httplib2 py2-cherrypy py2-cheetah yui
+Requires: python py2-simplejson py2-sqlalchemy11 py2-httplib2 py2-cherrypy py2-cheetah yui
 Requires: py2-cjson py2-cx-oracle py2-docutils dbs3-pycurl-client rotatelogs pystack cmsmonitoring
 Requires: jemalloc
 BuildRequires: py2-sphinx

--- a/py2-sqlalchemy11.spec
+++ b/py2-sqlalchemy11.spec
@@ -1,4 +1,4 @@
-### RPM external py2-sqlalchemy096 0.9.6
+### RPM external py2-sqlalchemy11 1.1.13
 ## IMPORT build-with-pip
 
 %define pip_name SQLAlchemy


### PR DESCRIPTION
This PR provides a new spec file for SQLAlchemy version 1.1.13, which hopefully will fix the issue seen in the DBS logs with the recent cx-Oracle upgrade to 7.3.0. Issue tracked here:
https://github.com/dmwm/DBS/issues/645

This SQLAlchemy version is still expected to be using python byte strings (instead of unicode), so I expect it to solve the "twophase" issue and not to cause another one. But we can only be sure once it gets deployed.

DBS spec files have been updated to use this SQLAlchemy as well.