### PR TITLE
Update Alpaka to version 0.6.0

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,4 +1,4 @@
-### RPM external alpaka 0.5.0
+### RPM external alpaka 0.6.0
 ## NOCOMPILER
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz

--- a/cupla.spec
+++ b/cupla.spec
@@ -1,7 +1,7 @@
 ### RPM external cupla 0.3.0-dev
 
 #%define tag %{realversion}
-%define tag ac24b2e0d906652054b1473635f9e1f98b2d31af
+%define tag 545702f1947feb1d46b2230b502f1f46179b3665
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{tag}.tar.gz
 Requires: alpaka


### PR DESCRIPTION
Update Alpaka to version 0.6.0, and update Cupla to a more recent snapshot of the development branch that supports it.