### PR TITLE
adding ppjjjj openloop library

### DIFF
--- a/openloops-user.coll.file
+++ b/openloops-user.coll.file
@@ -153,3 +153,4 @@ pphjj2
 pphjj_vbf
 pphjj_vbf_ew
 pphjjj2
+ppjjjj


### PR DESCRIPTION
Adding missing library, needed for SMP's four-jet production study. Will backport to 10_6.