### PR TITLE
Update python-ldap 3.4.0

### DIFF
--- a/pip/python-ldap.file
+++ b/pip/python-ldap.file
@@ -1,2 +1,4 @@
 Requires: openldap py3-pyasn1-modules
-%define PipBuildOptions --global-option=build_ext --global-option="-L${PYTHON3_ROOT}/lib" --global-option="-L${OPENLDAP_ROOT}/lib" --global-option="-I${PYTHON3_ROOT}/include" --global-option="-I${OPENLDAP_ROOT}/include"  --global-option="-UHAVE_SASL"
+%define patchsrc0 sed -i -e "s|\\[_ldap\\]|[_ldap]\\ninclude_dirs = ${PYTHON3_ROOT}/include ${OPENLDAP_ROOT}/include|" setup.cfg
+%define patchsrc1 sed -i -e "s|\\[_ldap\\]|[_ldap]\\nlibrary_dirs = ${PYTHON3_ROOT}/lib ${OPENLDAP_ROOT}/lib|" setup.cfg
+%define patchsrc2 sed -i -e "s|HAVE_SASL||" setup.cfg

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -230,7 +230,7 @@ pytest-cov==2.12.1
 pytest-runner==5.3.1
 python-daemon==2.3.0
 python-dateutil==2.8.2
-python-ldap==3.3.1
+python-ldap==3.4.0
 python-rapidjson==1.4
 pythran==0.9.12.post1
 pytoml==0.1.21


### PR DESCRIPTION
The LDAP schema parser of python-ldap 3.3.1 and earlier are vulnerable to a regular expression denial-of-service attack. The issue affects clients that use ldap.schema package to parse LDAP schema definitions from an untrusted source.