### PR TITLE
New specfile for py3 crabserver REST interface

### DIFF
--- a/comp.spec
+++ b/comp.spec
@@ -5,7 +5,7 @@
 # CMSWEB
 Requires: frontend das dbs3 reqmon
 Requires: dqmgui workqueue
-Requires: dbs3-client crabserver
+Requires: dbs3-client crabserver crabserver-py3
 Requires: acdcserver
 Requires: t0wmadatasvc dbs3-migration t0_reqmon reqmgr2 reqmgr2ms
 Requires: cmsweb-analytics

--- a/crabserver-py3.spec
+++ b/crabserver-py3.spec
@@ -1,0 +1,73 @@
+### RPM cms crabserver-py3 py3.211104patch1
+
+## INITENV +PATH PATH %i/xbin
+## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
+## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
+
+
+%define webdoc_files %{installroot}/%{pkgrel}/doc/
+%define wmcver 1.5.4
+
+Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
+Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
+
+# python
+Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle py3-dbs3-client py3-dbs3-pycurl-client 
+Requires: py3-retry py3-boto3 py3-future py3-pyOpenSSL py3-htcondor rotatelogs jemalloc
+BuildRequires: py3-sphinx
+#Patch1: crabserver3-setup
+
+%prep
+%setup -D -T -b 1 -n CRABServer-%{realversion}
+%setup -T -b 0 -n WMCore-%{wmcver}
+#%patch1 -p1
+
+%build
+touch $PWD/condor_config
+export CONDOR_CONFIG=$PWD/condor_config
+cd ../WMCore-%{wmcver}
+python3 setup.py build_system -s crabserver --skip-docs
+PYTHONPATH=$PWD/build/lib:$PYTHONPATH
+
+cd ../CRABServer-%{realversion}
+perl -p -i -e "s{<VERSION>}{%{realversion}}g" doc/crabserver/conf.py
+echo -e "\n__version__ = \"%{realversion}\"#Automatically added during RPM build process" >> src/python/CRABInterface/__init__.py
+python3 setup.py build_system -s CRABInterface --skip-docs=d
+
+%install
+mkdir -p %i/etc/profile.d %i/{x,}{bin,lib,data,doc} %i/{x,}$PYTHON_LIB_SITE_PACKAGES
+touch $PWD/condor_config
+export CONDOR_CONFIG=$PWD/condor_config
+cd ../WMCore-%{wmcver}
+python3 setup.py install_system -s crabserver --prefix=%i
+cd ../CRABServer-%{realversion}
+python3 setup.py install_system -s CRABInterface --prefix=%i
+find %i -name '*.egg-info' -exec rm {} \;
+
+# mkdir -p %i/bin # copied, dunno if it is necessary
+# cp -pfr %_builddir/%n/bin/[[:lower:]]* %i/bin # copied, dunno if it is necessary
+egrep -r -l '^#!.*python' %i | xargs perl -p -i -e 's{^#!.*python.*}{#!/usr/bin/env python3}'
+
+# Generate .pyc files.
+python3 -m compileall %i/$PYTHON_LIB_SITE_PACKAGES/CRABServer || true
+
+# Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
+mkdir -p %i/etc/profile.d
+: > %i/etc/profile.d/dependencies-setup.sh
+: > %i/etc/profile.d/dependencies-setup.csh
+for tool in $(echo %{requiredtools} | sed -e's|\s+| |;s|^\s+||'); do
+  root=$(echo $tool | tr a-z- A-Z_)_ROOT; eval r=\$$root
+  if [ X"$r" != X ] && [ -r "$r/etc/profile.d/init.sh" ]; then
+    echo "test X\$$root != X || . $r/etc/profile.d/init.sh" >> %i/etc/profile.d/dependencies-setup.sh
+    echo "test X\$?$root = X1 || source $r/etc/profile.d/init.csh" >> %i/etc/profile.d/dependencies-setup.csh
+  fi
+done
+
+%post
+%{relocateConfig}etc/profile.d/dependencies-setup.*sh
+
+%files
+%{installroot}/%{pkgrel}/
+%exclude %{installroot}/%{pkgrel}/doc
+
+## SUBPACKAGE webdoc


### PR DESCRIPTION
While we migrate the dmwm/CRABServer code related to crabserver REST interface, we convened that it is convinient to have two separate specfiles, one for a py2 environment for crabserver and one for py3.

After the migration is complete, we plan to replace `crabserver.spec` with `crabserver-py3.spec`.