### PR TITLE
[BuildRules] Cleanup debug messages

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-03-03
+%define configtag       V06-03-04
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This PR removes the debug messages which now appears when one runs `scram build`
```
Debug: CHECK_PRIVATE_HEADERS=1 IGNORE_PRIVATE_HEADER_ERRORS=/usr/bin/false
Debug: IS_RELEASE_AREA=0 IS_DEV_AREA=1
```