### PR TITLE
Buildrule tag update to V07-00-00

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-03-06
+%define configtag       V07-00-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
tag is same as V06-03-06. This is to allow old release to still use V06 with out private header file usage check