### PR TITLE
Update lxml to verion 4.6.5

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -138,7 +138,7 @@ lizard==1.17.9
 llvmlite==0.37.0
 lockfile==0.12.2
 luigi==3.0.3
-lxml==4.6.3
+lxml==4.6.5
 lz4==3.1.3
 Mako==1.1.5
 Markdown==3.3.4


### PR DESCRIPTION
GHSA-55x5-fj6c-h6m8 high severity
Vulnerable versions: < 4.6.5
Patched version: 4.6.5

Impact
The HTML Cleaner in lxml.html lets certain crafted script content pass through, as well as script content in SVG files embedded using data URIs.

Users that employ the HTML cleaner in a security relevant context should upgrade to lxml 4.6.5.