### PR TITLE
[BuildRules] use python3 in scripts

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-11
+%define configtag       V06-02-12
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
many python tools are not available for python2 any more, so start using python3 for helpers scripts in cmssw-config