### PR TITLE
ROOT - 6.22 update on cmsdist master

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,10 +1,10 @@
-### RPM lcg root 6.22.06
+### RPM lcg root 6.22.07
 ## INITENV +PATH PYTHON27PATH %{i}/lib
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
 
-%define tag 9496c05e656f9c18c83cce6658f9f8914eaf2244
-%define branch cms/v6-22-00-patches/v6-22-06
+%define tag caa3e2ba1f8de5445ce8718d685129721dedbe10
+%define branch cms/v6-22-00-patches/a97a17e
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 


### PR DESCRIPTION
We either use 6.22 with the commits on top of 07 tag or we use 6.22+dd4hep fixes branch:
https://github.com/cms-sw/root/tree/cms/v6-22-00-patches/v6-22-06+dd4fix