### PR TITLE
Update OpenMPI and other network components

### DIFF
--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.2
+### RPM external gdrcopy 2.3
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda

--- a/hwloc.spec
+++ b/hwloc.spec
@@ -1,5 +1,5 @@
-### RPM external hwloc 2.4.0
-Source: https://download.open-mpi.org/release/%{n}/v2.4/%{n}-%{realversion}.tar.bz2
+### RPM external hwloc 2.7.0
+Source: https://download.open-mpi.org/release/%{n}/v2.7/%{n}-%{realversion}.tar.bz2
 
 BuildRequires: autotools
 Requires: cuda libpciaccess libxml2 numactl

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 4.1.1
+### RPM external openmpi 4.1.2
 ## INITENV SET OPAL_PREFIX %{i}
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -1,4 +1,4 @@
-### RPM external rdma-core 36.0
+### RPM external rdma-core 36.3
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 
 Source: https://github.com/linux-rdma/%{n}/releases/download/v%{realversion}/rdma-core-%{realversion}.tar.gz

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,4 +1,4 @@
-### RPM external ucx 1.10.1
+### RPM external ucx 1.12.0
 Source: https://github.com/openucx/%{n}/releases/download/v%{realversion}/%{n}-%{realversion}.tar.gz
 BuildRequires: autotools
 Requires: numactl


### PR DESCRIPTION
#### Update OpenMPI to version 4.1.2
This is a bugfix release, see https://www.mail-archive.com/announce@lists.open-mpi.org/msg00145.html for the details.

#### Update UCX to version 1.12.0

This is a feature release, for a list of all changes, updates and bug fixes since 1.10.1 see:
  - https://github.com/openucx/ucx/releases/tag/v1.11.0
  - https://github.com/openucx/ucx/releases/tag/v1.12.0

#### Update RDMA Core to version 36.3

This is a bugfix release, for the changes since version 36.0 see:
  - https://github.com/linux-rdma/rdma-core/releases/tag/v36.1
  - https://github.com/linux-rdma/rdma-core/releases/tag/v36.3

#### Update GDRCopy to version 2.3

This is a bugfix release, for the changes since version 2.2 see https://github.com/NVIDIA/gdrcopy/releases/tag/v2.3 .

#### Update Hardware Locality library to version 2.7.0

This is a major release, see https://raw.githubusercontent.com/open-mpi/hwloc/v2.7/NEWS for all the changes.