### PR TITLE
Update Alpaka to v0.7.0 and Cupla to v0.3.0

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,4 +1,4 @@
-### RPM external alpaka 0.6.1
+### RPM external alpaka 0.7.0
 ## NOCOMPILER
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz

--- a/cupla.spec
+++ b/cupla.spec
@@ -1,7 +1,6 @@
-### RPM external cupla 0.3.0-dev
+### RPM external cupla 0.3.0
 
-#%define tag %{realversion}
-%define tag 545702f1947feb1d46b2230b502f1f46179b3665
+%define tag %{realversion}
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{tag}.tar.gz
 Requires: alpaka


### PR DESCRIPTION
Update Alpaka to version 0.7.0
Update Cupla to version 0.3.0 

In addition to new features and improvements, these have a workaround for an NVCC bug in CUDA 11.3.x/11.4.x.