### PR TITLE
[Aarch64] Build with -march=armv8-a

### DIFF
--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -22,7 +22,7 @@ make %{build_opts} TARGET=CORE2
 make %{build_opts} TARGET=ARMV8
 %endif
 %ifarch ppc64le
-make %{build_opts} CFLAGS="%{ppc64le_build_flags}"
+make %{build_opts} CFLAGS="%{arch_build_flags}"
 %endif
 
 %install

--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -19,7 +19,7 @@ Patch1: OpenBLAS-disable-tests
 make %{build_opts} TARGET=CORE2
 %endif
 %ifarch aarch64
-make %{build_opts} TARGET=ARMV8
+make %{build_opts} TARGET=ARMV8 CFLAGS="%{arch_build_flags}"
 %endif
 %ifarch ppc64le
 make %{build_opts} CFLAGS="%{arch_build_flags}"

--- a/boost.spec
+++ b/boost.spec
@@ -1,5 +1,5 @@
 ### RPM external boost 1.75.0
-
+## INCLUDE compilation_flags
 %define tag 3defebd61ecb0970c0046c85384bb34ec9572ac3
 %define branch cms/v%realversion
 %define github_user cms-externals
@@ -17,6 +17,12 @@ case %cmsos in
   *) TOOLSET=gcc ;;
 esac
 
+# enable boost::mpi
+%if "%{?arch_build_flags:set}" == "set"
+echo 'using gcc : : : <cxxflags>"%{arch_build_flags}" ;' > user-config.jam
+echo 'using gcc : : : <cflags>"%{arch_build_flags}" ;' >> user-config.jam
+%endif
+
 pushd tools/build
   sh bootstrap.sh ${TOOLSET}
   mkdir ./tmp-boost-build
@@ -27,12 +33,8 @@ popd
 PYTHONV3=$(echo $PYTHON3_VERSION | cut -f1,2 -d.)
 
 # enable boost::mpi
-echo "using mpi ;" > user-config.jam
+echo "using mpi ;" >> user-config.jam
 echo "using python : ${PYTHONV3} : ${PYTHON3_ROOT}/bin/python3 : ${PYTHON3_ROOT}/include/python${PYTHONV3} : ${PYTHON3_ROOT}/lib ;" >> user-config.jam
-%if "%{?arch_build_flags:set}" == "set"
-echo 'using gcc : : : <cxxflags>"%{arch_build_flags}" ;' >> user-config.jam
-echo 'using gcc : : : <cflags>"%{arch_build_flags}" ;' >> user-config.jam
-%endif
 
 b2 -q \
    -d2 \

--- a/boost.spec
+++ b/boost.spec
@@ -17,10 +17,8 @@ case %cmsos in
   *) TOOLSET=gcc ;;
 esac
 
-# enable boost::mpi
 %if "%{?arch_build_flags:set}" == "set"
-echo 'using gcc : : : <cxxflags>"%{arch_build_flags}" ;' > user-config.jam
-echo 'using gcc : : : <cflags>"%{arch_build_flags}" ;' >> user-config.jam
+echo 'using gcc : : : <cxxflags>"%{arch_build_flags}" <cflags>"%{arch_build_flags}" ;' > user-config.jam
 %endif
 
 pushd tools/build

--- a/boost.spec
+++ b/boost.spec
@@ -29,6 +29,10 @@ PYTHONV3=$(echo $PYTHON3_VERSION | cut -f1,2 -d.)
 # enable boost::mpi
 echo "using mpi ;" > user-config.jam
 echo "using python : ${PYTHONV3} : ${PYTHON3_ROOT}/bin/python3 : ${PYTHON3_ROOT}/include/python${PYTHONV3} : ${PYTHON3_ROOT}/lib ;" >> user-config.jam
+%if "%{?arch_build_flags:set}" == "set"
+echo 'using gcc : : : <cxxflags>"%{arch_build_flags}" ;' >> user-config.jam
+echo 'using gcc : : : <cflags>"%{arch_build_flags}" ;' >> user-config.jam
+%endif
 
 b2 -q \
    -d2 \

--- a/compilation_flags.file
+++ b/compilation_flags.file
@@ -3,6 +3,6 @@
 %define arch_build_flags  -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
 %endif
 %ifarch aarch64
-%define arch_build_flags -mcpu=armv8-a
+%define arch_build_flags -march=armv8-a
 %endif
 %endif

--- a/compilation_flags.file
+++ b/compilation_flags.file
@@ -1,8 +1,9 @@
 %if "%{?arch_build_flags:set}" != "set"
 %ifarch ppc64le
 %define arch_build_flags  -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
-%endif
 %ifarch aarch64
 %define arch_build_flags -march=armv8-a -mno-outline-atomics
+%else
+%define arch_build_flags %{nil}
 %endif
 %endif

--- a/compilation_flags.file
+++ b/compilation_flags.file
@@ -1,4 +1,8 @@
-%if "%{?ppc64le_build_flags:set}" != "set"
-%define ppc64le_build_flags  -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
+%if "%{?arch_build_flags:set}" != "set"
+%ifarch ppc64le
+%define arch_build_flags  -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
 %endif
