### PR TITLE
Remove root_numpy and root_pandas on cmsdist master

### DIFF
--- a/pip/py2-root_pandas.file
+++ b/pip/py2-root_pandas.file
@@ -1,1 +1,0 @@
-Requires: py2-pandas py2-root_numpy

--- a/pip/py3-root_pandas.file
+++ b/pip/py3-root_pandas.file
@@ -1,1 +1,0 @@
-Requires: py3-pandas py3-root_numpy

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -281,8 +281,6 @@ rep==0.6.6 ; python_version> '3.0'
 requests==2.25.1
 requests-toolbelt==0.9.1 ; python_version> '3.0'
 requests-oauthlib==1.3.0 ; python_version> '3.0'
-root_numpy==4.8.0
-root_pandas==0.7.0
 rootpy==1.0.1
 rsa==4.7.2 ; python_version>'3.0'
 scandir==1.10.0

--- a/pip/root_numpy.file
+++ b/pip/root_numpy.file
@@ -1,1 +1,0 @@
-Requires: py2-numpy root

--- a/pip/root_pandas.file
+++ b/pip/root_pandas.file
@@ -1,1 +1,0 @@
-Requires: py3-pandas py2-pandas py2-root_numpy

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -21,7 +21,6 @@ Requires: py3-tables
 Requires: py2-numexpr
 Requires: py2-histogrammar py3-histogrammar
 Requires: py2-pandas
-Requires: py2-root_numpy
 Requires: py2-Bottleneck
 Requires: py2-downhill
 Requires: py2-theanets
@@ -36,7 +35,6 @@ Requires: py2-hyperopt
 Requires: py2-seaborn
 Requires: py2-h5py
 Requires: py2-h5py-cache
-Requires: py2-root_pandas
 Requires: py2-uproot
 Requires: py2-uproot4
 Requires: py2-opt-einsum


### PR DESCRIPTION
while testing ROOT master integration, compilation failed due to unmaintained root_numpy
It's not compiling anymore with ROOT master, this is a request to remove both from everywhere