### PR TITLE
Add py3-cheetah3.spec

### DIFF
--- a/py3-cheetah3.spec
+++ b/py3-cheetah3.spec
@@ -1,6 +1,7 @@
-### RPM external py3-markdown 3.3.3
+### RPM external py3-cheetah3 3.2.6.post2
 ## IMPORT build-with-pip3
 
-%define pip_name Markdown
+Requires: py3-markdown
+%define pip_name Cheetah3
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -10,9 +10,10 @@ Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
 Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL
 Requires: py3-pyzmq py3-psutil py3-future py3-retry
 Requires: py3-cmsmonitoring py3-cmscouchapp
+Requires: py3-cheetah3
 Requires: mariadb
 
-# Alan Malta dropped on 2/Feb/2021: Requires: py3-cheetah py3-mysqldb
+# Alan Malta dropped on 2/Feb/2021: Requires: py3-mysqldb
 BuildRequires: py3-sphinx couchskel
 
 %prep


### PR DESCRIPTION
[dmwm/WMCore](https://github.com/dmwm/WMCore) depends on [Cheetah](https://pypi.org/project/Cheetah/), that does not support python3. 

The easiest solution is providing [Cheetah3](https://pypi.org/project/Cheetah3/) with the WMCore python3 environment. Since the interface did not change from `Cheetah` to `Cheetah3`, this PR should fix [dmwm/WMCore issue 6460](https://github.com/dmwm/WMCore/issues/6460).