### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v02.04.39
+### RPM cms dasgoclient v02.04.40
 ## NOCOMPILER
 Source0: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_amd64
 Source1: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_aarch64


### PR DESCRIPTION
It contains fix for `file dataset=XXX run=123 lumi=098` query based on recent transition of DBS server