### PR TITLE
[Protobuf] Patches to avoid GCC10 build errors

### DIFF
--- a/grpc-toolfile.spec
+++ b/grpc-toolfile.spec
@@ -19,6 +19,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/grpc.xml
     <environment name="INCLUDE" default="$GRPC_BASE/include"/>
     <environment name="LIBDIR" default="$GRPC_BASE/lib"/>
   </client>
+  <flags SYSTEM_INCLUDE="1"/>
   <use name="protobuf"/>
   <use name="openssl"/>
   <use name="pcre"/>

--- a/protobuf-3.15-gcc10.patch
+++ b/protobuf-3.15-gcc10.patch
@@ -1,0 +1,12 @@
+diff --git a/src/google/protobuf/parse_context.h b/src/google/protobuf/parse_context.h
+index 7966d99d57..3754f983b1 100644
+--- a/src/google/protobuf/parse_context.h
++++ b/src/google/protobuf/parse_context.h
+@@ -348,7 +348,6 @@ class PROTOBUF_EXPORT EpsCopyInputStream {
+     if (ptr - buffer_end_ > limit_) return nullptr;
+     while (limit_ > kSlopBytes) {
+       size_t chunk_size = buffer_end_ + kSlopBytes - ptr;
+-      GOOGLE_DCHECK_GE(chunk_size, static_cast<size_t>(0));
+       append(ptr, chunk_size);
+       ptr = Next();
+       if (ptr == nullptr) return limit_end_;

--- a/protobuf.spec
+++ b/protobuf.spec
@@ -1,6 +1,4 @@
 ### RPM external protobuf 3.15.1
-## INITENV SETV PROTOBUF_SOURCE %{source0}
-## INITENV SETV PROTOBUF_STRIP_PREFIX %{source_prefix}
 #============= IMPORTANT NOTE ========================#
 # When changing the version of protobuf, remember to regenerate protobuf objects in CMSSW
 # current recipe for this is:
@@ -10,17 +8,14 @@
 # protoc --cpp_out=. DQMServices/Core/src/ROOTFilePB.proto
 #######################################################
 
-#These are needed by Tensorflow sources
-#NOTE: Never apply any patch in the spec file, this way tensorflow gets the exact same sources
-%define source0 https://github.com/google/protobuf/archive/v%{realversion}.tar.gz
-%define source_prefix %{n}-%{realversion}
-
-Source: %{source0}
+Source: https://github.com/google/protobuf/archive/v%{realversion}.tar.gz
+Patch0: protobuf-3.15-gcc10
 Requires: zlib
 BuildRequires: cmake ninja
 
 %prep
-%setup -n %{source_prefix}
+%setup -n %{n}-%{realversion}
+%patch0 -p1
 sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD 17|' cmake/CMakeLists.txt
 %build
 rm -rf ../build

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -47,10 +47,6 @@ export CC_OPT_FLAGS="-mcpu=native -mtune=native"
 %endif
 %endif
 export CXX_OPT_FLAGS="-std=c++17"
-export EIGEN_SOURCE=${EIGEN_SOURCE}
-export PROTOBUF_SOURCE=${PROTOBUF_SOURCE}
-export EIGEN_STRIP_PREFIX=${EIGEN_STRIP_PREFIX}
-export PROTOBUF_STRIP_PREFIX=${PROTOBUF_STRIP_PREFIX}
 
 export TF_NEED_JEMALLOC=0
 export TF_NEED_HDFS=0


### PR DESCRIPTION
- Apply https://github.com/protocolbuffers/protobuf/commit/9d203953a9950a2f2054b9029490940859ba153f patch to avoid GCC10 build errors
- Removed unused protobuf/eigen and EIGEN variables
- Treat GRPC as system include to avoid compiler warnings coming from GRPC
