### PR TITLE
crabserver.spec: temporarily uses private WMCore branch for py3-env

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -14,12 +14,14 @@
 %define version_prefix %(echo %{realversion} | cut -d. -f1)
 %if "%{version_prefix}" == "py3"
 %define python_runtime %(echo python3)
-%define wmcver 1.5.5
+%define wmcrepo mapellidario
+%define wmcver py3.211209 
 Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle py3-dbs3-client py3-dbs3-pycurl-client 
 Requires: py3-retry py3-boto3 py3-future py3-pyOpenSSL py3-htcondor rotatelogs jemalloc
 BuildRequires: py3-sphinx
 %else
 %define python_runtime %(echo python)
+%define wmcrepo dmwm
 %define wmcver 1.4.6.crab1
 Requires: python py2-ipython py2-cherrypy py2-cjson rotatelogs py2-pycurl py2-cx-oracle
 Requires: py2-pyOpenSSL condor dbs3-pycurl-client dbs3-client py2-retry py2-future
@@ -29,7 +31,7 @@ BuildRequires: py2-sphinx
 %endif
 #Patch1: crabserver3-setup
 
-Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
+Source0: git://github.com/%{wmcrepo}/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
 %prep


### PR DESCRIPTION
#### status

[tested](https://cmsrep.cern.ch/cmssw/repos/comp.dmapelli/slc7_amd64_gcc630/latest/RPMS/8e/8eac95706c01f9156ec45748c2955525/cms+crabserver+v3.210701-comp6-1-1.slc7_amd64_gcc630.rpm), ready to merge

#### description

We would like to test the py3 crabserver in testbed, with the following requirements:
- we want to use our jenkins setup to build rpms and docker images
- we want to test a fix to a bug in dmwm/WMCore before opening a PR against upstream repo 
- we want to include a change to WMCore for debugging purposes, that we do not plan to open a PR for. We want to

These requirements pushed us towards using our private repo of WMCore in `crabserver.spec` specfile when building a py3 env.

This will be a temporary measure, we will revert back to using upstream repository sooner or later.

fyi: @belforte 

