### PR TITLE
Add GPU support for ONNXRuntime

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -170,6 +170,7 @@ Requires: gperftools-toolfile
 Requires: cuda-toolfile
 Requires: alpaka-toolfile
 Requires: cupla-toolfile
+Requires: cudnn-toolfile
 
 %ifnarch ppc64le
 Requires: libunwind-toolfile
@@ -185,7 +186,6 @@ Requires: intel-vtune
 Requires: glibc-toolfile
 Requires: cmsmon-tools
 Requires: dip-toolfile
-Requires: cudnn-toolfile
 %else
 Requires: tkonlinesw-fake-toolfile
 Requires: oracle-fake-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -170,7 +170,6 @@ Requires: gperftools-toolfile
 Requires: cuda-toolfile
 Requires: alpaka-toolfile
 Requires: cupla-toolfile
-Requires: cudnn-toolfile
 
 %ifnarch ppc64le
 Requires: libunwind-toolfile
@@ -186,6 +185,7 @@ Requires: intel-vtune
 Requires: glibc-toolfile
 Requires: cmsmon-tools
 Requires: dip-toolfile
+Requires: cudnn-toolfile
 %else
 Requires: tkonlinesw-fake-toolfile
 Requires: oracle-fake-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -170,7 +170,10 @@ Requires: gperftools-toolfile
 Requires: cuda-toolfile
 Requires: alpaka-toolfile
 Requires: cupla-toolfile
+
+%if "%{cmsos}" != "slc7_aarch64"
 Requires: cudnn-toolfile
+%endif
 
 %ifnarch ppc64le
 Requires: libunwind-toolfile

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -170,6 +170,7 @@ Requires: gperftools-toolfile
 Requires: cuda-toolfile
 Requires: alpaka-toolfile
 Requires: cupla-toolfile
+Requires: cudnn-toolfile
 
 %ifnarch ppc64le
 Requires: libunwind-toolfile

--- a/cuda.spec
+++ b/cuda.spec
@@ -34,6 +34,7 @@ mkdir -p %{i}/lib64/stubs
 
 # package only the runtime static library
 mv %_builddir/build/lib64/libcudadevrt.a %{i}/lib64/
+mv %_builddir/build/lib64/libcudart_static.a %{i}/lib64/
 rm -f %_builddir/build/lib64/lib*.a
 
 # package only the CUDA driver and NVML library stub
@@ -101,6 +102,7 @@ ln -sf libnvidia-ptxjitcompiler.so.1                                        %{i}
 sed \
   -e"/^TOP *=/s|= .*|= $CMS_INSTALL_PREFIX/%{pkgrel}|" \
   -e's|$(_HERE_)|$(TOP)/bin|g' \
+  -e's|$(TOP)/lib|$(TOP)/lib64|g' \
   -e's|/$(_TARGET_DIR_)||g' \
   -e's|$(_TARGET_SIZE_)|64|g' \
   -i $RPM_INSTALL_PREFIX/%{pkgrel}/bin/nvcc.profile

--- a/cuda.spec
+++ b/cuda.spec
@@ -34,7 +34,6 @@ mkdir -p %{i}/lib64/stubs
 
 # package only the runtime static library
 mv %_builddir/build/lib64/libcudadevrt.a %{i}/lib64/
-mv %_builddir/build/lib64/libcudart_static.a %{i}/lib64/
 rm -f %_builddir/build/lib64/lib*.a
 
 # package only the CUDA driver and NVML library stub
@@ -102,7 +101,6 @@ ln -sf libnvidia-ptxjitcompiler.so.1                                        %{i}
 sed \
   -e"/^TOP *=/s|= .*|= $CMS_INSTALL_PREFIX/%{pkgrel}|" \
   -e's|$(_HERE_)|$(TOP)/bin|g' \
-  -e's|$(TOP)/lib|$(TOP)/lib64|g' \
   -e's|/$(_TARGET_DIR_)||g' \
   -e's|$(_TARGET_SIZE_)|64|g' \
   -i $RPM_INSTALL_PREFIX/%{pkgrel}/bin/nvcc.profile

