### PR TITLE
Bump py3-cmscouchapp to 1.3.4

### DIFF
--- a/py3-cmscouchapp.spec
+++ b/py3-cmscouchapp.spec
@@ -1,4 +1,4 @@
-### RPM external py3-cmscouchapp 1.3.2
+### RPM external py3-cmscouchapp 1.3.4
 ## IMPORT build-with-pip3
 
 %define pip_name CMSCouchapp


### PR DESCRIPTION
Lower the requirements for the third-party library `requests` from 2.25.1 to =>2.20.0