### PR TITLE
[SCRAM] Fix scram build -j without N option bug

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V3_00_21
+### RPM lcg SCRAMV1 V3_00_22
 ## NOCOMPILER
 
 Provides: perl(BuildSystem::Template::Plugins::PluginCore)
@@ -6,7 +6,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag b481d08d9da36ba2203e0db85f239f2d50c2137d
+%define tag a77d36bb7ddad8d3b1ed4f8ca1651925c87f4ca0
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -67,7 +67,7 @@ Requires: glibc
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-03
+%define configtag       V06-02-04
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This PR fixes two issues
- `scram b -j` should run `gmake -j $(nproc)` . It was broken with SCRAM V3. This should be fixed now.
- `scram b disable-biglib` is broken with SCRAMV3. Disabling the biglib was commenting the biglib paths using `#` in the `config/Self.xml` file. `#` was a valid comment character for SCRSM V2 but as SCRAM V3 uses proper xml parser, so this was not a valid comment. BuildRules are fixed to use proper `<!--  -->` comment