### PR TITLE
 DD4Hep - get latest on master 11.3

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -1,6 +1,6 @@
 ### RPM external dd4hep v01-16-01
 
-%define tag %{realversion}
+%define tag 9bbe12b080ce52615251facc6f6ff5dd58a60e69
 %define branch master
 %define github_user AIDASoft
 %define keep_archives true


### PR DESCRIPTION
Resolves: #6812 (to close also the first issue on merge)
use latest on master also for 11.3, see #6824