### PR TITLE
Create wmagentpy3-dev spec, depending on python3 stack

### DIFF
--- a/comp.spec
+++ b/comp.spec
@@ -18,7 +18,7 @@ Requires: rotatelogs pystack wmcore-devtools
 Requires: wmagent-dev condor crabtaskworker t0 couchdb15 crab-devtools
 Requires: wmarchive
 # Python3
-BuildRequires: wmcorepy3-devtools wmagentpy3
+BuildRequires: wmcorepy3-devtools wmagentpy3-dev
 ### List of services that are likely no longer needed, but nobody could confirm that..
 BuildRequires: gitweb compsec
 ### List of obsolete services (or under deprecation), stop building them!

--- a/wmagentpy3-dev.spec
+++ b/wmagentpy3-dev.spec
@@ -1,0 +1,10 @@
+### RPM cms wmagent-dev 1.4.5.pre4
+
+# This is a meta-package to group development tool dependencies
+Requires: wmagentpy3 rotatelogs pystack wmcorepy3-devtools
+Requires: jemalloc
+
+%prep
+%build
+%install
+

--- a/wmagentpy3-dev.spec
+++ b/wmagentpy3-dev.spec
@@ -1,4 +1,4 @@
-### RPM cms wmagent-dev 1.4.5.pre4
+### RPM cms wmagentpy3-dev 1.4.5.pre4
 
 # This is a meta-package to group development tool dependencies
 Requires: wmagentpy3 rotatelogs pystack wmcorepy3-devtools

--- a/wmcorepy3-devtools.spec
+++ b/wmcorepy3-devtools.spec
@@ -1,8 +1,9 @@
 ### RPM cms wmcorepy3-devtools 0.1
 
 # This is a meta-package to group development tool dependencies
+Requires: yuicompressor
 Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint py3-coverage py3-nose py3-nose2
-Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo
+Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo py3-sphinx py3-cherrypy
 
 %prep
 %build

--- a/wmcorepy3-devtools.spec
+++ b/wmcorepy3-devtools.spec
@@ -3,7 +3,7 @@
 # This is a meta-package to group development tool dependencies
 Requires: yuicompressor
 Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint py3-coverage py3-nose py3-nose2
-Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo py3-sphinx py3-cherrypy
+Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo py3-future py3-sphinx py3-cherrypy
 
 %prep
 %build


### PR DESCRIPTION
This should be the last piece required to build a python3 wmagent docker image.

There are also a few dependencies that I was missing for wmcorepy3-devtools, such as:
```
yuicompressor py3-future py3-sphinx py3-cherrypy
```

Last but not least, notice that wmcorepy3-devtools depends on `mox3` instead of the `mox` library, as defined in wmcore-devtools.