### PR TITLE
Add py3-mysqclient

### DIFF
--- a/py3-mysqlclient.spec
+++ b/py3-mysqlclient.spec
@@ -1,4 +1,5 @@
 ### RPM external py3-mysqlclient 2.0.3
 ## IMPORT build-with-pip3
 
+Requires: mariadb
 %define pip_name mysqlclient

--- a/py3-mysqlclient.spec
+++ b/py3-mysqlclient.spec
@@ -1,0 +1,4 @@
+### RPM external py3-mysqlclient 2.0.3
+## IMPORT build-with-pip3
+
+%define pip_name mysqlclient

--- a/py3-sqlalchemy.spec
+++ b/py3-sqlalchemy.spec
@@ -1,4 +1,5 @@
 ### RPM external py3-sqlalchemy 1.3.3
 ## IMPORT build-with-pip3
 
+Requires: py3-mysqlclient
 %define pip_name SQLAlchemy

--- a/py3-sqlalchemy.spec
+++ b/py3-sqlalchemy.spec
@@ -1,5 +1,4 @@
 ### RPM external py3-sqlalchemy 1.3.3
 ## IMPORT build-with-pip3
 
-Requires: py3-mysqlclient
 %define pip_name SQLAlchemy

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -13,6 +13,7 @@ Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL
 Requires: py3-pyzmq py3-psutil py3-future py3-retry
 Requires: py3-cmsmonitoring py3-cmscouchapp
 Requires: py3-cheetah3
+Requires: py3-mysqlclient
 Requires: mariadb
 
 # Alan Malta dropped on 2/Feb/2021: Requires: py3-mysqldb


### PR DESCRIPTION
This PR is intending to fix the issue with porting the `MySQLdb` library in python3. In Python3 there is no such package such as `MySQL-python`. The package which provides full backwards compatibility in python3 is called  `mysqlclient`. More details in the related WMCore issue [1].  The current PR introduces a spec file for a pip based build of an RPM for `mysqlclient` for python3.

[1]
https://github.com/dmwm/WMCore/issues/9805