### PR TITLE
Update py-pillow to version 9.0.0

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -184,7 +184,7 @@ pathlib2==2.3.6
 pbr==5.6.0
 pexpect==4.8.0
 pickleshare==0.7.5
-pillow==8.3.2
+pillow==9.0.0
 pkgconfig==1.5.5
 plac==1.3.3
 platformdirs==2.3.0


### PR DESCRIPTION
To fix potential security vulnerabilities
- CVE-2022-22817 : PIL.ImageMath.eval in Pillow before 9.0.0 allows evaluation of arbitrary expressions, such as ones that use the Python exec method. 
- CVE-2022-22815: path_getbbox in path.c in Pillow before 9.0.0 improperly initializes ImagePath.Path.
- CVE-2022-22816: path_getbbox in path.c in Pillow before 9.0.0 has a buffer over-read during initialization of ImagePath.Path.