### PR TITLE
[DEVEL] enable build with python

### DIFF
--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -19,7 +19,7 @@ BuildRequires: py3-cython
 
 PYTHON=$(which python3) \
   ./configure --prefix=%{i} \
-  --disable-python
+  --enable-python
 
 %build
 sed -i -e 's| wrappers | |' Makefile


### PR DESCRIPTION
Python build was disabled as lhapdf 6.2.3 did not work with python 3.9. As now we have newer lhapdf version ( 6.3.0) so lets re-enable the python 