### PR TITLE
restore pyyaml on python2 as needed by conddb 

### DIFF
--- a/pip/Keras.file
+++ b/pip/Keras.file
@@ -1,2 +1,2 @@
-Requires: py3-PyYAML py2-six py2-scipy py3-Theano
+Requires: py2-PyYAML py2-six py2-scipy py3-Theano
 Requires: py3-h5py py3-keras-applications py3-keras-preprocessing

--- a/pip/bokeh.file
+++ b/pip/bokeh.file
@@ -1,3 +1,3 @@
-Requires: py2-pillow py3-PyYAML py3-python-dateutil py3-Jinja2 py2-numpy py2-packaging
+Requires: py2-pillow py2-PyYAML py3-python-dateutil py3-Jinja2 py2-numpy py2-packaging
 Requires: py3-tornado py3-numpy py3-pillow
 %define RelocatePython %{i}/bin/*

--- a/pip/conan.file
+++ b/pip/conan.file
@@ -1,3 +1,3 @@
-Requires: py3-python-dateutil py3-requests py3-PyJWT py3-tqdm py3-PyYAML py3-Jinja2 py3-Pygments py3-patch-ng py3-pluginbase
+Requires: py3-python-dateutil py3-requests py3-PyJWT py3-tqdm py2-PyYAML py3-Jinja2 py3-Pygments py3-patch-ng py3-pluginbase
 Requires: py3-fasteners py3-patch-ng py3-pluginbase py3-node-semver py3-distro py2-future py3-deprecation py3-bottle py3-colorama
 %define PipPostBuildPy3 sed -i -e 's| %{cmsroot}/.*python3 | python3 |' %{i}/bin/conan*

--- a/pip/hepdata-lib.file
+++ b/pip/hepdata-lib.file
@@ -1,1 +1,1 @@
-Requires: root py2-pytest py3-pytest-cov py3-PyYAML py2-future py3-pylint
+Requires: root py2-pytest py3-pytest-cov py2-PyYAML py2-future py3-pylint

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -248,7 +248,8 @@ python-rapidjson==1.0;python_version>'3.0'
 pytoml==0.1.21;python_version>'3.0'
 pytools==2020.3;python_version>'3.0'
 pytz==2021.1; python_version>'3.0'
-PyYAML==5.4.1; python_version>'3.0'
+#needed by getPayloadData.py which needs python2 until boost-python changes 
+PyYAML==5.4.1
 pyzmq==19.0.2; python_version>'3.0'
 qtconsole==4.7.7 ; python_version> '3.0'
 QtPy==1.9.0; python_version>'3.0'

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -133,7 +133,7 @@ Requires: py2-numpy-toolfile
 Requires: py2-sqlalchemy
 Requires: py2-pygithub
 Requires: py3-dxr-toolfile
-Requires: py3-PyYAML
+Requires: py2-PyYAML
 Requires: py3-pylint
 Requires: py2-pip
 Requires: py3-pip


### PR DESCRIPTION
some conditions tools need to be consistent with the python used by boost-python (which is still python2). These rely on pyyaml.