### PR TITLE
Update to latest Intel compiler: icpx 

### DIFF
--- a/cmssw-drop-tools.file
+++ b/cmssw-drop-tools.file
@@ -1,1 +1,1 @@
-%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp nvidia-drivers intel-vtune jemalloc-debug
+%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp nvidia-drivers intel-vtune jemalloc-debug icx-cxxcompiler icx-ccompiler icx-f77compiler 

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -107,7 +107,6 @@ Requires: llvm
 Requires: tbb
 Requires: mctester
 Requires: vdt
-Requires: icc
 Requires: gnuplot
 Requires: sloccount
 Requires: millepede
@@ -164,6 +163,7 @@ Requires: openloops
 %ifarch x86_64
 Requires: tkonlinesw
 Requires: oracle
+Requires: icc
 Requires: icx
 Requires: intel-vtune
 Requires: cmsmon-tools

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -164,6 +164,7 @@ Requires: openloops
 %ifarch x86_64
 Requires: tkonlinesw
 Requires: oracle
+Requires: icx
 Requires: intel-vtune
 Requires: cmsmon-tools
 Requires: dip

--- a/icc.spec
+++ b/icc.spec
@@ -1,4 +1,4 @@
-### RPM external icc 2017.2.174
+### RPM external icc 2020.4.304
 ## NOCOMPILER
 Source: none
 Provides: libimf.so()(64bit)
@@ -10,5 +10,5 @@ Provides: libsvml.so()(64bit)
 %build
 %install
 %post
-ln -s /cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2017/compilers_and_libraries_%{realversion}/linux $RPM_INSTALL_PREFIX/%{pkgrel}/installation
+ln -s /cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2020/compilers_and_libraries_%{realversion}/linux $RPM_INSTALL_PREFIX/%{pkgrel}/installation
 

--- a/icc.spec
+++ b/icc.spec
@@ -1,4 +1,4 @@
-### RPM external icc 2020.4.304
+### RPM external icc 2020
 ## NOCOMPILER
 Source: none
 Provides: libimf.so()(64bit)
@@ -10,5 +10,5 @@ Provides: libsvml.so()(64bit)
 %build
 %install
 %post
-ln -s /cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2020/compilers_and_libraries_%{realversion}/linux $RPM_INSTALL_PREFIX/%{pkgrel}/installation
+ln -s /cvmfs/projects.cern.ch/intelsw/oneAPI/linux/x86_64/2022/compiler/latest/linux/ $RPM_INSTALL_PREFIX/%{pkgrel}/installation
 

--- a/icx.spec
+++ b/icx.spec
@@ -1,0 +1,14 @@
+### RPM external icx 2022
+## NOCOMPILER
+Source: none
+Provides: libimf.so()(64bit)
+Provides: libintlc.so.5()(64bit)
+Provides: libirng.so()(64bit)
+Provides: libsvml.so()(64bit)
+
+%prep
+%build
+%install
+%post
+ln -s /cvmfs/projects.cern.ch/intelsw/oneAPI/linux/x86_64/%{realversion}/compiler/latest/linux $RPM_INSTALL_PREFIX/%{pkgrel}/installation
+

--- a/intel-vtune.spec
+++ b/intel-vtune.spec
@@ -1,4 +1,4 @@
-### RPM external intel-vtune 2018.0.2.525261
+### RPM external intel-vtune 2022
 ## NOCOMPILER
 
 %prep
@@ -11,11 +11,11 @@ cat << \EOF_TOOLFILE >%i/etc/scram.d/intel-vtune.xml
 <tool name="intel-vtune" version="%{realversion}">
   <info url="https://software.intel.com/en-us/intel-vtune-amplifier-xe"/>
   <client>
-    <environment name="INTEL_VTUNE_BASE" default="/cvmfs/projects.cern.ch/intelsw/psxe/linux/x86_64/2018/vtune_amplifier_%{realversion}"/>
+    <environment name="INTEL_VTUNE_BASE" default="/cvmfs/projects.cern.ch/intelsw/oneAPI/linux/x86_64/%{realversion}/vtune/latest/bin64"/>
     <environment name="BINDIR" default="$INTEL_VTUNE_BASE/bin64"/>
   </client>
   <runtime name="PATH" value="$INTEL_VTUNE_BASE/bin64" type="path"/>
-  <runtime name="VTUNE_AMPLIFIER_2018_DIR" value="$INTEL_VTUNE_BASE"/>
+  <runtime name="VTUNE_PROFILER_%{realversion}_DIR" value="$INTEL_VTUNE_BASE"/>
 </tool>
 EOF_TOOLFILE
 

--- a/scram-tools.file/tools/icc/intel-license.xml
+++ b/scram-tools.file/tools/icc/intel-license.xml
@@ -1,3 +1,3 @@
   <tool name="intel-license" version="@TOOL_VERSION@">
-    <runtime name="INTEL_LICENSE_FILE" value="28518@AT@lxlicen01.cern.ch,28518@AT@lxlicen02.cern.ch,28518@AT@lxlicen03.cern.ch" type="var" handler="warn"/>
+    <runtime name="INTEL_LICENSE_FILE" value="28518@AT@lxlicen01.cern.ch,28518@AT@lxlicen02.cern.ch,28518@AT@lxlicen03.cern.ch" handler="warn"/>
   </tool>

--- a/scram-tools.file/tools/icc/intel-license.xml
+++ b/scram-tools.file/tools/icc/intel-license.xml
@@ -1,3 +1,3 @@
   <tool name="intel-license" version="@TOOL_VERSION@">
