### PR TITLE
update conan and fix dip build

### DIFF
--- a/dip.spec
+++ b/dip.spec
@@ -18,7 +18,7 @@ cd %{_builddir}/platform-dependent
 conan create .
 
 cd %{_builddir}/dip
-conan create . --build=dip --build=log4cplus
+conan create . --build=dip --build=log4cplus --build=platform-dependent
 
 %install
 rm -rf %{_builddir}/build/.conan/data/dip/*/_/_/package/*/lib/cmake

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -56,7 +56,7 @@ climate==0.4.6
 cloudpickle==1.6.0
 colorama==0.4.4
 commonmark==0.9.1
-conan==1.39.0
+conan==1.40.3
 contextlib2==21.6.0
 contextvars==2.4
 coverage==5.5


### PR DESCRIPTION
Looks like conan server certificate is expire and it resulted in failure to build `dip`
```
ERROR: Failed requirement 'log4cplus/2.0.5' from 'dip/6.0.0'
ERROR: HTTPSConnectionPool(host='center.conan.io', port=443): Max retries exceeded with url: /v1/ping (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1129)')))
```

new conan version seems to fix this issue.