### PR TITLE
Update mkFit release to V3.5.1-0

### DIFF
--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,6 +1,6 @@
-### RPM external mkfit 3.4.0
+### RPM external mkfit 3.5.0
 ## INCLUDE compilation_flags
-%define tag V3.4.0-0+pr369
+%define tag V3.5.0-0+pr380
 %define branch devel
 %define github_user trackreco
 

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,6 +1,6 @@
-### RPM external mkfit 3.5.0
+### RPM external mkfit 3.5.1
 ## INCLUDE compilation_flags
-%define tag V3.5.0-0+pr380
+%define tag V3.5.1-0+pr382
 %define branch devel
 %define github_user trackreco
 


### PR DESCRIPTION
https://github.com/trackreco/mkFit/releases/tag/V3.5.1-0%2Bpr382

Related to cms-sw/cmssw#35974 and cms-data/RecoTracker-MkFit#7.
Note: this PR was updated in response to BTV results in https://its.cern.ch/jira/browse/PDMVRELVALS-136
