### PR TITLE
Update CUDA to version 11.5.2

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 11.4.4
+### RPM external cuda 11.5.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 470.82.01
+%define driversversion 495.29.05
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
@@ -99,6 +99,9 @@ ln -sf libcuda.so.1                                                         %{i}
 mv %_builddir/build/drivers/libnvidia-ptxjitcompiler.so.%{driversversion}   %{i}/drivers/
 ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                        %{i}/drivers/libnvidia-ptxjitcompiler.so.1
 ln -sf libnvidia-ptxjitcompiler.so.1                                        %{i}/drivers/libnvidia-ptxjitcompiler.so
+cp %{i}/nvvm/lib64/libnvvm.so.4.0.0                                         %{i}/drivers/
+ln -sf libnvvm.so.4.0.0                                                     %{i}/drivers/libnvvm.so.4
+ln -sf libnvvm.so.4                                                         %{i}/drivers/libnvvm.so
 
 %post
 # let nvcc find its components when invoked from the command line


### PR DESCRIPTION
Update CUDA to version 11.5.2:
  * CUDA runtime version 11.5.117
  * NVIDIA drivers version 495.29.05

See https://docs.nvidia.com/cuda/archive/11.5.2/cuda-toolkit-release-notes/index.html for the full CUDA 11.5.x release notes and change log.

Update cuDNN to version 8.3.2.44.
See https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html for the release notes and change log.
