### PR TITLE
Test onnxruntime 1.7.2 integration

### DIFF
--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,8 +1,8 @@
-### RPM external onnxruntime 1.6.0
+### RPM external onnxruntime 1.7.2
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 %define github_user cms-externals
 %define branch cms/v%{realversion}
-%define tag 89a104708d109afc7f41661be33062605b7776a3
+%define tag a3524b823f922f1ccdc8e5c5f5960563234767fc
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja


### PR DESCRIPTION
@hqucms any objection to move to 1.7.2 if it integrates,
we can update it to the last tag before trying to fix/report the Arm runtime errors