### PR TITLE
ReqMgr2MS / MSTransferor upgrade to 1.4.5.cmsweb1

### DIFF
--- a/reqmgr2ms.spec
+++ b/reqmgr2ms.spec
@@ -1,9 +1,9 @@
-### RPM cms reqmgr2ms 0.4.5.pre4
+### RPM cms reqmgr2ms 0.4.5.cmsweb1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-%define wmcorever 1.4.5.pre4
+%define wmcorever 1.4.5.cmsweb1
 
 Source: git://github.com/dmwm/WMCore?obj=master/%wmcorever&export=%n&output=/%n.tar.gz
 Requires: py2-cherrypy py2-pycurl py2-httplib2 py2-rucio-clients py2-retry py2-future


### PR DESCRIPTION
This release brings in this "feature" for MSTransferor: https://github.com/dmwm/WMCore/pull/10276
to handle all the RelVal workflows that are stuck in the system at the moment.