### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v02.04.45
+### RPM cms dasgoclient v02.04.46
 ## NOCOMPILER
 Source0: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_amd64
 Source1: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_aarch64


### PR DESCRIPTION
This PR fixes `lumi,run dataset=...` query reported by Stefano in this issue https://github.com/dmwm/das2go/issues/40 