### PR TITLE
[BuildRules] Fix the EDM_PLUGIN="0" flag in plugisn/BuildFile

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-14
+%define configtag       V06-02-15
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
There is bug in build rules and `<flags EDM_PLUGIN="0"/>` in `plugins/BuildFile.xml` still generate a plugin instead of a shared library. New build rule shoudl fix this. 

Currently we do not have any `plugins/BuildFile.xml` setting `<flags EDM_PLUGIN="0"/>` , so this fix should not break any thing