### PR TITLE
add correctionlib and dependencies. 

### DIFF
--- a/pip/correctionlib.file
+++ b/pip/correctionlib.file
@@ -1,0 +1,2 @@
+Requires: py2-pybind11 py3-numpy py3-pydantic py3-python-rapidjson
+

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -54,6 +54,7 @@ cachy==0.3.0 ; python_version>'3.0'
 cleo==0.8.1 ; python_version>'3.0'
 clikit==0.6.2 ; python_version>'3.0'
 cmsml==0.1.1
+correctionlib==1.1.0 ; python_version>'3.0'
 crashtest==0.3.1 ; python_version>'3.0'
 certifi==2020.12.5
 cffi==1.14.4
@@ -241,6 +242,7 @@ pyparsing==2.4.7
 pyrsistent==0.16.0 ; python_version<'3.0'
 pyrsistent==0.17.3 ; python_version>'3.0'
 py==1.10.0
+pydantic==1.7.3 ; python_version>'3.0'
 pylev==1.3.0 ; python_version>'3.0'
 pysqlite==2.8.3; python_version<'3.0'
 pytest==4.6.11 ; python_version<'3.0'
@@ -251,6 +253,7 @@ python-cjson==1.2.2;python_version<'3.0'
 python-daemon==2.2.4
 python-dateutil==2.8.1
 python-ldap==3.3.1
+python-rapidjson==1.0;python_version>'3.0'
 pytoml==0.1.21;python_version>'3.0'
 pytools==2020.3
 pytz==2020.5

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -237,6 +237,7 @@ Requires: py3-boost-histogram
 Requires: py3-hist
 Requires: py3-histoprint
 Requires: py3-mplhep
+Requires: py3-correctionlib
 
 %prep
 


### PR DESCRIPTION
Also adds python-rapidjson and pydantics as dependencies.

Currently pip installs only the python interface. There is a C++ one as well that hopefully we get from a future pypi release

@nsmith-
