### PR TITLE
crabserver: remove dbs-client, update wmcore. crabtaskworker: update wmcore.

### DIFF
--- a/crabserver.spec
+++ b/crabserver.spec
@@ -14,7 +14,8 @@
 %if "%{version_prefix}" == "py3"
 %define python_runtime %(echo python3)
 %define wmcrepo mapellidario
-%define wmcver 1.5.5
+%define wmcver py3.211221.dario
+%define crabrepo dmwm
 Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle
 Requires: py3-retry py3-boto3 py3-future py3-pyOpenSSL py3-htcondor rotatelogs jemalloc
 BuildRequires: py3-sphinx
@@ -22,6 +23,7 @@ BuildRequires: py3-sphinx
 %define python_runtime %(echo python)
 %define wmcrepo dmwm
 %define wmcver 1.4.6.crab1
+%define crabrepo dmwm
 Requires: python py2-ipython py2-cherrypy py2-cjson rotatelogs py2-pycurl py2-cx-oracle
 Requires: py2-pyOpenSSL condor dbs3-pycurl-client dbs3-client py2-retry py2-future
 Requires: py2-boto3
@@ -31,7 +33,7 @@ BuildRequires: py2-sphinx
 #Patch1: crabserver3-setup
 
 Source0: git://github.com/%{wmcrepo}/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
-Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
+Source1: git://github.com/%{crabrepo}/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 
 %prep
 %setup -D -T -b 1 -n CRABServer-%{realversion}

--- a/crabserver.spec
+++ b/crabserver.spec
@@ -15,7 +15,7 @@
 %define python_runtime %(echo python3)
 %define wmcrepo mapellidario
 %define wmcver 1.5.5
-Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle py3-dbs3-client py3-dbs3-pycurl 
+Requires: python3 py3-cherrypy py3-pycurl py3-cx-oracle
 Requires: py3-retry py3-boto3 py3-future py3-pyOpenSSL py3-htcondor rotatelogs jemalloc
 BuildRequires: py3-sphinx
 %else

--- a/crabtaskworker.spec
+++ b/crabtaskworker.spec
@@ -13,8 +13,9 @@
 %define version_prefix %(echo %{realversion} | cut -d. -f1)
 %if "%{version_prefix}" == "py3"
 %define python_runtime %(echo python3)
-%define wmcrepo mapellidario
-%define wmcver 1.5.5
+%define wmcrepo dmwm
+%define wmcver 1.5.7.pre4
+%define crabrepo dmwm
 Requires: p5-time-hires
 Requires: python3 py3-dbs3-client py3-pycurl py3-httplib2 py3-cherrypy py3-htcondor 
 Requires: py3-ldap 
@@ -25,6 +26,7 @@ Requires: jemalloc
 %define python_runtime %(echo python)
 %define wmcrepo dmwm
 %define wmcver 1.4.6.pre2
+%define crabrepo dmwm
 Requires: p5-time-hires
 Requires: python dbs3-client py2-pycurl py2-httplib2 cherrypy condor python-ldap py2-retry
 Requires: py2-rucio-clients py2-ipython py2-future
@@ -34,7 +36,7 @@ BuildRequires: py2-sphinx
 
 
 Source0: git://github.com/%{wmcrepo}/WMCore.git?obj=master/%{wmcver}&export=WMCore-%{wmcver}&output=/WMCore-%{n}-%{wmcver}.tar.gz
-Source1: git://github.com/dmwm/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
+Source1: git://github.com/%{crabrepo}/CRABServer.git?obj=master/%{realversion}&export=CRABServer-%{realversion}&output=/CRABServer-%{realversion}.tar.gz
 #Patch0: crabtaskworker_cherrypy
 
 #Patch0: crabserver3-setup


### PR DESCRIPTION
#### status

ready to be merged

- `crabserver`: currently running with this specfile in testbed 
- `crabtaskworker`: tested for a couple of days in 2021-12 in testbed. (I forgot that the jenkins build did not contain this (because i hadn't created this PR yet!), so during the holidays testbed did not contain the changes to WMCore added with 1.5.7.preXX)

#### description

This PR contains three main changes:
- crabserver: removed dbs client
- crabserver: moved to WMCore `1.5.7.pre4`, since it contains https://github.com/dmwm/WMCore/pull/10916. Keep in mind that `mapellidario/WMCore/py3.211221.dario` also contains a small addition to `dmwm/WMCore/1.5.7.pre3` (basically the same as `1.5.7.pre4` for what concerns CRAB) for debugging purposes.
- crabtaskworker: moved to WMCore `1.5.7.pre4`, since it contains https://github.com/dmwm/WMCore/pull/10918
- adding in both `crabserver.spec` and `crabtaskworker.spec` a variable to easily change the CRABServer repository, in the same fashion as used for WMCore. This is handy for testing changes before merging into `dmwm/CRABServer` branches. These changes are not necessary and can be excluded from this PR if anyone does not like those.

fyi: @belforte 

 