### PR TITLE
[11.3][OpenLoops] Generate process_src.tgz to be uploaded as source

### DIFF
--- a/openloops-common.file
+++ b/openloops-common.file
@@ -1,0 +1,8 @@
+%define openloop_version 2.1.1
+%define tag 5284f172973c666ef7e58b56b180b8703d9fba13
+%define branch cms/v%{openloop_version}
+%define github_user cms-externals
+
+Source: git+https://github.com/%{github_user}/openloops.git?obj=%{branch}/%{tag}&export=openloops-%{openloop_version}&output=/openloops-%{openloop_version}-%{tag}.tgz
+Source1: openloops-user.coll
+BuildRequires: python

--- a/openloops-process.spec
+++ b/openloops-process.spec
@@ -5,7 +5,7 @@
 ## NO_AUTO_DEPENDENCY
 
 %define process_src process_src.tgz
-Source2: https://cmsrep.cern.ch/cmssw/download/openloops/%{realversion}/%{cmsdist_chksum_source2}?cmdist-generated=1&output=/%{process_src}
+Source2: https://cmsrep.cern.ch/cmssw/download/openloops/%{realversion}/%{cmsdist_chksum_source1}?cmdist-generated=1&output=/%{process_src}
 Patch0: openloops-urlopen2curl
 
 %prep

--- a/openloops-process.spec
+++ b/openloops-process.spec
@@ -1,0 +1,30 @@
+## INCLUDE openloops-common
+### RPM external openloops-process %{openloop_version}
+
+## NOCOMPILER
+## NO_AUTO_DEPENDENCY
+
+%define process_src process_src.tgz
+Source2: https://cmsrep.cern.ch/cmssw/download/openloops/%{realversion}/%{cmsdist_chksum_source2}?cmdist-generated=1&output=/%{process_src}
+Patch0: openloops-urlopen2curl
+
+%prep
+%setup -n openloops-%{realversion}
+%patch0 -p1
+
+%build
+
+%install
+chksum_source2="SOURCES/cache/$(echo %{cmsdist_chksum_source2} | cut -c1-2)/%{cmsdist_chksum_source2}"
+if [ ! -e %{cmsroot}/${chksum_source2}/%{process_src} ] ; then
+  cp %{_sourcedir}/openloops-user.coll openloops-user.coll
+  pyol/bin/download_process.py $(cat %{_sourcedir}/openloops-user.coll | tr '\n' ' ')
+  tar -czf %{process_src} process_src proclib
+  mkdir -p %{cmsroot}/${chksum_source2}
+  mv %{process_src} %{cmsroot}/${chksum_source2}/
+fi
+if [ ! -e %{_sourcedir}/%{process_src} ] ; then
+  mkdir -p %{_sourcedir}
+  ln -s %{cmsroot}/${chksum_source2}/%{process_src} %{_sourcedir}/%{process_src}
+fi
+ln -s %{cmsroot}/${chksum_source2}/%{process_src} %{pkginstroot}/

--- a/openloops-urlopen2curl.patch
+++ b/openloops-urlopen2curl.patch
@@ -1,5 +1,5 @@
 diff --git a/pyol/bin/download_process.py b/pyol/bin/download_process.py
-index 4cecfb9..4f6c1b1 100755
+index 4cecfb9..c65b99b 100755
 --- a/pyol/bin/download_process.py
 +++ b/pyol/bin/download_process.py
 @@ -36,10 +36,9 @@ import OLBaseConfig
@@ -15,7 +15,7 @@ index 4cecfb9..4f6c1b1 100755
  
  commandline_options = [arg.split('=',1) for arg in sys.argv[1:] if ('=' in arg and not arg.startswith('-'))]
  config = OLBaseConfig.get_config(commandline_options)
-@@ -112,23 +111,25 @@ def update_channel_db(repo):
+@@ -112,24 +111,26 @@ def update_channel_db(repo):
          fh.close()
      else:
          local_hash = None
@@ -48,10 +48,12 @@ index 4cecfb9..4f6c1b1 100755
          lfh.write(hash_line.strip() + '  ' +
                    time.strftime(OLToolbox.timeformat) + '\n')
 -        for line in rfh:
+-            lfh.write(line.decode())
 +        for line in lines[1:]:
-             lfh.write(line.decode())
++            lfh.write(line.decode()+"\n")
              local_hash.update(line.strip())
          lfh.close()
+         local_hash = local_hash.hexdigest()
 @@ -140,7 +141,6 @@ def update_channel_db(repo):
              print('ERROR: downloaded channel database inconsistent ' +
                    'for repository ' + repo_name)


### PR DESCRIPTION
backport of #7066 

This change should allow to upload the openloops processes as an extra source. This will make sure that we reuse the previously downloaded sources as long as openloop realversion or contents of openloops-user.coll remain same.