### PR TITLE
Revert crabserver to use 1.3.6.crab6 WMCore tag

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -1,4 +1,4 @@
-### RPM cms crabserver v3.210204
+### RPM cms crabserver v3.210218
 
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
@@ -6,13 +6,13 @@
 
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
-%define wmcver 1.4.6.pre2
+%define wmcver 1.3.6.crab6
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
-Requires: python py2-cherrypy py2-cjson rotatelogs py2-pycurl py2-httplib2 py2-sqlalchemy py2-cx-oracle
-Requires: py2-pyOpenSSL condor py2-mysqldb dbs3-pycurl-client dbs3-client py2-retry py2-future
+Requires: python py2-cherrypy py2-cjson rotatelogs py2-pycurl py2-cx-oracle
+Requires: py2-pyOpenSSL condor dbs3-pycurl-client dbs3-client py2-retry py2-future
 Requires: jemalloc
 BuildRequires: py2-sphinx
 #Patch1: crabserver3-setup


### PR DESCRIPTION
This change reverts crabserver to the state that we had before #6621 PR was merged in terms of WMCore version used. In addition to that, we also remove 3 packages that are not needed for crabserver: `py2-mysqldb, py2-sqlalchemy, py2-httplib2`.

FYI @belforte 