### PR TITLE
Update HTCondor python bindings to 9.2.0

### DIFF
--- a/cms-htcondor-build.patch
+++ b/cms-htcondor-build.patch
@@ -12,8 +12,8 @@
 -
 +if (HAVE_EXT_GLOBUS AND HAVE_LDAP_H AND LDAP_FOUND )
  	add_definitions(-DLDAP_DEPRECATED)
- 
- 	condor_glob( HeaderFiles SourceFiles "" )
+
+	set(SourceFiles
 @@ -52,6 +47,6 @@ if (HAVE_EXT_GLOBUS)
  
  else()
@@ -34,14 +34,14 @@
  	if (WINDOWS)
  	  # need to expand the configure and
 --- a/externals/bundles/boost/1.66.0/CMakeLists.txt	
-+++ b/externals/bundles/boost/1.66.0/CMakeLists.txt	
-@@ -62,27 +62,27 @@
- 	message (STATUS "Boost components: ${BOOST_COMPONENTS}" )
- 
++++ b/externals/bundles/boost/1.66.0/CMakeLists.txt
+@@ -61,26 +61,26 @@
+     # set (Boost_DEBUG TRUE)
+
      message (STATUS "SYSTEM_NAME: ${SYSTEM_NAME}" )
 -    if (DEFINED SYSTEM_NAME)
 -        if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "64")
--            if ( ${SYSTEM_NAME} MATCHES "rhel7" OR ${SYSTEM_NAME} MATCHES "centos7" OR ${SYSTEM_NAME} MATCHES "sl7")
+-            if ( ${SYSTEM_NAME} MATCHES "rhel7" OR ${SYSTEM_NAME} MATCHES "centos7" OR ${SYSTEM_NAME} MATCHES "sl7" OR ${SYSTEM_NAME} MATCHES "amzn2")
 -                message (STATUS "Using system boost169 for 64-bit EL7" )
 -                # If you look for python on cmake 2.8.12.2 it fails.
 -                # Looking for thread finds boost for python for me.
@@ -53,16 +53,15 @@
 -                set(USE_SYSTEM_BOOST True)
 -            endif()
 -        endif()
--        if (${SYSTEM_NAME} MATCHES "Debian" OR ${SYSTEM_NAME} MATCHES "Ubuntu" OR ${SYSTEM_NAME} MATCHES "rhel8" OR ${SYSTEM_NAME} MATCHES "centos8")
+-        if (${SYSTEM_NAME} MATCHES "Debian" OR ${SYSTEM_NAME} MATCHES "Ubuntu" OR ${SYSTEM_NAME} MATCHES "rhel8" OR ${SYSTEM_NAME} MATCHES "centos8" OR ${SYSTEM_NAME} MATCHES "fc")
 -            set(USE_SYSTEM_BOOST True)
--        endif()
--        if (${SYSTEM_NAME} MATCHES "fc")
--            set(USE_SYSTEM_BOOST True)
+-            # BOOST_COMPONENTS breaks CMake boost detection on Ubuntu 20.04, Debian bullseye
+-            set(BOOST_COMPONENTS "" )
 -        endif()
 -    endif()
 +    #if (DEFINED SYSTEM_NAME)
 +    #    if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "64")
-+    #        if ( ${SYSTEM_NAME} MATCHES "rhel7" OR ${SYSTEM_NAME} MATCHES "centos7" OR ${SYSTEM_NAME} MATCHES "sl7")
++    #        if ( ${SYSTEM_NAME} MATCHES "rhel7" OR ${SYSTEM_NAME} MATCHES "centos7" OR ${SYSTEM_NAME} MATCHES "sl7" OR ${SYSTEM_NAME} MATCHES "amzn2")
 +    #            message (STATUS "Using system boost169 for 64-bit EL7" )
 +    #            # If you look for python on cmake 2.8.12.2 it fails.
 +    #            # Looking for thread finds boost for python for me.
@@ -74,13 +73,12 @@
 +    #            set(USE_SYSTEM_BOOST True)
 +    #        endif()
 +    #    endif()
-+    #    if (${SYSTEM_NAME} MATCHES "Debian" OR ${SYSTEM_NAME} MATCHES "Ubuntu" OR ${SYSTEM_NAME} MATCHES "rhel8" OR ${SYSTEM_NAME} MATCHES "centos8")
++    #    if (${SYSTEM_NAME} MATCHES "Debian" OR ${SYSTEM_NAME} MATCHES "Ubuntu" OR ${SYSTEM_NAME} MATCHES "rhel8" OR ${SYSTEM_NAME} MATCHES "centos8" OR ${SYSTEM_NAME} MATCHES "fc")
 +    #        set(USE_SYSTEM_BOOST True)
-+    #    endif()
-+    #    if (${SYSTEM_NAME} MATCHES "fc")
-+    #        set(USE_SYSTEM_BOOST True)
++    #        # BOOST_COMPONENTS breaks CMake boost detection on Ubuntu 20.04, Debian bullseye
++    #        set(BOOST_COMPONENTS "" )
 +    #    endif()
 +    #endif()
- 
+
+ 	message (STATUS "Boost components: ${BOOST_COMPONENTS}" )
  	find_package( Boost 1.33.1 COMPONENTS ${BOOST_COMPONENTS} )
- 

--- a/condor.spec
+++ b/condor.spec
@@ -1,4 +1,4 @@
-### RPM external condor 8.9.7
+### RPM external condor 9.2.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib/condor
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 %define condortag %(echo V%realversion | tr "." "_")
@@ -75,7 +75,7 @@ egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/
 # Strip libraries, we are not going to debug them.
 %define strip_files %i/lib
 
-# Clean things up; read the docs online;
+# Clean things up; read the docs online
 # remove condor_gather_info since it brings a dependency on Date::Manip
 rm -rf %i/{README,etc/{examples,init.d,sysconfig},examples} \
        %i/{include,sbin,libexec,src,condor*,bosco*}         \

--- a/condorpy3.spec
+++ b/condorpy3.spec
@@ -1,4 +1,4 @@
-### RPM external condorpy3 8.9.7
+### RPM external condorpy3 9.2.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib/condor
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 %define condortag %(echo V%realversion | tr "." "_")


### PR DESCRIPTION
Update HTCondor python2/3 bindings to the latest 9.2.0 version

Related issue:
https://github.com/dmwm/WMCore/issues/10256