### PR TITLE
[CC8][GCC] Patch binutils glod

### DIFF
--- a/bazel-3.7.0-patches.patch
+++ b/bazel-3.7.0-patches.patch
@@ -11,15 +11,3 @@ index 0ea30a9..8df189f 100755
              named = true,
              positional = false,
              doc = "Whether the action should use the built in shell environment or not."),
-diff --git a/tools/cpp/unix_cc_configure.bzl b/tools/cpp/unix_cc_configure.bzl
-index d48485b..40ca051 100755
---- a/tools/cpp/unix_cc_configure.bzl
-+++ b/tools/cpp/unix_cc_configure.bzl
-@@ -193,6 +193,7 @@ def _find_gold_linker_path(repository_ctx, cc):
-     Returns:
-       String to put as value to -fuse-ld= flag, or None if gold couldn't be found.
-     """
-+    return None
-     result = repository_ctx.execute([
-         cc,
-         str(repository_ctx.path("tools/cpp/empty.cc")),

--- a/binutils-2.31.1-gold-ignore-discarded-note-relocts.patch
+++ b/binutils-2.31.1-gold-ignore-discarded-note-relocts.patch
@@ -1,0 +1,17 @@
+# Patch ld.gold to skip warnings about unresolvable relocations in
+# the .gnu.build.attributes section. The patch is authored by Nick
+# Clifton and extracted from binutils-2.31.1-25.fc29.src.rpm.
+#
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1600431 for more information.
+#
+diff -ru binutils-2.31.1.orig/gold/target-reloc.h binutils-2.31.1/gold/target-reloc.h
+--- binutils-2.31.1.orig/gold/target-reloc.h	2018-06-24 20:38:57.000000000 +0200
++++ binutils-2.31.1/gold/target-reloc.h	2019-11-04 23:03:35.697024789 +0100
+@@ -136,6 +136,7 @@
+     if (Layout::is_debug_info_section(name))
+       return CB_PRETEND;
+     if (strcmp(name, ".eh_frame") == 0
++	|| strncmp(name, ".gnu.build.attributes", 21) == 0     // FIXME: We should really be checking the section type for ST_NOTE...
+ 	|| strcmp(name, ".gcc_except_table") == 0)
+       return CB_IGNORE;
+     return CB_ERROR;

--- a/gcc-fixincludes.spec
+++ b/gcc-fixincludes.spec
@@ -1,7 +1,6 @@
 ### RPM external gcc-fixincludes 1.0
 ## NO_VERSION_SUFFIX
 ## REVISION 1001
-## INSTALL_DEPENDENCIES gcc
 ## NOCOMPILER
 
 %prep

--- a/gcc-fixincludes.spec
+++ b/gcc-fixincludes.spec
@@ -1,7 +1,8 @@
 ### RPM external gcc-fixincludes 1.0
 ## NO_VERSION_SUFFIX
-## REVISION 1000
-Requires: gcc
+## REVISION 1001
+## INSTALL_DEPENDENCIES gcc
+## NOCOMPILER
 
 %prep
 %build

--- a/gcc.spec
+++ b/gcc.spec
@@ -39,6 +39,7 @@ Source11: https://github.com/westes/flex/releases/download/v%{flexVersion}/flex-
 Patch0: gcc-flex-nonfull-path-m4
 Patch1: gcc-flex-disable-doc
 Patch2: m4-centos8
+Patch3: binutils-2.31.1-gold-ignore-discarded-note-relocts
 
 %prep
 
@@ -99,6 +100,7 @@ EOF_CMS_H
 %ifos linux
 %setup -D -T -b 7 -n bison-%{bisonVersion}
 %setup -D -T -b 8 -n binutils-%{binutilsVersion}
+%patch3 -p1
 %setup -D -T -b 9 -n elfutils-%{elfutilsVersion}
 %setup -D -T -b 10 -n m4-%{m4Version}
 %patch2 -p1


### PR DESCRIPTION
Patch ld.gold to skip warnings about unresolvable relocations in the .gnu.build.attributes section. The patch is authored by Nick Clifton and extracted from binutils-2.31.1-25.fc29.src.rpm