### PR TITLE
Add precompiled support for A100 gpu (sm_80)

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -3,7 +3,7 @@
 
 # on X86 and Power, build support for Pascal, Volta and Turing
 %ifarch x86_64 ppc64le
-%define cuda_arch 60 70 75
+%define cuda_arch 60 70 75 80
 %endif
 
 # on ARM, build support for Volta, Xavier SoC and Turing

--- a/scram-tools.file/tools/cuda/nvidia-ptxjitcompiler.xml
+++ b/scram-tools.file/tools/cuda/nvidia-ptxjitcompiler.xml
@@ -1,0 +1,9 @@
+<tool name="nvidia-ptxjitcompiler" version="@TOOL_VERSION@">
+  <info url="https://docs.nvidia.com/cuda/index.html"/>
+  <lib name="cuda"/>
+  <lib name="nvidia-ptxjitcompiler"/>
+  <client>
+    <environment name="NVIDIA_DRIVERS_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"              default="$NVIDIA_DRIVERS_BASE/drivers"/>
+  </client>
+</tool>


### PR DESCRIPTION
Edited to summarize the discussion.

Perlmutter at NERSC has Nvidia A100's and the system nvidia software install only supports up to cuda 11.3. The cuda libraries in CMSSW support cuda 11.4. Running with this configuration produces a segfault with error `cudaErrorUnsupportedPtxVersion`. As I first stated "The JIT compilation does not work at the moment." The NVIDIA support person at NERSC suggested compiling for the sm_80 target or loading forward compatibility libraries. The forward compatibility libraries must be compiled with the same nvcc used for compiling cuda code in CMSSW.

* Compiling cuda code in CMSSW for the sm_80 target works.
* Making the forward compatibility libraries (for JIT compilation) available through LD_LIBRARY_PATH allows cuda code not compiled for the cm_80 target to be JIT compiled.