### PR TITLE
GCC 10 is supported by CUDA 11.x

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -39,8 +39,5 @@
 # link the CUDA runtime shared library
 %define cuda_flags_6 --cudart shared
 
-# disable nvcc check for supported host compiler versions
-%define cuda_flags_7 --allow-unsupported-compiler
-
 # collect all CUDA flags
-%define nvcc_cuda_flags %{nvcc_stdcxx} %{cuda_flags_0} %{cuda_flags_1} %{cuda_flags_2} %{cuda_flags_3} %{cuda_flags_4} %{cuda_flags_5} %{cuda_flags_6} %{cuda_flags_7}
+%define nvcc_cuda_flags %{nvcc_stdcxx} %{cuda_flags_0} %{cuda_flags_1} %{cuda_flags_2} %{cuda_flags_3} %{cuda_flags_4} %{cuda_flags_5} %{cuda_flags_6}


### PR DESCRIPTION
Drop the `--allow-unsupported-compiler` compilation flag.