### PR TITLE
[llvm] use same host triple as set by gcc

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -48,6 +48,7 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -DLLVM_ENABLE_EH:BOOL=ON \
   -DLLVM_ENABLE_PIC:BOOL=ON \
   -DLLVM_ENABLE_RTTI:BOOL=ON \
+  -DLLVM_HOST_TRIPLE=$(gcc -dumpmachine) \
   -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64;NVPTX" \
   -DLIBOMPTARGET_NVPTX_ALTERNATE_HOST_COMPILER=/usr/bin/gcc \
   -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES="%llvm_cuda_arch" \


### PR DESCRIPTION
For ppc64le gcc11 builds, gcc properly use host triple to `powerpc64le-redhat-linux-gnu` while llvm uses `powerpc64le-unknown-linux-gnu` which causes cmssw build to fail as llvm could not find gcc headers. This change should make sure that same host tripel is used by llvm and gcc