### PR TITLE
Drop qtconsole, qtpy and py3-jupyter

### DIFF
--- a/pip/jupyter.file
+++ b/pip/jupyter.file
@@ -1,1 +1,0 @@
-Requires: py3-notebook py3-qtconsole py3-jupyter-console py3-nbconvert py3-ipykernel py3-ipywidgets

--- a/pip/qtconsole.file
+++ b/pip/qtconsole.file
@@ -1,1 +1,0 @@
-Requires: py3-ipykernel py3-QtPy

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -238,8 +238,6 @@ pytools==2021.2.8
 pytz==2021.1
 PyYAML==5.4.1
 pyzmq==22.2.1
-qtconsole==5.1.1
-QtPy==1.11.0
 repoze-lru==0.7
 rep==0.6.6
 requests==2.26.0

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -124,7 +124,6 @@ jupyter-client==7.0.2
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.10.4
-jupyter==1.0.0
 jupyterlab-pygments==0.1.2
 jupyter-server==1.10.2
 jupyter-server-mathjax==0.2.3

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -57,7 +57,6 @@ Requires: py3-ipython
 Requires: py3-ipython_genutils
 Requires: py3-ipywidgets
 Requires: py3-jsonschema
-Requires: py3-jupyter
 Requires: py3-jupyter-client
 Requires: py3-jupyter-console
 Requires: py3-jupyter-core

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -74,7 +74,6 @@ Requires: py3-prompt_toolkit
 Requires: py3-ptyprocess
 Requires: py3-pyparsing
 Requires: py3-pyzmq
-Requires: py3-qtconsole
 Requires: py3-scandir
 Requires: py3-setuptools
 Requires: py3-simplegeneric


### PR DESCRIPTION
Qt5 was dropped in this PR: https://github.com/cms-sw/cmsdist/pull/5648
py3-jupyter is a metapackage (i.e. contain no code, only dependencies) to install jupyter and dependencies in one go.