### PR TITLE
Patch py2-mysqldb to not return long data type

### DIFF
--- a/py2-mysqldb.spec
+++ b/py2-mysqldb.spec
@@ -9,6 +9,9 @@ Patch0: py2-mysqldb-setup
 %prep
 %setup -n %downloadn-%realversion
 %patch0 -p0
+# Patch the converters module to avoid getting long data type back in the client
+sed -i 's|LONG: long|LONG: int|' MySQLdb/converters.py
+
 cat >> setup.cfg <<- EOF
 include_dirs = $MARIADB_ROOT/include
 library_dirs = $MARIADB_ROOT/lib


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10607

Instead of casting data to `long`, cast it to `int`. It affects only wmagent.spec (and t0, but they use only oracle).
