### PR TITLE
libunwind - rename lib64 to lib if exists

### DIFF
--- a/libunwind.spec
+++ b/libunwind.spec
@@ -18,5 +18,6 @@ make %{makeprocesses}
 
 %install
 make %{makeprocesses} install
+[ -d %{i}/lib64 ] && mv %i/lib64 %i/lib
 
 %define drop_files %{i}/share/man %{i}/lib/pkgconfig %{i}/lib/*.a


### PR DESCRIPTION
forcefully move lib64 to lib if it's there