### PR TITLE
[TBB] Use another repo/branch/tag for PPC

### DIFF
--- a/tbb.spec
+++ b/tbb.spec
@@ -1,8 +1,14 @@
 ### RPM external tbb v2021.2.0
 
+%ifarch ppc64le
+%define tag b5b7f777b26124d67554171763d891d27aa0749a
+%define branch master+fix
+%define github_user mrodozov
+%else
 %define tag %{realversion}
 %define branch onetbb_2021
 %define github_user oneapi-src
+%endif
 %define github_repo oneTBB
 Source: git+https://github.com/%{github_user}/%{github_repo}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{branch}-%{tag}.tgz
 Requires: hwloc

--- a/tbb.spec
+++ b/tbb.spec
@@ -1,13 +1,13 @@
 ### RPM external tbb v2021.2.0
 
-%ifarch ppc64le
-%define tag b5b7f777b26124d67554171763d891d27aa0749a
-%define branch master+fix
-%define github_user mrodozov
-%else
+%ifarch x86_64
 %define tag %{realversion}
 %define branch onetbb_2021
 %define github_user oneapi-src
+%else
+%define tag b5b7f777b26124d67554171763d891d27aa0749a
+%define branch master+fix
+%define github_user mrodozov
 %endif
 %define github_repo oneTBB
 Source: git+https://github.com/%{github_user}/%{github_repo}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{branch}-%{tag}.tgz


### PR DESCRIPTION
Patching our current tag v2021.2.0 isn't possible (the PR is over latest master and has too many changes compared with 21.2.0)
Even if we could've used that patch it's ~500 lines
Third option will be to fork oneTBB which will save one line - github_user