### PR TITLE
[BuildRules] Fixes for multi-target releases

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V2_2_9_pre12
+### RPM lcg SCRAMV1 V2_2_9_pre13
 ## NOCOMPILER
 
 BuildRequires: gmake

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -67,7 +67,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-01-21
+%define configtag       V06-01-22
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -67,7 +67,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-01-22
+%define configtag       V06-01-23
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
create `.edmplugincache` for each extra target too otherwise plugin manager load plugins for default lib directory