### PR TITLE
update tag of data-GeneratorInterface-EvtGenInterface to V02-07-00 from V01-00-00

### DIFF
--- a/data-GeneratorInterface-EvtGenInterface.spec
+++ b/data-GeneratorInterface-EvtGenInterface.spec
@@ -1,4 +1,4 @@
-### RPM cms data-GeneratorInterface-EvtGenInterface V01-00-00
+### RPM cms data-GeneratorInterface-EvtGenInterface V02-07-00
 
 %prep
 

--- a/data-GeneratorInterface-EvtGenInterface.spec
+++ b/data-GeneratorInterface-EvtGenInterface.spec
@@ -1,4 +1,4 @@
-### RPM cms data-GeneratorInterface-EvtGenInterface V02-07-00
+### RPM cms data-GeneratorInterface-EvtGenInterface V02-00-07
 
 %prep
 


### PR DESCRIPTION
As requested by @jordan-martins , this PR updates the tag of data-GeneratorInterface-EvtGenInterface from V01-00-00 to V02-07-00.
Please note that the difference between the two tag is just an addition of files (no changes)
https://github.com/cms-data/GeneratorInterface-EvtGenInterface/compare/V01-00-00...V02-00-07

V02-07-00 is the tag currently used in  `CMSSW_8_1_0`.

