### PR TITLE
Add Py3 mongomock library; add this dependency to wmcorepy3-devtools

### DIFF
--- a/py3-mongomock.spec
+++ b/py3-mongomock.spec
@@ -1,0 +1,5 @@
+### RPM external py3-mongomock 4.0.0
+## IMPORT build-with-pip3
+Requires: py3-packaging py3-sentinels py3-six
+
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-packaging.spec
+++ b/py3-packaging.spec
@@ -1,0 +1,5 @@
+### RPM external py3-packaging 21.3
+## IMPORT build-with-pip3
+Requires: py3-pyparsing 
+
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-sentinels.spec
+++ b/py3-sentinels.spec
@@ -1,0 +1,4 @@
+### RPM external py3-sentinels 1.0.0
+## IMPORT build-with-pip3
+
+%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/wmcorepy3-devtools.spec
+++ b/wmcorepy3-devtools.spec
@@ -4,6 +4,7 @@
 Requires: yuicompressor
 Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint py3-coverage py3-nose py3-nose2
 Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo py3-future py3-sphinx py3-cherrypy
+Requires: py3-mongomock
 
 %prep
 %build


### PR DESCRIPTION
Adding a new python3 spec for `mongomock`, and adding it as a dependency in the `wmcorepy3-devtools` spec.