### PR TITLE
igprof patch needed for aarch64

### DIFF
--- a/igprof-gcc8.patch
+++ b/igprof-gcc8.patch
@@ -7,7 +7,7 @@ index 57fe6b5..de08185 100644
  SET(CMAKE_REQUIRED_FLAGS ${CMAKE_ANSI_FLAGS})
  IF(CMAKE_COMPILER_IS_GNUCC)
 -  ADD_DEFINITIONS(-ansi -pedantic -W -Wall -Wno-long-long -Werror)
-+  ADD_DEFINITIONS(-ansi -pedantic -W -Wall -Wno-long-long -Werror -Wno-error=cast-function-type -Wno-error=pedantic)
++  ADD_DEFINITIONS(-ansi -pedantic -W -Wall -Wno-long-long -Werror -Wno-error=cast-function-type -Wno-error=pedantic -std=c++11)
  ENDIF()
  
  IF(UNIX)


### PR DESCRIPTION
igprof failed to build on aarch64. This is due to update of libunwind ( #7576 ) . see https://github.com/NixOS/nixpkgs/issues/153503and  https://github.com/NixOS/nixpkgs/pull/153519