### PR TITLE
[DEVEL] Disable python for lhapdf: need lhapdf 6.3.0 for py3.9

### DIFF
--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -23,9 +23,10 @@ BuildRequires: py3-cython
 
 PYTHON=$(which python3) \
   ./configure --prefix=%{i} \
-  --enable-python
+  --disable-python
 
 %build
+sed -i -e 's| wrappers | |' Makefile
 make all %makeprocesses 
 
 %install


### PR DESCRIPTION
@davidlange6 , looks like lhapdf 6.2.3 does not build with python 3.9 that is why DEVEL IBs are not building
For now I have disabled the python for lhapdf, we need lhapdf 6.3.0 which works with python 3.9