### PR TITLE
[backport] Update cms-data Geometry/TestReference to V00-08-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -5,7 +5,7 @@
 [default]
 GeneratorInterface-EvtGenInterface=V02-03-00
 L1Trigger-CSCTriggerPrimitives=V00-05-00
-Geometry-TestReference=V00-05-00
+Geometry-TestReference=V00-08-00
 L1Trigger-L1TMuon=V01-04-00
 RecoHGCal-TICL=V00-02-01
 EgammaAnalysis-ElectronTools=V00-03-01


### PR DESCRIPTION
Backport of #6920 to CMSSW_11_3_X in support of cms-sw/cmssw#33795

This reverts commit c4ba704789b32f09db367daff17e0bffb10185c3 , restoring PR #6921