### PR TITLE
[SCRAM] Update to support generating multiple tests using single command

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag 7ae4f6f332b3e41bf139a3a0f0916e7eb8ba5410
+%define tag fec485c5d1c55b1104e2860ee8a81fe74bbb38aa
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V3_00_24
+### RPM lcg SCRAMV1 V3_00_25
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag c27129a5a2acc8b56697e9ba42957c2c0eb6c9ce
+%define tag a2b0ce768a09d92e3061f829788eb2ddfa5d1d19
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag dfc0486e08986b819282d8438c64b74ae6710301
+%define tag 7ae4f6f332b3e41bf139a3a0f0916e7eb8ba5410
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag a2b0ce768a09d92e3061f829788eb2ddfa5d1d19
+%define tag a4921444b26092c9e4bbc4bf3d96a2fec1a0ceb2
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag a4921444b26092c9e4bbc4bf3d96a2fec1a0ceb2
+%define tag dfc0486e08986b819282d8438c64b74ae6710301
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
SCRAMV3 now supports to generate multiple unit tests using single command. The format to define multiple tests is
```
<test name="FOO${loop}" command="echo Foo ${loop}" loop="start,stop,step">
  <flags PRE_TEST="RunMeFirst"/>
</test>
```
e.g.
- To run 5 tests FOO1, FOO2,..., FOO5
```
<test name="FOO${loop}" command="echo Foo ${loop}" loop="5"/>
```

- To run 5 tests FOO6, FOO7,..., FOO10 
```
<test name="FOO${loop}" command="echo Foo ${loop}" loop="6,10"/>
```

- To run FOO0, FOO5, FOO10,..., FOO100
```
<test name="FOO${loop}" command="echo Running Foo${loop} for item number ${loop}" loop="0,100,5"/>
```



