### PR TITLE
Update Py3 Pygments/Sphinx packages and all required dependencies

### DIFF
--- a/py3-certifi.spec
+++ b/py3-certifi.spec
@@ -1,2 +1,2 @@
-### RPM external py3-certifi 2017.7.27.1
+### RPM external py3-certifi 2021.5.30
 ## IMPORT build-with-pip3

--- a/py3-charset-normalizer.spec
+++ b/py3-charset-normalizer.spec
@@ -1,5 +1,4 @@
-### RPM external py3-jinja2 3.0.1
+### RPM external py3-charset-normalizer 2.0.4
 ## IMPORT build-with-pip3
-Requires: py3-markupsafe
-%define pip_name Jinja2
+
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-docutils.spec
+++ b/py3-docutils.spec
@@ -1,4 +1,4 @@
-### RPM external py3-docutils 0.15.2
+### RPM external py3-docutils 0.17.1
 ## IMPORT build-with-pip3
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-idna.spec
+++ b/py3-idna.spec
@@ -1,4 +1,4 @@
-### RPM external py3-idna 2.6
+### RPM external py3-idna 3.2
 ## IMPORT build-with-pip3
 
 Requires: py3-certifi py3-urllib3

--- a/py3-imagesize.spec
+++ b/py3-imagesize.spec
@@ -1,28 +1,4 @@
-### RPM external py3-imagesize 0.7.1
-## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
+### RPM external py3-imagesize 1.2.0
+## IMPORT build-with-pip3
 
-Source: https://pypi.python.org/packages/53/72/6c6f1e787d9cab2cc733cf042f125abec07209a58308831c9f292504e826/imagesize-0.7.1.tar.gz
-Requires: python3 py3-certifi py3-urllib3 py3-idna py3-chardet
-BuildRequires: py3-setuptools
-
-%prep
-%setup -n imagesize-%realversion
-
-%build
-export PYTHON3_ROOT
-python3 setup.py build
-
-%install
-mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
-export LD_LIBRARY_PATH=$PYTHON3_ROOT/lib:$LD_LIBRARY_PATH
-PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH python3 setup.py install --prefix=%i
-find %i -name '*.egg-info' -exec rm {} \;
-
-# replace all instances of #!/path/bin/python into proper format
-%py3PathRelocation
-
-# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-%addDependency
-
-%post
-%{relocateConfig}etc/profile.d/dependencies-setup.*sh
+Requires: py3-certifi py3-urllib3 py3-idna py3-chardet

--- a/py3-pygments.spec
+++ b/py3-pygments.spec
@@ -1,24 +1,5 @@
-### RPM external py3-pygments 2.1.3
-## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
+### RPM external py3-pygments 2.10.0
+## IMPORT build-with-pip3
 
-Source: http://pypi.python.org/packages/source/P/Pygments/Pygments-%realversion.tar.gz
-Requires: python3 py3-setuptools
-
-%prep
-%setup -n Pygments-%realversion
-
-%build
-python3 setup.py build
-
-%install
-python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
-
-# replace all instances of #!/path/bin/python into proper format
-%py3PathRelocation
-
-# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-%addDependency
-
-%post
-%{relocateConfig}etc/profile.d/dependencies-setup.*sh
-
+%define pip_name Pygments
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-pytz.spec
+++ b/py3-pytz.spec
@@ -1,2 +1,2 @@
-### RPM external py3-pytz 2019.1
+### RPM external py3-pytz 2021.1
 ## IMPORT build-with-pip3

--- a/py3-requests.spec
+++ b/py3-requests.spec
@@ -1,6 +1,5 @@
-### RPM external py3-requests 2.25.1
+### RPM external py3-requests 2.26.0
 ## IMPORT build-with-pip3
 
