### PR TITLE
Patch tkonline to bring pure virtual functions

### DIFF
--- a/tkonlinesw-bring-pvf.patch
+++ b/tkonlinesw-bring-pvf.patch
@@ -1,0 +1,24 @@
+diff --git a/TrackerOnline/Fed9U/Fed9USoftware/Fed9UUtils/include/Fed9UUtils.hh b/TrackerOnline/Fed9U/Fed9USoftware/Fed9UUtils/include/Fed9UUtils.hh
+index ca2f0eb..c7a6b45 100644
+--- a/TrackerOnline/Fed9U/Fed9USoftware/Fed9UUtils/include/Fed9UUtils.hh
++++ b/TrackerOnline/Fed9U/Fed9USoftware/Fed9UUtils/include/Fed9UUtils.hh
+@@ -4789,7 +4789,8 @@ namespace Fed9U {
+      *
+      * \todo check numbering scheme (internal or external).
+      */
+-    virtual u32 getAllApvDisables(const Fed9UAddress&) { ICUTILS_VERIFY(0).msg("Method unimplemented in base class. Implement in derived class").error(); return 0;}
++    virtual u32 getAllApvDisables(const Fed9UAddress&) const = 0;
++    //virtual u32 getAllApvDisables(const Fed9UAddress&) { ICUTILS_VERIFY(0).msg("Method unimplemented in base class. Implement in derived class").error(); return 0;}
+ 
+     /**
+      * \brief  Returns the maximum buffer size that could be required by the Fed9UVmeDevice::getCompleteEvent method.
+@@ -4850,7 +4851,8 @@ namespace Fed9U {
+      * \brief  Returns the base of the FED in the crate.
+      * \return u32 Contains the value of the FED base address.
+      */
+-    virtual u32 getBaseAddress() { ICUTILS_VERIFY(0).msg("Method unimplemented in base class. Implement in derived class").error();  return 0;}
++    virtual u32 getBaseAddress() const = 0;
++    //virtual u32 getBaseAddress() { ICUTILS_VERIFY(0).msg("Method unimplemented in base class. Implement in derived class").error();  return 0;}
+ 
+     /**
+      * \brief  Number of the crate that the FED is located in.

--- a/tkonlinesw.spec
+++ b/tkonlinesw.spec
@@ -4,7 +4,7 @@
 Source0: http://cms-trackerdaq-service.web.cern.ch/cms-trackerdaq-service/download/sources/trackerDAQ-%{realversion}.tgz
 Patch0: tkonlinesw-2.7.0-macosx
 Patch1: tkonlinesw-4.0-clang-hash_map
-
+Patch2: tkonlinesw-bring-pvf
 # NOTE: given how broken the standard build system is
 #       on macosx, it's not worth fixing it.
 #       The 4 libraries we need can be built with the
@@ -24,6 +24,7 @@ Requires: root
 %prep
 %setup -q -n %releasename
 %patch1 -p1
+%patch2 -p1
 case %cmsos in 
   osx*)
 %patch0 -p1


### PR DESCRIPTION
In the latest CLANG IBs after LLVM12 was merged we have new warnings 
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc900/www/tue/12.0.CLANG-tue-23/CMSSW_12_0_CLANG_X_2021-06-08-2300
which complain about hidden virtual functions, coming from tkonline. this brings this functions to pure virtual again
the clang IB warnings are fixed with this