### PR TITLE
ThePEG - remove `-g` flag from the compilation

### DIFF
--- a/thepeg.spec
+++ b/thepeg.spec
@@ -53,7 +53,7 @@ sed -i -e "s|-lgslcblas|-lopenblas|" ./configure
             --with-fastjet=$FASTJET_ROOT \
             --without-javagui \
             --prefix=%{i} \
-            --disable-readline CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib"
+            --disable-readline CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib" CXXFLAGS="-g0 -O2 -DNDEBUG" CFLAGS="-g0 -O2 -DNDEBUG"
 
 make %{makeprocesses}
 


### PR DESCRIPTION
This removes the default CXXFLAGS="-g -O2" (same for CFLAGS) to -g0 -O2 -DNDEBUG to keep the optimization, set debug info to 0 and remove assertions if any
The original lib is 123 mb, the resulting new one 6512 bytes without further check whats in it (if any debug symbols remain)
The debug info for the failing job is reduced