### PR TITLE
[10.6] update EgammaAnalysis-ElectronTools to V00-03-01

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -20,7 +20,7 @@ Configuration-Generator=V01-00-03
 CondTools-SiPhase2Tracker=V00-01-00
 PhysicsTools-NanoAOD=V01-01-00
 CalibCalorimetry-EcalTrivialCondModules=V00-02-00
-EgammaAnalysis-ElectronTools=V00-03-00
+EgammaAnalysis-ElectronTools=V00-03-01
 RecoTauTag-TrainingFiles=V00-01-01
 
 ########################################################################################


### PR DESCRIPTION
backport of cms-data/EgammaAnalysis-ElectronTools#11

only new files were added. So, this should be straightforward to integrate.

This is needed in connection with cms-sw/cmssw#33359 , which does not trigger an existing workflow to use the new data files, but can be enabled in a local/analysis setup.

