### PR TITLE
Complete all the python3 dependencies for wmcorepy3-devtools

### DIFF
--- a/py3-decorator.spec
+++ b/py3-decorator.spec
@@ -1,0 +1,2 @@
+### RPM external py3-decorator 4.4.2
+## IMPORT build-with-pip3

--- a/py3-memory-profiler.spec
+++ b/py3-memory-profiler.spec
@@ -1,4 +1,6 @@
-### RPM external py3-coverage 5.4
+### RPM external py3-memory-profiler 0.58.0
 ## IMPORT build-with-pip3
+
+Requires: py3-psutil
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-nose2.spec
+++ b/py3-nose2.spec
@@ -1,4 +1,6 @@
-### RPM external py3-coverage 5.4
+### RPM external py3-nose2 0.10.0
 ## IMPORT build-with-pip3
+
+Requires: py3-coverage py3-six
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-psutil.spec
+++ b/py3-psutil.spec
@@ -1,4 +1,4 @@
-### RPM external py3-psutil 5.6.6
+### RPM external py3-psutil 5.8.0
 ## IMPORT build-with-pip3
 
 %define find %i -name '*.egg-info' -delete; \

--- a/py3-py.spec
+++ b/py3-py.spec
@@ -1,0 +1,2 @@
+### RPM external py3-py 1.10.0
+## IMPORT build-with-pip3

--- a/py3-pymongo.spec
+++ b/py3-pymongo.spec
@@ -1,6 +1,4 @@
 ### RPM external py3-pymongo 3.10.1
 ## IMPORT build-with-pip3
 
-Requires: python3
-
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-retry.spec
+++ b/py3-retry.spec
@@ -1,0 +1,4 @@
+### RPM external py3-retry 0.9.2
+## IMPORT build-with-pip3
+
+Requires: py3-decorator py3-py

--- a/wmcorepy3-devtools.spec
+++ b/wmcorepy3-devtools.spec
@@ -1,7 +1,8 @@
 ### RPM cms wmcorepy3-devtools 0.1
 
 # This is a meta-package to group development tool dependencies
-Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint
+Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint py3-coverage py3-nose py3-nose2
+Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo
 
 %prep
 %build


### PR DESCRIPTION
This PR builds the final python3 spec dependencies for wmcorepy3-devtools, such as:
* memory-profiler 
* retry and its dependencies
* nose2 (which we might decide to dump in the future if we do not evaluate unit test performance/wall clock)
* and I have also updated a few other python3 specs.

More updates could have been done, but I'd like to start in a conservative mode.