### PR TITLE
Update tag for L1Trigger-CSCTriggerPrimitives to V00-11-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,11 +3,11 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+L1Trigger-CSCTriggerPrimitives=V00-11-00
 RecoTracker-MkFit=V00-03-00
 RecoEgamma-ElectronIdentification=V01-07-00
 L1Trigger-L1THGCal=V01-06-00
 DataFormats-PatCandidates=V01-01-00
-L1Trigger-CSCTriggerPrimitives=V00-10-00
 L1Trigger-TrackFindingTracklet=V00-02-00
 GeneratorInterface-EvtGenInterface=V02-06-00
 RecoMuon-TrackerSeedGenerator=V00-01-00


### PR DESCRIPTION
Move L1Trigger-CSCTriggerPrimitives data to new tag, see 
https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/11