--- a/cudnn-toolfile.spec
+++ b/cudnn-toolfile.spec
@@ -1,0 +1,22 @@
+### RPM external cuda-toolfile 1.0
+Requires: cudnn
+%prep
+
+%build
+
+%install
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/cudnn.xml
+<tool name="cudnn" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/deeplearning/cudnn/index.html"/>
+  <lib name="cudnn"/>
+  <client>
+    <environment name="CUDNN_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$CUDNN_BASE/include"/>
+    <environment name="LIBDIR" default="$CUDNN_BASE/lib64"/>
+  </client>
+  <use name="cuda"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/cudnn-toolfile.spec
+++ b/cudnn-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external cuda-toolfile 1.0
+### RPM external cudnn-toolfile 1.0
 Requires: cudnn
 %prep
 

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,22 +1,27 @@
 ### RPM external cudnn 8.1.1.33
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define cudaver_maj 11.2
+%define cudaver 11.2
 %define cudnnver_maj %(echo %{realversion} | cut -f1,2,3 -d.)
 
 %ifarch x86_64
-Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver_maj}-linux-x64-v%{realversion}.tgz
+Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver}-linux-x64-v%{realversion}.tgz
 %endif
 %ifarch ppc64le
-Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver_maj}-linux-ppc64le-v%{realversion}.tgz
+Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver}-linux-ppc64le-v%{realversion}.tgz
 %endif
 %ifarch aarch64
-Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver_maj}-linux-aarch64sbsa-v%{realversion}.tgz
+Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver}-linux-aarch64sbsa-v%{realversion}.tgz
 %endif
 Requires: cuda
 
 %prep
 %setup -n cuda
+
+if [ "${CUDA_VERSION%.*}" != %{cudaver} ]; then
+    echo 'Incompatible CUDA version in cudnn.spec!'
+    exit 1
+fi
 
 %build
 

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -26,6 +26,6 @@ fi
 %build
 
 %install
