### PR TITLE
Update libffi to 3.4.2

### DIFF
--- a/libffi.spec
+++ b/libffi.spec
@@ -1,20 +1,24 @@
-### RPM external libffi 3.2.1
+### RPM external libffi 3.4.2
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 
-Source: ftp://sourceware.org/pub/%{n}/%{n}-%{realversion}.tar.gz
+%define tag v%{realversion}
+%define github_user libffi
+%define github_repo libffi
+%define branch master
 
-Patch0: libffi-3.2.1-fix-include-path
+Source: git+https://github.com/%{github_user}/%{github_repo}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz 
+BuildRequires: autotools
 
 %prep
 %setup -n %{n}-%{realversion}
-%patch0 -p1
+autoreconf -fiv
 
 %build
 ./configure \
   --prefix=%{i} \
   --enable-portable-binary \
   --disable-dependency-tracking \
-  --disable-static
+  --disable-static --disable-docs
 
 make %{makeprocesses}
 


### PR DESCRIPTION
the 3.2.1 version is 7 years old
https://github.com/libffi/libffi/releases/tag/v3.2.1