### PR TITLE
Update Geant4 to 10.7.2

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,4 +1,4 @@
-### RPM external geant4 10.7.1
+### RPM external geant4 10.7.2
 ## INCLUDE compilation_flags
 %define tag %{realversion}
 %define branch geant4-10.7-release


### PR DESCRIPTION
At PPD general meeting https://indico.cern.ch/event/1071293/  it was concluded that validation campaign for 10.7p02 is completed with success . It was agreed to use this version for 12_1_X.
It is not assumed to be regression in tests.