### PR TITLE
Enable libunwind-toolfile and rebuild the external

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -175,8 +175,8 @@ Requires: cupla-toolfile
 Requires: cudnn-toolfile
 %endif
 
-%ifnarch ppc64le
 Requires: libunwind-toolfile
+%ifnarch ppc64le
 Requires: igprof-toolfile
 Requires: openloops-toolfile
 %endif

--- a/libunwind.spec
+++ b/libunwind.spec
@@ -17,6 +17,7 @@ autoreconf -fiv
 make %{makeprocesses}
 
 %install
+
 make %{makeprocesses} install
 
 %define drop_files %{i}/share/man %{i}/lib/pkgconfig %{i}/lib/*.a


### PR DESCRIPTION
after some failures I found out libunwind is not built on PPC
https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_12_0_X/master/cmssw-tool-conf.spec#L180
and I'll enable it for this night IB to see what wrong with it
gperf requires libunwind 