### PR TITLE
LLVM - Don't flag EventSetupRecord::get calls if first argument is of type ESGetToken

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -8,7 +8,7 @@ Requires: gcc zlib python python3
 Requires: cuda
 AutoReq: no
 
-%define llvmCommit 6afd8d28e7729e1256cc832c60e4be6830f05dc6
+%define llvmCommit 78a28e50771b942539061987e51a1a5b39554454
 %define llvmBranch cms/release/11.x/1fdec59
 %define iwyuCommit 5db414ac448004fe019871c977905cb7c2cff23f
 %define iwyuBranch clang_11


### PR DESCRIPTION
see https://github.com/cms-externals/llvm-project/pull/11