### PR TITLE
[git] Added extra perl provides to avoid system package deps

### DIFF
--- a/git.spec
+++ b/git.spec
@@ -14,17 +14,20 @@ BuildRequires: autotools
 
 # Fake provides for git add --interactive
 # The following are not avaialble on SLC and Darwin platforms by default
-Provides: perl(DBI)
-Provides: perl(Error)
 Provides: perl(SVN::Core)
 Provides: perl(SVN::Delta)
 Provides: perl(SVN::Ra)
-Provides: perl(YAML::Any)
 Provides: perl(CGI::Carp)
 Provides: perl(CGI::Util)
-Provides: perl(Time::HiRes)
-Provides: perl(Encode)
 Provides: perl(Scalar::Util)
+Provides: perl(Time::HiRes)
+Provides: perl(YAML::Any)
+Provides: perl(DBI)
+Provides: perl(CGI)
+Provides: perl(Encode)
+Provides: perl(Error)
+Provides: perl(Storable)
+Provides: perl(Time::Local)
 
 %define drop_files %{i}/share/man
 


### PR DESCRIPTION
We do not make much use of git perl interface. These extra provides are to avoid perl system modules dependencies. If one needs to use git perl interface then they need to install extra perl modules on system