### PR TITLE
Removal of various python2 based packages, backported fromDEVEL

### DIFF
--- a/cmssw.spec
+++ b/cmssw.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw CMSSW_10_1_0_pre1
+### RPM cms cmssw CMSSW_12_0_0
 
 Requires: cmssw-tool-conf python
 

--- a/fwlite_python_tools.spec
+++ b/fwlite_python_tools.spec
@@ -4,7 +4,7 @@
 Source: none
  
 Requires: py2-six
-Requires: py2-scipy
+Requires: py3-scipy
 Requires: py2-numpy
 
 %prep

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -6,7 +6,7 @@
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja
-Requires: protobuf py3-numpy py2-wheel py2-onnx zlib libpng py3-pybind11
+Requires: protobuf py3-numpy py2-wheel py3-onnx zlib libpng py3-pybind11
 %if "%{cmsos}" != "slc7_aarch64"
 Requires: cuda cudnn
 %endif

--- a/pip/Keras.file
+++ b/pip/Keras.file
@@ -1,2 +1,2 @@
-Requires: py2-PyYAML py2-six py2-scipy py3-Theano
+Requires: py2-PyYAML py2-six py3-Theano
 Requires: py3-h5py py3-keras-applications py3-keras-preprocessing

--- a/pip/Theano.file
+++ b/pip/Theano.file
@@ -1,4 +1,3 @@
-Requires: py2-scipy py2-six
 Requires: py3-scipy
 %define RelocatePython %{i}/bin/theano-*
 %define PipPostBuildPy3 sed -i -e 's| %{cmsroot}/.*python3 | python3 |' %{i}/bin/theano-*

--- a/pip/absl-py.file
+++ b/pip/absl-py.file
@@ -1,1 +1,1 @@
-Requires: py2-enum34 py2-six
+Requires: py2-six

--- a/pip/aiohttp.file
+++ b/pip/aiohttp.file
@@ -1,1 +1,1 @@
-Requires: py2-attrs py3-chardet py3-multidict py3-yarl py3-async-timeout py2-typing_extensions
+Requires: py3-attrs py3-chardet py3-multidict py3-yarl py3-async-timeout py3-typing_extensions

--- a/pip/aiosqlite.file
+++ b/pip/aiosqlite.file
@@ -1,1 +1,1 @@
-Requires: py2-typing_extensions py3-flit-core
+Requires: py3-typing_extensions py3-flit-core

--- a/pip/argon2-cffi.file
+++ b/pip/argon2-cffi.file
@@ -1,1 +1,1 @@
-Requires: py3-cffi py2-six py2-enum34 py2-wheel
+Requires: py3-cffi py2-six py2-wheel

--- a/pip/astroid.file
+++ b/pip/astroid.file
@@ -1,2 +1,2 @@
-Requires: py3-lazy-object-proxy py2-six py3-wrapt py2-enum34 py3-singledispatch py2-backports-functools_lru_cache
-Requires: py2-pytest-runner
+Requires: py3-lazy-object-proxy py2-six py3-wrapt py3-singledispatch py2-backports-functools_lru_cache
+Requires: py3-pytest-runner

