### PR TITLE
New HTCondor specs from PyPi; update version to 9.2.0

### DIFF
--- a/py2-htcondor.spec
+++ b/py2-htcondor.spec
@@ -1,0 +1,20 @@
+### RPM external py2-htcondor 9.2.0
+## IMPORT build-with-pip
+
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0d)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0f)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0i)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_1)(64bit)
+Provides: libglobus_gssapi_gsi-46531449.so.4.10.9(globus_gssapi_gsi)(64bit)
+Provides: libgomp-3300acd3.so.1.0.0(GOMP_1.0)(64bit)
+Provides: libgomp-3300acd3.so.1.0.0(OMP_1.0)(64bit)
+Provides: libk5crypto-622ef25b.so.3.1(k5crypto_3_MIT)(64bit)
+Provides: libkeyutils-1-ff31573b.2.so(KEYUTILS_0.3)(64bit)
+Provides: libkrb5-fb0d2caa.so.3.3(krb5_3_MIT)(64bit)
+Provides: libkrb5support-d7ce89d4.so.0.1(krb5support_0_MIT)(64bit)
+Provides: libssl-6536aedd.so.1.1(OPENSSL_1_1_0)(64bit)
+
+%define PipDownloadSourceType none
+
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-htcondor.spec
+++ b/py3-htcondor.spec
@@ -1,0 +1,20 @@
+### RPM external py3-htcondor 9.2.0
+## IMPORT build-with-pip3
+
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0d)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0f)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0i)(64bit)
+Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_1)(64bit)
+Provides: libglobus_gssapi_gsi-46531449.so.4.10.9(globus_gssapi_gsi)(64bit)
+Provides: libgomp-3300acd3.so.1.0.0(GOMP_1.0)(64bit)
+Provides: libgomp-3300acd3.so.1.0.0(OMP_1.0)(64bit)
+Provides: libk5crypto-622ef25b.so.3.1(k5crypto_3_MIT)(64bit)
+Provides: libkeyutils-1-ff31573b.2.so(KEYUTILS_0.3)(64bit)
+Provides: libkrb5-fb0d2caa.so.3.3(krb5_3_MIT)(64bit)
+Provides: libkrb5support-d7ce89d4.so.0.1(krb5support_0_MIT)(64bit)
+Provides: libssl-6536aedd.so.1.1(OPENSSL_1_1_0)(64bit)
+
+%define PipDownloadSourceType none
+
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/wmagent.spec
+++ b/wmagent.spec
@@ -6,11 +6,9 @@
 Source: git://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=WMCore-%{realversion}&output=/WMCore-%{realversion}.tar.gz
 
 Requires: python py2-sqlalchemy py2-httplib2 py2-pycurl py2-rucio-clients
-Requires: py2-mysqldb py2-cx-oracle py2-cheetah py2-pyOpenSSL
-Requires: yui libuuid couchdb15 condor
+Requires: py2-mysqldb py2-cx-oracle py2-cheetah py2-pyOpenSSL py2-htcondor
+Requires: yui libuuid couchdb15 jemalloc cmsmonitoring
 Requires: dbs3-client py2-pyzmq py2-psutil py2-future py2-retry
-Requires: jemalloc cmsmonitoring
-
 BuildRequires: py2-sphinx couchskel
 
 %prep

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -5,14 +5,11 @@
 
 Source: git://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=WMCore-%{realversion}&output=/WMCore-%{realversion}.tar.gz
 
-Requires: yui libuuid couchdb16 condorpy3 jemalloc py3-dbs3-client
+Requires: yui libuuid couchdb16 jemalloc mariadb
 Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
-Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL
-Requires: py3-pyzmq py3-psutil py3-future py3-retry
-Requires: py3-cmsmonitoring py3-cmscouchapp
-Requires: py3-cheetah3
-Requires: py3-mysqlclient
-Requires: mariadb
+Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL py3-htcondor
+Requires: py3-pyzmq py3-psutil py3-future py3-retry py3-cheetah3
+Requires: py3-cmsmonitoring py3-cmscouchapp py3-mysqlclient py3-dbs3-client
 
 # Alan Malta dropped on 2/Feb/2021: Requires: py3-mysqldb
 BuildRequires: py3-sphinx couchskel


### PR DESCRIPTION
Fixes dmwm/WMCore#10256
Superseeds https://github.com/cms-sw/cmsdist/pull/7379

Please check out the full discussion on these two tickets above.

In short, this PR provides:
* a new method to building the htcondor python bindings (from PyPi and bypassing the dynamically linked libraries)
* updated the dependency name in the wmagent spec files

Note that the "old" condor spec files remain here, in case we have the need for a custom condor build.

All the credits go to Kenyi, Shahzad and Valentin!