### PR TITLE
crabtaskworker - py3-compatible env specfile with ldap

### DIFF
--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -17,7 +17,7 @@
 %define wmcver 1.5.5
 Requires: p5-time-hires
 Requires: python3 py3-dbs3-client py3-pycurl py3-httplib2 py3-cherrypy py3-htcondor 
-# Requires: py3-ldap 
+Requires: py3-ldap 
 Requires: py3-retry
 Requires: py3-rucio-clients py3-future
 Requires: jemalloc

--- a/py3-ldap.spec
+++ b/py3-ldap.spec
@@ -1,0 +1,10 @@
+### RPM external py3-ldap 3.4.0
+## IMPORT build-with-pip3
+
+%define pip_name python-ldap
+
+Requires: python3 openldap py3-pyasn1 py3-pyasn1modules
+
+%define patchsrc0 sed -i -e "s|\\[_ldap\\]|[_ldap]\\ninclude_dirs = ${PYTHON3_ROOT}/include ${OPENLDAP_ROOT}/include|" setup.cfg
+%define patchsrc1 sed -i -e "s|\\[_ldap\\]|[_ldap]\\nlibrary_dirs = ${PYTHON3_ROOT}/lib ${OPENLDAP_ROOT}/lib|" setup.cfg
+%define patchsrc2 sed -i -e "s|HAVE_SASL||" setup.cfg

--- a/py3-pyasn1.spec
+++ b/py3-pyasn1.spec
@@ -1,0 +1,2 @@
+### RPM external py3-pyasn1 0.4.8 
+## IMPORT build-with-pip3

--- a/py3-pyasn1modules.spec
+++ b/py3-pyasn1modules.spec
@@ -1,0 +1,6 @@
+### RPM external py3-pyasn1modules 0.2.8
+## IMPORT build-with-pip3
+
+%define pip_name pyasn1-modules
+
+Requires: py3-pyasn1


### PR DESCRIPTION
### status

This is ready to merge.

tested:
- [rpm](https://cmsrep.cern.ch/cmssw/repos/comp.dmapelli/slc7_amd64_gcc630/latest/RPMS/23/23afbc6de24810f9a3ae8ece5fb8ceb9/)
- image `cmssw/crabtaskworker:py3.211209patch1.ldap` in `cmsdocker01`

### description

After suggestions from Shahzad, we replicated in `comp_gcc630` the build process of `openldap` that is currently used in the default branch ( `IB/CMSW_12_.../master` ).

inside the docker image, we can now source `ldap`.

```plaintext
[crab3@ac257376fdf4 data]$ source srv/TaskManager/current/slc7_amd64_gcc630/cms/crabtaskworker/py3.211209patch1-comp/etc/profile.d/init.sh 
[crab3@ac257376fdf4 data]$ python3
Python 3.8.2 (default, Jan 22 2021, 17:57:37) 
[GCC 6.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ldap
>>> 
```

fyi: @belforte 