--- a/pip/autopep8.file
+++ b/pip/autopep8.file
@@ -1,2 +1,2 @@
-Requires: py3-pycodestyle py2-toml
+Requires: py3-pycodestyle py3-toml
 %define RelocatePython %{i}/bin/*

--- a/pip/awkward.file
+++ b/pip/awkward.file
@@ -1,1 +1,1 @@
-Requires: py2-numpy py3-numpy py2-pytest-runner
+Requires: py2-numpy py3-numpy py3-pytest-runner

--- a/pip/awkward1.file
+++ b/pip/awkward1.file
@@ -1,2 +1,2 @@
-Requires: py2-numpy py3-numpy py2-pytest-runner py3-pybind11 cmake
+Requires: py2-numpy py3-numpy py3-pytest-runner py3-pybind11 cmake
 %define source0 git+https://github.com/scikit-hep/awkward-1.0?obj=main/%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/source.tar.gz

--- a/pip/bokeh.file
+++ b/pip/bokeh.file
@@ -1,3 +1,3 @@
-Requires: py2-pillow py2-PyYAML py3-python-dateutil py3-Jinja2 py2-numpy py2-packaging
+Requires: py2-PyYAML py3-python-dateutil py3-Jinja2 py2-numpy py3-packaging
 Requires: py3-tornado py3-numpy py3-pillow
 %define RelocatePython %{i}/bin/*

--- a/pip/boost-histogram.file
+++ b/pip/boost-histogram.file
@@ -1,1 +1,1 @@
-Requires: py3-numpy py2-typing py2-wheel
+Requires: py3-numpy py3-typing py2-wheel

--- a/pip/deprecation.file
+++ b/pip/deprecation.file
@@ -1,1 +1,1 @@
-Requires: py2-packaging
+Requires: py3-packaging

--- a/pip/fire.file
+++ b/pip/fire.file
@@ -1,1 +1,1 @@
-Requires: py2-six py3-termcolor py2-enum34
+Requires: py2-six py3-termcolor

--- a/pip/flake8.file
+++ b/pip/flake8.file
@@ -1,2 +1,2 @@
-Requires: py2-backports py2-enum34 py3-mccabe py3-pycodestyle py3-pyflakes py3-entrypoints py2-typing py2-importlib-metadata
+Requires: py2-backports py3-mccabe py3-pycodestyle py3-pyflakes py3-entrypoints py3-typing py3-importlib-metadata
 %define RelocatePython %{i}/bin/*

--- a/pip/flit-core.file
+++ b/pip/flit-core.file
@@ -1,1 +1,1 @@
-Requires: py3-pytoml py2-toml
+Requires: py3-pytoml py3-toml

--- a/pip/fs.file
+++ b/pip/fs.file
@@ -1,2 +1,2 @@
-Requires: py2-six py2-typing py2-appdirs py3-pytz py2-backports py2-enum34
+Requires: py2-six py3-typing py3-appdirs py3-pytz py2-backports
 %define RelocatePython %{i}/bin/*

--- a/pip/grpcio-tools.file
+++ b/pip/grpcio-tools.file
@@ -1,1 +1,1 @@
-Requires: py2-protobuf py2-grpcio
+Requires: py3-protobuf py3-grpcio

--- a/pip/grpcio.file
+++ b/pip/grpcio.file
@@ -1,1 +1,1 @@
-Requires: py2-enum34 py2-futures py2-six
+Requires: py2-six

--- a/pip/hepdata-lib.file
+++ b/pip/hepdata-lib.file
@@ -1,1 +1,1 @@
-Requires: root py2-pytest py3-pytest-cov py2-PyYAML py2-future py3-pylint
+Requires: root py3-pytest py3-pytest-cov py2-PyYAML py2-future py3-pylint

--- a/pip/histoprint.file
+++ b/pip/histoprint.file
@@ -1,1 +1,1 @@
-Requires: py3-numpy py2-setuptools-scm py2-toml py3-Click
+Requires: py3-numpy py2-setuptools-scm py3-toml py3-Click

--- a/pip/html5lib.file
+++ b/pip/html5lib.file
@@ -1,1 +1,1 @@
-Requires: py3-ordereddict py2-six py2-packaging py3-webencodings py2-pyparsing py2-appdirs
+Requires: py2-six py3-packaging py3-webencodings py3-pyparsing py3-appdirs

--- a/pip/hyperopt.file
+++ b/pip/hyperopt.file
@@ -1,4 +1,4 @@
-Requires: py2-six py3-nose py2-future py3-pymongo py2-scipy py3-tqdm
+Requires: py2-six py3-nose py2-future py3-pymongo py3-scipy py3-tqdm
 Requires: py3-scipy py3-networkx py3-cloudpickle
 %define patchsrc sed -i -e 's|packages = None|packages = ["hyperopt"]|' setup.py
 %define RelocatePython %{i}/bin/*

--- a/pip/importlib-metadata.file
+++ b/pip/importlib-metadata.file
@@ -1,1 +1,1 @@
-Requires: py2-contextlib2 py2-configparser py2-pathlib2 py3-zipp py2-zipp
+Requires: py3-contextlib2 py3-pathlib2 py3-zipp

--- a/pip/importlib-resources.file
+++ b/pip/importlib-resources.file
@@ -1,3 +1,3 @@
 Requires: py2-wheel
-Requires: py2-pathlib2 py2-contextlib2 py3-singledispatch py2-typing py2-importlib-metadata py3-zipp
+Requires: py3-pathlib2 py3-contextlib2 py3-singledispatch py3-typing py3-importlib-metadata py3-zipp
 

--- a/pip/isort.file
+++ b/pip/isort.file
@@ -1,4 +1,4 @@
-Requires: py2-futures py2-backports-functools_lru_cache
+Requires:  py2-backports-functools_lru_cache
 
 %define patchsrc sed -i -e '/.*futures.*/d' isort.egg-info/requires.txt setup.py
 %define RelocatePython %{i}/bin/*

--- a/pip/jsonpickle.file
+++ b/pip/jsonpickle.file
@@ -1,4 +1,4 @@
-BuildRequires: py2-wheel
-Requires: py2-importlib-metadata
+Requires: py2-wheel
+Requires: py3-importlib-metadata
 
 

--- a/pip/jsonschema.file
+++ b/pip/jsonschema.file
@@ -1,4 +1,4 @@
 Requires: py3-repoze-lru py3-argparse py3-pyrsistent
-Requires: py2-attrs py2-six py2-importlib-metadata
+Requires: py3-attrs py2-six py3-importlib-metadata
 %define RelocatePython %{i}/bin/jsonschema
 

--- a/pip/llvmlite.file
+++ b/pip/llvmlite.file
@@ -1,4 +1,4 @@
-Requires: llvm py2-wheel py2-enum34
+Requires: llvm py2-wheel 
 Patch0: py2-llvmlite-fpic-flag
 Patch1: py2-llvmlite-llvm9
 Patch2: py2-llvmlite-removeduplicate

--- a/pip/luigi.file
+++ b/pip/luigi.file
@@ -1,4 +1,4 @@
-Requires: py3-tornado py3-python-daemon py3-python-dateutil py2-enum34
+Requires: py3-tornado py3-python-daemon py3-python-dateutil 
 
 %define PipPostBuildPy2 (cd "%{i}/bin" && for f in *; do cp ${f} ${f}2; done)
 %define PipPostBuildPy3 (cd "%{i}/bin" && for f in *; do mv ${f} ${f}3; done)

--- a/pip/matplotlib.file
+++ b/pip/matplotlib.file
@@ -1,2 +1,2 @@
-Requires: py3-cycler py3-kiwisolver py2-pyparsing py3-python-dateutil py3-certifi
+Requires: py3-cycler py3-kiwisolver py3-pyparsing py3-python-dateutil py3-certifi
 Requires: zlib libpng freetype

--- a/pip/mccabe.file
+++ b/pip/mccabe.file
@@ -1,1 +1,1 @@
-Requires: py2-pytest-runner
+Requires: py3-pytest-runner

--- a/pip/mock.file
+++ b/pip/mock.file
@@ -1,1 +1,1 @@
-Requires: py2-six py2-funcsigs py3-pbr
+Requires: py2-six py3-funcsigs py3-pbr

--- a/pip/mplhep.file
+++ b/pip/mplhep.file
@@ -1,1 +1,1 @@
-Requires: py3-numpy py3-matplotlib py3-scipy py3-requests py2-packaging
+Requires: py3-numpy py3-matplotlib py3-scipy py3-requests py3-packaging

--- a/pip/onnx.file
+++ b/pip/onnx.file
@@ -1,4 +1,4 @@
-Requires: cmake py2-numpy protobuf py2-protobuf py2-six py2-typing_extensions py3-numpy py2-pytest-runner
+Requires: cmake py2-numpy protobuf py3-protobuf py2-six py3-typing_extensions py3-numpy py3-pytest-runner
 
 %define PipPreBuild export ONNX_ML=1
 %define RelocatePython %{i}/bin/*

--- a/pip/packaging.file
+++ b/pip/packaging.file
@@ -1,1 +1,1 @@
-Requires: py2-pyparsing py2-six py2-attrs
+Requires: py3-pyparsing py2-six py3-attrs

--- a/pip/pathlib2.file
+++ b/pip/pathlib2.file
@@ -1,1 +1,1 @@
-Requires: py2-six py2-scandir
+Requires: py2-six py3-scandir

--- a/pip/pickleshare.file
+++ b/pip/pickleshare.file
@@ -1,1 +1,1 @@
-Requires: py2-pathlib2
+Requires: py3-pathlib2

--- a/pip/pluggy.file
+++ b/pip/pluggy.file
@@ -1,1 +1,1 @@
-Requires: py2-importlib-metadata
+Requires: py3-importlib-metadata

--- a/pip/protobuf.file
+++ b/pip/protobuf.file
@@ -1,1 +1,1 @@
-Requires: py2-six py2-packaging py2-pyparsing py2-appdirs
+Requires: py2-six py3-packaging py3-pyparsing py3-appdirs

--- a/pip/py2-scikit-learn.file
+++ b/pip/py2-scikit-learn.file
@@ -1,1 +1,0 @@
-Requires: py2-scipy

--- a/pip/py2-xgboost.file
+++ b/pip/py2-xgboost.file
@@ -1,4 +1,0 @@
-%ifnarch x86_64
-Patch0: xgboost-arm-and-ppc-py-0-82
-%endif
-Requires: py2-scipy

--- a/pip/py3-bokeh.file
+++ b/pip/py3-bokeh.file
@@ -1,2 +1,2 @@
-Requires: py2-typing_extensions
+Requires: py3-typing_extensions
 %define PipPostBuildPy3 for x in $(ls %{i}/bin/*) ; do mv $x ${x}3; done

--- a/pip/py3-keras2onnx.file
+++ b/pip/py3-keras2onnx.file
@@ -1,2 +1,2 @@
-Requires: py3-numpy py2-protobuf py3-requests py2-onnx py3-onnxconverter-common py3-fire
+Requires: py3-numpy py3-protobuf py3-requests py3-onnx py3-onnxconverter-common py3-fire
 %define source0 https://github.com/onnx/keras-onnx/archive/v%{realversion}.tar.gz

--- a/pip/py3-numba.file
+++ b/pip/py3-numba.file
@@ -1,2 +1,2 @@
-Requires: py2-funcsigs py2-six py3-singledispatch py3-llvmlite py3-numpy python3
+Requires: py3-funcsigs py2-six py3-singledispatch py3-llvmlite py3-numpy python3
 %define RelocatePython %{i}/bin/*

--- a/pip/py3-onnxconverter-common.file
+++ b/pip/py3-onnxconverter-common.file
@@ -1,2 +1,2 @@
-Requires: py2-numpy py3-numpy py2-onnx py2-protobuf py2-six
+Requires: py2-numpy py3-numpy py3-onnx py3-protobuf py2-six
 %define source0 https://github.com/microsoft/onnxconverter-common/archive/v%{realversion}.tar.gz

--- a/pip/py3-onnxmltools.file
+++ b/pip/py3-onnxmltools.file
@@ -1,2 +1,2 @@
-Requires: py3-numpy py2-onnx py2-protobuf py3-onnxconverter-common py3-skl2onnx py3-keras2onnx
+Requires: py3-numpy py3-onnx py3-protobuf py3-onnxconverter-common py3-skl2onnx py3-keras2onnx
 %define source0 https://github.com/onnx/onnxmltools/archive/v%{realversion}.tar.gz

--- a/pip/py3-onnxruntime.file
+++ b/pip/py3-onnxruntime.file
@@ -1,2 +1,2 @@
-Requires: onnxruntime py3-numpy py2-onnx
+Requires: onnxruntime py3-numpy py3-onnx
 %define PipDownloadSourceType none

--- a/pip/py3-pylint.file
+++ b/pip/py3-pylint.file
@@ -1,2 +1,2 @@
-Requires: py3-astroid py2-toml
+Requires: py3-astroid py3-toml
 %define PipPostBuildPy3 for x in $(ls %{i}/bin/*) ; do mv $x ${x}3; done ; sed -i -e 's| %{cmsroot}/.*python3 | python3 |' %{i}/bin/*3

--- a/pip/py3-skl2onnx.file
+++ b/pip/py3-skl2onnx.file
@@ -1,2 +1,2 @@
-Requires: py2-six py3-numpy py3-scipy py2-protobuf py2-onnx py3-scikit-learn py3-onnxconverter-common
+Requires: py2-six py3-numpy py3-scipy py3-protobuf py3-onnx py3-scikit-learn py3-onnxconverter-common
 %define source0 https://github.com/onnx/sklearn-onnx/archive/%{realversion}.tar.gz

--- a/pip/py3-tensorboard.file
+++ b/pip/py3-tensorboard.file
@@ -1,3 +1,3 @@
-Requires: py3-numpy py2-absl-py py2-grpcio
+Requires: py3-numpy py3-absl-py py3-grpcio
 Requires: py3-google-auth-oauthlib py3-tensorboard-plugin-wit
 %define PipPostBuild mv %{i}/bin/tensorboard %{i}/bin/tensorboard3

--- a/pip/pyasn1-modules.file
+++ b/pip/pyasn1-modules.file
@@ -1,1 +1,1 @@
-Requires: py2-pyasn1
+Requires: py3-pyasn1

--- a/pip/pybrain.file
+++ b/pip/pybrain.file
@@ -1,2 +1,1 @@
-Requires: py2-scipy
 %define source0 git+https://github.com/pybrain/pybrain?obj=master/%{realversion}&export=pybrain-%{realversion}&output=/source.tar.gz

--- a/pip/pycuda.file
+++ b/pip/pycuda.file
@@ -1,1 +1,1 @@
-Requires: py2-numpy py3-numpy cuda py3-pytools py2-pytest py3-decorator py2-appdirs py3-Mako
+Requires: py2-numpy py3-numpy cuda py3-pytools py3-pytest py3-decorator py3-appdirs py3-Mako

--- a/pip/pydantic.file
+++ b/pip/pydantic.file
@@ -1,1 +1,1 @@
-Requires: py2-typing_extensions
+Requires: py3-typing_extensions

--- a/pip/pydot.file
+++ b/pip/pydot.file
@@ -1,1 +1,1 @@
-Requires: py2-pyparsing
+Requires: py3-pyparsing

--- a/pip/pylint.file
+++ b/pip/pylint.file
@@ -1,1 +1,1 @@
-Requires: py3-astroid py2-six py3-isort py3-mccabe py2-configparser
+Requires: py3-astroid py2-six py3-isort py3-mccabe

--- a/pip/pytest.file
+++ b/pip/pytest.file
@@ -1,4 +1,4 @@
-Requires: py2-more-itertools py2-atomicwrites py2-attrs py2-funcsigs py2-pathlib2 py2-pluggy py2-py py2-scandir
-Requires: py2-packaging py2-wcwidth
-Requires: py2-iniconfig py2-toml
+Requires: py3-more-itertools py3-atomicwrites py3-attrs py3-funcsigs py3-pathlib2 py3-pluggy py3-py py3-scandir
+Requires: py3-packaging py2-wcwidth
+Requires: py3-iniconfig py3-toml
 %define PipPostBuildPy3 for x in $(ls %{i}/bin/*) ; do mv $x ${x}3; done

--- a/pip/pytools.file
+++ b/pip/pytools.file
@@ -1,1 +1,1 @@
-Requires: py3-decorator py2-appdirs py2-six py2-numpy py3-numpy
+Requires: py3-decorator py3-appdirs py2-six py2-numpy py3-numpy

--- a/pip/requests.file
+++ b/pip/requests.file
@@ -1,1 +1,1 @@
-Requires: py2-urllib3 py3-chardet py3-idna py3-certifi
+Requires: py3-urllib3 py3-chardet py3-idna py3-certifi

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -13,10 +13,10 @@
 #To customize a package build e.g. providing extra Requirements, build, install
 #flags or patching, please use either py{2,3}-package_name.file or package_name.file
 #############################################################################
-absl-py==0.11.0
+absl-py==0.11.0; python_version>'3.0'
 aiohttp==3.7.4 ;python_version>'3.0'
 aiosqlite==0.17.0 ;python_version>'3.0'
-appdirs==1.4.4
+appdirs==1.4.4; python_version>'3.0'
 argon2-cffi==20.1.0;python_version>'3.0'
 argparse==1.4.0; python_version>'3.0'
 asn1crypto==1.4.0; python_version>'3.0'
@@ -25,21 +25,14 @@ astroid==2.5.1 ; python_version>'3.0'
 astunparse==1.6.3; python_version>'3.0'
 async-lru==1.0.2 ; python_version>'3.0'
 async-timeout==3.0.1 ; python_version>'3.0'
-atomicwrites==1.4.0
-attrs==20.3.0
+atomicwrites==1.4.0; python_version>'3.0'
+attrs==20.3.0; python_version>'3.0'
 autopep8==1.5.5; python_version>'3.0'
 avro==1.10.1; python_version>'3.0'
 awkward==0.14.0; python_version>'3.0'
 awkward1==0.4.4; python_version>'3.0'
 backcall==0.2.0 ; python_version>'3.0'
-#backports_abc==0.5
 backports-functools_lru_cache==1.6.1
-backports-lzma==0.0.14
-backports-shutil_get_terminal_size==1.0.0
-backports-shutil_which==3.5.2
-backports-ssl_match_hostname==3.7.0.1
-backports-weakref==1.0.post1
-backports-os==0.1.1
 beautifulsoup4==4.9.3; python_version>'3.0'
 bleach==3.3.0; python_version>'3.0'
 bokeh==2.3.0 ; python_version>'3.0'
@@ -65,10 +58,10 @@ cloudpickle==1.3.0; python_version>'3.0'
 colorama==0.4.4; python_version>'3.0'
 conan==1.34.1 ; python_version>'3.0'
 configparser==4.0.2;python_version<'3.0'
-contextlib2==0.6.0.post1
+contextlib2==0.6.0.post1; python_version>'3.0'
 contextvars==2.4 ; python_version>'3.0'
 coverage==5.5; python_version>'3.0'
-cx-Oracle==7.3.0
+cx-Oracle==7.3.0; python_version>'3.0'
 cycler==0.10.0; python_version>'3.0'
 cython==0.29.22
 decorator==4.4.2; python_version>'3.0'
@@ -90,18 +83,17 @@ flake8==3.8.4 ; python_version>'3.0'
 flatbuffers==1.12.0 ; python_version>'3.0'
 flawfinder==2.0.15; python_version>'3.0'
 fs==2.4.12; python_version>'3.0'
-funcsigs==1.0.2
+funcsigs==1.0.2; python_version>'3.0'
 future==0.18.2
-futures==3.3.0;python_version<'3.0'
 gast==0.4.0; python_version>'3.0'
 gitdb==4.0.5 ; python_version>'3.0'
 GitPython==3.1.14 ; python_version>'3.0'
 google-auth==1.27.0 ; python_version>'3.0'
 google-auth-oauthlib==0.4.2 ; python_version>'3.0'
-google-common==0.0.1
+google-common==0.0.1; python_version>'3.0'
 google-pasta==0.2.0; python_version>'3.0'
-grpcio==1.36.0
-grpcio-tools==1.36.0 
+grpcio==1.36.0; python_version>'3.0'
+grpcio-tools==1.36.0; python_version>'3.0'
 #1.0.1 doesn't download (wheel only?)
 h5py-cache==1.0 ; python_version>'3.0'
 h5py==2.10.0; python_version>'3.0'
@@ -116,9 +108,9 @@ hyperas==0.4.1 ; python_version>'3.0'
 hyperopt==0.2.5; python_version>'3.0'
 idna==2.10; python_version>'3.0'
 immutables==0.15 ; python_version>'3.0'
-importlib-metadata==2.1.1
+importlib-metadata==2.1.1; python_version>'3.0'
 importlib-resources==3.3.1; python_version>'3.0'
-iniconfig==1.1.1
+iniconfig==1.1.1; python_version>'3.0'
 ipaddress==1.0.23;python_version>'3.0'
 ipykernel==5.5.0 ; python_version>'3.0'
 ipython_genutils==0.2.0; python_version>'3.0'
@@ -126,7 +118,6 @@ ipython==7.22.0 ; python_version>'3.0'
 ipywidgets==7.5.1 ; python_version>'3.0'
 isort==4.3.21; python_version>'3.0'
 jedi==0.17.2; python_version>'3.0'
-Jinja2==2.11.3; python_version<'3.0'
 Jinja2==2.11.3; python_version>'3.0'
 joblib==1.0.1 ; python_version>'3.0'
 jsonpickle==1.4.2; python_version>'3.0'
@@ -154,13 +145,11 @@ lxml==4.6.3; python_version>'3.0'
 lz4==3.1.3 ; python_version>'3.0'
 Mako==1.1.4; python_version>'3.0'
 Markdown==3.1.1; python_version>'3.0'
-MarkupSafe==1.1.1; python_version<'3.0'
 MarkupSafe==1.1.1; python_version>'3.0'
 matplotlib==3.3.4 ; python_version>'3.0'
 mccabe==0.6.1; python_version>'3.0'
 mistune==0.8.4; python_version>'3.0'
 mock==3.0.5; python_version>'3.0'
-more-itertools==5.0.0 ; python_version<'3.0'
 more-itertools==8.7.0 ; python_version>'3.0'
 mpld3==0.5.2; python_version>'3.0'
 mplhep==0.2.16 ; python_version>'3.0'
@@ -181,44 +170,41 @@ numexpr==2.7.2; python_version>'3.0'
 numpy==1.16.6 ; python_version<'3.0'
 #numpy 1.19 needs an updated tensorflow
 numpy==1.17.5 ; python_version>'3.0'
-onnx==1.8.1
+onnx==1.8.1; python_version>'3.0'
 onnxmltools==1.7.0 ; python_version>'3.0'
 onnxconverter-common==1.7.0 ; python_version>'3.0'
 oauthlib==3.1.0 ; python_version>'3.0'
 opt-einsum==3.3.0 ; python_version>'3.0'
-ordereddict==1.1; python_version>'3.0'
 pkginfo==1.7.0 ; python_version>'3.0'
-packaging==20.9
+packaging==20.9; python_version>'3.0'
 pandas==1.2.2 ; python_version>'3.0'
 pandocfilters==1.4.3; python_version>'3.0'
 parsimonious==0.8.1; python_version>'3.0'
 parso==0.7.1; python_version>'3.0'
 pastel==0.2.1 ; python_version>'3.0'
 patch-ng==1.17.4 ; python_version>'3.0'
-pathlib2==2.3.5
+pathlib2==2.3.5; python_version>'3.0'
 pbr==5.5.1; python_version>'3.0'
 pexpect==4.8.0; python_version>'3.0'
 pickleshare==0.7.5; python_version>'3.0'
-pillow==6.2.2 ; python_version<'3.0'
 pillow==8.2.0 ; python_version>'3.0'
 pkgconfig==1.5.2; python_version>'3.0'
 plac==1.3.2; python_version>'3.0'
 pluginbase==1.0.0 ; python_version>'3.0'
-pluggy==0.13.1
+pluggy==0.13.1; python_version>'3.0'
 ply==3.11; python_version>'3.0'
 poetry==1.1.4 ; python_version>'3.0'
 poetry-core==1.0.2 ; python_version>'3.0'
 prettytable==1.0.1
 prometheus_client==0.9.0; python_version>'3.0'
 prompt_toolkit==3.0.16 ; python_version>'3.0'
-protobuf==3.15.1
+protobuf==3.15.1; python_version>'3.0'
 prwlock==0.4.1; python_version>'3.0'
 psutil==5.8.0; python_version>'3.0'
 ptyprocess==0.7.0; python_version>'3.0'
 pyasn1-modules==0.2.8; python_version>'3.0'
-pyasn1==0.4.8
-pyasn1-modules==0.2.8 ; python_version>'3.0'
-pybind11==2.6.2; python_version>'3.0'
+pyasn1==0.4.8; python_version>'3.0'
+pybind11==2.6.2; python_version>'3.0' 
 pybrain==0.3.3; python_version>'3.0'
 pycodestyle==2.6.0; python_version>'3.0'
 pycparser==2.20; python_version>'3.0'
@@ -230,17 +216,15 @@ Pygments==2.8.1 ; python_version>'3.0'
 PyJWT==2.0.1 ; python_version>'3.0'
 pylint==2.7.2 ; python_version>'3.0'
 pymongo==3.11.3; python_version>'3.0'
-pyparsing==2.4.7
+pyparsing==2.4.7; python_version>'3.0'
 pyrsistent==0.17.3 ; python_version>'3.0'
-py==1.10.0
+py==1.10.0; python_version>'3.0'
 pydantic==1.8.2 ; python_version>'3.0'
 pylev==1.3.0 ; python_version>'3.0'
-pysqlite==2.8.3; python_version<'3.0'
 pysqlite3==0.4.6; python_version>'3.0'
-pytest==4.6.11 ; python_version<'3.0'
 pytest==6.2.2 ; python_version>'3.0'
 pytest-cov==2.11.1; python_version>'3.0'
-pytest-runner==5.2
+pytest-runner==5.2; python_version>'3.0'
 python-daemon==2.3.0; python_version>'3.0'
 python-dateutil==2.8.1; python_version>'3.0'
 python-ldap==3.3.1 ; python_version>'3.0'
@@ -262,9 +246,8 @@ root_numpy==4.8.0; python_version>'3.0'
 root_pandas==0.7.0 ; python_version>'3.0'
 rootpy==1.0.1; python_version>'3.0'
 rsa==4.7.2 ; python_version>'3.0'
-scandir==1.10.0
+scandir==1.10.0; python_version>'3.0'
 schema==0.7.4; python_version>'3.0'
-scikit-learn==0.20.4 ; python_version<'3.0'
 scikit-learn==0.24.1 ; python_version>'3.0'
 scinum==1.1.3; python_version>'3.0'
 scipy==1.2.3 ; python_version<'3.0'
@@ -297,20 +280,20 @@ terminado==0.8.3; python_version>'3.0'
 testpath==0.4.4 ; python_version>'3.0'
 theanets==0.7.3; python_version>'3.0'
 Theano==1.0.5; python_version>'3.0'
-toml==0.10.2
+toml==0.10.2; python_version>'3.0'
 tomlkit==0.7.0 ; python_version>'3.0'
 tornado==6.1 ; python_version>'3.0'
 #update needs setuptools update I think
 tqdm==4.51.0; python_version>'3.0'
 traitlets==4.3.3; python_version>'3.0'
 typed-ast==1.4.2 ; python_version>'3.0'
-typing_extensions==3.7.4.3
-typing==3.7.4.3
+typing_extensions==3.7.4.3; python_version>'3.0'
+typing==3.7.4.3; python_version>'3.0'
 uncertainties==3.1.5; python_version>'3.0'
 uproot==3.13.0; python_version>'3.0'
 uproot-methods==0.8.0; python_version>'3.0'
 uproot4==0.1.2; python_version>'3.0'
-urllib3==1.26.5
+urllib3==1.26.5; python_version>'3.0'
 virtualenv-clone==0.5.4; python_version>'3.0'
 virtualenv==20.4.2; python_version>'3.0'
 virtualenvwrapper==4.8.4; python_version>'3.0'
@@ -321,10 +304,8 @@ wheel==0.33.6
 widgetsnbextension==3.5.1 ; python_version>'3.0'
 #cannot wrapt update before astroid is
 wrapt==1.11.2; python_version>'3.0'
-xgboost==0.82 ; python_version<'3.0'
 xgboost==1.3.3 ; python_version>'3.0'
 #bumping this pulls in xrootd - which looks like it needs some understanding
 xrootdpyfs==0.2.1; python_version>'3.0'
 yarl==1.6.3 ;python_version>'3.0'
 zipp==3.4.0 ; python_version>'3.0'
-zipp==1.2.0 ; python_version<'3.0'

--- a/pip/rsa.file
+++ b/pip/rsa.file
@@ -1,1 +1,1 @@
-Requires: py2-pyasn1
+Requires: py3-pyasn1

--- a/pip/schema.file
+++ b/pip/schema.file
@@ -1,1 +1,1 @@
-Requires: py2-contextlib2 py2-wheel
+Requires: py3-contextlib2 py2-wheel

--- a/pip/tensorboard.file
+++ b/pip/tensorboard.file
@@ -1,2 +1,2 @@
-Requires: py3-Markdown py2-futures py3-Werkzeug py2-protobuf py3-html5lib py2-six py2-wheel py3-bleach
+Requires: py3-Markdown py3-Werkzeug py3-protobuf py3-html5lib py2-six py2-wheel py3-bleach
 %define PipDownloadSourceType none

--- a/pip/tensorflow.file
+++ b/pip/tensorflow.file
@@ -1,5 +1,5 @@
 ## INCLUDE tensorflow-requires
-Requires: py2-funcsigs py3-pbr py2-packaging py2-appdirs py2-pyparsing py3-mock py3-Werkzeug
-Requires: py2-grpcio py3-astunparse
+Requires: py3-funcsigs py3-pbr py3-packaging py3-appdirs py3-pyparsing py3-mock py3-Werkzeug
+Requires: py3-grpcio py3-astunparse
 %define source0 none
 %define source_file none

--- a/pip/traitlets.file
+++ b/pip/traitlets.file
@@ -1,1 +1,1 @@
-Requires: py3-ipython_genutils py2-six py3-decorator py2-enum34
+Requires: py3-ipython_genutils py2-six py3-decorator 

--- a/pip/typing_extensions.file
+++ b/pip/typing_extensions.file
@@ -1,1 +1,1 @@
-Requires: py2-typing
+Requires: py3-typing

--- a/pip/virtualenv.file
+++ b/pip/virtualenv.file
@@ -1,2 +1,2 @@
-Requires: py2-appdirs py3-distlib py3-filelock py2-six py2-importlib-metadata py3-importlib-resources
+Requires: py3-appdirs py3-distlib py3-filelock py2-six py3-importlib-metadata py3-importlib-resources
 %define RelocatePython %{i}/bin/*

--- a/pip/xrootdpyfs.file
+++ b/pip/xrootdpyfs.file
@@ -1,1 +1,1 @@
-Requires: xrootd py3-fs py2-typing
+Requires: xrootd py3-fs py3-typing

--- a/pip/zipp.file
+++ b/pip/zipp.file
@@ -1,1 +1,1 @@
-Requires: py2-more-itertools py3-more-itertools py2-setuptools-scm  py2-contextlib2
+Requires: py3-more-itertools py3-more-itertools py2-setuptools-scm py3-contextlib2

--- a/professor.spec
+++ b/professor.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON27PATH %i/lib/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 Source: http://www.hepforge.org/archive/professor/professor-%{realversion}.tar.gz
 
-Requires: py2-numpy py2-scipy pyminuit2 py3-matplotlib
+Requires: py2-numpy py3-scipy pyminuit2 py3-matplotlib
 %prep
 %setup -n professor-%{realversion}
 

--- a/py2-backports.spec
+++ b/py2-backports.spec
@@ -5,11 +5,7 @@ Source: none
 
 Requires: python python3
 
-BuildRequires: py2-backports-functools_lru_cache py2-backports-lzma
-BuildRequires: py2-backports-shutil_which py2-backports-ssl_match_hostname
-BuildRequires: py2-backports-shutil_get_terminal_size py2-configparser
-BuildRequires: py2-backports-weakref py2-backports-os
-
+BuildRequires: py2-backports-functools_lru_cache
 
 %prep
 

--- a/py2-googlePackages.spec
+++ b/py2-googlePackages.spec
@@ -3,57 +3,15 @@
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 Source: none
 
-Requires: python python3
-BuildRequires: py2-google-common
-BuildRequires: py2-protobuf
+Requires: python3
+BuildRequires: py3-google-common
+BuildRequires: py3-protobuf
 
 %prep
 
 %build
  
 %install
-
-mkdir -p %{i}/${PYTHON_LIB_SITE_PACKAGES}
-for pkg in %builddirectpkgreqs ; do
-  SOURCE=%{cmsroot}/%{cmsplatf}/${pkg}/${PYTHON_LIB_SITE_PACKAGES}
-  if [ -d $SOURCE ] ; then
-    echo "Checking for duplicates ...."
-    for f in $(ls $SOURCE) ; do
-      if [ -e %{i}/${PYTHON_LIB_SITE_PACKAGES}/$f ] ; then 
-        # https://github.com/jupyter/jupyter_core/issues/55 - now I delete jupyter.py from one of the providers
-        #backports is an example directory that can have multiple packages inside
-        if [ $f != "backports" ] ; then  
-        if [ $f != "google" ] ; then  
-           echo "  Duplicate file found: $f"
-           exit 1
-        fi
-        fi
-
-      fi
-    done
-    echo "Copying $SOURCE in %{pkgrel}"
-#try cp instead of rsync as we don't want to overwrite duplicate directories
-#    rsync -av $SOURCE/ %{i}/${PYTHON_LIB_SITE_PACKAGES}/
-    cp -r ${SOURCE}/* %{i}/${PYTHON_LIB_SITE_PACKAGES}/ 
-  fi
-done
-
-#and for bin
-mkdir -p %{i}/bin
-for pkg in %builddirectpkgreqs ; do
-  SOURCE=%{cmsroot}/%{cmsplatf}/${pkg}/bin
-  if [ -d $SOURCE ] ; then
-    echo "Checking for duplicates ...."
-    for f in $(ls $SOURCE) ; do
-      if [ -e %{i}/bin/$f ] ; then 
-           echo "  Duplicate file found: $f"
-           exit 1
-      fi
-    done
-    echo "Copying $SOURCE in %{pkgrel}"
-    rsync -av $SOURCE/ %{i}/bin/
-  fi
-done
 
 mkdir -p %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 for pkg in %builddirectpkgreqs ; do

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -5,10 +5,14 @@ Source: none
 
 Requires: root curl python python3 xrootd llvm hdf5 mxnet-predict yoda opencv
 
-Requires: py2-scipy
+#needed for cmssw until python2-> python3 switch of framework
+Requires: py2-configparser
+Requires: py2-enum34
+
+Requires: py3-scipy
 Requires: py3-Keras
 Requires: py3-Theano
-Requires: py2-scikit-learn
+Requires: py3-scikit-learn
 #save for the end
 Requires: py3-tensorflow
 Requires: py2-googlePackages
@@ -23,7 +27,7 @@ Requires: py3-pandas
 Requires: py3-Bottleneck
 Requires: py3-downhill
 Requires: py3-theanets
-Requires: py2-xgboost py3-xgboost
+Requires: py3-xgboost
 Requires: py3-llvmlite
 Requires: py3-numba
 Requires: py3-hep_ml
@@ -48,7 +52,7 @@ Requires: py3-entrypoints
 Requires: py3-psutil
 Requires: py3-repoze-lru
 Requires: py3-Pygments
-Requires: py2-appdirs
+Requires: py3-appdirs
 Requires: py3-argparse
 Requires: py3-bleach
 Requires: py3-certifi
@@ -67,18 +71,17 @@ Requires: py3-mistune
 Requires: py3-nbconvert
 Requires: py3-nbformat
 Requires: py3-notebook
-Requires: py3-ordereddict
-Requires: py2-packaging
+Requires: py3-packaging
 Requires: py3-pandocfilters
-Requires: py2-pathlib2
+Requires: py3-pathlib2
 Requires: py3-pexpect
 Requires: py3-pickleshare
 Requires: py3-prompt_toolkit
 Requires: py3-ptyprocess
-Requires: py2-pyparsing
+Requires: py3-pyparsing
 Requires: py3-pyzmq
 Requires: py3-qtconsole
-Requires: py2-scandir
+Requires: py3-scandir
 Requires: py2-setuptools
 Requires: py3-setuptools
 Requires: py3-simplegeneric
@@ -93,7 +96,6 @@ Requires: py3-webencodings
 Requires: py3-widgetsnbextension
 Requires: py3-cycler
 Requires: py3-docopt
-Requires: py2-futures
 Requires: py3-networkx
 Requires: py2-prettytable
 Requires: py2-pycurl
@@ -101,26 +103,24 @@ Requires: py3-pytz
 Requires: py3-requests
 Requires: py3-schema
 Requires: py3-python-dateutil
-Requires: py2-enum34
 Requires: py3-mock
 Requires: py3-pbr
 Requires: py3-mpmath
 Requires: py3-sympy
 Requires: py3-tqdm
-Requires: py2-funcsigs
+Requires: py3-funcsigs
 Requires: py3-nose
 Requires: py3-pkgconfig
-Requires: py2-pysqlite
 Requires: py3-Click
 Requires: py3-jsonpickle
 Requires: py3-prwlock
 Requires: py3-virtualenv
 Requires: py3-virtualenvwrapper
-Requires: py2-urllib3
+Requires: py3-urllib3
 Requires: py3-chardet
 Requires: py3-idna
 Requires: py3-Werkzeug
-Requires: py2-pytest
+Requires: py3-pytest
 Requires: py3-avro
 Requires: py3-fs
 Requires: py3-lizard
@@ -138,7 +138,7 @@ Requires: py3-pylint
 Requires: py2-pip
 Requires: py3-pip
 %ifarch x86_64
-Requires: py2-cx-Oracle
+Requires: py3-cx-Oracle
 %endif
 Requires: py2-cython
 Requires: py2-future
@@ -149,13 +149,13 @@ Requires: py3-autopep8
 Requires: py3-pycodestyle
 Requires: py3-lz4
 Requires: py3-ply
-Requires: py2-py
-Requires: py2-typing
+Requires: py3-py
+Requires: py3-typing
 Requires: py3-defusedxml
-Requires: py2-atomicwrites
-Requires: py2-attrs
+Requires: py3-atomicwrites
+Requires: py3-attrs
 Requires: py3-nbdime
-Requires: py2-onnx
+Requires: py3-onnx
 Requires: py3-onnxmltools
 Requires: py2-backports
 Requires: py3-colorama
@@ -165,27 +165,27 @@ Requires: py3-GitPython py3-GitPython
 Requires: py3-Send2Trash
 Requires: py3-ipaddress
 Requires: py3-mccabe
-Requires: py2-more-itertools
-Requires: py2-pluggy
+Requires: py3-more-itertools
+Requires: py3-pluggy
 Requires: py3-prometheus_client
 Requires: py3-pyasn1-modules
-Requires: py2-pyasn1
+Requires: py3-pyasn1
 Requires: py3-pyflakes
 Requires: py3-smmap2
 Requires: py3-stevedore
-Requires: py2-typing_extensions
+Requires: py3-typing_extensions
 Requires: py3-virtualenv-clone
 Requires: py3-asn1crypto
 Requires: py3-backcall
 Requires: py3-cffi
-Requires: py2-google-common
+Requires: py3-google-common
 Requires: py3-jedi
 Requires: py3-parso
 Requires: py3-pycparser
-Requires: py2-absl-py
+Requires: py3-absl-py
 Requires: py3-gast
-Requires: py2-grpcio
-Requires: py2-grpcio-tools
+Requires: py3-grpcio
+Requires: py3-grpcio-tools
 Requires: py3-Markdown
 Requires: py3-subprocess32
 Requires: py3-kiwisolver
@@ -194,7 +194,7 @@ Requires: py3-climate
 Requires: py3-mpld3
 Requires: py3-neurolab
 Requires: py3-nose-parameterized
-Requires: py2-pillow
+Requires: py3-pillow
 Requires: py3-pybrain
 Requires: py3-pymongo
 Requires: py3-pydot

--- a/tensorflow-requires.file
+++ b/tensorflow-requires.file
@@ -1,5 +1,5 @@
-Requires: python python3 py2-numpy py2-enum34 py3-mock py2-wheel py2-typing py2-typing_extensions
+Requires: python python3 py2-numpy py3-mock py2-wheel py3-typing py3-typing_extensions
 Requires: py3-keras-applications py3-keras-preprocessing py2-setuptools py2-future py3-wrapt py3-gast py3-setuptools
-Requires: py2-cython py2-googlePackages py3-astor py2-six py3-termcolor py2-absl-py
+Requires: py2-cython py2-googlePackages py3-astor py2-six py3-termcolor py3-absl-py
 Requires: py2-backports py3-opt-einsum py3-flatbuffers
 Requires: eigen protobuf zlib libpng libjpeg-turbo curl pcre giflib sqlite grpc flatbuffers

--- a/triton-inference-server.spec
+++ b/triton-inference-server.spec
@@ -4,7 +4,7 @@
 
 Source: git+https://github.com/%{github_user}/server.git?obj=%{branch}/v%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake
-Requires: opencv protobuf grpc curl python py2-wheel py2-setuptools py2-grpcio-tools python3 cuda
+Requires: opencv protobuf grpc curl cuda 
 
 %prep
 


### PR DESCRIPTION
These are the changes made by @davidlange6 to drop python2 based packages from cmssw software stack. These changes have been included/tested in DEVEL IBs. Thsi PR is based on the changes proposed by the following PRs

- https://github.com/cms-sw/cmsdist/pull/7019
- https://github.com/cms-sw/cmsdist/pull/7010
- https://github.com/cms-sw/cmsdist/pull/6990

As discussed  @makortel , @davidlange6 

