### PR TITLE
New spec for python3 gfal2

### DIFF
--- a/py3-gfal2-python.spec
+++ b/py3-gfal2-python.spec
@@ -1,0 +1,11 @@
+### RPM external py3-gfal2-python 1.11.0.post3
+## IMPORT build-with-pip3
+BuildRequires: cmake boost175py3
+Provides: libgfal2.so.2()(64bit)
+Provides: libgfal_transfer.so.2()(64bit)
+Provides: libglib-2.0.so.0()(64bit)
+Provides: libboost_python38.so.1.75.0()(64bit)
+
+Patch0: py3-gfal2
+%define PipPreBuild export Boost_LIBRARYDIR=${BOOST175PY3_ROOT}/lib ; export CXXFLAGS="-I${BOOST175PY3_ROOT}/include"
+#define PipBuildOptionsPy3 --global-option="--without=docs" --global-option="--without=python2"

--- a/py3-gfal2-python.spec
+++ b/py3-gfal2-python.spec
@@ -1,11 +1,11 @@
 ### RPM external py3-gfal2-python 1.11.0.post3
 ## IMPORT build-with-pip3
-BuildRequires: cmake boost175py3
+Requires: boost175py3
+BuildRequires: cmake
+
 Provides: libgfal2.so.2()(64bit)
 Provides: libgfal_transfer.so.2()(64bit)
 Provides: libglib-2.0.so.0()(64bit)
-Provides: libboost_python38.so.1.75.0()(64bit)
 
 Patch0: py3-gfal2
 %define PipPreBuild export Boost_LIBRARYDIR=${BOOST175PY3_ROOT}/lib ; export CXXFLAGS="-I${BOOST175PY3_ROOT}/include"
-#define PipBuildOptionsPy3 --global-option="--without=docs" --global-option="--without=python2"

--- a/py3-gfal2.patch
+++ b/py3-gfal2.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 461c8d3..9f3e4ef 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,7 +35,7 @@ if (PYTHON3_CURRENT_VERSION)
+     find_library(Boost_PYTHON_3_LIBRARY
+         NAMES boost_python${Boost_PYTHON_3_SUFFIX} boost_python-py${Boost_PYTHON_3_SUFFIX} boost_python3
+         HINTS
+-            ${Boost_LIBRARYDIR}
++            $ENV{Boost_LIBRARYDIR}
+             "/usr/lib"
+             "/usr/lib64"
+     )

--- a/reqmgr2ms.spec
+++ b/reqmgr2ms.spec
@@ -7,7 +7,8 @@
 
 Source: git://github.com/dmwm/WMCore?obj=master/%wmcorever&export=%n&output=/%n.tar.gz
 Requires: py3-cherrypy py3-pycurl py3-httplib2 py3-rucio-clients py3-retry py3-future
-Requires: py3-cmsmonitoring py3-pymongo rotatelogs jemalloc mongo
+Requires: py3-cmsmonitoring py3-pymongo py3-gfal2-python
+Requires: rotatelogs jemalloc mongo
 BuildRequires: py3-sphinx
 
 %prep


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10828

This PR has some requirements for the build node (and also for the node/container running MSUnmerged), given that we do not build all the dependencies brought up with `gfal2-python`. We need to install/enable this DMC EL7 Production repository:
```
sudo yum-config-manager --add-repo https://dmc-repo.web.cern.ch/dmc-repo/dmc-el7.repo
sudo yum-config-manager --enable dmc-el7/x86_64
```

and on the build and service-host node, we need to install these 4 packages (glib2 is likely already available):
```
yum install glib2 glib2-devel gfal2 gfal2-devel
``` 
note that the gfal2 and gfal2-devel packages must have the version `2.20.0-1.el7.cern` or higher.

Then, we also have to install the gfal2 plugins on the service-host node (container). This one is mandatory:
```
yum install gfal2-plugin-gridftp gfal2-plugin-file gfal2-plugin-http gfal2-plugin-srm gfal2-plugin-xrootd
```
but right now, this is the set of packages+plugins that we are deploying in the ms-unmerged image:
https://github.com/dmwm/CMSKubernetes/blob/master/docker/reqmgr2ms-unmerged/Dockerfile#L13-L21

Reference, discussion with gfal2 experts: https://cern.service-now.com/service-portal?id=ticket&table=u_request_fulfillment&n=RQF1903380