### PR TITLE
[scipy] disable rpm find_provide and explicitly set the needed Provdies

### DIFF
--- a/pip/scipy.file
+++ b/pip/scipy.file
@@ -4,7 +4,7 @@ Requires: py3-numpy py3-cython py3-pybind11 py3-pythran
   if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then export FFLAGS="${FFLAGS_OPT} -fallow-argument-mismatch -fPIC" ; fi \
 %define PipPreBuild export NPY_NUM_BUILD_JOBS=%{compiling_processes}
 %ifarch aarch64
-Provides: python%{cms_python2_major_minor_version}dist(scipy) = %{realversion}
+Provides: python%{cms_python3_major_minor_version}dist(scipy) = %{realversion}
 Provides: python3dist(scipy) = %{realversion}
 %define __find_provides true
 %endif

--- a/pip/scipy.file
+++ b/pip/scipy.file
@@ -4,7 +4,7 @@ Requires: py3-numpy py3-cython py3-pybind11 py3-pythran
   if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then export FFLAGS="${FFLAGS_OPT} -fallow-argument-mismatch -fPIC" ; fi \
 %define PipPreBuild export NPY_NUM_BUILD_JOBS=%{compiling_processes}
 %ifarch aarch64
-Provides: python3.9dist(scipy) = %{realversion}
+Provides: python%{cms_python2_major_minor_version}dist(scipy) = %{realversion}
 Provides: python3dist(scipy) = %{realversion}
 %define __find_provides true
 %endif

--- a/pip/scipy.file
+++ b/pip/scipy.file
@@ -3,3 +3,8 @@ Requires: py3-numpy py3-cython py3-pybind11 py3-pythran
 %define PipPreBuild\
   if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then export FFLAGS="${FFLAGS_OPT} -fallow-argument-mismatch -fPIC" ; fi \
 %define PipPreBuild export NPY_NUM_BUILD_JOBS=%{compiling_processes}
+%ifarch aarch64
+Provides: python3.9dist(scipy) = %{realversion}
+Provides: python3dist(scipy) = %{realversion}
+%define __find_provides true
+%endif


### PR DESCRIPTION
For some unknown reason , `rpmbuild` randomly hangs for `aarch64` while running `find_provides`.  To avoid this behaviour, this change now skips running  `find_provides` and explicitly add the needed provides. `rpm -q --provides <package>` command with and without this change generates the correct/same items for the rpm provides.

[a]
```
2675005              |                   \_ /bin/sh -c rm -rf /data/cmsbuild/jenkins_a/workspace/auto-builds/CMSSW_12_3_0_pre5-cs8_aarch64_gcc11/build/CMSSW_12_3_0_pre5-build/BUILD/cs8_aarch64_gcc11/external/py3-sci
2675012              |                       \_ rpmbuild --buildroot /data/cmsbuild/jenkins_a/workspace/auto-builds/CMSSW_12_3_0_pre5-cs8_aarch64_gcc11/build/CMSSW_12_3_0_pre5-build/tmp/BUILDROOT/86ccd5d4adb293d9654
3447417              |                           \_ /bin/sh /data/cmsbuild/jenkins_a/workspace/auto-builds/CMSSW_12_3_0_pre5-cs8_aarch64_gcc11/build/CMSSW_12_3_0_pre5-build/cs8_aarch64_gcc11/external/rpm/4.15.0-12ba
3447435              |                               \_ /data/cmsbuild/jenkins_a/workspace/auto-builds/CMSSW_12_3_0_pre5-cs8_aarch64_gcc11/build/CMSSW_12_3_0_pre5-build/cs8_aarch64_gcc11/external/rpm/4.15.0-12bac222
3447922              |                                   \_ bzip2 -cd
3447948              |                                   \_ gzip -cd
3447958              |                                   \_ [gzip] <defunct>
3447975              |                                   \_ [gzip] <defunct>
3448044              |                                   \_ [gzip] <defunct>

```