### PR TITLE
Bring the -mcpu=power8 flag

### DIFF
--- a/compilation_flags.file
+++ b/compilation_flags.file
@@ -1,4 +1,4 @@
 %if "%{?ppc64le_build_flags:set}" != "set"
-%define ppc64le_build_flags  -mcpu=powerpc64le -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
+%define ppc64le_build_flags  -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
 %endif
 


### PR DESCRIPTION
get back the power8 flag to build two IBs
this was the reasoning behind the ppc64le:

```
-mtune=cpu_type

    Set the instruction scheduling parameters for machine type cpu_type, but do not set the architecture type or register usage, as -mcpu=cpu_type does. The same values for cpu_type are used for -mtune as for -mcpu. If both are specified, the code generated uses the architecture and registers set by -mcpu, but the scheduling parameters set by -mtune.
```
the -mcpu=power8 specifies power8 machine which is more "generic" while the ppc64le is more specific for our machines.
If we read the following:
`The other options specify a specific processor. Code generated under those options runs best on that processor, and may not run at all on others. `
it seems to me the best flags to use will be those specifying the processor model (if it's in that list)
https://gcc.gnu.org/onlinedocs/gcc/RS_002f6000-and-PowerPC-Options.html#RS_002f6000-and-PowerPC-Options