### PR TITLE
Update python2/python3 httplib2 to version 0.19.0

### DIFF
--- a/py2-httplib2.spec
+++ b/py2-httplib2.spec
@@ -1,2 +1,4 @@
-### RPM external py2-httplib2 0.18.0
+### RPM external py2-httplib2 0.19.0
 ## IMPORT build-with-pip
+
+Requires: py2-pyparsing

--- a/py2-pyparsing.spec
+++ b/py2-pyparsing.spec
@@ -1,2 +1,2 @@
-### RPM external py2-pyparsing 2.4.0
+### RPM external py2-pyparsing 2.4.7
 ## IMPORT build-with-pip

--- a/py3-httplib2.spec
+++ b/py3-httplib2.spec
@@ -1,2 +1,4 @@
-### RPM external py3-httplib2 0.18.1
+### RPM external py3-httplib2 0.19.0
 ## IMPORT build-with-pip3
+
+Requires: py3-pyparsing

--- a/py3-pyparsing.spec
+++ b/py3-pyparsing.spec
@@ -1,0 +1,2 @@
+### RPM external py3-pyparsing 2.4.7
+## IMPORT build-with-pip3


### PR DESCRIPTION
Meant to fix a low severity vulnerability, as described here: https://github.com/advisories/GHSA-93xj-8mrv-444m

For reference, link to the release notes: https://github.com/httplib2/httplib2/blob/master/CHANGELOG 

FYI @smuzaffar , you might need it as well.