### PR TITLE
LLVM 11 in CLANG IB only

### DIFF
--- a/llvm-gcc-toolfile.spec
+++ b/llvm-gcc-toolfile.spec
@@ -51,7 +51,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/llvm-cxxcompiler.xml
     <flags REM_CXXFLAGS="-fipa-pta"/>
     <flags REM_CXXFLAGS="-frounding-math"/>
     <flags REM_CXXFLAGS="-mrecip"/>
-    <flags REM_CXXFLAGS="-Wno-psabi"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-fno-aggressive-loop-optimizations"/>
     <flags REM_CXXFLAGS="-mlong-double-64"/>

--- a/llvm.spec
+++ b/llvm.spec
@@ -1,4 +1,4 @@
-### RPM external llvm 10.0.0
+### RPM external llvm 11.1.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 ## INITENV +PATH PYTHON3PATH %{i}/lib64/python`echo $PYTHON3_VERSION | cut -d. -f 1,2`/site-packages
@@ -8,10 +8,10 @@ Requires: gcc zlib python python3
 Requires: cuda
 AutoReq: no
 
-%define llvmCommit 4b3acf7d70558fefca729efe381e3900da4591dd
-%define llvmBranch cms/release/10.x/92d5c1b
-%define iwyuCommit a5a6f27dabeb7fbc59b06ea949a312201c2fbdcf
-%define iwyuBranch master
+%define llvmCommit 9ac43ce9cfea653af380f1ac550c1171dab9a7cf
+%define llvmBranch cms/release/11.x/1fdec59
+%define iwyuCommit 5db414ac448004fe019871c977905cb7c2cff23f
+%define iwyuBranch clang_11
 
 Source0: git+https://github.com/cms-externals/llvm-project.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz
 Source1: git+https://github.com/include-what-you-use/include-what-you-use.git?obj=%{iwyuBranch}/%{iwyuCommit}&export=iwyu-%{realversion}-%{iwyuCommit}&module=iwyu-%{realversion}-%{iwyuCommit}&output=/iwyu-%{realversion}-%{iwyuCommit}.tgz

--- a/pip/llvmlite.file
+++ b/pip/llvmlite.file
@@ -1,6 +1,7 @@
 Requires: llvm py2-wheel py2-enum34
 Patch0: py2-llvmlite-fpic-flag
 Patch1: py2-llvmlite-llvm9
+Patch2: py2-llvmlite-removeduplicate
 
-%define source0 git+https://github.com/numba/llvmlite?obj=master/0be433f000ddad39a43a7469ce19e0692a8b73de&export=llvmlite-%{realversion}&output=/source.tar.gz
+%define source0 git+https://github.com/numba/llvmlite?obj=release0.35/v0.35.0&export=llvmlite-%{realversion}&output=/source.tar.gz
 %define PipPreBuild export LLVM_CONFIG=${LLVM_ROOT}/bin/llvm-config

