### PR TITLE
Remove unavailable download for openloops

### DIFF
--- a/openloops-user.coll.file
+++ b/openloops-user.coll.file
@@ -107,7 +107,6 @@ ppvj_ew
 ppwj_ckm
 ppwjj
 ppwjj_ckm
-ppwjj_ew
 ppwjjj
 ppzjj
 ppzjj_ew


### PR DESCRIPTION
The file in question failed in gcc10 which means it's not available
