### PR TITLE
Enable the use of cuDNN in ONNX on ARM for CentOS 8

### DIFF
--- a/scram-tools.file/tools/onnxruntime/onnxruntime.xml
+++ b/scram-tools.file/tools/onnxruntime/onnxruntime.xml
@@ -6,7 +6,7 @@
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
   </client>
   <use name="protobuf"/>
-  <ifarchitecture name="!aarch64">
+  <ifarchitecture name="!slc7_aarch64">
     <use name="cuda"/>
     <use name="cudnn"/>
   </ifarchitecture>


### PR DESCRIPTION
Enable the use of cuDNN on ARM for CentOS 8, which is supported starting from CUDA 11.1 and cuDNN 8.