--- a/pip/py3-numba.file
+++ b/pip/py3-numba.file
@@ -1,2 +1,2 @@
-Requires: py2-funcsigs py2-six py2-singledispatch py2-llvmlite py3-numpy python3
+Requires: py2-funcsigs py2-six py2-singledispatch py3-llvmlite py3-numpy python3
 %define RelocatePython %{i}/bin/*

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -153,8 +153,8 @@ law==0.1.3
 #can not go to 1.5.x in python2 due to astroid
 lazy-object-proxy==1.4.3
 lizard==1.17.7
-#NO_AUTO_UPDATE: Source is defined in llvmlite.file, changing version here is not going to get new sources
-llvmlite==0.33.0
+#NO_AUTO_UPDATE: Source is defined in llvmlite.file, changing version here is not going to get new sources. Still, keep the version
+llvmlite==0.35.0 ; python_version>'3.0'
 lockfile==0.12.2
 luigi==2.8.13 ; python_version<'3.0'
 luigi==3.0.2 ; python_version>'3.0'

--- a/py2-llvmlite-llvm9.patch
+++ b/py2-llvmlite-llvm9.patch
@@ -1,25 +1,13 @@
-diff -Naur a/ffi/build.py b/ffi/build.py
---- a/ffi/build.py	2020-01-10 14:51:38.000000000 +0100
-+++ b/ffi/build.py	2020-01-10 14:45:27.059843040 +0100
-@@ -110,7 +110,7 @@
-     out = out.decode('latin1')
-     print(out)
-     if not (out.startswith('8.0.') or out.startswith('7.0.')
--            or out.startswith('7.1.')):
-+            or out.startswith('7.1.') or out.startswith('9.0.') or out.startswith('10.0.')):
-         msg = (
-             "Building llvmlite requires LLVM 7.0.x, 7.1.x or 8.0.x Be sure to "
-             "set LLVM_CONFIG to the right executable path.\n"
-diff --git a/ffi/linker.cpp b/ffi/linker.cpp
-index 57bb80b..2cc0019 100644
---- a/ffi/linker.cpp
-+++ b/ffi/linker.cpp
-@@ -42,7 +42,7 @@ LLVMPY_LinkModules(LLVMModuleRef Dest, LLVMModuleRef Src, const char **Err)
-     auto OldDiagnosticHandler = Ctx.getDiagnosticHandler();
+diff --git a/ffi/build.py b/ffi/build.py
+index 09e95da..add3945 100755
+--- a/ffi/build.py
++++ b/ffi/build.py
+@@ -134,7 +134,7 @@ def main_posix(kind, library_ext):
+         print(warning + '\n')
+     else:
  
-     // set the handler to a new one
--    Ctx.setDiagnosticHandler(llvm::make_unique<ReportNotAbortDiagnosticHandler>(errstream));
-+    Ctx.setDiagnosticHandler(std::make_unique<ReportNotAbortDiagnosticHandler>(errstream));
- 
-     // link
-     bool failed = LLVMLinkModules2(Dest, Src);
+-        if not (out.startswith('10.0.') or out.startswith('9.0')):
++        if not (out.startswith('11.1.') or out.startswith('9.0')):
+             msg = ("Building llvmlite requires LLVM 10.0.x or 9.0.x, got "
+                    "{!r}. Be sure to set LLVM_CONFIG to the right executable "
+                    "path.\nRead the documentation at "

--- a/py2-llvmlite-removeduplicate.patch
+++ b/py2-llvmlite-removeduplicate.patch
@@ -1,0 +1,34 @@
+diff --git a/ffi/custom_passes.cpp b/ffi/custom_passes.cpp
+index 5758aad..860df2d 100644
+--- a/ffi/custom_passes.cpp
++++ b/ffi/custom_passes.cpp
+@@ -400,7 +400,7 @@ struct RefPrunePass : public FunctionPass {
+                 // LLVM 9 postdomtree.dominates takes basic blocks
+                 if ( domtree.dominates(incref, decref)
+                         && postdomtree.dominates(decref->getParent(), incref->getParent()) ){
+-#elif LLVM_VERSION_MAJOR == 10
++#elif LLVM_VERSION_MAJOR == 11
+                 // LLVM 10 postdomtree.dominates can handle instructions
+                 if ( domtree.dominates(incref, decref)
+                         && postdomtree.dominates(decref, incref) ){
+diff --git a/ffi/transforms.cpp b/ffi/transforms.cpp
+index 23bfd72..2eac2e9 100644
+--- a/ffi/transforms.cpp
++++ b/ffi/transforms.cpp
+@@ -6,6 +6,7 @@
+ 
+ extern "C" {
+ 
++  /*
+ namespace llvm {
+     inline PassManagerBuilder *unwrap(LLVMPassManagerBuilderRef P) {
+         return reinterpret_cast<PassManagerBuilder*>(P);
+@@ -15,7 +16,7 @@ namespace llvm {
+         return reinterpret_cast<LLVMPassManagerBuilderRef>(P);
+     }
+ }
+-
++  */
+ 
+ API_EXPORT(LLVMPassManagerBuilderRef)
+ LLVMPY_PassManagerBuilderCreate()

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -26,7 +26,7 @@ Requires: py2-Bottleneck
 Requires: py2-downhill
 Requires: py2-theanets
 Requires: py2-xgboost py3-xgboost
-Requires: py2-llvmlite
+Requires: py3-llvmlite
 Requires: py3-numba
 Requires: py2-hep_ml
 Requires: py2-rep


### PR DESCRIPTION
We can do something like
1. Make a temp branch for the clang IB -> https://github.com/cms-sw/cmsdist/tree/IB/CMSSW_11_3_X%2Fclang
2. Change the branch in the config.map
3. Get LLVM 11 in the cmsdist/clang branch
4. Fix the warnings
5. Sync back cmsdist/clang to cmsdist/master 
needs this:
https://github.com/cms-sw/cms-bot/pull/1502