### PR TITLE
Drop -fsanitize=pointer-compare from ASAN IB

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-00-03
+%define configtag       V07-00-04
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
see https://github.com/cms-sw/cmssw-config/pull/88 and https://github.com/cms-sw/cmssw/issues/36480