### PR TITLE
Update tag for PhysicsTools-NanoAOD to V01-02-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+PhysicsTools-NanoAOD=V01-02-00
 RecoTracker-FinalTrackSelectors=V01-02-00
 RecoTauTag-TrainingFiles=V00-03-00
 RecoTracker-MkFit=V00-06-00
@@ -38,7 +39,6 @@ L1Trigger-L1TCalorimeter=V01-01-00
 SimTransport-PPSProtonTransport=V00-02-00
 DQM-SiStripMonitorClient=V01-01-00
 RecoMET-METPUSubtraction=V01-01-00
-PhysicsTools-NanoAOD=V01-01-00
 RecoMTD-TimingIDTools=V00-01-00
 Configuration-Generator=V01-02-00
 MagneticField-Engine=V00-01-00


### PR DESCRIPTION
Move PhysicsTools-NanoAOD data to new tag, see 
https://github.com/cms-data/PhysicsTools-NanoAOD/pull/13
