### PR TITLE
Update tag for L1Trigger-CSCTriggerPrimitives to V00-08-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,7 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
-L1Trigger-CSCTriggerPrimitives=V00-06-00
+L1Trigger-CSCTriggerPrimitives=V00-08-00
 RecoEgamma-ElectronIdentification=V01-05-00
 GeneratorInterface-EvtGenInterface=V02-04-00
 RecoBTag-Combined=V01-11-00


### PR DESCRIPTION
Move L1Trigger-CSCTriggerPrimitives data to new tag, see 
https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/8
