### PR TITLE
Enable DYNAMIC_CPU_ARCH in ONNXRuntime to use up to AVX2

### DIFF
--- a/onnxruntime-toolfile.spec
+++ b/onnxruntime-toolfile.spec
@@ -20,7 +20,7 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/onnxruntime.xml
   <use name="cuda"/>
   <use name="cudnn"/>
 %endif
-  <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="0"/>
+  <runtime name="MLAS_DYNAMIC_CPU_ARCH" value="2"/>
 </tool>
 EOF_TOOLFILE
 


### PR DESCRIPTION
As discussed in https://github.com/cms-sw/cmssw/issues/32883#issuecomment-828393966, we would like to test the dynamic arch option in ONNXRuntime. The `MLAS_DYNAMIC_CPU_ARCH` is changed from 0 (no dynamic arch) to 2 (dynamic arch, use up to AVX2).