### PR TITLE
Update RecoTracker-FinalTrackSelectors tag (backport of #36285)

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -6,7 +6,7 @@
 RecoTracker-MkFit=V00-07-00
 DQM-EcalMonitorClient=V00-01-00
 PhysicsTools-NanoAOD=V01-02-00
-RecoTracker-FinalTrackSelectors=V01-02-00
+RecoTracker-FinalTrackSelectors=V01-03-00
 RecoTauTag-TrainingFiles=V00-03-00
 RecoEgamma-ElectronIdentification=V01-08-00
 RecoEgamma-PhotonIdentification=V01-02-00


### PR DESCRIPTION
Update the tag for RecoTracker-FinalTrackSelectors to complete backport of https://github.com/cms-sw/cmssw/pull/36285 to CMSSW_12_1_X, which is done in https://github.com/cms-sw/cmssw/pull/36327. This is needed to use the updated track DNN selection network file introduced in https://github.com/cms-data/RecoTracker-FinalTrackSelectors/pull/11 in CMSSW_12_1_X to match the version of mkFit that is also being backported to that release. 