### PR TITLE
Disable a warning message when using Eigen in CUDA code

### DIFF
--- a/eigen-toolfile.spec
+++ b/eigen-toolfile.spec
@@ -15,6 +15,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/eigen.xml
   </client>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags CPPDEFINES="EIGEN_DONT_PARALLELIZE"/>
+  <flags CUDA_FLAGS="--diag-suppress 20014"/>
 </tool>
 EOF_TOOLFILE
 

--- a/eigen-toolfile.spec
+++ b/eigen-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external eigen-toolfile 1.0
+### RPM external eigen-toolfile 2.0
 Requires: eigen
 %prep
 


### PR DESCRIPTION
Disable one more "calling a `__host__` function from a `__host__` `__device__` function is not allowed" message when compiling CUDA device code that includes Eigen objects with NVCC.

Fixes cms-sw/cmssw#33369 .