### PR TITLE
added suport to build indiviual toolfiles

### DIFF
--- a/cmssw-patch-tool-conf.spec
+++ b/cmssw-patch-tool-conf.spec
@@ -1,6 +1,5 @@
 ### RPM cms cmssw-patch-tool-conf 4.0
 
-## NOCOMPILER
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes
 
 Requires: cmssw

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,7 +1,6 @@
 ### RPM cms cmssw-tool-conf 51.0
 # With cmsBuild, change the above version only when a new tool is added
 
-## NOCOMPILER
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cmssw-osenv cms-git-tools
 ## UPLOAD_DEPENDENCIES dqmgui
 

--- a/coral-tool-conf.spec
+++ b/coral-tool-conf.spec
@@ -1,5 +1,4 @@
 ### RPM cms coral-tool-conf 10.0
-## NOCOMPILER
 
 Requires: pcre
 Requires: python

--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -1,5 +1,4 @@
 ### RPM cms fwlite-tool-conf 20.0
-## NOCOMPILER
 # with cmsBuild, change the above version only when a new
 # tool is added
 ## INITENV SET CMSSW_TOOL_CONF_ROOT $FWLITE_TOOL_CONF_ROOT
@@ -54,6 +53,5 @@ Requires: zstd
 Requires: freetype
 %endif
 
-%define skipreqtools jcompiler db6 expat fftw3 sqlite
-
+## INCLUDE cmssw-drop-tools
 ## INCLUDE scram-tool-conf

--- a/scram-tool-conf.file
+++ b/scram-tool-conf.file
@@ -1,11 +1,9 @@
 ### FILE scram-tool-conf
 ## NOCOMPILER
-## BUILDREQUIRE-TOOLFILE
-Requires: gmake
+## NO_AUTO_RUNPATH
+## NO_AUTO_DEPENDENCY
 BuildRequires: SCRAMV1
 Source99: scram-tools
-## INCLUDE compilation_flags
-## INCLUDE cuda-flags
 Source: none
 
 %if "%{?vec_tools:set}" != "set"
@@ -27,23 +25,7 @@ mkdir -p %i/tools/selected %i/tools/available
 %define skipreqtools %{nil}
 %endif
 
-export ROOT_CXXMODULES="0"
-%if "%{?package_vectorization}" != ""
-export PKG_VECTORIZATION=`echo %package_vectorization`
-%endif
-export CMSDIST_DIR=%cmsdist_directory
-
-%ifarch x86_64
-export COMPILER_CXXFLAGS="$(%{cmsdist_directory}/vectorization/cmsdist_packages.py)"
-%endif
-%ifarch ppc64le
-export COMPILER_CXXFLAGS="%{ppc64le_build_flags}"
-%endif
-export ORACLE_ENV_ROOT=""
-export CUDA_FLAGS="%{nvcc_cuda_flags}"
-export CUDA_HOST_CXXFLAGS="%{nvcc_stdcxx}"
-if [ $(echo ' %requiredtools ' | grep ' python3 ' |wc -l) -gt 0 ] ; then export PYTHON3_LIB_SITE_PACKAGES ; fi
-if [ $(echo ' %requiredtools ' | grep ' python ' |wc -l) -gt 0 ] ;  then export PYTHON_LIB_SITE_PACKAGES ; fi
+## INCLUDE scram-tools.file/tool-env
 
 for tool in %requiredtools; do
   echo ">> Copying tool files from: $tool"

--- a/scram-tools.file/cmsdist_packages.py
+++ b/scram-tools.file/cmsdist_packages.py
@@ -1,0 +1,8 @@
+def packages(virtual_packages, *args):
+  from os.path import dirname, join, basename
+  from glob import glob
+  tools_dir = join(dirname(__file__), "tools")
+  for tool in [basename(t) for t in glob(tools_dir+"/*")]:
+    spec = "%s-toolfile" % tool
+    virtual_packages[spec] = 'echo -e "### RPM cms %s 1.0\nRequires: %s\n## INCLUDE scram-tools.file/toolfile"' % (spec, tool)
+  return

--- a/scram-tools.file/tool-env.file
+++ b/scram-tools.file/tool-env.file
@@ -1,0 +1,20 @@
+## INCLUDE compilation_flags
+## INCLUDE cuda-flags
+
+export ROOT_CXXMODULES="0"
+%if "%{?package_vectorization}" != ""
+export PKG_VECTORIZATION=`echo %package_vectorization`
+%endif
+export CMSDIST_DIR=%cmsdist_directory
+
+%ifarch x86_64
+export COMPILER_CXXFLAGS="$(%{cmsdist_directory}/vectorization/cmsdist_packages.py)"
+%endif
+%ifarch ppc64le
+export COMPILER_CXXFLAGS="%{ppc64le_build_flags}"
+%endif
+export ORACLE_ENV_ROOT=""
+export CUDA_FLAGS="%{nvcc_cuda_flags}"
+export CUDA_HOST_CXXFLAGS="%{nvcc_stdcxx}"
+if [ $(echo ' %requiredtools ' | grep ' python3 ' |wc -l) -gt 0 ] ; then export PYTHON3_LIB_SITE_PACKAGES ; fi
+if [ $(echo ' %requiredtools ' | grep ' python ' |wc -l) -gt 0 ] ;  then export PYTHON_LIB_SITE_PACKAGES ; fi

--- a/scram-tools.file/toolfile.file
+++ b/scram-tools.file/toolfile.file
@@ -1,0 +1,23 @@
+## NOCOMPILER
+## NO_AUTO_RUNPATH
+## NO_AUTO_DEPENDENCY
+Source: none
+%define tool   %(echo %{n} | sed 's|-toolfile$||')
+%define uctool %(echo %{tool} | tr '[a-z-]' '[A-Z_]')
+
+%prep
+
+%build
+
+%install
+## INCLUDE scram-tools.file/tool-env
+%{cmsdist_directory}/scram-tools.file/bin/get_tools "${%{uctool}_ROOT}" "${%{uctool}_VERSION}" %i "%{tool}"
+mkdir %{i}/etc
+mv %{i}/tools/selected %{i}/etc/scram.d
+rm -rf %{i}/tools
+
+%post
+if [ "X$CMS_INSTALL_PREFIX" = "X" ] ; then CMS_INSTALL_PREFIX=$RPM_INSTALL_PREFIX; export CMS_INSTALL_PREFIX; fi
+%{relocateConfig}etc/scram.d/*.xml
+echo "%{uctool}_TOOLFILE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
+echo "set %{uctool}_TOOLFILE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh


### PR DESCRIPTION
This PR allows to optionally build `<package>-toolfile`. This is helpfull when you only want to build a single package and its toolfile instead of full cmssw-tool-conf. 

Cleanup of some of the existing `*-tool-conf` specs