-
+%ifarch aarch64
+%define arch_build_flags -mcpu=armv8-a
+%endif
+%endif

--- a/compilation_flags.file
+++ b/compilation_flags.file
@@ -3,6 +3,6 @@
 %define arch_build_flags  -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
 %endif
 %ifarch aarch64
-%define arch_build_flags -march=armv8-a
+%define arch_build_flags -march=armv8-a -mno-outline-atomics
 %endif
 %endif

--- a/compilation_flags.file
+++ b/compilation_flags.file
@@ -1,9 +1,11 @@
 %if "%{?arch_build_flags:set}" != "set"
 %ifarch ppc64le
 %define arch_build_flags  -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512
+%endif
 %ifarch aarch64
 %define arch_build_flags -march=armv8-a -mno-outline-atomics
-%else
+%endif
+%ifarch x86_64
 %define arch_build_flags %{nil}
 %endif
 %endif

--- a/fastjet.spec
+++ b/fastjet.spec
@@ -26,8 +26,8 @@ CXXFLAGS="-O3 -Wall -ffast-math -ftree-vectorize"
 %ifarch x86_64
 CXXFLAGS="${CXXFLAGS} -msse3"
 %endif
-%ifarch ppc64le
-CXXFLAGS="${CXXFLAGS} %{ppc64le_build_flags}"
+%if "%{?arch_build_flags:set}" == "set"
+CXXFLAGS="${CXXFLAGS} %{arch_build_flags}"
 %endif
 
 PYTHON=$(which python3) \

--- a/fftjet.spec
+++ b/fftjet.spec
@@ -25,8 +25,8 @@ chmod +x ./config.{sub,guess}
 touch pkg-config ; chmod +x pkg-config
 ./configure $PLATF_CONF_OPTS --disable-dependency-tracking --enable-threads \
             --prefix=%i F77="$F77" CXX="$CXX" DEPS_CFLAGS=-I$FFTW3_ROOT/include \
-%ifarch ppc64le
-            CXXFLAGS="-O2 %{ppc64le_build_flags}" \
+%if "%{?arch_build_flags:set}" == "set"
+            CXXFLAGS="-O2 %{arch_build_flags}" \
 %else
             CXXFLAGS="-O2" \
 %endif

--- a/fmt.spec
+++ b/fmt.spec
@@ -14,8 +14,8 @@ rm -rf build && mkdir build && cd build
 cmake ../%{n}-%{realversion} \
     -DCMAKE_INSTALL_PREFIX:STRING=%{i} \
     -DCMAKE_INSTALL_LIBDIR:STRING=lib \
-%ifarch ppc64le
-    -DCMAKE_CXX_FLAGS="%{ppc64le_build_flags}" \
+%if "%{?arch_build_flags:set}" == "set"
+    -DCMAKE_CXX_FLAGS="%{arch_build_flags}" \
 %endif
     -DBUILD_SHARED_LIBS=TRUE
 

--- a/gcc.spec
+++ b/gcc.spec
@@ -42,6 +42,10 @@ Patch1: gcc-flex-disable-doc
 %prep
 
 %setup -T -b 0 -n %{moduleName}
+#disable outline atomic by default
+%ifarch aarch64
+sed -i -e 's|#define\s\s*TARGET_OUTLINE_ATOMICS\s.*|#define TARGET_OUTLINE_ATOMICS (0)|' gcc/config/aarch64/aarch64.h
+%endif
 
 # Filter out private stuff from RPM requires headers.
 cat << \EOF > %{name}-req

--- a/gcc.spec
+++ b/gcc.spec
@@ -42,10 +42,6 @@ Patch1: gcc-flex-disable-doc
 %prep
 
 %setup -T -b 0 -n %{moduleName}
-#disable outline atomic by default
-%ifarch aarch64
-sed -i -e 's|#define\s\s*TARGET_OUTLINE_ATOMICS\s.*|#define TARGET_OUTLINE_ATOMICS (0)|' gcc/config/aarch64/aarch64.h
-%endif
 
 # Filter out private stuff from RPM requires headers.
 cat << \EOF > %{name}-req

--- a/geant4.spec
+++ b/geant4.spec
@@ -32,10 +32,10 @@ export VecGeom_DIR=${VECGEOM_ROOT}/lib/cmake/VecGeom
 
 cmake ../%{n}.%{realversion} \
   -DCMAKE_CXX_COMPILER="g++" \
-%ifarch ppc64le
-  -DCMAKE_CXX_FLAGS="-fPIC %{ppc64le_build_flags}" \
-  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC %{ppc64le_build_flags}" \
-  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC %{ppc64le_build_flags}" \
+%if "%{?arch_build_flags:set}" == "set"
+  -DCMAKE_CXX_FLAGS="-fPIC %{arch_build_flags}" \
+  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC %{arch_build_flags}" \
+  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC %{arch_build_flags}" \
 %else
   -DCMAKE_CXX_FLAGS="-fPIC" \
   -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC" \

