### PR TITLE
[RHEL8] use python3 instead of python2 which is not available

### DIFF
--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from platform import machine
 from sys import exit, argv
 


### PR DESCRIPTION
To migrate away from python2 dependency