### PR TITLE
[BuildRules] Fix TSAN build issues

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-08
+%define configtag       V06-02-09
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Due to a typo ( https://github.com/cms-sw/cmssw-config/commit/229fca01867107f8dcdbed23b36bd2bde569c34e#diff-3e9a48949cfadd3ba1749276c06334910c0478305c1d8554a72001f7dbb15c7b ) TSAN IBs were not running edm class checks tools. This shoudl fix this issue.