### PR TITLE
CORAL: Replace deprecated std::auto_ptr with std::unique_ptr and movesome header files out of src

### DIFF
--- a/coral.spec
+++ b/coral.spec
@@ -1,5 +1,5 @@
 ### RPM cms coral CORAL_2_3_21
-%define tag a066b91461946f6128403755ad7dbc2fbee8408e
+%define tag a879b41c994fa956ff0ae78e3410bb409582ad20
 %define branch cms/%{realversion}py3
 %define github_user cms-externals
 


### PR DESCRIPTION
Integrating changes from https://github.com/cms-externals/coral/pull/9
backport of #7644

This has been tested in DEVEL IBs