### PR TITLE
Remove h5py_cache

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -92,8 +92,6 @@ google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 grpcio==1.39.0
 grpcio-tools==1.39.0
-#1.0.1 doesn't download (wheel only?)
-h5py-cache==1.0
 h5py==3.4.0
 hepdata-lib==0.8.1
 hep_ml==0.6.2

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -31,7 +31,6 @@ Requires: py3-hep_ml
 Requires: py3-uncertainties
 Requires: py3-seaborn
 Requires: py3-h5py
-Requires: py3-h5py-cache
 Requires: py3-uproot
 Requires: py3-vector
 Requires: py3-opt-einsum


### PR DESCRIPTION
> This module is now redundant, because its functionality has now been merged into h5py itself, and is available as of h5py version 2.9.0.

from [package github](https://github.com/moble/h5py_cache). Test removed in cms-sw/cmssw#36447