### PR TITLE
Revert "remove python2 bindings from opencv and llvm "

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -1,9 +1,10 @@
 ### RPM external llvm 12.0.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
+## INITENV +PATH PYTHON27PATH %{i}/lib64/python`echo $PYTHON_VERSION | cut -d. -f 1,2`/site-packages
 ## INITENV +PATH PYTHON3PATH %{i}/lib64/python`echo $PYTHON3_VERSION | cut -d. -f 1,2`/site-packages
 
 BuildRequires: cmake ninja
-Requires: gcc zlib python3
+Requires: gcc zlib python python3
 Requires: cuda
 AutoReq: no
 
@@ -62,6 +63,9 @@ bin/clang-tidy --checks=* --list-checks | grep cms-handle
 cd ../build
 ninja -v %{makeprocesses} install
 
+BINDINGS_PATH=%{i}/lib64/python$(echo $PYTHON_VERSION | cut -d. -f 1,2)/site-packages
+mkdir -p $BINDINGS_PATH
+cp -r %{_builddir}/llvm-%{realversion}-%{llvmCommit}/clang/bindings/python/clang $BINDINGS_PATH
 BINDINGS_PATH=%{i}/lib64/python$(echo $PYTHON3_VERSION | cut -d. -f 1,2)/site-packages
 mkdir -p $BINDINGS_PATH
 cp -r %{_builddir}/llvm-%{realversion}-%{llvmCommit}/clang/bindings/python/clang $BINDINGS_PATH

--- a/opencv.spec
+++ b/opencv.spec
@@ -1,4 +1,5 @@
 ### RPM external opencv 4.5.1
+## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 %define tag %{realversion}
 %define branch master
@@ -7,7 +8,7 @@
 Source0: git+https://github.com/%{github_user}/opencv.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 Source1: https://patch-diff.githubusercontent.com/raw/opencv/opencv/pull/19692.patch
 BuildRequires: cmake ninja
-Requires: python3 py2-numpy py3-numpy libpng libjpeg-turbo libtiff zlib eigen OpenBLAS
+Requires: python python3 py2-numpy py3-numpy libpng libjpeg-turbo libtiff zlib eigen OpenBLAS
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -23,11 +24,14 @@ cmake ../%{n}-%{realversion} \
     -DCMAKE_INSTALL_PREFIX="%{i}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DWITH_EIGEN=ON \
+    -DPYTHON2_EXECUTABLE:FILEPATH="${PYTHON_ROOT}/bin/python" \
+    -DPYTHON2_INCLUDE_DIR:PATH="${PYTHON_ROOT}/include/python2.7" \
+    -DPYTHON2_LIBRARY:FILEPATH="${PYTHON_ROOT}/lib/libpython2.7.so" \
     -DPYTHON3_EXECUTABLE:FILEPATH="${PYTHON3_ROOT}/bin/python3" \
-    -DPYTHON3_INCLUDE_DIR:PATH="${PYTHON3_ROOT}/include/python%{cms_python3_major_minor_version}" \
-    -DPYTHON3_LIBRARY:FILEPATH="${PYTHON3_ROOT}/lib/libpython%{cms_python3_major_minor_version}.so" \
+    -DPYTHON3_INCLUDE_DIR:PATH="${PYTHON3_ROOT}/include/python3.8" \
+    -DPYTHON3_LIBRARY:FILEPATH="${PYTHON3_ROOT}/lib/libpython3.8.so" \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_PREFIX_PATH="${LIBPNG_ROOT};${LIBTIFF_ROOT};${LIBJPEG_TURBO_ROOT};${ZLIB_ROOT};${PYTHON3_ROOT};${PY2_NUMPY_ROOT};${PY3_NUMPY_ROOT};${EIGEN_ROOT};${OPENBLAS_ROOT}"
+    -DCMAKE_PREFIX_PATH="${LIBPNG_ROOT};${LIBTIFF_ROOT};${LIBJPEG_TURBO_ROOT};${ZLIB_ROOT};${PYTHON_ROOT};${PYTHON3_ROOT};${PY2_NUMPY_ROOT};${PY3_NUMPY_ROOT};${EIGEN_ROOT};${OPENBLAS_ROOT}"
 
 ninja -v %{makeprocesses}
 


### PR DESCRIPTION
Reverts cms-sw/cmsdist#7093

@davidlange6 , I think this causes the build errors https://github.com/cms-sw/cmsdist/pull/7092#issuecomment-873179444 . Looks like some changes are needed on cmssw side too. For now I am reverting it and will open a re-revert to test full cmssw 