### PR TITLE
Include tensorflow dependencies

### DIFF
--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -4,6 +4,7 @@
 %else
 %define source_package tensorflow-sources_%{vectorized_package}
 %endif
+## INCLUDE tensorflow-requires
 BuildRequires: %{source_package}
 %define tf_root %(echo %{source_package}_ROOT | tr '[a-z-]' '[A-Z_]')
 %define tf_version %(echo %{source_package}_VERSION | tr '[a-z-]' '[A-Z_]')


### PR DESCRIPTION
Include the tensorflow dependencies otherwise installing only tensorflow package end up with error
```
The following NEW packages will be installed:
  external+gcc+9.3.0-3cf91c792ceaa2a3434a606b35cb6063
  external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b
0 upgraded, 2 newly installed, 0 removed and 0 not upgraded.
TIME: Downlaod: 5.432518720626831 secs for 2 packages
Continue installation (Y/n): Y
Downloaded 255MB of archives.
After unpacking 1041MB of additional disk space will be used.
Executing RPM (source /build/muz/cc8/share/cms/cmspkg/V00-00-47/rpm_env.sh cc8_amd64_gcc9; rpm -U -v -h -r /build/muz/cc8 --prefix /build/muz/cc8 --force --ignoreos --ignorearch --oldpackage)...
error: Failed dependencies:
        libgif.so.5()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libgpr.so.14()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libgrpc++.so.1()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libgrpc.so.14()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libjpeg.so.8()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libjpeg.so.8(LIBJPEG_8.0)(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libpng16.so.16()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libpng16.so.16(PNG16_0)(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libprotobuf.so.3.15.1.0()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libsqlite3.so.0()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libz.so.1()(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64
        libz.so.1(ZLIB_1.2.0)(64bit) is needed by external+tensorflow+2.6.0-f736082d44a444a9c5ce73128ed2e48b-1-1.x86_64

```