### PR TITLE
DXR needs py2-parsimonious to run

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -207,7 +207,7 @@ packaging==20.9
 pandas==0.24.2 ; python_version<'3.0'
 pandas==1.2.2 ; python_version>'3.0'
 pandocfilters==1.4.3
-parsimonious==0.8.1; python_version>'3.0'
+parsimonious==0.8.1
 parso==0.7.1
 pastel==0.2.1 ; python_version>'3.0'
 patch-ng==1.17.4 ; python_version>'3.0'

--- a/py2-dxr.spec
+++ b/py2-dxr.spec
@@ -1,7 +1,7 @@
 ### RPM external py2-dxr 1.0
 ## INITENV +PATH PYTHON27PATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
-Requires: python python3 zlib py2-setuptools py2-pysqlite llvm sqlite py3-setuptools
+Requires: python python3 zlib py2-parsimonious py2-setuptools py2-pysqlite llvm sqlite py3-setuptools
 %define dxrCommit 6ea764102a
 %define triliteCommit e64a2a1 
 %define re2Version 20140304

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -101,7 +101,7 @@ Requires: py2-cycler
 Requires: py3-docopt
 Requires: py2-futures
 Requires: py2-networkx
-Requires: py3-parsimonious
+Requires: py2-parsimonious
 Requires: py2-prettytable
 Requires: py2-pycurl
 Requires: py2-pytz


### PR DESCRIPTION
dxr-cmssw-index jobs is failing because of missing py2 package DXR was using without requiring it