### PR TITLE
update mkfit to 3.0.1

### DIFF
--- a/mkfit-toolfile.spec
+++ b/mkfit-toolfile.spec
@@ -26,6 +26,7 @@ done
 cat << \EOF_TOOLFILE >>%i/etc/scram.d/%{base_package}.xml
   </client>
   <use name="tbb"/>
+  <use name="json"/>
   <runtime name="MKFIT_BASE" value="$MKFITBASE"/>
 </tool>
 EOF_TOOLFILE

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,6 +1,6 @@
-### RPM external mkfit 2.1.0
+### RPM external mkfit 3.0.0
 ## INCLUDE compilation_flags
-%define tag V2.1.0-0+pr291
+%define tag V3.0.0-0+pr315
 %define branch devel
 %define github_user trackreco
 

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -20,7 +20,7 @@ sed -i -e 's|-std=c++14|-std=c++1z|' Makefile.config
 
 %build
 %ifarch x86_64
-BUILD_ARGS=VEC_GCC="-msse3"
+BUILD_ARGS=SSE3="1"
 %endif
 %ifarch aarch64
 BUILD_ARGS=VEC_GCC="-march=native"

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,6 +1,6 @@
-### RPM external mkfit 3.0.0
+### RPM external mkfit 3.0.1
 ## INCLUDE compilation_flags
-%define tag V3.0.0-0+pr315
+%define tag V3.0.1-1+e081989
 %define branch devel
 %define github_user trackreco
 


### PR DESCRIPTION
A new release of mkfit is now available
https://github.com/trackreco/mkFit/releases/tag/V3.0.0-0%2Bpr315

this cmsdist PR still needs a matching PR in cms-sw/cmssw
