### PR TITLE
build py2-Pygments which is needed by dxr; treat .icc as cpp files

### DIFF
--- a/Pygments-cpp-extension-fix.patch
+++ b/Pygments-cpp-extension-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/pygments/lexers/_mapping.py b/pygments/lexers/_mapping.py
+index acb71ad..e8169a3 100644
+--- a/pygments/lexers/_mapping.py
++++ b/pygments/lexers/_mapping.py
+@@ -101,7 +101,7 @@ LEXERS = {
+     'CommonLispLexer': ('pygments.lexers.lisp', 'Common Lisp', ('common-lisp', 'cl', 'lisp'), ('*.cl', '*.lisp'), ('text/x-common-lisp',)),
+     'ComponentPascalLexer': ('pygments.lexers.oberon', 'Component Pascal', ('componentpascal', 'cp'), ('*.cp', '*.cps'), ('text/x-component-pascal',)),
+     'CoqLexer': ('pygments.lexers.theorem', 'Coq', ('coq',), ('*.v',), ('text/x-coq',)),
+-    'CppLexer': ('pygments.lexers.c_cpp', 'C++', ('cpp', 'c++'), ('*.cpp', '*.hpp', '*.c++', '*.h++', '*.cc', '*.hh', '*.cxx', '*.hxx', '*.C', '*.H', '*.cp', '*.CPP'), ('text/x-c++hdr', 'text/x-c++src')),
++    'CppLexer': ('pygments.lexers.c_cpp', 'C++', ('cpp', 'c++'), ('*.icc', '*.cpp', '*.hpp', '*.c++', '*.h++', '*.cc', '*.hh', '*.cxx', '*.hxx', '*.C', '*.H', '*.cp', '*.CPP'), ('text/x-c++hdr', 'text/x-c++src')),
+     'CppObjdumpLexer': ('pygments.lexers.asm', 'cpp-objdump', ('cpp-objdump', 'c++-objdumb', 'cxx-objdump'), ('*.cpp-objdump', '*.c++-objdump', '*.cxx-objdump'), ('text/x-cpp-objdump',)),
+     'CrmshLexer': ('pygments.lexers.dsls', 'Crmsh', ('crmsh', 'pcmk'), ('*.crmsh', '*.pcmk'), ()),
+     'CrocLexer': ('pygments.lexers.d', 'Croc', ('croc',), ('*.croc',), ('text/x-crocsrc',)),

--- a/pip/Pygments.file
+++ b/pip/Pygments.file
@@ -1,1 +1,2 @@
+Patch0: Pygments-cpp-extension-fix
 %define RelocatePython %{i}/bin/pygmentize

--- a/pip/Pygments.file
+++ b/pip/Pygments.file
@@ -1,2 +1,2 @@
 Patch0: Pygments-cpp-extension-fix
-%define RelocatePython %{i}/bin/pygmentize
+%define PipPostBuildPy3 mv %{i}/bin/pygmentize %{i}/bin/pygmentize3

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -246,6 +246,7 @@ pycuda==2019.1.2
 pycurl==7.43.0.5
 pydot==1.4.2
 pyflakes==2.2.0
+Pygments==2.5.2 ; python_version<'3.0'
 Pygments==2.8.1 ; python_version>'3.0'
 PyJWT==2.0.1 ; python_version>'3.0'
 pylint==1.9.5 ; python_version<'3.0'

--- a/py2-dxr.patch
+++ b/py2-dxr.patch
@@ -11,4 +11,16 @@ index a095d2a..bf101ab 100644
 
  PLUGIN_NAME   = 'clang'
 
+diff --git a/dxr/mime.py b/dxr/mime.py
+index bf036f5..4648ae6 100644
+--- a/dxr/mime.py
++++ b/dxr/mime.py
+@@ -26,6 +26,7 @@ ext_map = {
+     "cpp":        'cpp',
+     "cc":         'cpp',
+     "cxx":        'cpp',
++    "icc":        'cpp',
+     "c":          'c',
+     "xul":        'ui',
+     "svg":        'svg',
 

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -1,7 +1,7 @@
 ### RPM external py2-dxr 1.0
 ## INITENV +PATH PYTHON27PATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
-Requires: python python3 zlib py2-setuptools py2-pysqlite llvm sqlite py3-setuptools
+Requires: python zlib py2-setuptools py2-pysqlite llvm sqlite
 %define dxrCommit 6ea764102a
 %define triliteCommit e64a2a1 
 %define re2Version 20140304
@@ -59,12 +59,10 @@ cd re2
 make
 cd ../../
 python2 setup.py build
-python3 setup.py build
 
 %install
 mkdir %i/lib
 cp -p trilite/libtrilite.so %i/lib
 cp -p trilite/re2/obj/libre2.a %i/lib
 python2 setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null
-python3 setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null
 perl -p -i -e "s|^#!%{cmsroot}/.*|#!/usr/bin/env python|" %{i}/bin/*.py

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -1,7 +1,7 @@
 ### RPM external py2-dxr 1.0
 ## INITENV +PATH PYTHON27PATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
-Requires: python zlib py2-setuptools py2-pysqlite llvm sqlite
+Requires: python python3 zlib py2-setuptools py2-pysqlite llvm sqlite py3-setuptools
 %define dxrCommit 6ea764102a
 %define triliteCommit e64a2a1 
 %define re2Version 20140304
@@ -59,10 +59,12 @@ cd re2
 make
 cd ../../
 python2 setup.py build
+python3 setup.py build
 
 %install
 mkdir %i/lib
 cp -p trilite/libtrilite.so %i/lib
 cp -p trilite/re2/obj/libre2.a %i/lib
 python2 setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null
+python3 setup.py install --prefix=%i  --single-version-externally-managed --record=/dev/null
 perl -p -i -e "s|^#!%{cmsroot}/.*|#!/usr/bin/env python|" %{i}/bin/*.py

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -52,6 +52,7 @@ Requires: py2-psutil
 Requires: py2-repoze-lru
 Requires: py2-Jinja2
 Requires: py2-MarkupSafe
+Requires: py2-Pygments
 Requires: py3-Pygments
 Requires: py2-appdirs
 Requires: py2-argparse


### PR DESCRIPTION
DXR which needs py2-Pygments is only available for Python2. Python3 support seems unlikely ( https://github.com/mozilla/dxr/issues/704 ) . So for now, we add back py2-Pygments  and also patch dxr and Pygments  to treat our `.icc` files as `c++` files