### PR TITLE
configure pythia8 to use hepmc3 and hepmc2

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -2,12 +2,12 @@
 
 Source: https://pythia.org/download/pythia83/%{n}%{realversion}.tgz
 
-Requires: hepmc lhapdf
+Requires: hepmc hepmc3 lhapdf
 
 %prep
 %setup -q -n %{n}%{realversion}
 
-./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-lhapdf6=${LHAPDF_ROOT}
+./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-hepmc3=${HEPMC3_ROOT} --with-lhapdf6=${LHAPDF_ROOT}
 
 %build
 make %makeprocesses

--- a/scram-tools.file/tools/pythia8/pythia8.xml
+++ b/scram-tools.file/tools/pythia8/pythia8.xml
@@ -9,6 +9,7 @@
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="cxxcompiler"/>
+  <use name="hepmc3"/>
   <use name="hepmc"/>
   <use name="lhapdf"/>
   <flags SYSTEM_INCLUDE="1"/>


### PR DESCRIPTION
Configure pythia8 to be able to use both conversions: to HepMC2 and HepMC3