### PR TITLE
[10.6.X] Correctionlib C++ and python2 binding

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -11,6 +11,7 @@
 %define isnotaarch64 %(case %{cmsplatf} in (*_aarch64_*) echo 0 ;; (*) echo 1 ;; esac)
 %define isslc7 %(case %{cmsplatf} in (slc7_amd64*) echo 1 ;; (*) echo 0 ;; esac)
 
+Requires: correctionlib-toolfile
 Requires: google-benchmark-toolfile
 Requires: catch2-toolfile
 Requires: starlight-toolfile

--- a/correctionlib-toolfile.spec
+++ b/correctionlib-toolfile.spec
@@ -1,0 +1,25 @@
+### RPM external correctionlib-toolfile 1.1
+Requires: correctionlib
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/correctionlib.xml
+<tool name="correctionlib" version="@TOOL_VERSION@">
+  <lib name="correctionlib"/>
+  <client>
+    <environment name="CORRECTIONLIB_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$CORRECTIONLIB_BASE/@PYTHON_LIB_SITE_PACKAGES@/correctionlib/include"/>
+    <environment name="LIBDIR" default="$CORRECTIONLIB_BASE/@PYTHON_LIB_SITE_PACKAGES@/correctionlib/lib"/>
+    <environment name="BINDIR" default="$CORRECTIONLIB_BASE/bin"/>
+  </client>
+  <runtime name="PATH" default="$BINDIR" type="path"/>
+</tool>
+EOF_TOOLFILE
+
+export PYTHON_LIB_SITE_PACKAGES
+
+## IMPORT scram-tools-post

--- a/correctionlib.spec
+++ b/correctionlib.spec
@@ -1,0 +1,18 @@
+### RPM external correctionlib 2.1.0
+## INITENV +PATH PYTHON27PATH %i/${PYTHON_LIB_SITE_PACKAGES}
+%define tag v%{realversion}cms0
+Source: none
+
+Requires: zlib python
+
+%prep
+
+%build
+git clone https://github.com/cms-nanoAOD/correctionlib.git --recursive -b %{tag} --depth 1
+cd correctionlib
+make
+
+%install
+cd correctionlib
+make install PREFIX=%i/${PYTHON_LIB_SITE_PACKAGES}/correctionlib
+mkdir -p %i/bin


### PR DESCRIPTION
This uses a special Makefile rather than pip because the normal package is python3-only. This build has the C++ evaluator and python2 bindings only. A subset of the high-level wrapper could be backported as well, in principle.

TODO: in my test area, the python2 binding is not available until I run the corresponding `...build/slc7_amd64_gcc700/external/correctionlib/2.1.0-3822e3561f9af87ea18bc53317ea8ebf/etc/profile.d/init.sh`. Is there anywhere else I have to add the site package since I am not pip installing in cmsdist? For reference, a sufficient python2 test would be:
```python
import correctionlib._core as cc
cs = cc.CorrectionSet.from_file("/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2017_UL/photon.json.gz")
cs["UL-Photon-ID-SF"].evaluate("2017", "sf", "Loose", 1.2, 25.3)
```

Closes #7510 