### PR TITLE
[12.0.X] Build rules updated to V06-03-07

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-03-01
+%define configtag       V06-03-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This is same as  V06-03-06 but without private header file check enable. 12.0.X is not clean fo private header usage.