### PR TITLE
Backport CUDA updates from the 12.1.x branch

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,4 +1,4 @@
-### RPM external alpaka 0.6.0
+### RPM external alpaka 0.7.0
 ## NOCOMPILER
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{realversion}.tar.gz

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -152,6 +152,7 @@ Requires: dablooms
 Requires: openldap
 Requires: gperftools
 Requires: cuda
+Requires: cuda-compatible-runtime
 Requires: alpaka
 Requires: cupla
 

--- a/cuda-compatible-runtime.spec
+++ b/cuda-compatible-runtime.spec
@@ -1,0 +1,26 @@
+### RPM external cuda-compatible-runtime 1.0
+
+%define branch master
+%define commit 18d5a51bfb32fbb7b765dd2eecd14e193cce8126
+
+Source: git+https://:@gitlab.cern.ch:8443/cms-patatrack/%{n}.git?obj=%{branch}/%{commit}&export=%{n}&filter=./test.c&output=/%{n}-%{realversion}.tgz
+Requires: cuda
+AutoReq: no
+
+%prep
+%setup -n %{n}
+
+%build
+rm -rf %{_builddir}/build && mkdir %{_builddir}/build
+gcc -std=c99 -O2 -Wall test.c -I $CUDA_ROOT/include -L $CUDA_ROOT/lib64 -L $CUDA_ROOT/lib64/stubs -l cudart_static -l cuda -ldl -lrt -pthread -static-libgcc -o %{_builddir}/build/cuda-compatible-runtime # || true
+
+%install
+
+mkdir %{i}/test
+if [ -f %{_builddir}/build/cuda-compatible-runtime ]; then
+  cp %{_builddir}/build/cuda-compatible-runtime %{i}/test/cuda-compatible-runtime
+else
+  ln -s /usr/bin/false %{i}/test/cuda-compatible-runtime
+fi
+
+%post

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,7 +1,7 @@
-### RPM external cuda 11.2.2
+### RPM external cuda 11.4.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define driversversion 460.32.03
+%define driversversion 470.57.02
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/cuda.spec
+++ b/cuda.spec
@@ -37,9 +37,11 @@ mv %_builddir/build/lib64/libcudadevrt.a %{i}/lib64/
 mv %_builddir/build/lib64/libcudart_static.a %{i}/lib64/
 rm -f %_builddir/build/lib64/lib*.a
 
-# package only the CUDA driver and NVML library stub
-mv %_builddir/build/lib64/stubs/libcuda.so %{i}/lib64/stubs/
-mv %_builddir/build/lib64/stubs/libnvidia-ml.so %{i}/lib64/stubs/
+# package only the CUDA driver and NVML library stubs
+mv %_builddir/build/lib64/stubs/libcuda.so      %{i}/lib64/stubs/libcuda.so
+ln -sf libcuda.so                               %{i}/lib64/stubs/libcuda.so.1
+mv %_builddir/build/lib64/stubs/libnvidia-ml.so %{i}/lib64/stubs/libnvidia-ml.so
+ln -sf libnvidia-ml.so                          %{i}/lib64/stubs/libnvidia-ml.so.1
 rm -rf %_builddir/build/lib64/stubs/
 
 # do not package the OpenCL libraries

--- a/cuda.spec
+++ b/cuda.spec
@@ -32,8 +32,9 @@ mkdir -p %{i}/include
 mkdir -p %{i}/lib64
 mkdir -p %{i}/lib64/stubs
 
-# package only the runtime static library
+# package only the runtime static libraries
 mv %_builddir/build/lib64/libcudadevrt.a %{i}/lib64/
+mv %_builddir/build/lib64/libcudart_static.a %{i}/lib64/
 rm -f %_builddir/build/lib64/lib*.a
 
 # package only the CUDA driver and NVML library stub

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,7 +1,7 @@
-### RPM external cudnn 8.1.1.33
+### RPM external cudnn 8.2.2.26
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define cudaver 11.2
+%define cudaver 11.4
 %define cudnnver_maj %(echo %{realversion} | cut -f1,2,3 -d.)
 
 %ifarch x86_64

--- a/cupla.spec
+++ b/cupla.spec
@@ -1,7 +1,6 @@
-### RPM external cupla 0.3.0-dev
+### RPM external cupla 0.3.0
 
-#%define tag %{realversion}
-%define tag 545702f1947feb1d46b2230b502f1f46179b3665
+%define tag %{realversion}
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{tag}.tar.gz
 Requires: alpaka

--- a/eigen.spec
+++ b/eigen.spec
@@ -1,7 +1,7 @@
-### RPM external eigen f612df273689a19d25b45ca4f8269463207c4fee
+### RPM external eigen 82dd3710dac619448f50331c1d6a35da673f764a
 ## INITENV +PATH PKG_CONFIG_PATH %{i}/share/pkgconfig
 ## NOCOMPILER
-%define tag 4fc3872b0dc7540aeaea8de04835508bbd90aae3
+%define tag 733e6166b2f8b4edd23da33985187fd60903e9ca
 %define branch cms/master/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/eigen-git-mirror.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
+++ b/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
@@ -1,0 +1,8 @@
+<tool name="cuda-compatible-runtime" version="@TOOL_VERSION@">
+  <info url="https://gitlab.cern.ch/cms-patatrack/cuda-compatible-runtime/"/>
+  <use name="cuda"/>
+  <use name="cuda-stubs"/>
+  <client>
+    <environment name="CUDA_COMPATIBLE_RUNTIME_BASE" default="@TOOL_ROOT@"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/onnxruntime/onnxruntime.xml
+++ b/scram-tools.file/tools/onnxruntime/onnxruntime.xml
@@ -6,7 +6,7 @@
     <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
   </client>
   <use name="protobuf"/>
-  <ifarchitecture name="!aarch64">
+  <ifarchitecture name="!slc7_aarch64">
     <use name="cuda"/>
     <use name="cudnn"/>
   </ifarchitecture>


### PR DESCRIPTION
Update to CUDA 11.4.2 (SDK 11.4.20210830):
  * CUDA runtime version 11.4.108
  * NVIDIA drivers version 470.57.02
  * add support for GCC 11 and clang 12
  * see the [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)

Update cuDNN to v8.2.2.26 for CUDA 11.4:
  * enable the use of cuDNN for ONNX on ARM for CentOS 8

Update the CUDA external packaging:
  - include the CUDA runtime static library in the external package
  - create symlinks for the library stubs to satisfy link-time checks

Add the cuda-compatible-runtime test as a new external.

Update Eigen.

Backport #7257, #7277, #7278, #7279 _et al_.