### PR TITLE
Update tag for L1Trigger-CSCTriggerPrimitives to V00-10-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,8 +3,8 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+L1Trigger-CSCTriggerPrimitives=V00-10-00
 L1Trigger-TrackFindingTracklet=V00-02-00
-L1Trigger-CSCTriggerPrimitives=V00-09-00
 GeneratorInterface-EvtGenInterface=V02-06-00
 RecoTracker-MkFit=V00-01-00
 RecoMuon-TrackerSeedGenerator=V00-01-00


### PR DESCRIPTION
Move L1Trigger-CSCTriggerPrimitives data to new tag, see 
https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/10
