### PR TITLE
Update protobuf 3.15.1 and grpc 1.35.0

### DIFF
--- a/grpc-ssl-fix.patch
+++ b/grpc-ssl-fix.patch
@@ -1,0 +1,38 @@
+--- a/src/core/tsi/ssl_transport_security.cc	2021-02-24 07:48:45.470971187 +0100
++++ b/src/core/tsi/ssl_transport_security.cc	2021-02-23 13:06:20.469007951 +0100
+@@ -553,7 +553,7 @@
+   X509* certificate = nullptr;
+   BIO* pem;
+   GPR_ASSERT(pem_cert_chain_size <= INT_MAX);
+-  pem = BIO_new_mem_buf(pem_cert_chain, static_cast<int>(pem_cert_chain_size));
++  pem = BIO_new_mem_buf((void*)pem_cert_chain, static_cast<int>(pem_cert_chain_size));
+   if (pem == nullptr) return TSI_OUT_OF_RESOURCES;
+ 
+   do {
+@@ -673,7 +673,7 @@
+   EVP_PKEY* private_key = nullptr;
+   BIO* pem;
+   GPR_ASSERT(pem_key_size <= INT_MAX);
+-  pem = BIO_new_mem_buf(pem_key, static_cast<int>(pem_key_size));
++  pem = BIO_new_mem_buf((void*)pem_key, static_cast<int>(pem_key_size));
+   if (pem == nullptr) return TSI_OUT_OF_RESOURCES;
+   do {
+     private_key =
+@@ -718,7 +718,7 @@
+   X509_NAME* root_name = nullptr;
+   BIO* pem;
+   GPR_ASSERT(pem_roots_size <= INT_MAX);
+-  pem = BIO_new_mem_buf(pem_roots, static_cast<int>(pem_roots_size));
++  pem = BIO_new_mem_buf((void*)pem_roots, static_cast<int>(pem_roots_size));
+   if (cert_store == nullptr) return TSI_INVALID_ARGUMENT;
+   if (pem == nullptr) return TSI_OUT_OF_RESOURCES;
+   if (root_names != nullptr) {
+@@ -837,7 +837,7 @@
+   tsi_result result = TSI_OK;
+   X509* cert = nullptr;
+   BIO* pem;
+-  pem = BIO_new_mem_buf(pem_cert, static_cast<int>(strlen(pem_cert)));
++  pem = BIO_new_mem_buf((void*)pem_cert, static_cast<int>(strlen(pem_cert)));
+   if (pem == nullptr) return TSI_OUT_OF_RESOURCES;
+ 
+   cert = PEM_read_bio_X509(pem, nullptr, nullptr, const_cast<char*>(""));

--- a/grpc.spec
+++ b/grpc.spec
@@ -1,7 +1,7 @@
-### RPM external grpc 1.28.1
+### RPM external grpc 1.35.0
 
 Source: git+https://github.com/grpc/grpc.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
-
+Patch0: grpc-ssl-fix
 BuildRequires: cmake ninja go
 Requires: protobuf zlib pcre
 %define keep_archives true
@@ -9,19 +9,22 @@ Requires: protobuf zlib pcre
 %prep
 
 %setup -n %{n}-%{realversion}
+if [ ! -z "$OPENSSL_ROOT" ]; then
+%patch0 -p1
+fi
 
 %build
-
 rm -rf ../build
 mkdir ../build
 cd ../build
 OPENSSLROOT=""
-if [[ ! -z "$OPENSSL_ROOT" ]]; then OPENSSLROOT=";${OPENSSL_ROOT}" ; fi
+if [ ! -z "$OPENSSL_ROOT" ]; then OPENSSLROOT=";${OPENSSL_ROOT}" ; fi
 
 cmake ../%{n}-%{realversion} \
     -G Ninja \
     -DgRPC_INSTALL=ON \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
     -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DgRPC_ABSL_PROVIDER=module \

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -219,7 +219,7 @@ prettytable==1.0.1
 prometheus_client==0.9.0
 prompt_toolkit==1.0.18 ; python_version<'3.0'
 prompt_toolkit==3.0.10 ; python_version>'3.0'
-protobuf==3.10.0
+protobuf==3.15.1
 prwlock==0.4.1
 psutil==5.8.0
 ptyprocess==0.7.0

--- a/protobuf.spec
+++ b/protobuf.spec
@@ -1,4 +1,4 @@
-### RPM external protobuf 3.11.3
+### RPM external protobuf 3.15.1
 ## INITENV SETV PROTOBUF_SOURCE %{source0}
 ## INITENV SETV PROTOBUF_STRIP_PREFIX %{source_prefix}
 #============= IMPORTANT NOTE ========================#
@@ -21,7 +21,7 @@ BuildRequires: cmake ninja
 
 %prep
 %setup -n %{source_prefix}
-
+sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD 17|' cmake/CMakeLists.txt
 %build
 rm -rf ../build
 mkdir ../build


### PR DESCRIPTION
Update protobuf to version 3.15.1 and GRPC to version 1.35.0 which allows to build with c++17 .
These changes are needed by newer Tensorflow but can go in before we converge on TF 2.4.1