### PR TITLE
Update OpenBLAS to 0.3.15, remove it's long-double-64 flag

### DIFF
--- a/OpenBLAS-fix-dynamic-arch.patch
+++ b/OpenBLAS-fix-dynamic-arch.patch
@@ -1,22 +1,13 @@
 diff --git a/Makefile.x86_64 b/Makefile.x86_64
-index f2de51e..e1c348a 100644
+index f62ab9e..f23a65b 100644
 --- a/Makefile.x86_64
 +++ b/Makefile.x86_64
 @@ -9,7 +9,7 @@ endif
  endif
  
- ifeq ($(CORE), SKYLAKEX)
--ifndef DYNAMIC_ARCH
-+ifneq ($(DYNAMIC_ARCH), 1)
- ifndef NO_AVX512
- CCOMMON_OPT += -march=skylake-avx512
- FCOMMON_OPT += -march=skylake-avx512
-@@ -28,7 +28,7 @@ endif
- endif
  
- ifeq ($(CORE), HASWELL)
 -ifndef DYNAMIC_ARCH
 +ifneq ($(DYNAMIC_ARCH), 1)
- ifndef NO_AVX2
- ifeq ($(C_COMPILER), GCC)
- CCOMMON_OPT += -mavx2
+ ADD_CPUFLAGS = 1
+ else
+ ifdef TARGET_CORE

--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -1,4 +1,4 @@
-### RPM external OpenBLAS 0.3.9
+### RPM external OpenBLAS 0.3.15
 ## INCLUDE compilation_flags
 Source: https://github.com/xianyi/OpenBLAS/archive/v%{realversion}.tar.gz
 Patch0: OpenBLAS-fix-dynamic-arch
@@ -20,7 +20,7 @@ make FC=gfortran BINARY=64 TARGET=CORE2 NUM_THREADS=256 DYNAMIC_ARCH=0
 %ifarch aarch64
 make FC=gfortran BINARY=64 TARGET=ARMV8 NUM_THREADS=256 DYNAMIC_ARCH=0
 %else
-make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=0 CFLAGS="%{ppc64le_build_flags}"
+make FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=0 CFLAGS="%{ppc64le_build_flags_no_longdouble}"
 %endif # aarch64
 %endif # x86_64
 

--- a/compilation_flags.file
+++ b/compilation_flags.file
@@ -1,4 +1,7 @@
 %if "%{?ppc64le_build_flags:set}" != "set"
 %define ppc64le_build_flags  -mlong-double-64 -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
 %endif
+%if "%{?ppc64le_build_flags_no_longdouble:set}" != "set"
+%define ppc64le_build_flags_no_longdouble -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
+%endif
 


### PR DESCRIPTION
see https://github.com/cms-sw/cmssw/issues/33743#issuecomment-845951214
although I don't think all externals can be compiled without this flag