-    <runtime name="INTEL_LICENSE_FILE" value="28518@AT@lxlicen01.cern.ch,28518@AT@lxlicen02.cern.ch,28518@AT@lxlicen03.cern.ch" type="path" handler="warn"/>
+    <runtime name="INTEL_LICENSE_FILE" value="28518@AT@lxlicen01.cern.ch,28518@AT@lxlicen02.cern.ch,28518@AT@lxlicen03.cern.ch" type="var" handler="warn"/>
   </tool>

--- a/scram-tools.file/tools/icx/env.sh
+++ b/scram-tools.file/tools/icx/env.sh
@@ -1,0 +1,2 @@
+source ${SCRAM_TOOLS_BIN_DIR}/os_libdir.sh
+export AT="@"

--- a/scram-tools.file/tools/icx/icx-ccompiler.xml
+++ b/scram-tools.file/tools/icx/icx-ccompiler.xml
@@ -7,4 +7,5 @@
     <architecture name="_mic_">
       <flags CFLAGS="-mmic"/>
     </architecture>
+    <flags SKIP_TOOL_SYMLINKS="1"/>
   </tool>

--- a/scram-tools.file/tools/icx/icx-ccompiler.xml
+++ b/scram-tools.file/tools/icx/icx-ccompiler.xml
@@ -1,0 +1,10 @@
+  <tool name="icx-ccompiler" version="@TOOL_VERSION@" type="compiler">
+    <use name="gcc-ccompiler"/>
+    <client>
+      <environment name="ICX_CCOMPILER_BASE" default="@TOOL_ROOT@/installation" handler="warn"/>
+      <environment name="CC" value="$ICX_CCOMPILER_BASE/bin/icx" handler="warn"/>
+    </client>
+    <architecture name="_mic_">
+      <flags CFLAGS="-mmic"/>
+    </architecture>
+  </tool>

--- a/scram-tools.file/tools/icx/icx-cxxcompiler.xml
+++ b/scram-tools.file/tools/icx/icx-cxxcompiler.xml
@@ -1,0 +1,28 @@
+  <tool name="icx-cxxcompiler" version="@TOOL_VERSION@" type="compiler">
+    <use name="gcc-cxxcompiler"/>
+    <client>
+      <environment name="ICX_CXXCOMPILER_BASE" default="@TOOL_ROOT@/installation" handler="warn"/>
+      <environment name="CXX" value="$ICX_CXXCOMPILER_BASE/bin/icpx" handler="warn"/>
+      <environment name="LIBDIR" default="$ICX_CXXCOMPILER_BASE/compiler/lib"/>
+    </client>
+    <flags REM_CXXFLAGS="-felide-constructors"/>
+    <flags REM_CXXFLAGS="-ftree-vectorize"/>
+    <flags REM_CXXFLAGS="-Wstrict-overflow"/>
+    <flags REM_CXXFLAGS="-fno-crossjumping"/>
+    <flags REM_CXXFLAGS="-Wno-non-template-friend"/>
+    <flags REM_CXXFLAGS="-Wno-psabi"/>
+    <flags REM_CXXFLAGS="-Wno-unused-local-typedefs"/>
+    <flags REM_CXXFLAGS="-Wno-vla"/>
+    <flags REM_CXXFLAGS="--param vect-max-version-for-alias-checks=50"/>
+    <flags REM_CXXFLAGS="-Werror=format-contains-nul"/>
+    <flags REM_CXXFLAGS="-Wclass-memaccess"/>
+    <flags REM_CXXFLAGS="-Werror=return-local-addr"/>
+    <flags REM_LDFLAGS="-Wl,--icf=all"/>
+    <flags CXXFLAGS="-Wno-unknown-pragmas"/>
+    <architecture name="_mic_">
+      <flags CXXFLAGS="-mmic"/>
+      <flags LDFLAGS="-mmic"/>
+    </architecture>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$ICX_CXXCOMPILER_BASE/compiler/lib" type="path" handler="warn"/>
+    <runtime name="PATH" value="$ICX_CXXCOMPILER_BASE/bin" type="path" handler="warn"/>
+  </tool>

--- a/scram-tools.file/tools/icx/icx-cxxcompiler.xml
+++ b/scram-tools.file/tools/icx/icx-cxxcompiler.xml
@@ -19,6 +19,7 @@
     <flags REM_CXXFLAGS="-Werror=return-local-addr"/>
     <flags REM_LDFLAGS="-Wl,--icf=all"/>
     <flags CXXFLAGS="-Wno-unknown-pragmas"/>
+    <flags SKIP_TOOL_SYMLINKS="1"/>
     <architecture name="_mic_">
       <flags CXXFLAGS="-mmic"/>
       <flags LDFLAGS="-mmic"/>

--- a/scram-tools.file/tools/icx/icx-f77compiler.xml
+++ b/scram-tools.file/tools/icx/icx-f77compiler.xml
@@ -1,0 +1,6 @@
+  <tool name="icx-f77compiler" version="@TOOL_VERSION@" type="compiler">
+    <use name="gcc-f77compiler"/>
+    <client>
+      <environment name="FC" default="@GCC_ROOT@/bin/gfortran"/>
+    </client>
+  </tool>

--- a/scram-tools.file/tools/icx/icx-f77compiler.xml
+++ b/scram-tools.file/tools/icx/icx-f77compiler.xml
@@ -3,4 +3,5 @@
     <client>
       <environment name="FC" default="@GCC_ROOT@/bin/gfortran"/>
     </client>
+    <flags SKIP_TOOL_SYMLINKS="1"/>
   </tool>


### PR DESCRIPTION
The new Intel compiler uses llvm/clang as the backend. It no longer includes a fortran compiler.
Update icc version to the last version released/available on /cvmfs/projects.cern.ch/intelsw