### PR TITLE
WMAgent and WMAgent-dev with 1.4.9.pre1 and CMSCouchapp

### DIFF
--- a/wmagent-dev.spec
+++ b/wmagent-dev.spec
@@ -1,4 +1,4 @@
-### RPM cms wmagent-dev 1.4.7.pre8
+### RPM cms wmagent-dev 1.4.9.pre1
 
 # This is a meta-package to group development tool dependencies
 Requires: wmagent rotatelogs pystack wmcore-devtools

--- a/wmagent.spec
+++ b/wmagent.spec
@@ -1,4 +1,4 @@
-### RPM cms wmagent 1.4.7.patch3
+### RPM cms wmagent 1.4.9.pre1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
These 2 rpms should be built on top of the new couchapp spec, provided in:
https://github.com/cms-sw/cmsdist/pull/6892