### PR TITLE
[12.1.X] Update of mkFit release and configuration (backport of PRs #7465 + #7481)

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,7 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
-RecoTracker-MkFit=V00-07-00
+RecoTracker-MkFit=V00-08-00
 DQM-EcalMonitorClient=V00-01-00
 PhysicsTools-NanoAOD=V01-02-00
 RecoTracker-FinalTrackSelectors=V01-02-00

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -1,6 +1,6 @@
-### RPM external mkfit 3.5.1
+### RPM external mkfit 3.5.3
 ## INCLUDE compilation_flags
-%define tag V3.5.1-0+pr382
+%define tag V3.5.3-0+pr388
 %define branch devel
 %define github_user trackreco
 


### PR DESCRIPTION
### PR description

Backport to 12_1_X of PRs #7465 + #7481 (cms-data/RecoTracker-MkFit#8).
This is related to backport of PR cms-sw/cmssw#36246, realized in cms-sw/cmssw#36315.