-rm %_builddir/cuda/lib64/*.a
+rm -f %_builddir/cuda/lib64/*.a
 mv %_builddir/cuda/* %{i}/
 

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -26,6 +26,12 @@ fi
 %build
 
 %install
+%ifarch ppc64le
+rm -f %_builddir/cuda/targets/ppc64le-linux/lib/*.a
+mv %_builddir/cuda/targets/ppc64le-linux/lib %{i}/lib64
+mv %_builddir/cuda/targets/ppc64le-linux/* %{i}/
+%else
 rm -f %_builddir/cuda/lib64/*.a
 mv %_builddir/cuda/* %{i}/
+%endif
 

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,0 +1,26 @@
+### RPM external cudnn 8.1.1.33
+## INITENV +PATH LD_LIBRARY_PATH %i/lib64
+
+%define cudaver_maj 11.2
+%define cudnnver_maj %(echo %{realversion} | cut -f1,2,3 -d.)
+
+%ifarch x86_64
+Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver_maj}-linux-x64-v%{realversion}.tgz
+%endif
+%ifarch ppc64le
+Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver_maj}-linux-ppc64le-v%{realversion}.tgz
+%endif
+%ifarch aarch64
+Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/cudnn-%{cudaver_maj}-linux-aarch64sbsa-v%{realversion}.tgz
+%endif
+Requires: cuda
+
+%prep
+%setup -n cuda
+
+%build
+
+%install
+rm %_builddir/cuda/lib64/*.a
+mv %_builddir/cuda/* %{i}/
+

--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -16,8 +16,10 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
   </client>
   <use name="protobuf"/>
+%if "%{cmsos}" != "slc7_aarch64"
   <use name="cuda"/>
   <use name="cudnn"/>
+%endif
   <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
 </tool>
 EOF_TOOLFILE

--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -16,10 +16,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
   </client>
   <use name="protobuf"/>
-%ifarch x86_64
   <use name="cuda"/>
   <use name="cudnn"/>
-%endif
   <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
 </tool>
 EOF_TOOLFILE

--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -16,6 +16,8 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
   </client>
   <use name="protobuf"/>
+  <use name="cuda"/>
+  <use name="cudnn"/>
   <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
 </tool>
 EOF_TOOLFILE

--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -16,8 +16,10 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
   </client>
   <use name="protobuf"/>
+%ifarch x86_64
   <use name="cuda"/>
   <use name="cudnn"/>
+%endif
   <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
 </tool>
 EOF_TOOLFILE

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -43,6 +43,9 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -Donnxruntime_DISABLE_CONTRIB_OPS=OFF \
    -Donnxruntime_USE_PREINSTALLED_PROTOBUF=ON \
    -Donnxruntime_PREFER_SYSTEM_LIB=ON \
+   -DCMAKE_CUDA_FLAGS="-cudart shared" \
+   -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared \
+   -DCMAKE_TRY_COMPILE_PLATFORM_VARIABLES="CMAKE_CUDA_RUNTIME_LIBRARY" \
    -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${LIBPNG_ROOT};${PROTOBUF_ROOT};${PY2_PYBIND11_ROOT}"
 
 ninja -v %{makeprocesses}

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -7,6 +7,7 @@ Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 Requires: protobuf py3-numpy py2-wheel py2-onnx zlib libpng py2-pybind11
+Requires: cuda cudnn
 
 %prep
 %setup -q -n %{n}-%{realversion}
@@ -21,7 +22,10 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DCMAKE_INSTALL_LIBDIR=lib \
    -Donnxruntime_ENABLE_PYTHON=ON \
    -Donnxruntime_BUILD_SHARED_LIB=ON \
-   -Donnxruntime_USE_CUDA=OFF \
+   -Donnxruntime_USE_CUDA=ON \
+   -Donnxruntime_CUDA_VERSION="${CUDA_VERSION}" \
+   -Donnxruntime_CUDA_HOME="${CUDA_ROOT}" \
+   -Donnxruntime_CUDNN_HOME="${CUDNN_ROOT}" \
    -Donnxruntime_BUILD_CSHARP=OFF \
    -Donnxruntime_USE_EIGEN_FOR_BLAS=ON \
    -Donnxruntime_USE_OPENBLAS=OFF \

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -7,7 +7,9 @@ Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 Requires: protobuf py3-numpy py2-wheel py2-onnx zlib libpng py2-pybind11
+%if "%{cmsos}" != "slc7_aarch64"
 Requires: cuda cudnn
+%endif
 
 %prep
 %setup -q -n %{n}-%{realversion}
@@ -15,7 +17,11 @@ Requires: cuda cudnn
 %build
 rm -rf ../build; mkdir ../build; cd ../build
 
+%if "%{cmsos}" != "slc7_aarch64"
 USE_CUDA=ON
+%else
+USE_CUDA=OFF
+%endif
 
 cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3 \

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -7,13 +7,21 @@ Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 Requires: protobuf py3-numpy py2-wheel py2-onnx zlib libpng py2-pybind11
+%ifarch x86_64
 Requires: cuda cudnn
+%endif
 
 %prep
 %setup -q -n %{n}-%{realversion}
 
 %build
 rm -rf ../build; mkdir ../build; cd ../build
+
+%ifarch x86_64
+USE_CUDA=ON
+%else
+USE_CUDA=OFF
+%endif
 
 cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3 \
@@ -22,7 +30,7 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DCMAKE_INSTALL_LIBDIR=lib \
    -Donnxruntime_ENABLE_PYTHON=ON \
    -Donnxruntime_BUILD_SHARED_LIB=ON \
-   -Donnxruntime_USE_CUDA=ON \
+   -Donnxruntime_USE_CUDA=${USE_CUDA} \
    -Donnxruntime_CUDA_VERSION="${CUDA_VERSION}" \
    -Donnxruntime_CUDA_HOME="${CUDA_ROOT}" \
    -Donnxruntime_CUDNN_HOME="${CUDNN_ROOT}" \

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -7,9 +7,7 @@ Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 Requires: protobuf py3-numpy py2-wheel py2-onnx zlib libpng py2-pybind11
-%ifarch x86_64
 Requires: cuda cudnn
-%endif
 
 %prep
 %setup -q -n %{n}-%{realversion}
@@ -17,11 +15,7 @@ Requires: cuda cudnn
 %build
 rm -rf ../build; mkdir ../build; cd ../build
 
-%ifarch x86_64
 USE_CUDA=ON
-%else
-USE_CUDA=OFF
-%endif
 
 cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3 \


### PR DESCRIPTION
This PR adds the GPU support for ONNXRuntime. The built library still runs on CPU by default (thus current applications in CMSSW are unaffected), while GPU inference can be enabled if needed (see [example](https://www.onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html)).

A few changes needed:
 - a small modification on `cuda` is needed (namely, keeping `libcudart_static.a`) for cmake to detect `nvcc` correctly
 - `cudnn` is added as a dependency. Note that generally downloading `cudnn` needs NVIDIA Developer Program Membership, though direct download link w/o authentication exists (and used here). Experts should probably double check if  the way we distribute it complies with its [SLA](https://docs.nvidia.com/deeplearning/cudnn/sla/index.html).


Also I am not sure if this will compile on `ppc64le` or `aarch64` (though `cudnn` exists for them).

FYI @riga @mialiu149