### PR TITLE
[CS9] Update py3-debugpy to version 1.5.1

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -65,7 +65,7 @@ cx-Oracle==8.2.1
 cycler==0.10.0
 cython==0.29.24
 decorator==5.0.9
-debugpy==1.4.1
+debugpy==1.5.1
 defusedxml==0.7.1
 deprecation==2.1.0
 deprecated==1.2.13


### PR DESCRIPTION
Existing version failing to build on CS9 [a]

[a]
```
RpmInstallFailed: Failed to install package py3-debugpy. Reason:
error: Failed dependencies:
        libc.so.6(GLIBC_2.0) is needed by external+py3-debugpy+1.4.1-14c032d398e191d5ffcef4d2efc7c678-1-1.x86_64
        libc.so.6(GLIBC_2.4) is needed by external+py3-debugpy+1.4.1-14c032d398e191d5ffcef4d2efc7c678-1-1.x86_64
        libgcc_s.so.1 is needed by external+py3-debugpy+1.4.1-14c032d398e191d5ffcef4d2efc7c678-1-1.x86_64
        libgcc_s.so.1(GCC_3.0) is needed by external+py3-debugpy+1.4.1-14c032d398e191d5ffcef4d2efc7c678-1-1.x86_64
        libstdc++.so.6 is needed by external+py3-debugpy+1.4.1-14c032d398e191d5ffcef4d2efc7c678-1-1.x86_64
        libstdc++.so.6(CXXABI_1.3) is needed by external+py3-debugpy+1.4.1-14c032d398e191d5ffcef4d2efc7c678-1-1.x86_64
        libstdc++.so.6(GLIBCXX_3.4) is needed by external+py3-debugpy+1.4.1-14c032d398e191d5ffcef4d2efc7c678-1-1.x86_64
```