### PR TITLE
Remove vecgeom macros to avoid redefinition warnings

### DIFF
--- a/vecgeom-toolfile.spec
+++ b/vecgeom-toolfile.spec
@@ -18,8 +18,6 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/vecgeom_interface.xml
     <environment name="INCLUDE" default="$VECGEOM_INTERFACE_BASE/include"/>
     <environment name="INCLUDE" default="$VECGEOM_INTERFACE_BASE/include/VecGeom"/>
   </client>
-  <flags CPPDEFINES="VECGEOM_REPLACE_USOLIDS"/>
-  <flags CPPDEFINES="VECGEOM_USOLIDS"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$VECGEOM_INTERFACE_BASE/include" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$VECGEOM_INTERFACE_BASE/include/VecGeom" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/vecgeom-toolfile.spec
+++ b/vecgeom-toolfile.spec
@@ -18,12 +18,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/vecgeom_interface.xml
     <environment name="INCLUDE" default="$VECGEOM_INTERFACE_BASE/include"/>
     <environment name="INCLUDE" default="$VECGEOM_INTERFACE_BASE/include/VecGeom"/>
   </client>
-  <flags CPPDEFINES="VECGEOM_SCALAR"/>
   <flags CPPDEFINES="VECGEOM_REPLACE_USOLIDS"/>
-  <flags CPPDEFINES="VECGEOM_NO_SPECIALIZATION"/>
   <flags CPPDEFINES="VECGEOM_USOLIDS"/>
-  <flags CPPDEFINES="VECGEOM_INPLACE_TRANSFORMATIONS"/>
-  <flags CPPDEFINES="VECGEOM_USE_INDEXEDNAVSTATES"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$VECGEOM_INTERFACE_BASE/include" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$VECGEOM_INTERFACE_BASE/include/VecGeom" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/vecgeom-toolfile.spec
+++ b/vecgeom-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external vecgeom-toolfile 3.0
+### RPM external vecgeom-toolfile 4.0
 %define base_package %(echo %{n} | sed 's|-toolfile||')
 %define base_package_uc %(echo %{base_package} | tr '[a-z-]' '[A-Z_]')
 %{expand:%(for v in %{package_vectorization}; do echo Requires: %{base_package}_$v; done)}


### PR DESCRIPTION
`Vecgeom VecGeom/base/Config.h`  build now set the following macros which now causes compilation warnings as scram is also setting these  https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_11_3_X_2021-03-23-1400/SimG4Core/Geometry

```
#define VECGEOM_SCALAR
#define VECGEOM_NO_SPECIALIZATION
#define VECGEOM_INPLACE_TRANSFORMATIONS
#define VECGEOM_USE_INDEXEDNAVSTATES
```

also looks like vecgeom does not use `VECGEOM_REPLACE_USOLIDS` and `VECGEOM_USOLIDS` any more, so no need to set these in toolfile.