### PR TITLE
[OpenLoops 2.1.2] Generate process_src.tgz to be uploaded as source

### DIFF
--- a/openloops-common.file
+++ b/openloops-common.file
@@ -1,5 +1,5 @@
-%define openloop_version 2.1.1
-%define tag 5284f172973c666ef7e58b56b180b8703d9fba13
+%define openloop_version 2.1.2
+%define tag 4247179369144b0134c7b8014a5d38a90dc9b6ba
 %define branch cms/v%{openloop_version}
 %define github_user cms-externals
 

--- a/openloops-common.file
+++ b/openloops-common.file
@@ -1,0 +1,8 @@
+%define openloop_version 2.1.1
+%define tag 5284f172973c666ef7e58b56b180b8703d9fba13
+%define branch cms/v%{openloop_version}
+%define github_user cms-externals
+
+Source: git+https://github.com/%{github_user}/openloops.git?obj=%{branch}/%{tag}&export=openloops-%{openloop_version}&output=/openloops-%{openloop_version}-%{tag}.tgz
+Source1: openloops-user.coll
+BuildRequires: python

--- a/openloops-process.spec
+++ b/openloops-process.spec
@@ -5,7 +5,7 @@
 ## NO_AUTO_DEPENDENCY
 
 %define process_src process_src.tgz
-Source2: https://cmsrep.cern.ch/cmssw/download/openloops/%{realversion}/%{cmsdist_chksum_source2}?cmdist-generated=1&output=/%{process_src}
+Source2: https://cmsrep.cern.ch/cmssw/download/openloops/%{realversion}/%{cmsdist_chksum_source1}?cmdist-generated=1&output=/%{process_src}
 Patch0: openloops-urlopen2curl
 
 %prep

--- a/openloops-process.spec
+++ b/openloops-process.spec
@@ -19,7 +19,7 @@ chksum_source2="SOURCES/cache/$(echo %{cmsdist_chksum_source2} | cut -c1-2)/%{cm
 if [ ! -e %{cmsroot}/${chksum_source2}/%{process_src} ] ; then
   cp %{_sourcedir}/openloops-user.coll openloops-user.coll
   pyol/bin/download_process.py $(cat %{_sourcedir}/openloops-user.coll | tr '\n' ' ')
-  tar -czf %{process_src} process_src
+  tar -czf %{process_src} process_src proclib
   mkdir -p %{cmsroot}/${chksum_source2}
   mv %{process_src} %{cmsroot}/${chksum_source2}/
 fi

--- a/openloops-process.spec
+++ b/openloops-process.spec
@@ -1,0 +1,30 @@
+## INCLUDE openloops-common
+### RPM external openloops-process %{openloop_version}
+
+## NOCOMPILER
+## NO_AUTO_DEPENDENCY
+
+%define process_src process_src.tgz
+Source2: https://cmsrep.cern.ch/cmssw/download/openloops/%{realversion}/%{cmsdist_chksum_source2}?cmdist-generated=1&output=/%{process_src}
+Patch0: openloops-urlopen2curl
+
+%prep
+%setup -n openloops-%{realversion}
+%patch0 -p1
+
+%build
+
+%install
+chksum_source2="SOURCES/cache/$(echo %{cmsdist_chksum_source2} | cut -c1-2)/%{cmsdist_chksum_source2}"
+if [ ! -e %{cmsroot}/${chksum_source2}/%{process_src} ] ; then
+  cp %{_sourcedir}/openloops-user.coll openloops-user.coll
+  pyol/bin/download_process.py $(cat %{_sourcedir}/openloops-user.coll | tr '\n' ' ')
+  tar -czf %{process_src} process_src
+  mkdir -p %{cmsroot}/${chksum_source2}
+  mv %{process_src} %{cmsroot}/${chksum_source2}/
+fi
+if [ ! -e %{_sourcedir}/%{process_src} ] ; then
+  mkdir -p %{_sourcedir}
+  ln -s %{cmsroot}/${chksum_source2}/%{process_src} %{_sourcedir}/%{process_src}
+fi
+ln -s %{cmsroot}/${chksum_source2}/%{process_src} %{pkginstroot}/

