### PR TITLE
Py2lz4 103x drop

### DIFF
--- a/cms-git-tools.spec
+++ b/cms-git-tools.spec
@@ -1,9 +1,9 @@
-### RPM cms cms-git-tools 180914.0
+### RPM cms cms-git-tools 191028.0
 ## NOCOMPILER
 
 # ***Do not change minor number of the above version. ***
 
-%define commit e2366422b57c6569ad0f38cf78ec25451dc1158e
+%define commit bb27807c53f462ede4b170980a932db4a93f2508
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when they are dependencies.

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -169,7 +169,6 @@ Requires: igprof-toolfile
 Requires: dmtcp-toolfile
 Requires: tkonlinesw-toolfile
 Requires: oracle-toolfile
-Requires: cms_oracleocci_abi_hack-toolfile
 Requires: cuda-toolfile
 Requires: cuda-gdb-wrapper-toolfile
 Requires: cub-toolfile
@@ -183,7 +182,6 @@ Requires: glibc-toolfile
 %else
 Requires: tkonlinesw-fake-toolfile
 Requires: oracle-fake-toolfile
-Requires: cms_oracleocci_abi_hack-fake-toolfile
 %endif
 %endif
 

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -107,6 +107,7 @@ Requires: pyminuit2-toolfile
 Requires: professor-toolfile
 Requires: professor2-toolfile
 Requires: xz-toolfile
+Requires: lz4-toolfile
 Requires: protobuf-toolfile
 Requires: lcov-toolfile
 Requires: llvm-gcc-toolfile

--- a/lz4.spec
+++ b/lz4.spec
@@ -1,19 +1,14 @@
-### RPM external lz4 1.8.2
+### RPM external lz4 1.9.2
 
-%define tag %{realversion}
-%define branch tbb_2018
 %define github_user lz4
-Source: https://github.com/%{github_user}/lz4/archive/v%{realversion}.tar.gz
+Source: https://github.com/%{github_user}/%{n}/archive/v%{realversion}.tar.gz
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
-
 make %{makeprocesses} 
 
 %install
-
-
-make DESTDIR=%i install
+make PREFIX=%{i} install
 

--- a/oracle-fake-toolfile.spec
+++ b/oracle-fake-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external oracle-fake-toolfile 1.0
+### RPM external oracle-fake-toolfile 2.0
 Requires: oracle-fake
 %prep
 
@@ -25,8 +25,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/oracle.xml
 </tool>
 EOF_TOOLFILE
 
-cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci-official.xml
-<tool name="oracleocci-official" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
+<tool name="oracleocci" version="@TOOL_VERSION@">
   <lib name="occi"/>
   <use name="oracle"/>
 </tool>

--- a/oracle-toolfile.spec
+++ b/oracle-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external oracle-toolfile 1.0
+### RPM external oracle-toolfile 2.0
 Requires: oracle
 %prep
 
@@ -27,8 +27,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/oracle.xml
 </tool>
 EOF_TOOLFILE
 
-cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci-official.xml
-<tool name="oracleocci-official" version="@TOOL_VERSION@">
+cat << \EOF_TOOLFILE >%i/etc/scram.d/oracleocci.xml
+<tool name="oracleocci" version="@TOOL_VERSION@">
   <lib name="occi"/>
   <use name="oracle"/>
 </tool>

--- a/oracle.spec
+++ b/oracle.spec
@@ -33,6 +33,7 @@ Source3: %{http_mirror}/%{client_arch}/instantclient-odbc-%{client_arch}-%{realv
 Source4: %{http_mirror}/%{client_arch}/instantclient-sdk-%{client_arch}-%{realversion}.zip
 Source5: %{http_mirror}/%{client_arch}/instantclient-sqlplus-%{client_arch}-%{realversion}.zip
 Source6: %{http_mirror}/%{client_arch}/instantclient-tools-%{client_arch}-%{realversion}.zip
+Source7: http://cmsrep.cern.ch/cmssw/oracle-mirror/%{client_arch}/libocci.so.12.1.zip
 
 Source10: oracle-license
 
@@ -46,9 +47,12 @@ rm -rf instantclient_*
 %setup -D -T -b 4 -n %{client_dir} instantclient-sdk-%{client_arch}-%{realversion}.zip
 %setup -D -T -b 5 -n %{client_dir} instantclient-sqlplus-%{client_arch}-%{realversion}.zip
 %setup -D -T -b 6 -n %{client_dir} instantclient-tools-linux-%{client_arch}-%{realversion}.zip
+#OCCI lib with new C++ ABI (GCC 5 and above)
+%setup -D -T -b 7 -n %{client_dir} libocci.so.12.1.zip
 
 %build
 chmod a-x sdk/include/*.h *.sql
+chmod +x libocci.so.12.1
 
 %install
 mkdir -p %{i}/{bin,lib,java,demo,include,doc,etc}

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -155,7 +155,6 @@ Requires: py2-histbook
 Requires: py2-flake8-toolfile
 Requires: py2-autopep8-toolfile
 Requires: py2-pycodestyle
-Requires: py2-lz4
 Requires: py2-ply
 Requires: py2-py
 Requires: py2-typing


### PR DESCRIPTION
10.3.X Ibs are failing due to py2-lz4 deps now requires newer version of setuptools. Instead of rebuilding all the python tools for 10.3.X , I suggest that we drop py2-lz4 ( looks like nothing is using it). In case it is really needed then we have to basicllay update setuptools and pip for python3 