### PR TITLE
build tensorflow with correct ppc64le_build_flags

### DIFF
--- a/bootstrap-bundle.spec
+++ b/bootstrap-bundle.spec
@@ -38,7 +38,7 @@ rm -f %{i}/bin/xml2-config %{i}/lib/xml2Conf.sh
 %if %ismac
 cp -P $GCC_ROOT/lib/lib{stdc++,gcc_s}*.%{soname} %{i}/lib
 %else
-cp -P $GCC_ROOT/%{libdir}/lib{stdc++,gcc_s}.%{soname}* %{i}/lib
+cp -P $GCC_ROOT/%{libdir}/lib{stdc++,gcc_s,gomp}.%{soname}* %{i}/lib
 cp -P $GCC_ROOT/lib/libelf.%{soname}* %{i}/lib
 cp -P $GCC_ROOT/lib/libelf-*.%{soname} %{i}/lib
 %endif

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -35,8 +35,7 @@ BAZEL_OPTS="--batch --output_user_root ../build build -s --verbose_failures --di
 BAZEL_OPTS="$BAZEL_OPTS --copt=%{vectorize_flag}"
 %else
 %ifarch ppc64le
-BAZEL_OPTS="$BAZEL_OPTS --copt=-mcpu=native --copt=-mtune=native"
-BAZEL_OPTS="$BAZEL_OPTS --copt=--param=l1-cache-size=64 --copt=--param=l1-cache-line-size=128 --copt=--param=l2-cache-size=512"
+BAZEL_OPTS="$BAZEL_OPTS $(echo %{ppc64le_build_flags} | tr ' ' '\n' | grep -v '^$' | sed -e 's|^|--copt=|' | tr '\n' ' ')"
 %else
 BAZEL_OPTS="$BAZEL_OPTS --copt=-mcpu=native --copt=-mtune=native"
 %endif


### PR DESCRIPTION
- Fix bootstrap to include `gomp` lib needed by rpm.
- Fix Tensorflow compilation flags for `pcc64le`