### PR TITLE
keep cmssw tools to drop in a common file

### DIFF
--- a/cmssw-drop-tools.file
+++ b/cmssw-drop-tools.file
@@ -1,0 +1,1 @@
+%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp nvidia-drivers intel-vtune jemalloc-debug

--- a/cmssw-patch-tool-conf.spec
+++ b/cmssw-patch-tool-conf.spec
@@ -1,13 +1,9 @@
-### RPM cms cmssw-patch-tool-conf 3.0
-# with cmsBuild, change the above version only when a new
-# tool is added
+### RPM cms cmssw-patch-tool-conf 4.0
 
 ## NOCOMPILER
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes
 
 Requires: cmssw
 
-# still need this (from the non-patch tool-conf spec ...
-%define skipreqtools jcompiler
-
+## INCLUDE cmssw-drop-tools
 ## INCLUDE scram-tool-conf

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 50.0
+### RPM cms cmssw-tool-conf 51.0
 # With cmsBuild, change the above version only when a new tool is added
 
 ## NOCOMPILER
@@ -183,6 +183,5 @@ Requires: xtensor
 Requires: xtl
 Requires: xgboost
 
-%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp nvidia-drivers intel-vtune jemalloc-debug
-
+## INCLUDE cmssw-drop-tools
 ## INCLUDE scram-tool-conf


### PR DESCRIPTION
The PR makes sure that the tools dropped for full cmssw release are also dropped for patch release. Thisis done via  common cmssw-drop-tool.file which is included by both cmssw and cmssw-patch.

This should fix the issue  reported here cms-sw/cmssw#34841