### PR TITLE
[VecGeom] Update to version v1.1.17

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,4 +1,4 @@
-### RPM external vecgeom v1.1.16
+### RPM external vecgeom v1.1.17
 ## INCLUDE compilation_flags
 %define tag ed9a40412c354652262ec80af449f5531206e52c
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
@@ -41,8 +41,6 @@ make %{makeprocesses}
 %install
 cd ../build
 make %{makeprocesses} install
-perl -p -i -e 's|set\(VECGEOM_EXTERNAL_INCLUDES .*|set(VECGEOM_EXTERNAL_INCLUDES "")|' \
-  $(grep -R 'set(VECGEOM_EXTERNAL_INCLUDES ' %{i}/lib/cmake | sed 's|:.*||' | sort | uniq)
 
 %post
 %{relocateConfig}lib/cmake/VecGeom/*.cmake

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -44,4 +44,3 @@ make %{makeprocesses} install
 
 %post
 %{relocateConfig}lib/cmake/VecGeom/*.cmake
-

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -24,8 +24,6 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_BUILD_TYPE=Release \
   -DNO_SPECIALIZATION=ON \
   -DBACKEND=Scalar \
-  -DUSOLIDS=ON \
-  -DUSOLIDS_VECGEOM=ON \
 %ifarch x86_64
   -DVECGEOM_VECTOR=sse3 \
 %endif


### PR DESCRIPTION
Updated to version 1.1.17 and cleanup the `VECGEOM_EXTERNAL_INCLUDES` relocation.
Remove `USOLIDS` flags see https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/f54e04fb697cf5a7e260620ee2361713d7403282 and https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/b08c5b98fde306974f6d9ea1b034a7b899f592ef