### PR TITLE
crabtaskworker - py3-compatible env specfile

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -42,9 +42,9 @@ touch $PWD/condor_config
 export CONDOR_CONFIG=$PWD/condor_config
 cd ../WMCore-%{wmcver}
 %if "%{version_prefix}" == "py3"
-python3 setup.py build_system -s crabserver --skip-docs
+%{python_runtime} setup.py build_system -s crabserver --skip-docs
 %else
-python setup.py build_system -s crabserver
+%{python_runtime} setup.py build_system -s crabserver
 %endif
 PYTHONPATH=$PWD/build/lib:$PYTHONPATH
 

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -21,6 +21,7 @@ Requires: py3-retry
 Requires: py3-rucio-clients py3-future
 Requires: jemalloc
 %else
+%define python_runtime %(echo python)
 %define wmcver 1.4.6.pre2
 Requires: p5-time-hires
 Requires: python dbs3-client py2-pycurl py2-httplib2 cherrypy condor python-ldap py2-retry

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -1,23 +1,40 @@
 ### RPM cms crabtaskworker v3.210301
 
+# This specfile accepts both following types of tags:
+# - v3.210701 -> builds py2 environment
+# - py3.211129 -> build py3 environment
+
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
+
+%define version_prefix %(echo %{realversion} | cut -d. -f1)
+%if "%{version_prefix}" == "py3"
+%define python_runtime %(echo python3)
+%define wmcver 1.5.5
+Requires: p5-time-hires
+Requires: python3 py3-dbs3-client py3-pycurl py3-httplib2 py3-cherrypy py3-htcondor 
+# Requires: py3-ldap 
+Requires: py3-retry
+Requires: py3-rucio-clients py3-future
+Requires: jemalloc
+%else
 %define wmcver 1.4.6.pre2
+Requires: p5-time-hires
+Requires: python dbs3-client py2-pycurl py2-httplib2 cherrypy condor python-ldap py2-retry
+Requires: py2-rucio-clients py2-ipython py2-future
+Requires: jemalloc
+BuildRequires: py2-sphinx
+%endif
+
 
 Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 #Patch0: crabtaskworker_cherrypy
 
 #Patch0: crabserver3-setup
-
-Requires: p5-time-hires
-Requires: python dbs3-client py2-pycurl py2-httplib2 cherrypy condor python-ldap py2-retry
-Requires: py2-rucio-clients py2-ipython py2-future
-Requires: jemalloc
-BuildRequires: py2-sphinx
 
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}
@@ -29,13 +46,21 @@ BuildRequires: py2-sphinx
 touch $PWD/condor_config
 export CONDOR_CONFIG=$PWD/condor_config
 cd ../WMCore-%{wmcver}
-python setup.py build_system -s crabtaskworker
+%if "%{version_prefix}" == "py3"
+%{python_runtime} setup.py build_system -s crabtaskworker --skip-docs
+%else
+%{python_runtime} setup.py build_system -s crabtaskworker
+%endif
 PYTHONPATH=$PWD/build/lib:$PYTHONPATH
 
 cd ../CRABServer-%{realversion}
 perl -p -i -e "s{<VERSION>}{%{realversion}}g" doc/taskworker/conf.py
 echo -e "\n__version__ = \"%{realversion}\"#Automatically added during RPM build process" >> src/python/TaskWorker/__init__.py
-python setup.py build_system -s TaskWorker
+%if "%{version_prefix}" == "py3"
+%{python_runtime} setup.py build_system -s TaskWorker --skip-docs=d
+%else
+%{python_runtime} setup.py build_system -s TaskWorker
+%endif
 
 sed -i 's|CRAB3_VERSION=.*|CRAB3_VERSION=%{realversion}|' bin/htcondor_make_runtime.sh
 sed -i 's|CRABSERVERVER=.*|CRABSERVERVER=%{realversion}|' bin/htcondor_make_runtime.sh
@@ -48,15 +73,15 @@ mkdir -p %i/etc/profile.d %i/{x,}{bin,lib,data,doc} %i/{x,}$PYTHON_LIB_SITE_PACK
 touch $PWD/condor_config
 export CONDOR_CONFIG=$PWD/condor_config
 cd ../WMCore-%{wmcver}
-python setup.py install_system -s  crabtaskworker --prefix=%i
+%{python_runtime} setup.py install_system -s  crabtaskworker --prefix=%i
 cd ../CRABServer-%{realversion}
-python setup.py install_system -s TaskWorker  --prefix=%i
+%{python_runtime} setup.py install_system -s TaskWorker  --prefix=%i
 cp TaskManagerRun-%{realversion}.tar.gz  %i/data/TaskManagerRun.tar.gz
 cp CMSRunAnalysis-%{realversion}.tar.gz  %i/data/CMSRunAnalysis.tar.gz
 find %i -name '*.egg-info' -exec rm {} \;
 
 # Generate .pyc files.
-python -m compileall %i/$PYTHON_LIB_SITE_PACKAGES/CRABServer || true
+%{python_runtime} -m compileall %i/$PYTHON_LIB_SITE_PACKAGES/CRABServer || true
 
 # Generate dependencies-setup.{sh,csh} so init.{sh,csh} picks full environment.
 mkdir -p %i/etc/profile.d


### PR DESCRIPTION
This is ready to be merged.

changes:
- `crabserver.spec`: small changes
- `crabtaskworker.spec`: py3 env for tasworker, emulating changes to `crabserver.spec`. excluding ldap temporarily
- `py3-ldap.spec`: first draft, not working yet -> excluded from this PR. build fails with [1]. We would like to proceed with this PR anyway to start working on TW py3 migration, then we will make a new PR when we have a proper solution. Building directly with pip builder fails with [2]

