### PR TITLE
Add libunwind dependency on zlib.

### DIFF
--- a/libunwind.spec
+++ b/libunwind.spec
@@ -3,6 +3,7 @@
 %define branch v1.5-stable
 Source0: git://github.com/%{n}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 BuildRequires: autotools gmake
+Requires: zlib
 
 Patch0: libunwind-fix-comma
 

--- a/libunwind.spec
+++ b/libunwind.spec
@@ -13,7 +13,7 @@ Patch0: libunwind-fix-comma
 
 %build
 autoreconf -fiv
-./configure CFLAGS="-g -O3 -fcommon" --prefix=%{i} --disable-block-signals
+./configure CFLAGS="-g -O3 -fcommon" --prefix=%{i} --disable-block-signals --enable-zlibdebuginfo
 make %{makeprocesses}
 
 %install


### PR DESCRIPTION
Changes between libunwind v1.4 and v1.5 
https://github.com/libunwind/libunwind/compare/v1.4.0...v1.5
may include a dependency on libz.so. 
Since we use our own libz.so libunwind.so should be linked against it.