### PR TITLE
Update glimpse to 4.18.7-6; fix source URL (the old one is dead)

### DIFF
--- a/glimpse.spec
+++ b/glimpse.spec
@@ -1,14 +1,18 @@
-### RPM external glimpse 4.18.5
-Source: http://webglimpse.net/trial/glimpse-%{realversion}.tar.gz
+### RPM external glimpse 4.18.7-6
+%define tag 5426ca983218befa4aeadf21cad2305d90c84adb
+Source: git+https://github.com/cms-externals/glimpse.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+
 BuildRequires: autotools
+
 %prep
-%setup -n glimpse-%realversion
+%setup -n %{n}-%realversion
 %build
 ./configure --prefix=%{i} 
 # Turn off this part, it causes problems for 32-bit-on-64-bit and is only
 # needed for webglimpse
 perl -p -i -e "s|dynfilters||g" Makefile
-make 
+# Notice: parallel build doesn't work
+make -j1
 
 %install
 make install


### PR DESCRIPTION
backport of #7639
but without extra commits for patches