### PR TITLE
[11.1.X] Remove crab dependency

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,8 +1,7 @@
-### RPM cms cmssw-tool-conf 45.0
+### RPM cms cmssw-tool-conf 45.1
 ## NOCOMPILER
 # With cmsBuild, change the above version only when a new tool is added
 
-Requires: crab
 Requires: google-benchmark-toolfile
 Requires: catch2-toolfile
 Requires: starlight-toolfile


### PR DESCRIPTION
CMSSW 11.1.X release cycle has an old version of crab (3.3.2005). New crab version scheme is vN.N and that is already included in latest CMSSW release cycles ( 11.2 and above). We suggest to drop crab in 11.1.X. 

There is no need to build a full CMSSW_11_1 release now. Just include this in any future full cmssw 11.1 release. 