--- a/grpc-gcc11.patch
+++ b/grpc-gcc11.patch
@@ -10,3 +10,15 @@ index 19f9aab..27fec21 100644
  #include "absl/base/internal/hide_ptr.h"
  #include "absl/base/internal/raw_logging.h"
  #include "absl/base/internal/spinlock.h"
+diff --git a/third_party/abseil-cpp/absl/copts/GENERATED_AbseilCopts.cmake b/third_party/abseil-cpp/absl/copts/GENERATED_AbseilCopts.cmake
+index 97bd283..40d66ea 100644
+--- a/third_party/abseil-cpp/absl/copts/GENERATED_AbseilCopts.cmake
++++ b/third_party/abseil-cpp/absl/copts/GENERATED_AbseilCopts.cmake
+@@ -205,6 +205,7 @@ list(APPEND ABSL_RANDOM_HWAES_ARM32_FLAGS
+
+ list(APPEND ABSL_RANDOM_HWAES_ARM64_FLAGS
+     "-march=armv8-a+crypto"
++    "-mno-outline-atomics"
+ )
+
+ list(APPEND ABSL_RANDOM_HWAES_MSVC_X64_FLAGS

--- a/mkfit.spec
+++ b/mkfit.spec
@@ -22,11 +22,8 @@ sed -i -e 's|-std=c++14|-std=c++1z|' Makefile.config
 %ifarch x86_64
 BUILD_ARGS=SSE3="1"
 %endif
-%ifarch aarch64
-BUILD_ARGS=VEC_GCC="-march=native"
-%endif
-%ifarch ppc64le
-BUILD_ARGS=VEC_GCC="%{ppc64le_build_flags}"
+%if "%{?arch_build_flags:set}" == "set"
+BUILD_ARGS=VEC_GCC="%{arch_build_flags}"
 %endif
 make %{makeprocesses} TBB_PREFIX=$TBB_ROOT "${BUILD_ARGS}"
 

--- a/root.spec
+++ b/root.spec
@@ -1,7 +1,7 @@
 ### RPM lcg root 6.24.07
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
-
+## INCLUDE compilation_flags
 %define tag 11009abdb2a84fb354cea142c16bf27963053db6
 %define branch cms/v6-24-00-patches/292e441
 
@@ -31,8 +31,8 @@ rm -rf ../build
 mkdir ../build
 cd ../build
 
-export CFLAGS=-D__ROOFIT_NOBANNER
-export CXXFLAGS=-D__ROOFIT_NOBANNER
+export CFLAGS="-D__ROOFIT_NOBANNER %{arch_build_flags}"
+export CXXFLAGS="-D__ROOFIT_NOBANNER %{arch_build_flags}"
 
 cmake ../%{n}-%{realversion} \
   -G Ninja \

--- a/scram-tools.file/tool-env.file
+++ b/scram-tools.file/tool-env.file
@@ -10,8 +10,8 @@ export CMSDIST_DIR=%cmsdist_directory
 %ifarch x86_64
 export COMPILER_CXXFLAGS="$(%{cmsdist_directory}/vectorization/cmsdist_packages.py)"
 %endif
-%ifarch ppc64le
-export COMPILER_CXXFLAGS="%{ppc64le_build_flags}"
+%if "%{?arch_build_flags:set}" == "set"
+export COMPILER_CXXFLAGS="%{arch_build_flags}"
 %endif
 export ORACLE_ENV_ROOT=""
 export CUDA_FLAGS="%{nvcc_cuda_flags}"

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -34,8 +34,8 @@ BAZEL_OPTS="--batch --output_user_root ../build build -s --verbose_failures --di
 %ifarch x86_64
 BAZEL_OPTS="$BAZEL_OPTS --copt=%{vectorize_flag}"
 %else
-%ifarch ppc64le
-BAZEL_OPTS="$BAZEL_OPTS $(echo %{ppc64le_build_flags} | tr ' ' '\n' | grep -v '^$' | sed -e 's|^|--copt=|' | tr '\n' ' ')"
+%if "%{?arch_build_flags:set}" == "set"
+BAZEL_OPTS="$BAZEL_OPTS $(echo %{arch_build_flags} | tr ' ' '\n' | grep -v '^$' | sed -e 's|^|--copt=|' | tr '\n' ' ')"
 %else
 BAZEL_OPTS="$BAZEL_OPTS --copt=-mcpu=native --copt=-mtune=native"
 %endif

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -29,8 +29,8 @@ cmake ../%{n}-%{realversion} \
 %endif
   -DCMAKE_VERBOSE_MAKEFILE=TRUE \
   -DCMAKE_CXX_STANDARD=17 \
-%ifarch ppc64le
-  -DCMAKE_CXX_FLAGS="%{ppc64le_build_flags}" \
+%if "%{?arch_build_flags:set}" == "set"
+  -DCMAKE_CXX_FLAGS="%{arch_build_flags}" \
 %endif
   -DGEANT4=OFF
 


### PR DESCRIPTION
This PR disables the outline atomics for gcc 11 on aarch64. see https://github.com/cms-sw/cmssw/issues/36788 where we think that aarch64 relvals might be failing due to outline atomics (enabled by defaults for GCC 10.1 and above).