### PR TITLE
Fixes needed for GCC11 IBs

### DIFF
--- a/cmsLHEtoEOSManager.tmpl
+++ b/cmsLHEtoEOSManager.tmpl
@@ -1,4 +1,4 @@
-### RPM cms cmsLHEtoEOSManager @VERSION@01
+### RPM cms cmsLHEtoEOSManager @VERSION@02
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 

--- a/cmssw-wm-tools.spec
+++ b/cmssw-wm-tools.spec
@@ -1,7 +1,7 @@
 ################################################################
 ####For any change, always update version number to latest date#
 ################################################################
-### RPM cms cmssw-wm-tools 211103
+### RPM cms cmssw-wm-tools 211210
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 04
+%define version_suffix 05
 %define crabclient_version v3.210825
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.3.6.crab6

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.211130
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.5.3


### PR DESCRIPTION
GCC 11 IBs rebuilds these packages and fails as cmsBuild adds the hash suffix. I force updated the versions so that cmsBuild do not add hash suffixes