### PR TITLE
[BuildRules] Added checks for private header usage

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-03-01
+%define configtag       V06-03-02
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Currently this check only generate an error message but does not fail the build process. Once all the cmssw code is clean of such privbate header usage then we can enable this check to fail in the user dev area.

Lets first integrate it in devel IBs to see the side effects