### PR TITLE
[10.3.X] Drop py2-lx4 deps as it does not build any more

### DIFF
--- a/python_tools.spec
+++ b/python_tools.spec
@@ -155,7 +155,6 @@ Requires: py2-histbook
 Requires: py2-flake8-toolfile
 Requires: py2-autopep8-toolfile
 Requires: py2-pycodestyle
-Requires: py2-lz4
 Requires: py2-ply
 Requires: py2-py
 Requires: py2-typing


### PR DESCRIPTION
10.3.X Ibs are failing due to py2-lz4 deps now requires newer version of setuptools. Instead of rebuilding all the python tools for 10.3.X , I suggest that we drop py2-lz4 ( looks like nothing is using it). In case it is really needed then we have to basicllay update setuptools and pip for python3 