### PR TITLE
make sure to use python2 for pylint and ipython

### DIFF
--- a/pip/py2-ipython.file
+++ b/pip/py2-ipython.file
@@ -1,0 +1,1 @@
+%define PipPostBuild sed -i -e "s|^#!.*python.*|#!/usr/bin/env python2|" %{i}/bin/*

--- a/pip/py2-pylint.file
+++ b/pip/py2-pylint.file
@@ -1,0 +1,1 @@
+%define PipPostBuild sed -i -e "s|^#!.*python.*|#!/usr/bin/env python2|" %{i}/bin/*


### PR DESCRIPTION
`ipython, ipython2 and pylint` commands failed in PY3 IBs as then default python points to python3 in this IB. This PR proposes to use python2 for these commands 