### PR TITLE
[10_6_X] upgrade sherpa 2.2.10 to 2.2.11

### DIFF
--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,4 +1,4 @@
-### RPM external sherpa 2.2.10
+### RPM external sherpa 2.2.11
 %define tag 600078cc741021be898f15563235cf6c809ca5ff
 %define branch cms/v%realversion
 %define github_user cms-externals

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -39,7 +39,6 @@ esac
 %build
 ./configure --prefix=%i --enable-analysis --disable-silent-rules \
             --enable-fastjet=$FASTJET_ROOT \
-            --enable-mcfm=$MCFM_ROOT \
             --enable-hepmc2=$HEPMC_ROOT \
             --enable-rivet=$RIVET_ROOT \
             --enable-lhapdf=$LHAPDF_ROOT \


### PR DESCRIPTION
First attempt to upgrade sherpa to 2.2.11, expecting better prediction for v+jets samples compares to previous release. If this PR is successful, will followup with backports.