### PR TITLE
Update buildrule and scram

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V3_00_23
+### RPM lcg SCRAMV1 V3_00_24
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag 9794c2f7b7f2690687c41eb67778023d5c2a6e1b
+%define tag c27129a5a2acc8b56697e9ba42957c2c0eb6c9ce
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-12
+%define configtag       V06-02-13
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
SCRAM V3 fails ( as reported https://github.com/cms-sw/cmssw/issues/33698 ) when devarea/tmp is a symlink on a different device. This up should fix this issue.

Fixes cms-sw/cmssw#33698