### PR TITLE
move pybind11 to python3 only 

### DIFF
--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -44,7 +44,7 @@ Requires: md5-toolfile
 Requires: davix-toolfile
 Requires: py2-numpy-toolfile
 Requires: OpenBLAS-toolfile
-Requires: py2-pybind11-toolfile
+Requires: py3-pybind11-toolfile
 Requires: fwlite_python_tools
 Requires: zstd-toolfile
 

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -6,7 +6,7 @@
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja
-Requires: protobuf py3-numpy py2-wheel py2-onnx zlib libpng py2-pybind11
+Requires: protobuf py3-numpy py2-wheel py2-onnx zlib libpng py3-pybind11
 %if "%{cmsos}" != "slc7_aarch64"
 Requires: cuda cudnn
 %endif
@@ -54,7 +54,7 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DCMAKE_CUDA_FLAGS="-cudart shared" \
    -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared \
    -DCMAKE_TRY_COMPILE_PLATFORM_VARIABLES="CMAKE_CUDA_RUNTIME_LIBRARY" \
-   -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${LIBPNG_ROOT};${PROTOBUF_ROOT};${PY2_PYBIND11_ROOT}"
+   -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${LIBPNG_ROOT};${PROTOBUF_ROOT};${PY3_PYBIND11_ROOT}"
 
 ninja -v %{makeprocesses}
 python3 ../%{n}-%{realversion}/setup.py build

--- a/pip/awkward1.file
+++ b/pip/awkward1.file
@@ -1,2 +1,2 @@
-Requires: py2-numpy py3-numpy py2-pytest-runner py2-pybind11 cmake
+Requires: py2-numpy py3-numpy py2-pytest-runner py3-pybind11 cmake
 %define source0 git+https://github.com/scikit-hep/awkward-1.0?obj=main/%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/source.tar.gz

--- a/pip/correctionlib.file
+++ b/pip/correctionlib.file
@@ -1,2 +1,2 @@
-Requires: py2-pybind11 py3-numpy py3-pydantic py3-python-rapidjson
+Requires: py3-pybind11 py3-numpy py3-pydantic py3-python-rapidjson
 

--- a/pip/py3-scipy.file
+++ b/pip/py3-scipy.file
@@ -1,4 +1,4 @@
-Requires: py3-numpy py2-cython py2-wheel py2-pybind11
+Requires: py3-numpy py2-cython py2-wheel py3-pybind11
 
 %define PipPreBuild\
   if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then export FFLAGS="${FFLAGS_OPT} -fallow-argument-mismatch -fPIC" ; fi \

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -221,7 +221,7 @@ ptyprocess==0.7.0; python_version>'3.0'
 pyasn1-modules==0.2.8; python_version>'3.0'
 pyasn1==0.4.8
 pyasn1-modules==0.2.8 ; python_version>'3.0'
-pybind11==2.6.2
+pybind11==2.6.2; python_version>'3.0'
 pybrain==0.3.3; python_version>'3.0'
 pycodestyle==2.6.0; python_version>'3.0'
 pycparser==2.20

--- a/py2-pybind11-toolfile.spec
+++ b/py2-pybind11-toolfile.spec
@@ -11,8 +11,8 @@ mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pybind11.xml
 <tool name="py2-pybind11" version="@TOOL_VERSION@">
   <client>
-    <environment name="PY2_PYBIND11_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$PY2_PYBIND11_BASE/lib/python3.8/site-packages/pybind11/include"/>
+    <environment name="PY3_PYBIND11_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$PY3_PYBIND11_BASE/lib/python3.8/site-packages/pybind11/include"/>
   </client>
 </tool>
 EOF_TOOLFILE

--- a/py2-pybind11-toolfile.spec
+++ b/py2-pybind11-toolfile.spec
@@ -1,5 +1,5 @@
 ### RPM external py2-pybind11-toolfile 1.0
-Requires: py2-pybind11
+Requires: py3-pybind11
 
 %prep
 
@@ -12,7 +12,7 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pybind11.xml
 <tool name="py2-pybind11" version="@TOOL_VERSION@">
   <client>
     <environment name="PY2_PYBIND11_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$PY2_PYBIND11_BASE/lib/python2.7/site-packages/pybind11/include"/>
+    <environment name="INCLUDE" default="$PY2_PYBIND11_BASE/lib/python3.8/site-packages/pybind11/include"/>
   </client>
 </tool>
 EOF_TOOLFILE

--- a/py3-pybind11-toolfile.spec
+++ b/py3-pybind11-toolfile.spec
@@ -8,7 +8,7 @@ Requires: py3-pybind11
 %install
 
 mkdir -p %{i}/etc/scram.d
-cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pybind11.xml
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py3-pybind11.xml
 <tool name="py3-pybind11" version="@TOOL_VERSION@">
   <client>
     <environment name="PY3_PYBIND11_BASE" default="@TOOL_ROOT@"/>

--- a/py3-pybind11-toolfile.spec
+++ b/py3-pybind11-toolfile.spec
@@ -1,4 +1,4 @@
-### RPM external py2-pybind11-toolfile 1.0
+### RPM external py3-pybind11-toolfile 1.0
 Requires: py3-pybind11
 
 %prep
@@ -9,7 +9,7 @@ Requires: py3-pybind11
 
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pybind11.xml
-<tool name="py2-pybind11" version="@TOOL_VERSION@">
+<tool name="py3-pybind11" version="@TOOL_VERSION@">
   <client>
     <environment name="PY3_PYBIND11_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE" default="$PY3_PYBIND11_BASE/lib/python3.8/site-packages/pybind11/include"/>
@@ -17,8 +17,6 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/py2-pybind11.xml
 </tool>
 EOF_TOOLFILE
 
-
-export PYTHON_LIB_SITE_PACKAGES
 export PYTHON3_LIB_SITE_PACKAGES
 
 ## IMPORT scram-tools-post

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -143,7 +143,7 @@ Requires: py2-cx-Oracle
 %endif
 Requires: py2-cython
 Requires: py2-future
-Requires: py2-pybind11-toolfile
+Requires: py3-pybind11-toolfile
 Requires: py3-histbook
 Requires: py3-flake8
 Requires: py3-autopep8


### PR DESCRIPTION
This PR takes advantage of pybind11 being used as a header only package having only a loose connection to python version. The pybind11 toolfile should be renamed. This will be done as a follow-on PR as it also involves cmssw changes