### PR TITLE
cleanup scram provides

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,11 +1,6 @@
-### RPM lcg SCRAMV1 V3_00_32
+### RPM lcg SCRAMV1 V3_00_33
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
-
-Provides: perl(BuildSystem::Template::Plugins::PluginCore)
-Provides: perl(BuildSystem::TemplateStash)
-Provides: perl(Cache::CacheUtilities)
-Provides: perl(BuildSystem::ToolManager)
 
 %define tag 4ae4e4cde2026f0b88189e8f748a5fd47f0f44fb
 %define branch SCRAMV3

--- a/fakesystem.spec
+++ b/fakesystem.spec
@@ -1,4 +1,4 @@
-### RPM external fakesystem 1.0
+### RPM external fakesystem 2.0
 ## NOCOMPILER
 
 # Various system scripts
@@ -8,6 +8,7 @@ Provides: /bin/sed
 Provides: /bin/bash
 Provides: /usr/bin/awk
 Provides: /usr/bin/python
+Provides: /usr/bin/python3
 # Various perl modules/dependencies that are needed only for specialized
 # scripts
 Provides: perl(Date::Format)


### PR DESCRIPTION
- Drop extra provides from SCRAM: There is no PERL modules in SCRAM any more
- Added python3 provide in fakesystem package