### PR TITLE
Update hwloc to version 2.7.1

### DIFF
--- a/hwloc.spec
+++ b/hwloc.spec
@@ -1,4 +1,4 @@
-### RPM external hwloc 2.7.0
+### RPM external hwloc 2.7.1
 Source: https://download.open-mpi.org/release/%{n}/v2.7/%{n}-%{realversion}.tar.bz2
 
 BuildRequires: autotools


### PR DESCRIPTION
2.7.1 fixes several issues, all users are encouraged to upgrade.
The following is a summary of the changes since v2.7.0.

Version 2.7.1
-------------
* Workaround crashes when virtual machines report incoherent x86 CPUID
  information about numbers of cores and threads.
  Thanks to Peter Bense for the report.
* Use setenv() instead of putenv() when trying to force enable oneAPI L0
  support, to avoid issues with applications that touch the environment,
  thanks to Josh Hursey for the patch.
* Add some warnings at the end of configure when GPU libraries are
  missing on the system or their path is missing in the environment.