### PR TITLE
Update UCX libraries to v1.10.1, and link to the RDMA core libraries 

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -73,6 +73,7 @@ Requires: libpciaccess
 Requires: numactl
 Requires: hwloc
 Requires: gdrcopy
+Requires: rdma-core
 Requires: ucx
 Requires: openmpi
 Requires: sigcpp

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -1,0 +1,42 @@
+### RPM external rdma-core 36.0
+## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
+
+Source: https://github.com/linux-rdma/%{n}/releases/download/v%{realversion}/rdma-core-%{realversion}.tar.gz
+BuildRequires: cmake ninja
+
+%prep
+%setup -q -n %{n}-%{realversion}
+
+%build
+rm -rf build
+mkdir build
+cd build
+
+# currently there is no way to use a custom location for libnl3, so disable neighbours resolution
+cmake \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_INSTALL_RUNDIR=/var/run \
+  -DENABLE_RESOLVE_NEIGH=FALSE \
+  -DENABLE_STATIC=FALSE \
+  -DNO_MAN_PAGES=TRUE \
+  ..
+
+cmake -L .
+
+ninja -v %{makeprocesses}
+
+%install
+cd build
+ninja -v %{makeprocesses} install
+
+# remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
+rm -rf %{i}/lib64/pkgconfig
+
+# keep only the libraries and include files
+rm -rf %{i}/bin
+rm -rf %{i}/etc
+rm -rf %{i}/lib
+rm -rf %{i}/libexec
+rm -rf %{i}/sbin
+rm -rf %{i}/share

--- a/scram-tools.file/tools/rdma-core/libibumad.xml
+++ b/scram-tools.file/tools/rdma-core/libibumad.xml
@@ -1,0 +1,5 @@
+<tool name="libibumad" version="@TOOL_VERSION@">
+  <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
+  <use name="rdma-core"/>
+  <lib name="ibumad"/>
+</tool>

--- a/scram-tools.file/tools/rdma-core/libibverbs.xml
+++ b/scram-tools.file/tools/rdma-core/libibverbs.xml
@@ -1,0 +1,5 @@
+<tool name="libibverbs" version="@TOOL_VERSION@">
+  <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
+  <use name="rdma-core"/>
+  <lib name="ibverbs"/>
+</tool>

--- a/scram-tools.file/tools/rdma-core/librdmacm.xml
+++ b/scram-tools.file/tools/rdma-core/librdmacm.xml
@@ -1,0 +1,6 @@
+<tool name="librdmacm" version="@TOOL_VERSION@">
+  <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
+  <use name="rdma-core"/>
+  <use name="libibverbs"/>
+  <lib name="rdmacm"/>
+</tool>

--- a/scram-tools.file/tools/rdma-core/rdma-core.xml
+++ b/scram-tools.file/tools/rdma-core/rdma-core.xml
@@ -1,0 +1,9 @@
+<tool name="rdma-core" version="@TOOL_VERSION@">
+  <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
+  <client>
+    <environment name="RDMA_CORE_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$RDMA_CORE_BASE/lib64"/>
+    <environment name="INCLUDE"        default="$RDMA_CORE_BASE/include"/>
+  </client>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+</tool>

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,13 +1,13 @@
-### RPM external ucx 1.9.0
+### RPM external ucx 1.10.1
 Source: https://github.com/openucx/%{n}/releases/download/v%{realversion}/%{n}-%{realversion}.tar.gz
 BuildRequires: autotools
-Requires: numactl cuda gdrcopy
+Requires: numactl
+Requires: gdrcopy cuda
+Requires: rdma-core
 AutoReq: no
 # external libraries are needed for additional protocols:
 #   --with-rocm:        AMD ROCm platform for accelerated compute
-#   --with-verbs:       Verbs library for direct userspace use of RDMA (InfiniBand/iWARP) hardware
-#   --with-cm:          Userspace InfiniBand Communication Managment library
-#   --with-rdmacm:      Userspace RDMA Connection Manager
+#   --with-cm:          Userspace InfiniBand Communication Managment library: deprecated and removed from RDMA core v17 on December 2017
 #   --with-knem:        KNEM High-Performance Intra-Node MPI Communication
 # etc.
 
@@ -36,7 +36,7 @@ AutoReq: no
   --with-cuda=$CUDA_ROOT \
   --without-rocm \
   --with-gdrcopy=$GDRCOPY_ROOT \
-  --without-verbs \
+  --with-verbs=$RDMA_CORE_ROOT \
   --with-rc \
   --with-ud \
   --with-dc \
@@ -44,7 +44,7 @@ AutoReq: no
   --with-ib-hw-tm \
   --with-dm \
   --without-cm \
-  --without-rdmacm \
+  --with-rdmacm=$RDMA_CORE_ROOT \
   --without-knem \
   --with-xpmem \
   CPPFLAGS="-I$NUMACTL_ROOT/include" \


### PR DESCRIPTION
### Add the Linux RDMA Core Userspace Libraries and Daemons, v36.0

These are the userspace components for the Linux Kernel's drivers and infiniband subsystem. Specifically this contains the userspace libraries for the following device nodes:
  - `/dev/infiniband/uverbsX` (libibverbs)
  - `/dev/infiniband/rdma_cm` (librdmacm)
  - `/dev/infiniband/umadX`   (libibumad)

See https://github.com/linux-rdma/rdma-core/blob/master/README.md for more details.

###  Update the UCX libraries to v1.10.1, and link to the RDMA core libraries

For the change log since v1.9.0, see
  - https://github.com/openucx/ucx/releases/tag/v1.10.0
  - https://github.com/openucx/ucx/releases/tag/v1.10.1

Use the RDMA core libraries to implement support for Infiniband verbs (libibverbs) and RDMA Connection Manager (librdmacm).

