### PR TITLE
allow version suffix options

### DIFF
--- a/cmsLHEtoEOSManager.tmpl
+++ b/cmsLHEtoEOSManager.tmpl
@@ -6,10 +6,7 @@
 Source0: https://raw.githubusercontent.com/cms-sw/cmssw/%{commit}/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
 
 %prep
-%if "%{v}" != "%{realversion}"
-  echo "ERROR: %{v} does not match %{realversion}. Please update version number for %{n}."
-  exit 1
-%endif
+%{?check_version_suffix:%check_version_suffix}
 
 %build
 

--- a/cmsLHEtoEOSManager.tmpl
+++ b/cmsLHEtoEOSManager.tmpl
@@ -1,4 +1,4 @@
-### RPM cms cmsLHEtoEOSManager @VERSION@00
+### RPM cms cmsLHEtoEOSManager @VERSION@01
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 

--- a/cmssw-ib.spec
+++ b/cmssw-ib.spec
@@ -7,6 +7,7 @@ BuildRequires: cmssw SCRAMV1
 Source: https://raw.githubusercontent.com/cms-sw/cms-bot/0a77459fa43029366cb43ae03c1f67b4176df095/buildLogAnalyzer.py
 
 %prep
+%{?check_version_suffix:%check_version_suffix}
 cd ..
 %build
 cd $CMSSW_ROOT

--- a/cmssw-wm-tools.spec
+++ b/cmssw-wm-tools.spec
@@ -1,7 +1,7 @@
 ################################################################
 ####For any change, always update version number to latest date#
 ################################################################
-### RPM cms cmssw-wm-tools 210915
+### RPM cms cmssw-wm-tools 211103
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -10,10 +10,7 @@
 Source0: git://github.com/cms-sw/%{n}.git?obj=%{branch}/%{commit}&export=%{n}&output=/%{n}-%{commit}.tgz
 
 %prep
-%if "%{v}" != "%{realversion}"
-  echo "ERROR: %{v} does not match %{realversion}. Please update version number for %{n}."
-  exit 1
-%endif
+%{?check_version_suffix:%check_version_suffix}
 %setup -n %{n}
 
 %build

--- a/crab-build.file
+++ b/crab-build.file
@@ -18,10 +18,7 @@ Source2: git://github.com/dmwm/CRABServer.git?obj=master/%{crabserver_version}&e
 Source3: git://github.com/dmwm/DBS.git?obj=master/%{dbs_version}&export=DBS&output=/DBS-%{dbs_version}.tar.gz
 
 %prep
-if [ "%{v}" != "%{realversion}" ] ; then
-  echo "ERROR: %{v} not same as %{realversion}. Please increment version suffix in %{n}.spec file."
-  exit 1
-fi
+%{?check_version_suffix:%check_version_suffix}
 %setup -D -T -b 0 -n CRABClient
 %setup -D -T -b 1 -n WMCore
 %setup -D -T -b 2 -n CRABServer

--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.211026
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.5.3

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.210323
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.6.crab6

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.210825
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.6.crab6

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -273,11 +273,21 @@ fi
 
 %define common_revision_script() \
   OLD_REV=0 \
-  if [ -f %2 ] ; then OLD_REV=$(grep '^\s*#\s*CMSDIST_FILE_REVISION\s*=' %{2} | tail -1 | sed 's|.*=||;s| ||g') ; fi \
+  if [ -f %{2} ] ; then OLD_REV=$(grep '^\s*#\s*CMSDIST_FILE_REVISION\s*=' %{2} | tail -1 | sed 's|.*=||;s| ||g') ; fi \
   NEW_REV=$(grep '^\s*#\s*CMSDIST_FILE_REVISION\s*=' %{1} | tail -1 | sed 's|.*=||;s| ||g') \
-  if [ ${OLD_REV} -lt ${NEW_REV} ] ; then rm -f %2 ; cp %1 %2 ; fi
+  if [ ${OLD_REV} -lt ${NEW_REV} ] ; then rm -f %{2} ; cp %{1} %{2} ; fi
 
 %define cms_python2_major_minor_version %(echo %{allpkgreqs} | tr ' ' '\\n' | grep /python/ | cut -d/ -f3 | cut -f1,2 -d.)
 %define cms_python2_major_minor $(echo %{cms_python2_major_minor_version} | sed 's|[.]||')
 %define cms_python3_major_minor_version %(echo %{allpkgreqs} | tr ' ' '\\n' | grep /python3/ | cut -d/ -f3 | cut -f1,2 -d.)
 %define cms_python3_major_minor $(echo %{cms_python3_major_minor_version} | sed 's|[.]||')
+
+%if "%{?allow_version_suffix:set}" == "set"
+%define check_version_suffix echo "%%allow_version_suffix defined, skipping version suffix check."
+%else
+%define check_version_suffix \
+  if [ "%{v}" != "%{realversion}" ] ; then \
+    echo "ERROR: %{v} not same as %{realversion}. Automatic version suffix was added, please update the version explicitly for %{n}.spec to avoid this error." ;\
+    exit 1 ;\
+  fi
+%endif


### PR DESCRIPTION
- update crab suffix due to change in crab-build
- explicitly update versions to avoid version suffix