### PR TITLE
Dasgoclient v02.04.45

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v02.04.42
+### RPM cms dasgoclient v02.04.45
 ## NOCOMPILER
 Source0: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_amd64
 Source1: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_aarch64

--- a/millepede.spec
+++ b/millepede.spec
@@ -1,10 +1,9 @@
 ### RPM external millepede V04-11-01
-%define tag 9ee817fc61fe3e1b6543a8a16f7bcd8e1f8c331f
-Source: git+https://gitlab.desy.de/claus.kleinwort/millepede-ii.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source: https://gitlab.desy.de/claus.kleinwort/millepede-ii/-/archive/%{realversion}/%{n}-ii-%{realversion}.tar.gz
 Requires: zlib
 
 %prep
-%setup -n %{n}-%{realversion}
+%setup -n %{n}-ii-%{realversion}
 
 %build
 make \


### PR DESCRIPTION
The new version brings the following:
- adds gzip encoding to HTTP requests
- adds keep-alive HTTP headers
- adds `-noKeepAlive` option to turn off keep-alive header
- adds `GODEBUG=asyncpreemptoff=1` option on Linux to prevent race condition on AFS
- change details DBS query on `file dataset=...` DAS query when user does not provide `-json` flag and when no DAS filters are used. This will significantly reduce DBS output for large datasets
- adds `dnsCache` option to avoid extensive DNS queries of cmsweb.
- adds binary build on macOS using Apple Silicon chip