### PR TITLE
BuildRules: Do not add EDM_TOOL_PREFIX if unit tests sets NO_TEST_PREFIX

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-00-00
+%define configtag       V07-00-01
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
The new flag can be used by unit tests for ASAN IBs. This will allow scram to not set `LD_PRELOAD=libasan.so` which causes some unit tests to hang e.g. [a] which hangs for one hour

```
===== Test "TestDQMOnlineClient-beam_dqm_sourceclient" ====
+ [[ 1 -eq 0 ]]
+ [[ -z '' ]]
+ LOCAL_TEST_DIR=.
+ [[ -z '' ]]
+ CLIENTS_DIR=./src/DQM/Integration/python/clients
+ mkdir -p ./upload
+ cmsRun ./src/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py unitTest=True
Querying DAS for files...
the query is file run=344518 dataset=/ExpressCosmics/Commissioning2021-Express-v1/FEVT lumi=1

---> test TestDQMOnlineClient-beam_dqm_sourceclient had ERRORS
TestTime:3600
^^^^ End Test TestDQMOnlineClient-beam_dqm_sourceclient ^^^^
```