### PR TITLE
Boost - update to 1.75.0

### DIFF
--- a/boost-1.75.0-disable-statx.patch
+++ b/boost-1.75.0-disable-statx.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/filesystem/build/Jamfile.v2 b/libs/filesystem/build/Jamfile.v2
+index 132641a..0f2c2c8 100644
+--- a/libs/filesystem/build/Jamfile.v2
++++ b/libs/filesystem/build/Jamfile.v2
+@@ -53,8 +53,6 @@ project boost/filesystem
+       [ check-target-builds ../config//has_stat_st_birthtim "has stat::st_birthtim" : <define>BOOST_FILESYSTEM_HAS_STAT_ST_BIRTHTIM ]
+       [ check-target-builds ../config//has_stat_st_birthtimensec "has stat::st_birthtimensec" : <define>BOOST_FILESYSTEM_HAS_STAT_ST_BIRTHTIMENSEC ]
+       [ check-target-builds ../config//has_stat_st_birthtimespec "has stat::st_birthtimespec" : <define>BOOST_FILESYSTEM_HAS_STAT_ST_BIRTHTIMESPEC ]
+-      [ check-target-builds ../config//has_statx "has statx" : <define>BOOST_FILESYSTEM_HAS_STATX ]
+-      [ check-target-builds ../config//has_statx_syscall "has statx syscall" : <define>BOOST_FILESYSTEM_HAS_STATX_SYSCALL ]
+       <conditional>@select-windows-crypto-api
+     : source-location ../src
+     : usage-requirements # pass these requirement to dependents (i.e. users)

--- a/boost.spec
+++ b/boost.spec
@@ -4,11 +4,12 @@
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%n.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-
+Patch0: boost-1.75.0-disable-statx
 Requires: python bz2lib zlib openmpi xz zstd
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 case %cmsos in 

--- a/boost.spec
+++ b/boost.spec
@@ -1,6 +1,6 @@
-### RPM external boost 1.72.0
+### RPM external boost 1.75.0
 
-%define tag 88b813f91130f8d34977861990c24d8c0e3b6e47
+%define tag 3defebd61ecb0970c0046c85384bb34ec9572ac3
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%n.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
Reverts cms-sw/cmsdist#6698

Patched boost to avoid `statx()` calls which are only available on newer kernels (4.11+). As mentioned https://github.com/boostorg/filesystem/issues/172 , if boost is built on a newer kernel then `statx()` will fail if run on an older kernel. We have seen such issues with our ARM machines where one machine has kernel `4.18` and other is `4.5` . The `boost-1.75.0-disable-statx` patch disable the `statx()` checks and should work for both old and new kernels.