### PR TITLE
[BuildRules] Fix issue with generating rootmap files during PR tests

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-09
+%define configtag       V06-02-11
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
when external PR tests are run with `full_cmssw=true` then rootmap files are nor generated. The reason was that SCRAMV3 based build rules were making `SCRAM_NOEDM_CHECKS=yes` persistant which was hiding the edm_checks rules to run. 

This PR should fix this issue