### PR TITLE
add SYSTEM_INCLUDE to tensorflow

### DIFF
--- a/tensorflow-toolfile.spec
+++ b/tensorflow-toolfile.spec
@@ -26,6 +26,7 @@ done
 cat << \EOF_TOOLFILE >>%i/etc/scram.d/%{base_package}.xml
   </client>
   <runtime name="PATH" value="$TENSORFLOW_BASE/bin" type="path"/>
+  <flags SYSTEM_INCLUDE="1"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
When TensorFlow is compiled with optimization off, e.g. with `USER_CXXFLAGS="-g -O0"`, it fails to compile with several "integer expressions of different signedness" diagnostics that we promote to errors.  This PR adds the `SYSTEM_INCLUDE` flag so that these diagnostics are suppressed.  Detailed discussion is in https://github.com/cms-sw/cmssw/pull/32852