### PR TITLE
dump crab packages suffix

### DIFF
--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.211015
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.5.2

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.210323
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.6.crab6

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.210825
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.6.crab6


### PR DESCRIPTION
This is needed as https://github.com/cms-sw/pkgtools/pull/185 rebuild `crab-*` packages and adds random suffix to crab packages. This change makes sure that crab packages versions contains valid suffix

FYI @ddaina and @belforte 