### PR TITLE
Add condor python3 version and make wmagentpy3 require it

### DIFF
--- a/boost-1.75.0-disable-statx.patch
+++ b/boost-1.75.0-disable-statx.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/filesystem/build/Jamfile.v2 b/libs/filesystem/build/Jamfile.v2
+index 132641a..0f2c2c8 100644
+--- a/libs/filesystem/build/Jamfile.v2
++++ b/libs/filesystem/build/Jamfile.v2
+@@ -53,8 +53,6 @@ project boost/filesystem
+       [ check-target-builds ../config//has_stat_st_birthtim "has stat::st_birthtim" : <define>BOOST_FILESYSTEM_HAS_STAT_ST_BIRTHTIM ]
+       [ check-target-builds ../config//has_stat_st_birthtimensec "has stat::st_birthtimensec" : <define>BOOST_FILESYSTEM_HAS_STAT_ST_BIRTHTIMENSEC ]
+       [ check-target-builds ../config//has_stat_st_birthtimespec "has stat::st_birthtimespec" : <define>BOOST_FILESYSTEM_HAS_STAT_ST_BIRTHTIMESPEC ]
+-      [ check-target-builds ../config//has_statx "has statx" : <define>BOOST_FILESYSTEM_HAS_STATX ]
+-      [ check-target-builds ../config//has_statx_syscall "has statx syscall" : <define>BOOST_FILESYSTEM_HAS_STATX_SYSCALL ]
+       <conditional>@select-windows-crypto-api
+     : source-location ../src
+     : usage-requirements # pass these requirement to dependents (i.e. users)

--- a/boost175py3.spec
+++ b/boost175py3.spec
@@ -1,0 +1,84 @@
+### RPM external boost175py3 1.75.0
+
+%define tag 3defebd61ecb0970c0046c85384bb34ec9572ac3
+%define branch cms/v%realversion
+%define github_user cms-externals
+Source: git+https://github.com/%github_user/boost.git?obj=%{branch}/%{tag}&export=boost-%{realversion}&output=/boost-%{realversion}.tgz
+Patch0: boost-1.75.0-disable-statx
+Requires: python3 bz2lib zlib openmpi xz zstd
+
+%prep
+%setup -n boost-%{realversion}
+%patch0 -p1
+
+%build
+case %cmsos in 
+  osx*) TOOLSET=darwin ;;
+  *) TOOLSET=gcc ;;
+esac
+
+pushd tools/build
+  sh bootstrap.sh ${TOOLSET}
+  mkdir ./tmp-boost-build
+  ./b2 install --prefix=./tmp-boost-build
+  export PATH=${PWD}/tmp-boost-build/bin:${PATH}
+popd
+
+PYTHONV3=$(echo $PYTHON3_VERSION | cut -f1,2 -d.)
+
+# enable boost::mpi
+echo "using mpi ;" > user-config.jam
+echo "using python : ${PYTHONV3} : ${PYTHON3_ROOT}/bin/python3 : ${PYTHON3_ROOT}/include/python${PYTHONV3} : ${PYTHON3_ROOT}/lib ;" >> user-config.jam
+
+b2 -q \
+   -d2 \
+   %{makeprocesses} \
+   --build-dir=build-boost \
+   --disable-icu \
+   --without-atomic \
+   --without-container \
+   --without-context \
+   --without-coroutine \
+   --without-exception \
+   --without-graph \
+   --without-graph_parallel \
+   --without-locale \
+   --without-log \
+   --without-math \
+   --without-random \
+   --without-wave \
+   --user-config=${PWD}/user-config.jam \
+   toolset=${TOOLSET} \
+   link=shared \
+   threading=multi \
+   variant=release \
+   python=${PYTHONV3} \
+   -sBZIP2_INCLUDE=${BZ2LIB_ROOT}/include \
+   -sBZIP2_LIBPATH=${BZ2LIB_ROOT}/lib \
+   -sZLIB_INCLUDE=${ZLIB_ROOT}/include \
+   -sZLIB_LIBPATH=${ZLIB_ROOT}/lib \
+   -sLZMA_INCLUDE=${XZ_ROOT}/include \
+   -sLZMA_LIBPATH=${XZ_ROOT}/lib \
+   -sZSTD_INCLUDE=${ZSTD_ROOT}/include \
+   -sZSTD_LIBPATH=${ZSTD_ROOT}/lib \
+   stage
+
+%install
+case %{cmsos} in
+  osx*) so=dylib ;;
+     *) so=so ;;
+esac
+mkdir -p %{i}/lib %{i}/include
+# copy files around in their final location.
+# We use tar to reduce the number of processes required
+# and because we need to build the build hierarchy for
+# the files that we are copying.
+pushd stage/lib
+  find . -name "*.${so}*" -type f | tar cf - -T - | (cd %{i}/lib; tar xfp -)
+popd
+find boost -name '*.[hi]*' | tar cf - -T - | ( cd %{i}/include; tar xfp -)
+
+for l in $(find %{i}/lib -name "*.${so}.*")
+do
+  ln -s $(basename ${l}) $(echo ${l} | sed -e "s|[.]${so}[.].*|.${so}|")
+done

--- a/condorpy3.spec
+++ b/condorpy3.spec
@@ -1,0 +1,99 @@
+### RPM external condorpy3 8.9.7
+## INITENV +PATH LD_LIBRARY_PATH %i/lib/condor
+## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
+%define condortag %(echo V%realversion | tr "." "_")
+
+Source: git://github.com/htcondor/htcondor.git?obj=master/%{condortag}&export=condor-%{realversion}&output=/condor-%{realversion}.tar.gz
+Patch0: cms-htcondor-build
+Patch1: condor-vomsapi-static
+
+Requires: zlib expat pcre libtool boost175py3 p5-archive-tar curl libxml2 p5-time-hires libuuid sqlite
+BuildRequires: cmake gcc python3 py3-setuptools
+
+%prep
+%setup -n condor-%{realversion}
+%patch0 -p1
+%patch1 -p1
+
+%build
+export CMAKE_INCLUDE_PATH=${LIBTOOL_ROOT}/include:${ZLIB_ROOT}/include:${PCRE_ROOT}/include:${BOOST175PY3_ROOT}/include:${EXPAT_ROOT}/include:${CURL_ROOT}/include:${LIBXML2_ROOT}/include:${LIBUUID_ROOT}/include:${SQLITE_ROOT}/include
+export CMAKE_LIBRARY_PATH=${LIBTOOL_ROOT}/lib:${ZLIB_ROOT}/lib:${PCRE_ROOT}/lib:${BOOST175PY3_ROOT}/lib:${EXPAT_ROOT}/lib:${CURL_ROOT}/lib:${LIBXML2_ROOT}/lib:${LIBUUID_ROOT}/lib:${SQLITE_ROOT}/lib
+export CXXFLAGS="-I${LIBTOOL_ROOT}/include -I$ZLIB_ROOT/include -I$PCRE_ROOT/include -I$BOOST175PY3_ROOT/include -I$EXPAT_ROOT/include -I$CURL_ROOT/include -I$LIBXML2_ROOT/include -I${LIBUUID_ROOT}/include -I${SQLITE_ROOT}/include"
+export LDFLAGS="-L${LIBTOOL_ROOT}/lib -L$ZLIB_ROOT/lib -L$PCRE_ROOT/lib -L$BOOST175PY3_ROOT/lib -L$EXPAT_ROOT/lib -L$CURL_ROOT/lib -L$LIBXML2_ROOT/lib -L${LIBUUID_ROOT}/lib -L${SQLITE_ROOT}/lib"
+export CFLAGS="$CXXFLAGS"
+
+cmake \
+  -DCMAKE_INSTALL_PREFIX=%i \
+  -DPROPER:BOOL=OFF \
+  -DBUILD_TESTING:BOOL=OFF \
+  -DBoost_INCLUDE_DIR:PATH=$BOOST175PY3_ROOT/include \
+  -DBoost_LIBRARY_DIRS:FILEPATH=$BOOST175PY3_ROOT/lib \
+  -DBoost_THREAD_LIBRARY:FILEPATH=$BOOST175PY3_ROOT/lib/libboost_thread.so \
+  -DBoost_THREAD_LIBRARY_DEBUG:FILEPATH=$BOOST175PY3_ROOT/lib/libboost_thread.so \
+  -DBoost_THREAD_LIBRARY_RELEASE:FILEPATH=$BOOST175PY3_ROOT/lib/libboost_thread.so \
+  -DBoost_PYTHON_LIBRARY:FILEPATH=$BOOST175PY3_ROOT/$PYTHON_LIB_SITE_PACKAGES \
+  -DUW_BUILD:BOOL=ON \
+  -DWITH_GLOBUS:BOOL=ON \
+  -DWITH_CREAM:BOOL=OFF \
+  -DWITH_PYTHON_BINDINGS:BOOL=ON \
+  -DWITH_VOMS:BOOL=ON \
+  -DHAVE_SSH_TO_JOB:BOOL=OFF \
+  -DWITH_COREDUMPER:BOOL=OFF \
+  -DWITH_DRMAA:BOOL=OFF \
+  -DWITH_GSOAP:BOOL=OFF \
+  -DWITH_BLAHP:BOOL=OFF \
+  -DWITH_KRB5:BOOL=OFF \
+  -DWITH_LIBCGROUP:BOOL=OFF \
+  -DWITH_LIBVIRT:BOOL=OFF \
+  -DLDAP_FOUND_SEARCH_lber:PATH=LDAP_FOUND_SEARCH_lber-NOTFOUND \
+  -DLDAP_FOUND_SEARCH_ldap:PATH=LDAP_FOUND_SEARCH_ldap-NOTFOUND \
+  -DWITH_UNICOREGAHP:BOOL=OFF \
+  -DWITH_LIBDELTACLOUD:BOOL=OFF \
+  -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON3_ROOT}/bin/python3.8 \
+  -DPYTHON_INCLUDE_DIR:PATH=${PYTHON3_ROOT}/include/python3.8 \
+  -DPYTHON_LIBRARY:FILEPATH=${PYTHON3_ROOT}/lib/libpython3.8.so \
+  -DEXPAT_FOUND_SEARCH_expat:FILEPATH=${EXPAT_ROOT}/lib/libexpat.so \
+  -DCLIPPED:BOOL=ON \
+  -DWITH_BOINC:BOOL=OFF \
+  -DWITH_SCITOKENS:BOOL=OFF \
+  -DCMAKE_SKIP_RPATH:BOOL=ON
+
+# Use makeprocess macro, it uses compiling_processes defined by
+# build configuration file or build argument
+make %makeprocesses VERBOSE=1 externals
+make %makeprocesses VERBOSE=1
+
+%install
+make install
+
+# Move the python-bindings to the correct place
+mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
+mv %i/lib/python/* %i/$PYTHON_LIB_SITE_PACKAGES
+# Get rid of hardcoded /usr/bin/python
+egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/env python}'
+
+# Strip libraries, we are not going to debug them.
+%define strip_files %i/lib
+
+# Clean things up; read the docs online;
+# remove condor_gather_info since it brings a dependency on Date::Manip
+rm -rf %i/{README,etc/{examples,init.d,sysconfig},examples} \
+       %i/{include,sbin,libexec,src,condor*,bosco*}         \
+       %i/bin/{condor_gather_info,bosco*} %i/lib/python     \
+       %i/lib/condor/{libcom*,libcrypto*,libk*,libl*,libp*} \
+       %i/lib/condor/{libssl*,libgssapi_krb5*,libexpat*1}
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -5,9 +5,7 @@
 
 Source: git://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=WMCore-%{realversion}&output=/WMCore-%{realversion}.tar.gz
 
-# Alan on 19/05/2021: commenting out condor for now, otherwise it will bring in some python2 dependencies
-# Requires: condor
-Requires: yui libuuid couchdb16 jemalloc py3-dbs3-client
+Requires: yui libuuid couchdb16 condorpy3 jemalloc py3-dbs3-client
 Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
 Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL
 Requires: py3-pyzmq py3-psutil py3-future py3-retry


### PR DESCRIPTION
This PR builds a python3 compatible version of the condor python bindings and adds it as a requirement for wmagentpy3