### PR TITLE
Upgrade MariaDB spec from 10.1.21 to 10.6.5

### DIFF
--- a/mariadb.spec
+++ b/mariadb.spec
@@ -1,8 +1,10 @@
-### RPM external mariadb 10.1.21
+### RPM external mariadb 10.6.5
 ## INITENV +PATH %{dynamic_path_var} %i/lib/mysql
 ## INITENV +PATH PATH %i/scripts
 ## INITENV SET MYSQL_HOME $MYSQL_ROOT
-Source: https://ftp.igh.cnrs.fr/pub/archive.mariadb.org/mariadb-%{realversion}/source/mariadb-%{realversion}.tar.gz
+#Source: https://ftp.igh.cnrs.fr/pub/archive.mariadb.org/mariadb-%{realversion}/source/mariadb-%{realversion}.tar.gz
+Source: git+https://github.com/MariaDB/server.git?obj=10.6/%{n}-%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
+
 Requires: zlib ncurses libxml2
 BuildRequires: cmake
 Provides: perl(GD)
@@ -10,7 +12,7 @@ Provides: perl(DBI)
 Provides: perl(List::Util)
 
 %prep
-%setup -n %n-%realversion
+%setup -n %{n}-%realversion
 
 %build
 cmake .  -DCURSES_LIBRARY=${NCURSES_ROOT}/lib/libncurses.a \
@@ -23,7 +25,7 @@ cmake .  -DCURSES_LIBRARY=${NCURSES_ROOT}/lib/libncurses.a \
          -DHAVE_SETUPTERM:INTERNAL=0 \
          -DCMAKE_INSTALL_PREFIX=%i \
          -DWITH_EXTRA_CHARSETS=complex \
-         -DENABLED_LOCAL_INFILE=1
+         -DENABLED_LOCAL_INFILE=ON
 
 make %{makeprocesses}
 %install

--- a/py2-mysqldb.spec
+++ b/py2-mysqldb.spec
@@ -11,6 +11,8 @@ Patch0: py2-mysqldb-setup
 %patch0 -p0
 # Patch the converters module to avoid getting long data type back in the client
 sed -i 's|LONG: long|LONG: int|' MySQLdb/converters.py
+# Patch for "no member named 'reconnect', see: https://github.com/DefectDojo/django-DefectDojo/issues/407
+sed -i '/st_mysql_options options;/a unsigned int reconnect;' $MARIADB_ROOT/include/mysql/mysql.h
 
 cat >> setup.cfg <<- EOF
 include_dirs = $MARIADB_ROOT/include


### PR DESCRIPTION
This PR provides a major upgrade for MariaDB, from 10.1.21 all the way to 10.6.5.

Erik ran extensive tests, including jenkins unit tests and there was only 1 new test failing.
In terms of configuration, our current configuration is very similar to the default values provided in 10.6.5. Further tweak and exploration might be needed, in a future phase though.