### PR TITLE
dont add WMCore packages to crab-dev client

### DIFF
--- a/crab-build.file
+++ b/crab-build.file
@@ -40,13 +40,19 @@ echo dbs >> %{i}/etc/crab_py_pkgs.txt
 echo RestClient >> %{i}/etc/crab_py_pkgs.txt
 
 #Copy WMCore
-for pkg in %{wmcore_packages} ; do
-  if [ -d %{_builddir}/WMCore/src/python/${pkg} ] ; then
-    rsync -a %{_builddir}/WMCore/src/python/${pkg} %{i}/lib/
-  else
-    cp %{_builddir}/WMCore/src/python/${pkg} %{i}/lib/${pkg}
-  fi
-done
+if [ "%{crab_type}" != "dev" ] ; then
+  for pkg in %{wmcore_packages} ; do
+    if [ -d %{_builddir}/WMCore/src/python/${pkg} ] ; then
+      rsync -a %{_builddir}/WMCore/src/python/${pkg} %{i}/lib/
+    else
+      cp %{_builddir}/WMCore/src/python/${pkg} %{i}/lib/${pkg}
+    fi
+  done
+else
+  mkdir %{i}/lib/WMCore
+  cp %{_builddir}/CRABClient/src/python/CRABClient/WMCoreConfigWrapper.py %{i}/lib/WMCore/Configuration.py 
+  touch %{i}/lib/WMCore/__init__.py
+fi
 
 #Copy CRABServer
 for pkg in %{crabserver_packages} ; do

--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.211112
+%define crabclient_version v3.211117
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.5.3
 %define crabserver_version v3.211025

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 01
+%define version_suffix 02
 %define crabclient_version v3.210323
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.6.crab6

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 01
+%define version_suffix 02
 %define crabclient_version v3.210825
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.6.crab6


### PR DESCRIPTION
changes:
- dont add WMCore packages to crab-dev client, instead copy WMCoreConfigWrapper.py to WMCore dir and rename it to Configuration.py. This will allow users to keep in their config files `from WMCore.Configuration import Configuration` line instead of changing it to `from CRABClient.Configuration import Configuration`;
- update to v3.211117 version

fyi @belforte 