### PR TITLE
[12.2.X] Millipede to V04-11-01

### DIFF
--- a/millepede.spec
+++ b/millepede.spec
@@ -1,10 +1,9 @@
-### RPM external millepede V04-09-01
-
-Source: svn://svnsrv.desy.de/public/MillepedeII/tags/%{realversion}/?scheme=http&module=%{realversion}&output=/%{n}-%{realversion}.tgz
+### RPM external millepede V04-11-01
+Source: https://gitlab.desy.de/claus.kleinwort/millepede-ii/-/archive/%{realversion}/%{n}-ii-%{realversion}.tar.gz
 Requires: zlib
 
 %prep
-%setup -n %{realversion}
+%setup -n %{n}-ii-%{realversion}
 
 %build
 make \


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/7685

I suspect this will cure the issue with the failing test in 12_2_X IBs:

```
----- Begin Fatal Exception 24-Mar-2022 12:45:07 CET-----------------------
An exception of category 'LogicError' occurred while
   [0] Processing end ProcessBlock
   [1] Calling method for module AlignmentProducerAsAnalyzer/'SiPixelAliPedeAlignmentProducer'
Exception Message:
@SUB=MillePedeFileReader::getStringFromHLS
Found an alignable structure not possible to map in the default AlignPCLThresholds partitions
----- End Fatal Exception -------------------------------------------------
```

see log at: https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc900/CMSSW_12_2_X_2022-03-24-1100/unitTestLogs/Calibration/TkAlCaRecoProducers#/156