### PR TITLE
Drop py3-nbdime from cmssw distribution

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -159,7 +159,7 @@ mpmath==1.2.1
 multidict==5.1.0
 nbclient==0.5.4
 nbconvert==6.1.0
-nbdime==3.1.0
+#nbdime==3.1.0 ; disabled not used by cmssw
 nbformat==5.1.3
 nest-asyncio==1.5.1
 networkx==2.6.2

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -7,6 +7,8 @@ Requires: root curl python python3 xrootd llvm hdf5 mxnet-predict yoda opencv
 Requires: professor2 rivet frontier_client onnxruntime openldap
 Requires: py2-future
 
+Requires: py3-anyio
+Requires: py3-sniffio
 Requires: py3-scipy
 Requires: py3-keras
 Requires: py3-Theano

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -139,7 +139,6 @@ Requires: py3-typing
 Requires: py3-defusedxml
 Requires: py3-atomicwrites
 Requires: py3-attrs
-Requires: py3-nbdime
 Requires: py3-onnx
 Requires: py3-onnxmltools
 Requires: py3-colorama


### PR DESCRIPTION
This should fix the security issue reported https://github.com/cms-sw/cmsdist/security/dependabot/pip/requirements.txt/nbdime/open