### PR TITLE
Update tag for RecoEgamma-PhotonIdentification to V01-04-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-PhotonIdentification=V01-04-00
 CondTools-SiStrip=V00-01-00
 Alignment-OfflineValidation=V00-02-00
 Geometry-TestReference=V00-09-00
@@ -16,7 +17,6 @@ CondTools-SiPhase2Tracker=V00-02-00
 RecoTracker-FinalTrackSelectors=V01-03-00
 RecoTracker-MkFit=V00-08-00
 RecoEgamma-ElectronIdentification=V01-09-00
-RecoEgamma-PhotonIdentification=V01-03-00
 CalibCalorimetry-CaloMiscalibTools=V01-00-00
 FastSimulation-MaterialEffects=V05-00-00
 L1Trigger-RPCTrigger=V00-15-00


### PR DESCRIPTION
Move RecoEgamma-PhotonIdentification data to new tag, see 
https://github.com/cms-data/RecoEgamma-PhotonIdentification/pull/11
