### PR TITLE
Bump py3-dbs3-client to 4.0.7

### DIFF
--- a/py3-dbs3-client.spec
+++ b/py3-dbs3-client.spec
@@ -1,3 +1,3 @@
-### RPM cms py3-dbs3-client 4.0.6
+### RPM cms py3-dbs3-client 4.0.7
 ## IMPORT build-with-pip3
 Requires: py3-pycurl py3-dbs3-pycurl


### PR DESCRIPTION
Has a bug fix for the `listParentDSTrio` API.