### PR TITLE
Update mkFit release for CMSSW_12_2_0_pre3

### DIFF
--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,6 +1,6 @@
-### RPM external mkfit 3.5.1
+### RPM external mkfit 3.5.2
 ## INCLUDE compilation_flags
-%define tag V3.5.1-0+pr382
+%define tag V3.5.2-0+pr387
 %define branch devel
 %define github_user trackreco
 

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,6 +1,6 @@
-### RPM external mkfit 3.5.2
+### RPM external mkfit 3.5.3
 ## INCLUDE compilation_flags
-%define tag V3.5.2-0+pr387
+%define tag V3.5.3-0+pr388
 %define branch devel
 %define github_user trackreco
 


### PR DESCRIPTION
https://github.com/trackreco/mkFit/releases/tag/V3.5.3-0%2Bpr388

Related to cms-sw/cmssw#36246 and cms-data/RecoTracker-MkFit#8.

Note: this PR was update on November 28th, following a technical update in mkFit (with a new mkFit release), that allowed to obtain a further speedup with no change in physics.
