### PR TITLE
Update python2 pip to 19.3.1

### DIFF
--- a/py2-pip.spec
+++ b/py2-pip.spec
@@ -1,4 +1,4 @@
-### RPM external py2-pip 9.0.3
+### RPM external py2-pip 19.3.1
 ## INITENV +PATH PATH %{i}/bin
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib
 ## INITENV +PATH PYTHONPATH %{i}/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
It looks like a newer pip is what is required to be able to find/download some package versions from pypi (like htcondor, pylint, etc), so giving it a try.