--- a/openloops-urlopen2curl.patch
+++ b/openloops-urlopen2curl.patch
@@ -1,5 +1,5 @@
 diff --git a/pyol/bin/download_process.py b/pyol/bin/download_process.py
-index 4cecfb9..4f6c1b1 100755
+index 4cecfb9..c65b99b 100755
 --- a/pyol/bin/download_process.py
 +++ b/pyol/bin/download_process.py
 @@ -36,10 +36,9 @@ import OLBaseConfig
@@ -15,7 +15,7 @@ index 4cecfb9..4f6c1b1 100755
  
  commandline_options = [arg.split('=',1) for arg in sys.argv[1:] if ('=' in arg and not arg.startswith('-'))]
  config = OLBaseConfig.get_config(commandline_options)
-@@ -112,23 +111,25 @@ def update_channel_db(repo):
+@@ -112,24 +111,26 @@ def update_channel_db(repo):
          fh.close()
      else:
          local_hash = None
@@ -48,10 +48,12 @@ index 4cecfb9..4f6c1b1 100755
          lfh.write(hash_line.strip() + '  ' +
                    time.strftime(OLToolbox.timeformat) + '\n')
 -        for line in rfh:
+-            lfh.write(line.decode())
 +        for line in lines[1:]:
-             lfh.write(line.decode())
++            lfh.write(line.decode()+"\n")
              local_hash.update(line.strip())
          lfh.close()
+         local_hash = local_hash.hexdigest()
 @@ -140,7 +141,6 @@ def update_channel_db(repo):
              print('ERROR: downloaded channel database inconsistent ' +
                    'for repository ' + repo_name)

