### PR TITLE
drop root_numpy and root_pandas deps

### DIFF
--- a/python_tools.spec
+++ b/python_tools.spec
@@ -20,7 +20,6 @@ Requires: py3-tables
 Requires: py2-numexpr
 Requires: py3-histogrammar
 Requires: py3-pandas
-Requires: py3-root_numpy
 Requires: py3-Bottleneck
 Requires: py3-downhill
 Requires: py3-theanets
@@ -35,7 +34,6 @@ Requires: py3-hyperopt
 Requires: py3-seaborn
 Requires: py2-h5py
 Requires: py3-h5py-cache
-Requires: py3-root_pandas
 Requires: py3-uproot
 Requires: py3-uproot4
 Requires: py2-opt-einsum


### PR DESCRIPTION
Another try of https://github.com/cms-sw/cmsdist/pull/6912 . CMSSW DQM bin by bin script which was using it has now dropped its usage ( https://github.com/cms-sw/cmssw/pull/33751 )