### PR TITLE
To update pythia8.240 into 7_1_X to make a special release

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,22 +1,16 @@
-### RPM external pythia8 226
+### RPM external pythia8 240
 
-Requires: hepmc lhapdf
-Requires: boost
-
-%define tag 7ea2c89a92fdfe2f110a1a669c0f3b185ec2978b
+%define tag 8d04d8f5080ad06cf3806e32e20d08850fe123f0
 %define branch cms/%{realversion}
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}%{realversion}&output=/%{n}-%{realversion}.tgz
 
-%if "%{?cms_cxxflags:set}" != "set"
-%define cms_cxxflags -std=c++0x
-%endif
+Requires: hepmc lhapdf
 
 %prep
-%setup -q -n %{n}-%{realversion}
- 
-export USRCXXFLAGS="%cms_cxxflags"
-./configure --prefix=%i --enable-shared --with-boost=${BOOST_ROOT} --with-hepmc2=${HEPMC_ROOT} --with-lhapdf6=${LHAPDF_ROOT} --with-lhapdf6-plugin=LHAPDF6.h
+%setup -q -n %{n}%{realversion}
+
+./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-lhapdf6=${LHAPDF_ROOT}
 
 %build
 make %makeprocesses


### PR DESCRIPTION
Replacing https://github.com/cms-sw/cmsdist/pull/6549
This should be the minimal change to update Pythia8 to 240 in CMSSW_7_1_X, as requested by PdmV/GEN.