### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient-binary.spec
+++ b/dasgoclient-binary.spec
@@ -1,11 +1,11 @@
-### RPM cms dasgoclient-binary v02.04.36
+### RPM cms dasgoclient-binary v02.04.37
 Source0: git+https://github.com/dmwm/dasgoclient?obj=master/%{realversion}&export=dasgoclient&output=/dasgoclient.tar.gz
 Source1: git+https://github.com/dmwm/cmsauth?obj=master/e9fca92e3335252a5f71d8e6d09c64012f7d3c0c&export=github.com/dmwm/cmsauth&output=/cmsauth.tar.gz
 Source2: git+https://github.com/vkuznet/x509proxy?obj=master/c93f6cae85114060b3b65861ea8436e4e14c54a6&export=github.com/vkuznet/x509proxy&output=/x509proxy.tar.gz
 Source3: git+https://github.com/buger/jsonparser?obj=master/6bd16707875b997f7a60327f888a28a3d28cf8c2&export=github.com/buger/jsonparser&output=/jsonparser.tar.gz
 Source4: git+https://github.com/go-mgo/mgo?obj=v2/3f83fa5005286a7fe593b055f0d7771a7dce4655&export=gopkg.in/mgo.v2&output=/mgo.v2.tar.gz
 Source5: git+https://github.com/pkg/profile?obj=master/3a8809bd8a80f8ecfe4ee1b34b3f37194968617c&export=github.com/pkg/profile&output=/profile.tar.gz
-Source6: git+https://github.com/dmwm/das2go?obj=master/2007d43e3d20b5f269fb6b2f532c43308efd2899&export=github.com/dmwm/das2go&output=/das2go.tar.gz
+Source6: git+https://github.com/dmwm/das2go?obj=master/c338f552707c415b4a2659c72d2fc6489d7a6664&export=github.com/dmwm/das2go&output=/das2go.tar.gz
 Source7: git+https://github.com/sirupsen/logrus?obj=master/a3f95b5c423586578a4e099b11a46c2479628cac&export=github.com/sirupsen/logrus&output=/logrus.tar.gz
 
 Requires: go

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v02.04.36
+### RPM cms dasgoclient v02.04.37
 ## NOCOMPILER
 Source0: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_amd64
 Source1: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_aarch64


### PR DESCRIPTION
It provides proper URLs to `config dataset=/z/v/x` queries pointing to ReqMgr config cache. Switched to new GO compiler and updated code dependencies.