### PR TITLE
[SCRAM] use system python3 when project env is not set

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V3_00_30
+### RPM lcg SCRAMV1 V3_00_31
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -7,7 +7,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag 16d116bf9059ce52e2deb1e58580cf55df636ca5
+%define tag e61917ac8b26a2fd0d9f67847aa8271ffe871671
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
This addresses the issue mentioned https://github.com/dmwm/WMCore/issues/10765 . Previously COMP was setting python2 based paths which were breaking system python3 (used by scram). To avoid this SCRAMV3 dropped `LD_LIBRARY_PATH` and `PYTHONPATH` env. Now COMP sets python3 paths which breaks comp python3 ( due to missing LD_LIBRARY_PATH). 

The PR proposes to use system python3 (instead of COMP) when project env is not set. In case project (CMSSW env is set) then scram can use python3 from cms software stack.

The change in SCRAM is https://github.com/cms-sw/SCRAM/commit/e61917ac8b26a2fd0d9f67847aa8271ffe871671