### PR TITLE
Created py3-cmscouchapp spec; bump py3-requests to 2.25.1; dependency for wmagentpy3

### DIFF
--- a/py3-cmscouchapp.spec
+++ b/py3-cmscouchapp.spec
@@ -1,6 +1,7 @@
-### RPM external py3-requests 2.25.1
+### RPM external py3-cmscouchapp 1.3.0
 ## IMPORT build-with-pip3
 
-Requires: py3-certifi py3-urllib3 py3-idna py3-chardet
+%define pip_name CMSCouchapp
 
+Requires: py3-requests
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -9,7 +9,7 @@ Requires: yui libuuid couchdb15 condor jemalloc dbs3-client
 Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
 Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL
 Requires: py3-pyzmq py3-psutil py3-future py3-retry
-Requires: py3-cmsmonitoring
+Requires: py3-cmsmonitoring py3-cmscouchapp
 Requires: mariadb
 
 # Alan Malta dropped on 2/Feb/2021: Requires: py3-cheetah py3-mysqldb


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10303

The CMSCouchapp still needs to be validated in python3 though.

Another task to be done is, we need to decide how to deal with the couchdb15 spec, which right now depends on the python2 CMSCouchapp.