### PR TITLE
Patch herwig to use python3 when running madgraph in the Matchbox

### DIFF
--- a/herwig7.spec
+++ b/herwig7.spec
@@ -16,9 +16,12 @@ Requires: openloops
 BuildRequires: autotools
 
 
+Patch0: herwig_Matchbox_mg_py3
+
 %prep
 %setup -q -n Herwig-%{realversion}
 
+%patch0 -p1
 
 # Regenerate build scripts
 autoreconf -fiv

--- a/herwig_Matchbox_mg_py3.patch
+++ b/herwig_Matchbox_mg_py3.patch
@@ -1,0 +1,11 @@
+--- Herwig-7.2.2/MatrixElement/Matchbox/External/MadGraph/mg2herwig.in	2021-07-21 03:10:26.000000001 +0200
++++ mg2herwig_patched	2021-07-21 13:33:43.000000001 +0200
+@@ -224,7 +224,7 @@
+   sys.stderr.write("*** MadGraph build failed, check logfile for details ***")
+   exit(1)
+ 
+-os.system("python "+options.madgraph+"/mg5_aMC proc.dat")
++os.system("python3 "+options.madgraph+"/mg5_aMC proc.dat")
+ 
+ 
+ 


### PR DESCRIPTION
Fix for https://github.com/cms-sw/cmssw/issues/34529 - patch herwig matchbox to call madgraph with python3 rather than python2. Tested this fixes workflow 511 (Herwig matchbox)