### PR TITLE
Update to CUDA 11.4.4

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 11.4.2
+### RPM external cuda 11.4.4
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 470.57.02
+%define driversversion 470.82.01
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run


### PR DESCRIPTION
Update to CUDA 11.4.4:
  * CUDA runtime version 11.4.148
  * NVIDIA drivers version 470.82.01

Fixes various Apache Log4J vulnerabilities.

See https://docs.nvidia.com/cuda/archive/11.4.4/cuda-toolkit-release-notes/index.html for the full CUDA 11.4.x release notes and change log.