### PR TITLE
[10.6.X] Update of GeneratorInterface-EvtGenInterface tag in cmsswdata.txt

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,7 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
-GeneratorInterface-EvtGenInterface=V02-03-00
+GeneratorInterface-EvtGenInterface=V02-04-00
 Alignment-OfflineValidation=V00-01-00
 CalibPPS-ESProducers=V01-03-00
 RecoMET-METPUSubtraction=V01-01-00


### PR DESCRIPTION
Update of GeneratorInterface-EvtGenInterface to the new tag V02-04-00 in order to use new pdl files added in https://github.com/cms-data/GeneratorInterface-EvtGenInterface/pull/18. This is needed for the central production of UL Bs->MuMu samples.