### PR TITLE
[7_1_X] upgrade sherpa to 2.2.11

### DIFF
--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,4 +1,4 @@
-### RPM external sherpa 2.2.8
+### RPM external sherpa 2.2.11
 %define tag 600078cc741021be898f15563235cf6c809ca5ff
 %define branch cms/v%realversion
 %define github_user cms-externals
@@ -36,7 +36,6 @@ esac
 %build
 ./configure --prefix=%i --enable-analysis --disable-silent-rules \
             --enable-fastjet=$FASTJET_ROOT \
-            --enable-mcfm=$MCFM_ROOT \
             --enable-hepmc2=$HEPMC_ROOT \
             --enable-lhapdf=$LHAPDF_ROOT \
             --enable-blackhat=$BLACKHAT_ROOT \


### PR DESCRIPTION
upgrade sherpa to 2.2.11, expecting better prediction for v+jets samples compares to previous release. Backport #6681 #6680
_________________________________
It is needed by an SMP analysis that doesn't have a CADI line yet but it's near completion. These Sherpa samples will be added as another theory prediction to compare to the particle-level W(munu)+jets differential cross sections in this analysis (within the SMP PAG). The analysts (Andrew Wisecarver et al) confirmed that they are not planning on moving to the UltraLegacy datasets, so the Legacy samples are what they are after.

