### PR TITLE
crabtaskworker.spec - temporarily uses private WMCore branch for py3-env

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -8,14 +8,13 @@
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-
 %define webdoc_files %{installroot}/%{pkgrel}/doc/
 
 %define version_prefix %(echo %{realversion} | cut -d. -f1)
 %if "%{version_prefix}" == "py3"
 %define python_runtime %(echo python3)
 %define wmcrepo mapellidario
-%define wmcver py3.211209 
+%define wmcver 1.5.5
 Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle py3-dbs3-client py3-dbs3-pycurl-client 
 Requires: py3-retry py3-boto3 py3-future py3-pyOpenSSL py3-htcondor rotatelogs jemalloc
 BuildRequires: py3-sphinx

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -13,6 +13,7 @@
 %define version_prefix %(echo %{realversion} | cut -d. -f1)
 %if "%{version_prefix}" == "py3"
 %define python_runtime %(echo python3)
+%define wmcrepo mapellidario
 %define wmcver 1.5.5
 Requires: p5-time-hires
 Requires: python3 py3-dbs3-client py3-pycurl py3-httplib2 py3-cherrypy py3-htcondor 
@@ -22,6 +23,7 @@ Requires: py3-rucio-clients py3-future
 Requires: jemalloc
 %else
 %define python_runtime %(echo python)
+%define wmcrepo dmwm
 %define wmcver 1.4.6.pre2
 Requires: p5-time-hires
 Requires: python dbs3-client py2-pycurl py2-httplib2 cherrypy condor python-ldap py2-retry
@@ -31,7 +33,7 @@ BuildRequires: py2-sphinx
 %endif
 
 
-Source0: git://github.com/dmwm/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
+Source0: git://github.com/%{wmcrepo}/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
 Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 #Patch0: crabtaskworker_cherrypy
 


### PR DESCRIPTION
#### status

ready to merge

tested, py3 specfiles [here](https://cmsrep.cern.ch/cmssw/repos/comp.dmapelli/slc7_amd64_gcc630/latest/RPMS.json)

#### description

Since our [jenkins build job](https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_BuildOnRelease/) at every new tag build both crabserver and taskworker, replacing the `wmcver` parameter in both `crabserver.spec` and `crabtaskworker.spec`, we need to port to `crabtaskworker.spec` similar changes as in #7496 .

fyi: @belforte 

PS: in `crabserver.spec` i moved back the version of WMCore, since it is going to be replaced anyway by jenkins. we can leave there the "desired" version, not the current one from my repo.