### PR TITLE
include compilation_flags

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,4 +1,5 @@
 ### RPM external vecgeom v1.1.8
+## INCLUDE compilation_flags
 %define tag 5a275d77ef80b12240d59fd276231ad50d5df577
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake gmake


### PR DESCRIPTION
while back porting geant4 changes we missed to include `compilation_flags` which causes vecgeom to fail on ppc64le. This should fix that issue