### PR TITLE
fix git to not fail is build direction is not reachable

### DIFF
--- a/git-2.19.0-runtime.patch
+++ b/git-2.19.0-runtime.patch
@@ -1,5 +1,5 @@
 diff --git a/exec-cmd.c b/exec-cmd.c
-index 4f81f44..9102708 100644
+index 7deeab3..927d76c 100644
 --- a/exec-cmd.c
 +++ b/exec-cmd.c
 @@ -35,19 +35,21 @@
@@ -30,3 +30,21 @@ index 4f81f44..9102708 100644
  		prefix = FALLBACK_RUNTIME_PREFIX;
  		trace_printf("RUNTIME_PREFIX requested, "
  				"but prefix computation failed.  "
+@@ -245,7 +247,7 @@ void git_resolve_executable_dir(const char *argv0)
+  */
+ static const char *system_prefix(void)
+ {
+-	return FALLBACK_RUNTIME_PREFIX;
++	return git_exec_path();
+ }
+ 
+ /*
+@@ -269,7 +271,7 @@ char *system_path(const char *path)
+ 	return strbuf_detach(&d, NULL);
+ }
+ 
+-static const char *exec_path_value;
++static const char *exec_path_value = NULL;
+ 
+ void git_set_exec_path(const char *exec_path)
+ {

--- a/git.spec
+++ b/git.spec
@@ -34,6 +34,7 @@ Provides: perl(Time::Local)
 %prep
 %setup -b 0 -n %{n}-%{realversion}
 %patch1 -p1
+sed -i -e 's|$(sysconfdir)/git|etc/git|' Makefile
 
 %build
 export LDFLAGS=""


### PR DESCRIPTION
This fixes the errors like [a] when the directory used for building git package not reachable. This happens as `/data/cmsbuild` directory exists but is not readable by the user who is now trying to use git.

[a]
```
fatal: unable to access '/data/cmsbuild/muz/w/tmp/BUILDROOT/41d8deb8bae89161b7233b9737d9ca24/opt/cmssw/slc7_aarch64_gcc9/external/git/2.23.0-41d8deb8bae89161b7233b9737d9ca24/etc/gitconfig': Permission denied
```