### PR TITLE
adapting crabserver.spec to #7508

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -15,7 +15,7 @@
 %define python_runtime %(echo python3)
 %define wmcrepo mapellidario
 %define wmcver 1.5.5
-Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle py3-dbs3-client py3-dbs3-pycurl-client 
+Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle py3-dbs3-client py3-dbs3-pycurl 
 Requires: py3-retry py3-boto3 py3-future py3-pyOpenSSL py3-htcondor rotatelogs jemalloc
 BuildRequires: py3-sphinx
 %else


### PR DESCRIPTION
#### status

ready to merge, 

tested: [crabserver-py3.211215](https://cmsrep.cern.ch/cmssw/repos/comp.dmapelli/SOURCES/links/slc7_amd64_gcc630-6bbdc2e24e5ed6b7bb059545938bcb49a70c6c4e63cf6a33a3036e8805bf4c00/RPMS/e3/e3ff50671aa49e815ef231c935ce86cc/cms+crabserver+py3.211215-1-1.slc7_amd64_gcc630.rpm)

#### description

After the changes in #7508 , we need to adapt `crabserver.spec`, while `crabtaskwoker.spec` is ok

fyi: @belforte 