### PR TITLE
Bump py3 dbs3-client to 4.0.5

### DIFF
--- a/py3-dbs3-client.spec
+++ b/py3-dbs3-client.spec
@@ -1,4 +1,4 @@
-### RPM cms py3-dbs3-client 4.0.4
+### RPM cms py3-dbs3-client 4.0.5
 ## IMPORT build-with-pip3
 Requires: py3-pycurl py3-dbs3-pycurl
 


### PR DESCRIPTION
This has a fix to sanitize the DbsUrl in the DbsApi class, such that no trailing slashes will pass through.