--- a/openloops-urlopen2curl.patch
+++ b/openloops-urlopen2curl.patch
@@ -1,0 +1,166 @@
+diff --git a/pyol/bin/download_process.py b/pyol/bin/download_process.py
+index 4cecfb9..4f6c1b1 100755
+--- a/pyol/bin/download_process.py
++++ b/pyol/bin/download_process.py
+@@ -36,10 +36,9 @@ import OLBaseConfig
+ import OLToolbox
+ 
+ if sys.version_info < (3,0,0):
+-    from urllib2 import urlopen, URLError
++    from commands import getstatusoutput
+ else:
+-    from urllib.request import urlopen
+-    from urllib.error import URLError
++    from subprocess import getstatusoutput
+ 
+ commandline_options = [arg.split('=',1) for arg in sys.argv[1:] if ('=' in arg and not arg.startswith('-'))]
+ config = OLBaseConfig.get_config(commandline_options)
+@@ -112,23 +111,25 @@ def update_channel_db(repo):
+         fh.close()
+     else:
+         local_hash = None
+-    try:
+-        if remote_channel_url.startswith('/'):
+-            rfh = open(remote_channel_url, 'rb')
+-        else:
+-            rfh = urlopen(remote_channel_url)
+-    except (URLError, IOError) as e:
+-        print('Warning: Channel database update for repository ' + repo_name +
+-              ' failed (' + str(e) + '). Skip this repository.')
+-        return False
+-    hash_line = rfh.readline().decode()
++    lines = []
++    if remote_channel_url.startswith('/'):
++        e, out = getstatusoutput("cat %s" % remote_channel_url)
++        lines = out.split("\n")
++    else:
++        e, out = getstatusoutput("curl -s -k -L %s" % remote_channel_url)
++        if e:
++            print('Warning: Channel database update for repository ' + repo_name +
++              ' failed (' + rfh + '). Skip this repository.')
++            return False
++        lines = out.split("\n")
++    hash_line = lines[0].decode()
+     if local_hash != hash_line.split()[0]:
+         local_hash = hashlib.md5()
+         tmp_file = local_channel_file + '.~' + str(os.getpid())
+         lfh = open(tmp_file, 'w')
+         lfh.write(hash_line.strip() + '  ' +
+                   time.strftime(OLToolbox.timeformat) + '\n')
+-        for line in rfh:
++        for line in lines[1:]:
+             lfh.write(line.decode())
+             local_hash.update(line.strip())
+         lfh.close()
+@@ -140,7 +141,6 @@ def update_channel_db(repo):
+             print('ERROR: downloaded channel database inconsistent ' +
+                   'for repository ' + repo_name)
+             sys.exit(1)
+-    rfh.close()
+     return True
+ 
+ 
+@@ -214,21 +214,17 @@ def download(process, dbs, libmaps):
+     # download the process
+     print('download from repository: '+ available[3] +'...',end=' ')
+     sys.stdout.flush()
+-    try:
+-        if remote_archive.startswith('/'):
+-            rf = open(remote_archive, 'rb')
+-        else:
+-            rf = urlopen(remote_archive)
+-    except (URLError, IOError):
+-        print('*** DOWNLOAD FAILED ***')
+-        if args.ignore:
+-            return
+-        else:
+-            sys.exit(1)
+-    lf = open(local_archive, 'wb')
+-    lf.write(rf.read())
+-    rf.close()
+-    lf.close()
++    if remote_archive.startswith('/'):
++        getstatusoutput ("cp -f %s %s" % (remote_archive, local_archive))
++    else:
++        e, out = getstatusoutput("curl -s -k -L -o '%s' '%s'" % (local_archive, remote_archive))
++        if e:
++            print('*** DOWNLOAD FAILED ***')
++            print(out)
++            if args.ignore:
++                return
++            else:
++                sys.exit(1)
+     print('extract ...', end=' ')
+     sys.stdout.flush()
+     # remove target directory if it already exists
+diff --git a/pyol/tools/OLToolbox.py b/pyol/tools/OLToolbox.py
+index 380e06f..2d2c26e 100644
+--- a/pyol/tools/OLToolbox.py
++++ b/pyol/tools/OLToolbox.py
+@@ -29,6 +29,11 @@ try:
+ except NameError:
+     strtype = str
+ 
++if sys.version_info < (3,0,0):
++    from commands import getstatusoutput
++else:
++    from subprocess import getstatusoutput
++
+ timeformat = '%Y-%m-%d-%H-%M-%S'
+ 
+ def remove_duplicates(ls):
+@@ -56,29 +61,14 @@ def import_list(filename, lines=None, fatal=True,
+     and empty elements. filename can be a file name or a file object."""
+     # OLD PYTHON
+     decode = False
++    new_data = []
+     if isinstance(filename, strtype):
+         if not filename.startswith('http:'):
+-            try:
+-                fh = open(filename, 'r')
+-            except IOError:
+-                if fatal:
+-                    if '%s' in error_message:
+-                        print(error_message % (filename,))
+-                    else:
+-                        print(error_message)
+-                    raise
+-                else:
+-                    return None
++            e, out = getstatusoutput("cat %s" % filename)
++            new_data = out.split("\n")
+         else:
+-            if sys.version_info < (3,0,0):
+-                from urllib2 import urlopen, URLError
+-            else:
+-                from urllib.request import urlopen
+-                from urllib.error import URLError
+-                decode = True
+-            try:
+-                fh = urlopen(filename)
+-            except URLError:
++            e, out = getstatusoutput("curl -s -k -L %s" % filename)
++            if e:
+                 if fatal:
+                     if '%s' in error_message:
+                         print(error_message % (filename,))
+@@ -87,14 +77,14 @@ def import_list(filename, lines=None, fatal=True,
+                     raise
+                 else:
+                     return None
++            new_data = out.split("\n")
+     else:
+-        fh = filename
++        new_data = filename.readlines()
+     if lines:
+-        ls = [fh.readline() for n in range(lines)]
++        ls = [new_data[n] for n in range(lines)]
+     else:
+-        ls = fh.readlines()
+-    fh.close()
+-    if decode:
++        ls = new_data
++    if sys.version_info > (3,0,0):
+         ls = [li.decode() for li in ls]
+     return strip_comments(ls)
+ 

--- a/openloops.spec
+++ b/openloops.spec
@@ -15,7 +15,7 @@ sed -i -e 's|^ *process_download_script *=.*|process_download_script = download_
 #Remove conditional processes
 %ifarch aarch64
 %define drop_process pplljj_ew
-sed -i e 's|^ *cmodel *=.*|cmodel = small|' pyol/config/default.cfg
+sed -i -e 's|^ *cmodel *=.*|cmodel = small|' pyol/config/default.cfg
 %else
 %define drop_process %{nil}
 %endif

--- a/openloops.spec
+++ b/openloops.spec
@@ -43,6 +43,7 @@ rm -rf process_src
 tar -xzf $OPENLOOPS_PROCESS_ROOT/process_src.tgz
 for xproc in %{drop_process} ; do
   sed -i -e "/^${xproc}$/d" openloops-user.coll
+  sed -i -e "/^${xproc} .*/d" process_src/downloaded.dat
   rm -rf process_src/${xproc}
 done
 

--- a/openloops.spec
+++ b/openloops.spec
@@ -16,7 +16,7 @@ sed -i -e 's|^ *process_download_script *=.*|process_download_script = download_
 %ifarch aarch64
 %define drop_process pplljj_ew
 %else
-%define drop_process pplljj_ew
+%define drop_process %{nil}
 %endif
 
 #Fix for GCC 10

--- a/openloops.spec
+++ b/openloops.spec
@@ -15,6 +15,7 @@ sed -i -e 's|^ *process_download_script *=.*|process_download_script = download_
 #Remove conditional processes
 %ifarch aarch64
 %define drop_process pplljj_ew
+sed -i e 's|^ *cmodel *=.*|cmodel = small|' pyol/config/default.cfg
 %else
 %define drop_process %{nil}
 %endif

--- a/openloops.spec
+++ b/openloops.spec
@@ -1,17 +1,25 @@
-### RPM external openloops 2.1.1
-%define tag 5284f172973c666ef7e58b56b180b8703d9fba13
-%define branch cms/v2.1.1
-%define github_user cms-externals
-Source: git+https://github.com/%github_user/openloops.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
-Source1: openloops-user.coll
-BuildRequires: python scons
+## INCLUDE openloops-common
+### RPM external openloops %{openloop_version}
+
+BuildRequires: scons openloops-process
 
 %define keep_archives true
 
 %prep
 %setup -n %{n}-%{realversion}
 
-%build
+#process_src should be available via $OPENLOOPS_PROCESS_ROOT
+echo 'import sys;print(sys.argv)' > download_dummy.py
+sed -i -e 's|^ *process_download_script *=.*|process_download_script = download_dummy.py|' pyol/config/default.cfg
+
+#Remove conditional processes
+%ifarch aarch64
+%define drop_process pplljj_ew
+%else
+%define drop_process pplljj_ew
+%endif
+
+#Fix for GCC 10
 gcc10_extra_flag=""
 if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then export gcc10_extra_flag=-fallow-invalid-boz ; fi
 
@@ -25,14 +33,19 @@ loop_optimisation = -O0
 link_optimisation = -O2
 EOF
 
-%ifarch aarch64
-grep -v '^pplljj_ew$' %{_sourcedir}/openloops-user.coll > openloops-user.coll
-%else
-cp %{_sourcedir}/openloops-user.coll openloops-user.coll
-%endif
-
+%build
 export SCONSFLAGS="-j %{compiling_processes}"
+cp %{_sourcedir}/openloops-user.coll openloops-user.coll
 ./openloops update --processes generator=0
+
+#create process_src and delete any un-needed processes
+rm -rf process_src
+tar -xzf $OPENLOOPS_PROCESS_ROOT/process_src.tgz
+for xproc in %{drop_process} ; do
+  sed -i -e "/^${xproc}$/d" openloops-user.coll
+  rm -rf process_src/${xproc}
+done
+
 ./openloops libinstall openloops-user.coll
 
 %install


### PR DESCRIPTION
This change should allow to upload the openloops processes as an extra source. This will make sure that we reuse the previously downloaded sources as long as openloop `realversion` or contents of `openloops-user.coll` remain same.

This should be tested with https://github.com/cms-sw/pkgtools/pull/176 which supports creation of extra sources during the build