### PR TITLE
Update to CUDA 11.4.1

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,7 +1,7 @@
-### RPM external cuda 11.2.2
+### RPM external cuda 11.4.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define driversversion 460.32.03
+%define driversversion 470.57.02
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,7 +1,7 @@
-### RPM external cudnn 8.1.1.33
+### RPM external cudnn 8.2.2.26
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define cudaver 11.2
+%define cudaver 11.4
 %define cudnnver_maj %(echo %{realversion} | cut -f1,2,3 -d.)
 
 %ifarch x86_64


### PR DESCRIPTION
Update to CUDA 11.4.1 (11.4.20210728):
  * CUDA runtime version 11.4.108
  * NVIDIA drivers version 470.57.02
  * cuDNN version 8.2.2.26

Add support for GCC 11 and clang 12.

See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html .