### PR TITLE
Remove pystack dependency from all specs

### DIFF
--- a/comp.spec
+++ b/comp.spec
@@ -13,7 +13,7 @@ Requires: exporters exitcodes
 # FIXME: remove these 3 PhEDEx specs from the building list for January/2021
 Requires: PHEDEX-combined-web PHEDEX-combined-agents PHEDEX-lifecycle
 # Common
-Requires: rotatelogs pystack wmcore-devtools
+Requires: rotatelogs wmcore-devtools
 # Other
 Requires: wmagent-dev condor crabtaskworker t0 couchdb15 crab-devtools
 Requires: wmarchive
@@ -24,7 +24,7 @@ BuildRequires: gitweb compsec
 ### List of obsolete services (or under deprecation), stop building them!
 #BuildRequires: filemover PHEDEX-combined-web PHEDEX-combined-agents PHEDEX-lifecycle
 #BuildRequires: overview happyface sreadiness lifecycle-das webtools
-#BuildRequires: DCAFPilot DMWMMON-datasvc spacemon-client
+#BuildRequires: DCAFPilot DMWMMON-datasvc spacemon-client pystack
 
 %prep
 %build

--- a/dbs3-migration.spec
+++ b/dbs3-migration.spec
@@ -8,7 +8,7 @@
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore&output=/WMCore4%{n}.tar.gz
 Source1: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&output=/%{n}.tar.gz
 Requires: python py2-simplejson py2-sqlalchemy11 py2-httplib2 py2-cherrypy py2-cheetah yui
-Requires: py2-cjson py2-cx-oracle dbs3-pycurl-client rotatelogs pystack
+Requires: py2-cjson py2-cx-oracle dbs3-pycurl-client rotatelogs
 BuildRequires: py2-sphinx
 #
 %prep

--- a/dbs3.spec
+++ b/dbs3.spec
@@ -9,7 +9,7 @@ Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore&out
 Source1: git://github.com/dmwm/DBS.git?obj=master/%{realversion}&export=DBS&output=/%{n}.tar.gz
 
 Requires: python py2-simplejson py2-sqlalchemy11 py2-httplib2 py2-cherrypy py2-cheetah yui
-Requires: py2-cjson py2-cx-oracle py2-docutils dbs3-pycurl-client rotatelogs pystack cmsmonitoring
+Requires: py2-cjson py2-cx-oracle py2-docutils dbs3-pycurl-client rotatelogs cmsmonitoring
 Requires: jemalloc
 BuildRequires: py2-sphinx
 

--- a/t0.spec
+++ b/t0.spec
@@ -14,7 +14,7 @@ Source1: git://github.com/dmwm/WMCore?obj=master/%wmcver&export=%{wmcpkg}_%n&out
 
 Requires: python py2-sqlalchemy py2-httplib2 py2-pycurl py2-rucio-clients
 Requires: py2-mysqldb py2-cx-oracle py2-cheetah py2-pyOpenSSL
-Requires: yui libuuid couchdb15 condor pystack
+Requires: yui libuuid couchdb15 condor
 Requires: dbs3-client py2-pyzmq py2-psutil py2-future py2-retry
 Requires: jemalloc cmsmonitoring
 

--- a/wmagent-dev.spec
+++ b/wmagent-dev.spec
@@ -1,7 +1,7 @@
 ### RPM cms wmagent-dev 1.4.9.pre6
 
 # This is a meta-package to group development tool dependencies
-Requires: wmagent rotatelogs pystack wmcore-devtools
+Requires: wmagent rotatelogs wmcore-devtools
 Requires: jemalloc
 
 %prep

--- a/wmagent.spec
+++ b/wmagent.spec
@@ -7,7 +7,7 @@ Source: git://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=WMCore
 
 Requires: python py2-sqlalchemy py2-httplib2 py2-pycurl py2-rucio-clients
 Requires: py2-mysqldb py2-cx-oracle py2-cheetah py2-pyOpenSSL
-Requires: yui libuuid couchdb15 condor pystack
+Requires: yui libuuid couchdb15 condor
 Requires: dbs3-client py2-pyzmq py2-psutil py2-future py2-retry
 Requires: jemalloc cmsmonitoring
 

--- a/workqueue.spec
+++ b/workqueue.spec
@@ -4,7 +4,7 @@
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 Source: git://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=%n&output=/%n.tar.gz
-Requires: python py2-httplib2 pystack rotatelogs couchdb15 yui py2-sphinx dbs3-client py2-cherrypy py2-pycurl
+Requires: python py2-httplib2 rotatelogs couchdb15 yui py2-sphinx dbs3-client py2-cherrypy py2-pycurl
 Requires: py2-future py2-retry py2-psutil py2-rucio-clients
 Requires: jemalloc cmsmonitoring
 


### PR DESCRIPTION
With this pull request, we remove the obsolete `pystack` dependency from a few spec files.
Further information can be found in this HN thread: https://hypernews.cern.ch/HyperNews/CMS/get/webInterfaces/1785.html

This PR has to go together with: https://github.com/dmwm/deployment/pull/1056