### PR TITLE
adding ppjjjj library [10_6_X backport]

### DIFF
--- a/openloops-user.coll.file
+++ b/openloops-user.coll.file
@@ -156,3 +156,4 @@ pphjjj2
 heftppllj
 heftpplljj
 heftpplljjj
+ppjjjj

--- a/openloops-user.coll.file
+++ b/openloops-user.coll.file
@@ -153,7 +153,4 @@ pphjj2
 pphjj_vbf
 pphjj_vbf_ew
 pphjjj2
-heftppllj
-heftpplljj
-heftpplljjj
 ppjjjj


### PR DESCRIPTION
Adding missing library, needed for SMP's four-jet production study.

backport from
https://github.com/cms-sw/cmsdist/pull/6956