### PR TITLE
Update tag for RecoEgamma-ElectronIdentification to V01-05-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-ElectronIdentification=V01-05-00
 RecoBTag-Combined=V01-11-00
 RecoEgamma-PhotonIdentification=V01-01-00
 Geometry-TestReference=V00-06-00
@@ -18,7 +19,6 @@ L1Trigger-TrackTrigger=V00-01-00
 RecoParticleFlow-PFProducer=V16-01-00
 RecoJets-JetProducers=V05-13-00
 RecoTracker-TkSeedGenerator=V00-02-00
-RecoEgamma-ElectronIdentification=V01-04-00
 CalibTracker-SiPixelESProducers=V02-02-00
 CalibPPS-ESProducers=V01-03-00
 L1Trigger-L1THGCal=V01-04-00


### PR DESCRIPTION
Move RecoEgamma-ElectronIdentification data to new tag, see 
https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/18