fyi: @belforte 

[1]:

```plaintext
* The action "build-cms+crabtaskworker+py3.211129" was not completed successfully because The following dependencies could not complete:
install-external+py3-ldap+3.4.0
* The action "install-external+py3-ldap+3.4.0" was not completed successfully because The following dependencies could not complete:
build-external+py3-ldap+3.4.0
* The action "install-cms+crabtaskworker-webdoc+py3.211129" was not completed successfully because The following dependencies could not complete:
install-cms+crabtaskworker+py3.211129
* The action "build-cms+crab-devtools+1.1-comp110" was not completed successfully because The following dependencies could not complete:
install-cms+crabtaskworker+py3.211129
* The action "final-job" was not completed successfully because The following dependencies could not complete:
build-external+py3-ldap+3.4.0
* The action "install-cms+crab-devtools+1.1-comp110" was not completed successfully because The following dependencies could not complete:
build-cms+crab-devtools+1.1-comp110
* The action "build-cms+comp+HG2112b-comp" was not completed successfully because The following dependencies could not complete:
install-cms+crabtaskworker+py3.211129
* The action "install-cms+comp+HG2112b-comp" was not completed successfully because The following dependencies could not complete:
build-cms+comp+HG2112b-comp
* The action "build-external+py3-ldap+3.4.0" was not completed successfully because Failed to build py3-ldap. Log file in /build/dmapelli/w/BUILD/slc7_amd64_gcc630/external/py3-ldap/3.4.0/log. Final lines of the log file:
copying Lib/slapdtest/certs/server.conf -> build/lib.linux-x86_64-3.8/slapdtest/certs
copying Lib/slapdtest/certs/server.key -> build/lib.linux-x86_64-3.8/slapdtest/certs
copying Lib/slapdtest/certs/server.pem -> build/lib.linux-x86_64-3.8/slapdtest/certs
running build_ext
building '_ldap' extension
creating build/temp.linux-x86_64-3.8
creating build/temp.linux-x86_64-3.8/Modules
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DHAVE_TLS -DHAVE_LIBLDAP_R -DHAVE_LIBLDAP_R -DLDAPMODULE_VERSION=3.4.0 -DLDAPMODULE_AUTHOR=python-ldap project -DLDAPMODULE_LICENSE=Python style -IModules -I/build/dmapelli/w/slc7_amd64_gcc630/external/python3/3.8.2-comp/include/python3.8 -c Modules/LDAPObject.c -o build/temp.linux-x86_64-3.8/Modules/LDAPObject.o
In file included from Modules/LDAPObject.c:3:0:
Modules/common.h:15:18: fatal error: lber.h: No such file or directory
#include <lber.h>
^
compilation terminated.
error: command 'gcc' failed with exit status 1
error: Bad exit status from /build/dmapelli/w/tmp/rpm-tmp.qdzCdr (%build)


RPM build errors:
Macro %rpmbuild_libdir defined but not used within scope
Bad exit status from /build/dmapelli/w/tmp/rpm-tmp.qdzCdr (%build)

* The action "install-cms+crabtaskworker+py3.211129" was not completed successfully because The following dependencies could not complete:
build-cms+crabtaskworker+py3.211129
```

[2]:

```plaintext
* The action "install-cms+crab-devtools+1.1-comp110" was not completed successfully because The following dependencies could not complete:
build-cms+crab-devtools+1.1-comp110
* The action "build-cms+comp+HG2112b-comp" was not completed successfully because The following dependencies could not complete:
install-cms+crabtaskworker+py3.211129
* The action "install-cms+comp+HG2112b-comp" was not completed successfully because The following dependencies could not complete:
build-cms+comp+HG2112b-comp
* The action "build-external+py3-ldap+3.4.0" was not completed successfully because Failed to build py3-ldap. Log file in /build/dmapelli/w/BUILD/slc7_amd64_gcc630/external/py3-ldap/3.4.0/log. Final lines of the log file:
Building wheel for python-ldap (PEP 517): finished with status 'error'
ERROR: Failed building wheel for python-ldap
Failed to build python-ldap
ERROR: Could not build wheels for python-ldap which use PEP 517 and cannot be installed directly
Exception information:
Traceback (most recent call last):
File "/build/dmapelli/w/slc7_amd64_gcc630/external/py3-pip/20.3.3/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 224, in _main
status = self.run(options, args)
File "/build/dmapelli/w/slc7_amd64_gcc630/external/py3-pip/20.3.3/lib/python3.8/site-packages/pip/_internal/cli/req_command.py", line 180, in wrapper
return func(self, options, args)
File "/build/dmapelli/w/slc7_amd64_gcc630/external/py3-pip/20.3.3/lib/python3.8/site-packages/pip/_internal/commands/install.py", line 361, in run
raise InstallationError(
pip._internal.exceptions.InstallationError: Could not build wheels for python-ldap which use PEP 517 and cannot be installed directly
Removed build tracker: '/build/dmapelli/w/tmp/pip-req-tracker-lv72ypqj'
error: Bad exit status from /build/dmapelli/w/tmp/rpm-tmp.gUNOYa (%build)


RPM build errors:
Macro %rpmbuild_libdir defined but not used within scope
Bad exit status from /build/dmapelli/w/tmp/rpm-tmp.gUNOYa (%build)

* The action "install-cms+crabtaskworker+py3.211129" was not completed successfully because The following dependencies could not complete:
build-cms+crabtaskworker+py3.211129
```