### PR TITLE
Update tag for L1Trigger-CSCTriggerPrimitives to V00-09-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+L1Trigger-CSCTriggerPrimitives=V00-09-00
 GeneratorInterface-EvtGenInterface=V02-06-00
 RecoTracker-MkFit=V00-01-00
 RecoMuon-TrackerSeedGenerator=V00-01-00
@@ -15,7 +16,6 @@ L1Trigger-L1TMuon=V01-05-00
 L1Trigger-L1THGCal=V01-05-00
 Geometry-TestReference=V00-08-00
 L1Trigger-DTTriggerPhase2=V00-02-00
-L1Trigger-CSCTriggerPrimitives=V00-08-00
 RecoBTag-Combined=V01-11-00
 RecoEgamma-PhotonIdentification=V01-01-00
 RecoHGCal-TICL=V00-02-01


### PR DESCRIPTION
Move L1Trigger-CSCTriggerPrimitives data to new tag, see 
https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/9
