### PR TITLE
[BuildRules] Set LD_PRELOAD for various Sanitizer builds

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -62,7 +62,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-01-14
+%define configtag       V06-01-15
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
fixes cms-sw/cmssw#32854
For various Sanitizer IBs, tools (e.g. root, listcomponents pyroot) which are not build with sanitizer options failed to load CMSSW libs. Change https://github.com/cms-sw/cmssw-config/commit/80a7d7ce4b33f9292ab00d8b707e4de7f8fc0364 should now set LD_PRELOAD env for these IBs to make sure that any external tool run in cmssw env can load its libs