### PR TITLE
Fix libunwind libdir path

### DIFF
--- a/libunwind.spec
+++ b/libunwind.spec
@@ -16,5 +16,5 @@ make %{makeprocesses}
 %install
 
 make %{makeprocesses} install
-
+[ -d %{i}/lib64 ] && mv %{i}/lib64 %{i}/lib
 %define drop_files %{i}/share/man %{i}/lib/pkgconfig %{i}/lib/*.a

--- a/scram-tools.file/tools/gperftools/gperf.xml
+++ b/scram-tools.file/tools/gperftools/gperf.xml
@@ -4,5 +4,6 @@
     <environment name="GPERF_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"        default="$GPERF_BASE/lib"/>
   </client>
+  <use name="libunwind"/>
   <runtime name="PATH" value="$GPERF_BASE/bin" type="path"/>
 </tool>


### PR DESCRIPTION
For ppc64 archs, libunwind installs its libs under `lib64` for other arch is use `lib`. This change makes sure that libdir is lib