### PR TITLE
Revert the build flags for Cupla wth GCC 10

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,4 +1,4 @@
-### RPM external alpaka 0.5.0
+### RPM external alpaka 0.6.0
 ## NOCOMPILER
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,7 +1,7 @@
-### RPM external cuda 11.2.0
+### RPM external cuda 11.2.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define driversversion 460.27.04
+%define driversversion 460.32.03
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/cupla.spec
+++ b/cupla.spec
@@ -1,7 +1,7 @@
 ### RPM external cupla 0.3.0-dev
 
 #%define tag %{realversion}
-%define tag ac24b2e0d906652054b1473635f9e1f98b2d31af
+%define tag 545702f1947feb1d46b2230b502f1f46179b3665
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{tag}.tar.gz
 Requires: alpaka

--- a/cupla.spec
+++ b/cupla.spec
@@ -21,8 +21,8 @@ mkdir build lib
 rm -rf alpaka
 
 CXXFLAGS="-DALPAKA_DEBUG=0 -I$CUDA_ROOT/include -I$TBB_ROOT/include -I$BOOST_ROOT/include -I$ALPAKA_ROOT/include -Iinclude"
-HOST_FLAGS="%{nvcc_stdcxx} -std=c++14 -O2 -pthread -fPIC -Wall -Wextra"
-NVCC_FLAGS="%{nvcc_cuda_flags} -std=c++14"
+HOST_FLAGS="%{nvcc_stdcxx} -O2 -pthread -fPIC -Wall -Wextra"
+NVCC_FLAGS="%{nvcc_cuda_flags}"
 FILES=$(find src -type f -name *.cpp)
 
 # build the serial CPU backend


### PR DESCRIPTION
Requires (and includes):
  - #6663 Update to CUDA 11.2 Update 1
  - #6664 Update Alpaka to version 0.6.0