### PR TITLE
[BuildRules] Fix the issue with scram b after adding an extra package

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-04
+%define configtag       V06-02-05
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
SCRAM does not compile a newly checkout package after successfully building the initially checked out packages [a]. New build rules should fix this issue.

[a]
```
scram p CMSSW_12_0_X_2021-05-31-1100
cd CMSSW_12_0_X_2021-05-31-1100/src
cmsenv
git cms-addpkg FWCore/Version
scram b -j 20
git cms-addpkg Utilities/General
scram b # this does not re-build Utilities/General
```