### PR TITLE
update ipython  to get a security fix

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -113,7 +113,7 @@ iniconfig==1.1.1
 ipaddress==1.0.23
 ipykernel==6.3.1
 ipython_genutils==0.2.0
-ipython==7.27.0
+ipython==7.31.1
 ipywidgets==7.6.4
 isort==5.9.3
 jedi==0.18.0


### PR DESCRIPTION
GHSA-pq7m-3gw7-gq5x
Vulnerable versions: >= 7.17.0, < 7.31.1
Patched version: 7.31.1
We’d like to disclose an arbitrary code execution vulnerability in IPython that stems from IPython executing untrusted files in CWD. This vulnerability allows one user to run code as another.