### PR TITLE
Bump py3-cmsmonitoring to 0.3.4; add it as dependency on wmagentpy3 specs; drop pystack

### DIFF
--- a/py3-cmsmonitoring.spec
+++ b/py3-cmsmonitoring.spec
@@ -1,7 +1,7 @@
-### RPM external py3-cmsmonitoring 0.2.4
+### RPM external py3-cmsmonitoring 0.5.23
 ## IMPORT build-with-pip3
 
 %define pip_name cmsmonitoring
-Requires: python3 py3-stomp py3-jsonschema py3-genson
+Requires: py3-stomp py3-jsonschema py3-genson
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-cmsmonitoring.spec
+++ b/py3-cmsmonitoring.spec
@@ -1,4 +1,4 @@
-### RPM external py3-cmsmonitoring 0.5.23
+### RPM external py3-cmsmonitoring 0.3.4
 ## IMPORT build-with-pip3
 
 %define pip_name cmsmonitoring

--- a/wmagentpy3-dev.spec
+++ b/wmagentpy3-dev.spec
@@ -1,4 +1,4 @@
-### RPM cms wmagentpy3-dev 1.4.6.pre7
+### RPM cms wmagentpy3-dev 1.4.7.pre2
 
 # This is a meta-package to group development tool dependencies
 Requires: wmagentpy3 rotatelogs wmcorepy3-devtools

--- a/wmagentpy3-dev.spec
+++ b/wmagentpy3-dev.spec
@@ -1,7 +1,7 @@
 ### RPM cms wmagentpy3-dev 1.4.6.pre7
 
 # This is a meta-package to group development tool dependencies
-Requires: wmagentpy3 rotatelogs pystack wmcorepy3-devtools
+Requires: wmagentpy3 rotatelogs wmcorepy3-devtools
 Requires: jemalloc
 
 %prep

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -5,10 +5,11 @@
 
 Source: git://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=WMCore-%{realversion}&output=/WMCore-%{realversion}.tar.gz
 
-Requires: yui libuuid couchdb15 condor pystack jemalloc cmsmonitoring dbs3-client
+Requires: yui libuuid couchdb15 condor jemalloc dbs3-client
 Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
 Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL
 Requires: py3-pyzmq py3-psutil py3-future py3-retry
+Requires: py3-cmsmonitoring
 # Alan Malta dropped on 2/Feb/2021: Requires: py3-cheetah py3-mysqldb
 BuildRequires: py3-sphinx couchskel
 

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -1,4 +1,4 @@
-### RPM cms wmagentpy3 1.4.6.pre7
+### RPM cms wmagentpy3 1.4.7.pre2
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10304
Fixes https://github.com/dmwm/WMCore/issues/10305

Summary of changes (not locally tested) are:
* bump version of py3-cmsmonitoring from 0.2.4 to 0.3.4 (same as used in production in py2 right now)
* drop `pystack` dependency on the wmagentpy3 and wmagentpy3-dev specs
* replace `cmsmonitoring` by `py3-cmsmonitoring` dependency in the wmagentpy3 specs