### PR TITLE
[BuildRules] Fixes for clang tidy rules

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-07
+%define configtag       V06-02-08
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-05
+%define configtag       V06-02-06
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-06
+%define configtag       V06-02-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Fix `code-checks-all` rule to apply changes for the inculded headers too
- Fix clang-tidy apply script to make use of new `Notes` Diagnostics messages
- Added new `use-iboes` target. When used as `scram build runtests use-ibeos` then it uses the ibeos caches for running tests i.e.
  - sets CMS_PATH=/cvmfs/cms-ib.cern.ch which allow to access ibeos root files
  - override dasgoclient with cms-bot/das_utils/dasgoclient which uses cached das queries 