### PR TITLE
[G4][geant4_vecgeom] Update geant4 to 10.7.2

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,4 +1,4 @@
-### RPM external geant4 10.7.1
+### RPM external geant4 10.7.2
 ## INCLUDE compilation_flags
 %define tag %{realversion}
 %define branch geant4-10.7-release


### PR DESCRIPTION
This branch is identical to master for geant4 and vecgeom.
We can start building that IB again for G4 people to do their tests/validation
Currently there is no fresh IB for this branch