### PR TITLE
py2 cleanup: doxygen lhapdf and libxslt

### DIFF
--- a/doxygen.spec
+++ b/doxygen.spec
@@ -2,9 +2,7 @@
 %define doxygen_release Release_%(echo %{realversion} | tr '.' '_')
 
 Source: https://github.com/doxygen/doxygen/archive/%{doxygen_release}.tar.gz
-BuildRequires: flex bison graphviz autotools gmake cmake python
-
-#define drop_files %{i}/man
+BuildRequires: flex bison graphviz autotools gmake cmake python3
 
 %prep
 %setup -n %{n}-%{doxygen_release}
@@ -18,6 +16,7 @@ cmake ../%{n}-%{doxygen_release} \
   -DCMAKE_INSTALL_PREFIX="%{i}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+  -DPYTHON_EXECUTABLE="${PYTHON3_ROOT}/bin/python3" \
   -Dbuild_doc=OFF \
   -Denglish_only=ON
 

--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -13,15 +13,16 @@ Source6: https://www.hepforge.org/archive/lhapdf/pdfsets/6.1/MMHT2014nlo68cl.tar
 
 Source7: lhapdf_pdfsetsindex
 
-Requires: python
-BuildRequires: py2-cython
+Requires: python3
 
 %define keep_archives true
 
 %prep
 %setup -q -n LHAPDF-%{realversion}
 
-./configure --prefix=%{i} 
+PYTHON=$(which python3) \
+  ./configure --prefix=%{i} \
+  --enable-python
 
 %build
 make all %makeprocesses 

--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -14,6 +14,7 @@ Source6: https://www.hepforge.org/archive/lhapdf/pdfsets/6.1/MMHT2014nlo68cl.tar
 Source7: lhapdf_pdfsetsindex
 
 Requires: python3
+BuildRequires: py2-cython
 
 %define keep_archives true
 

--- a/libxslt.spec
+++ b/libxslt.spec
@@ -5,7 +5,7 @@
 %define github_user cms-externals
 Source0: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
-Requires: libxml2 python
+Requires: libxml2
 BuildRequires: autotools
 %prep
 %setup -n %{n}-%{realversion}
@@ -16,7 +16,7 @@ BuildRequires: autotools
   --with-libxml-prefix=$LIBXML2_ROOT \
   --with-libxml-include-prefix=$LIBXML2_ROOT/include \
   --with-libxml-libs-prefix=$LIBXML2_ROOT/lib \
-  --without-crypto
+  --without-crypto --without-python
 make
 
 %install


### PR DESCRIPTION
drop python2 dependency for doxygen lhapdf and libxslt