### PR TITLE
py3-Theano: fix relocation

### DIFF
--- a/pip/Theano.file
+++ b/pip/Theano.file
@@ -1,3 +1,4 @@
 Requires: py2-scipy py2-six
 Requires: py3-scipy
-%define RelocatePython %{i}/bin/theano-nose %{i}/bin/theano-cache %{i}/bin/theano-test
+%define RelocatePython %{i}/bin/theano-*
+%define PipPostBuildPy3 sed -i -e 's| %{cmsroot}/.*python3 | python3 |' %{i}/bin/theano-*


### PR DESCRIPTION
This should fix the 3 failing unit tests in 12.0.X Ibs.
This PR fixes the relocation of Theano scripts which some time uses
```
#!/bin/sh
'''exec' path/to/python "$0" "$@"
```
OR
```
#!/path/to/python
```