### PR TITLE
Update CMSCouchapp from 1.2.9 to 1.2.10

### DIFF
--- a/py2-cmscouchapp.spec
+++ b/py2-cmscouchapp.spec
@@ -1,4 +1,4 @@
-### RPM external py2-cmscouchapp 1.2.9
+### RPM external py2-cmscouchapp 1.2.10
 ## IMPORT build-with-pip
 
 %define pip_name CMSCouchapp


### PR DESCRIPTION
Basically the same as 1.2.9, but less verbose (especially with regards to the payload)