### PR TITLE
fix py3-anyio dependency. Adding setuptools-scm deps properly fix the version issue

### DIFF
--- a/pip/anyio.file
+++ b/pip/anyio.file
@@ -1,0 +1,2 @@
+BuildRequires: py3-setuptools-scm
+Requires: py3-idna py3-sniffio

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -14,7 +14,7 @@
 absl-py==0.13.0
 aiohttp==3.7.4
 aiosqlite==0.17.0
-anyio==3.3.0
+anyio==3.3.2
 appdirs==1.4.4
 argon2-cffi==21.1.0
 argparse==1.4.0
@@ -268,6 +268,7 @@ six==1.16.0
 skl2onnx==1.9.2
 smmap==4.0.0
 smmap2==3.0.1
+sniffio==1.2.0
 soupsieve==2.2.1
 sqlalchemy==1.3.24
 stevedore==3.4.0


### PR DESCRIPTION
Fixes #7365
using setuptools-scm properly set the anyio version.