### PR TITLE
Added detect_odr_violation=0 to asan option

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-02-15
+%define configtag       V06-02-16
 %endif
 
 %if "%{?cvssrc:set}" != "set"
@@ -216,7 +216,7 @@ for cmd in edmPluginRefresh ; do
     for lib in %{cmssw_libs} ; do
       if [ -d %i/$lib ] ; then
         rm -f %i/$lib/.edmplugincache
-        $cmd %i/$lib || true
+        $cmd %i/$lib
       fi
     done
   fi


### PR DESCRIPTION
To avoid build error like [a]. We need to see why ASAN complains aboit this later.

```
==13090==ERROR: AddressSanitizer: odr-violation (0x2b5fe7583ac0):
  [1] size=8 'fInstance' CMSSW_12_0_ASAN_X_2021-06-25-2300/src/GeneratorInterface/Core/interface/FortranCallback.h:46:20
  [2] size=8 'fInstance' CMSSW_12_0_ASAN_X_2021-06-25-2300/src/GeneratorInterface/Core/interface/FortranCallback.h:46:20
These globals were registered at these points:
  [1]:
    #0 0x2b5f3ab95f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x2b5f3a94a9c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7ffd95da3fbe  (<unknown module>)

  [2]:
    #0 0x2b5f3ab95f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x2b5f3a94a9c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7ffd95da3fbe  (<unknown module>)

==13090==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
```