### PR TITLE
use default aiohttp version 3.7.4

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -12,7 +12,7 @@
 #flags or patching, please use package_name.file
 #############################################################################
 absl-py==0.13.0
-aiohttp==3.7.4.post0
+aiohttp==3.7.4
 aiosqlite==0.17.0
 anyio==3.3.0
 appdirs==1.4.4


### PR DESCRIPTION
This should avoid the security warning https://github.com/cms-sw/cmsdist/security/dependabot/pip/requirements.txt/aiohttp/open as github system treats 3.7.4 as newer than 3.7.4.post0