### PR TITLE
Update the NVIDIA GDRCopy library to version 2.2

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -72,9 +72,7 @@ Requires: sherpa
 Requires: libpciaccess
 Requires: numactl
 Requires: hwloc
-%ifnarch aarch64
 Requires: gdrcopy
-%endif
 Requires: ucx
 Requires: openmpi
 Requires: sigcpp

--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.1
+### RPM external gdrcopy 2.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda
@@ -7,9 +7,9 @@ Requires: cuda
 %setup -n %{n}-%{realversion}
 
 %build
-make %{makeprocesses} PREFIX=%{i} CUDA=$CUDA_ROOT lib
+make %{makeprocesses} prefix=%{i} libdir=%{i}/lib64 CUDA=$CUDA_ROOT lib
 
 %install
-make %{makeprocesses} PREFIX=%{i} CUDA=$CUDA_ROOT lib_install
+make %{makeprocesses} prefix=%{i} libdir=%{i}/lib64 CUDA=$CUDA_ROOT lib_install
 
 %post

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,10 +1,7 @@
 ### RPM external ucx 1.9.0
 Source: https://github.com/openucx/%{n}/releases/download/v%{realversion}/%{n}-%{realversion}.tar.gz
 BuildRequires: autotools
-Requires: numactl cuda
-%ifnarch aarch64
-Requires: gdrcopy
-%endif
+Requires: numactl cuda gdrcopy
 AutoReq: no
 # external libraries are needed for additional protocols:
 #   --with-rocm:        AMD ROCm platform for accelerated compute
@@ -38,11 +35,7 @@ AutoReq: no
   --without-java \
   --with-cuda=$CUDA_ROOT \
   --without-rocm \
-%ifarch aarch64
-  --without-gdrcopy \
-%else
   --with-gdrcopy=$GDRCOPY_ROOT \
-%endif
   --without-verbs \
   --with-rc \
   --with-ud \


### PR DESCRIPTION
Add support for ARM64.

See https://github.com/NVIDIA/gdrcopy/releases/tag/v2.2 for more details.