### PR TITLE
Add mariadb dependency to wmagentpy3.spec

### DIFF
--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -10,6 +10,8 @@ Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
 Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL
 Requires: py3-pyzmq py3-psutil py3-future py3-retry
 Requires: py3-cmsmonitoring
+Requires: mariadb
+
 # Alan Malta dropped on 2/Feb/2021: Requires: py3-cheetah py3-mysqldb
 BuildRequires: py3-sphinx couchskel
 


### PR DESCRIPTION
This is a change needed to fix the dependencies for the python3 version of `wmagent` from `MariaDB`