### PR TITLE
Update to CUDA 11.2 Update 2

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,4 +1,4 @@
-### RPM external cuda 11.2.1
+### RPM external cuda 11.2.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define driversversion 460.32.03


### PR DESCRIPTION
Update to CUDA 11.2 Update 2 (11.2.20210226):
  * CUDA runtime version 11.2.152
  * NVIDIA drivers version 460.32.03

Various bug fixes.

See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html .