### PR TITLE
Minimal backport of CUDA-related changes

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -152,6 +152,7 @@ Requires: dablooms
 Requires: openldap
 Requires: gperftools
 Requires: cuda
+Requires: cuda-compatible-runtime
 Requires: alpaka
 Requires: cupla
 

--- a/cuda-compatible-runtime.spec
+++ b/cuda-compatible-runtime.spec
@@ -1,0 +1,26 @@
+### RPM external cuda-compatible-runtime 1.0
+
+%define branch master
+%define commit 18d5a51bfb32fbb7b765dd2eecd14e193cce8126
+
+Source: git+https://:@gitlab.cern.ch:8443/cms-patatrack/%{n}.git?obj=%{branch}/%{commit}&export=%{n}&filter=./test.c&output=/%{n}-%{realversion}.tgz
+Requires: cuda
+AutoReq: no
+
+%prep
+%setup -n %{n}
+
+%build
+rm -rf %{_builddir}/build && mkdir %{_builddir}/build
+gcc -std=c99 -O2 -Wall test.c -I $CUDA_ROOT/include -L $CUDA_ROOT/lib64 -L $CUDA_ROOT/lib64/stubs -l cudart_static -l cuda -ldl -lrt -pthread -static-libgcc -o %{_builddir}/build/cuda-compatible-runtime # || true
+
+%install
+
+mkdir %{i}/test
+if [ -f %{_builddir}/build/cuda-compatible-runtime ]; then
+  cp %{_builddir}/build/cuda-compatible-runtime %{i}/test/cuda-compatible-runtime
+else
+  ln -s /usr/bin/false %{i}/test/cuda-compatible-runtime
+fi
+
+%post

--- a/cuda.spec
+++ b/cuda.spec
@@ -32,13 +32,16 @@ mkdir -p %{i}/include
 mkdir -p %{i}/lib64
 mkdir -p %{i}/lib64/stubs
 
-# package only the runtime static library
+# package only the runtime static libraries
 mv %_builddir/build/lib64/libcudadevrt.a %{i}/lib64/
+mv %_builddir/build/lib64/libcudart_static.a %{i}/lib64/
 rm -f %_builddir/build/lib64/lib*.a
 
-# package only the CUDA driver and NVML library stub
-mv %_builddir/build/lib64/stubs/libcuda.so %{i}/lib64/stubs/
-mv %_builddir/build/lib64/stubs/libnvidia-ml.so %{i}/lib64/stubs/
+# package only the CUDA driver and NVML library stubs
+mv %_builddir/build/lib64/stubs/libcuda.so      %{i}/lib64/stubs/libcuda.so
+ln -sf libcuda.so                               %{i}/lib64/stubs/libcuda.so.1
+mv %_builddir/build/lib64/stubs/libnvidia-ml.so %{i}/lib64/stubs/libnvidia-ml.so
+ln -sf libnvidia-ml.so                          %{i}/lib64/stubs/libnvidia-ml.so.1
 rm -rf %_builddir/build/lib64/stubs/
 
 # do not package the OpenCL libraries

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V06-03-01
+%define configtag       V06-03-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
+++ b/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
@@ -1,0 +1,8 @@
+<tool name="cuda-compatible-runtime" version="@TOOL_VERSION@">
+  <info url="https://gitlab.cern.ch/cms-patatrack/cuda-compatible-runtime/"/>
+  <use name="cuda"/>
+  <use name="cuda-stubs"/>
+  <client>
+    <environment name="CUDA_COMPATIBLE_RUNTIME_BASE" default="@TOOL_ROOT@"/>
+  </client>
+</tool>


### PR DESCRIPTION
Update the CUDA external packaging:
  - include the CUDA runtime static library in the external package;
  - create symlinks for the library stubs to satisfy link-time checks.

Add the cuda-compatible-runtime test as a new external.