-Requires: py3-certifi py3-urllib3 py3-idna py3-chardet
-
+Requires: py3-certifi py3-urllib3 py3-idna py3-charset-normalizer
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-sphinx.spec
+++ b/py3-sphinx.spec
@@ -1,49 +1,6 @@
-### RPM external py3-sphinx 1.6.3
-## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
+### RPM external py3-sphinx 4.0.3
+## IMPORT build-with-pip3
 
-%define sphinx_rtd_theme_version 0.1.9
-%define alabaster_version 0.7.8
-%define babel_version 2.3.4
-%define snowballstemmer_version 1.2.1
-
-#Source0: http://pypi.python.org/packages/source/S/Sphinx/Sphinx-%realversion.tar.gz
-Source0: https://pypi.python.org/packages/10/91/ceb2e0d763e0c626f7afd7e3272a5bb76dd06eed1f0b908270ea31984062/Sphinx-%realversion.tar.gz
-Source1: http://github.com/snide/sphinx_rtd_theme/archive/%sphinx_rtd_theme_version.tar.gz
-Source2: http://github.com/bitprophet/alabaster/archive/%alabaster_version.tar.gz
-Source3: http://github.com/python-babel/babel/archive/%babel_version.tar.gz
-Source4: http://pypi.python.org/packages/source/s/snowballstemmer/snowballstemmer-%snowballstemmer_version.tar.gz
-Requires: python3 py3-docutils py3-jinja py3-pygments py3-setuptools py3-six py3-pytz py3-requests py3-imagesize
-
-%prep
-%setup -T -b 0 -n Sphinx-%realversion
-%setup -D -T -b 1 -n sphinx_rtd_theme-%sphinx_rtd_theme_version
-%setup -D -T -b 2 -n alabaster-%alabaster_version
-%setup -D -T -b 3 -n babel-%babel_version
-%setup -D -T -b 4 -n snowballstemmer-%snowballstemmer_version
-
-%build
-for d in ../Sphinx-* ../sphinx_rtd_theme-* ../alabaster-* ../babel-* ../snowballstemmer-*; do
-  cd $d
-  python3 setup.py build
-done
-
-%install
-mkdir -p %i/$PYTHON_LIB_SITE_PACKAGES
-for d in ../Sphinx-* ../sphinx_rtd_theme-* ../alabaster-* ../babel-* ../snowballstemmer-*; do
-  cd $d
-  if [ $d != ../snowballstemmer-* ]; then
-    python3 setup.py install --prefix=%i --single-version-externally-managed --record=/dev/null
-  else
-    PYTHONPATH=%i/$PYTHON_LIB_SITE_PACKAGES:$PYTHONPATH \
-    python3 setup.py install --prefix=%i
-  fi
-done
-
-# replace all instances of #!/path/bin/python into proper format
-%py3PathRelocation
-
-# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
-%addDependency
-
-%post
-%{relocateConfig}etc/profile.d/dependencies-setup.*sh
+Requires: py3-docutils py3-jinja2 py3-pygments py3-pytz py3-requests py3-imagesize
+%define pip_name Sphinx
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-urllib3.spec
+++ b/py3-urllib3.spec
@@ -1,2 +1,2 @@
-### RPM external py3-urllib3 1.25.11
+### RPM external py3-urllib3 1.26.6
 ## IMPORT build-with-pip3


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/pull/10790

which reports two high security vulnerabilities with the python `Pygments` package, used by `Sphinx`. All the request is just version updates from a `pip install` test; including `requests` to `2.26.0`, which required the following:
```
Successfully installed certifi-2021.5.30 charset-normalizer-2.0.4 idna-3.2 requests-2.26.0 urllib3-1.26.6
```

List of services that will get rebuilt with these changes are:
acdcserver
reqmgr2
reqmgr2ms
reqmon
t0_reqmon
wmagentpy3
wmagentpy3-dev
wmcorepy3-devtools
workqueue
couchdb16

Special attention is needed for `wmagentpy3`, since the next time we build this service, it will come with this different set of python version dependencies.