### PR TITLE
Py3 cleanup: drop py3-rep

### DIFF
--- a/pip/pkgconfig.file
+++ b/pip/pkgconfig.file
@@ -1,2 +1,1 @@
-Requires: py3-nose
 Requires: py3-poetry

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -31,7 +31,7 @@ avro==1.10.2
 awkward==1.5.1
 backcall==0.2.0
 backports-entry-points-selectable==1.1.0
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
 beniget==0.4.1
 bleach==4.1.0
 bokeh==2.3.3

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -29,10 +29,7 @@ Requires: py3-xgboost
 Requires: py3-llvmlite
 Requires: py3-numba
 Requires: py3-hep_ml
-Requires: py3-rep
 Requires: py3-uncertainties
-Requires: py3-hyperas
-Requires: py3-hyperopt
 Requires: py3-seaborn
 Requires: py3-h5py
 Requires: py3-h5py-cache
@@ -103,7 +100,6 @@ Requires: py3-mpmath
 Requires: py3-sympy
 Requires: py3-tqdm
 Requires: py3-funcsigs
-Requires: py3-nose
 Requires: py3-pkgconfig
 Requires: py3-Click
 Requires: py3-jsonpickle
@@ -180,7 +176,6 @@ Requires: py3-bokeh py3-bokeh
 Requires: py3-climate
 Requires: py3-mpld3
 Requires: py3-neurolab
-Requires: py3-nose-parameterized
 Requires: py3-pillow
 Requires: py3-pybrain
 Requires: py3-pymongo

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -17,7 +17,6 @@ Requires: py3-cmsml
 Requires: py3-law
 Requires: py3-protobuf
 
-Requires: py3-cloudpickle
 Requires: py3-tables
 Requires: py3-numexpr
 Requires: py3-histogrammar
@@ -172,13 +171,8 @@ Requires: py3-grpcio-tools
 Requires: py3-Markdown
 Requires: py3-subprocess32
 Requires: py3-kiwisolver
-Requires: py3-bokeh py3-bokeh
 Requires: py3-climate
-Requires: py3-mpld3
-Requires: py3-neurolab
 Requires: py3-pillow
-Requires: py3-pybrain
-Requires: py3-pymongo
 Requires: py3-pydot
 
 Requires: py3-astroid


### PR DESCRIPTION
Dropped `py3-rep` and extra py3 packages which are only used by `py3-rep`