### PR TITLE
disable scipy auto provides as it sometimes hangs the rpm build process

### DIFF
--- a/pip/scipy.file
+++ b/pip/scipy.file
@@ -1,4 +1,5 @@
 Requires: py3-numpy py3-cython py3-pybind11 py3-pythran
+AutoProv: no
 
 %define PipPreBuild\
   if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then export FFLAGS="${FFLAGS_OPT} -fallow-argument-mismatch -fPIC" ; fi \


### PR DESCRIPTION
We have noticed that `scipy` build sometimes hangs when rpm tries to automatically find its provides [a]. This PR proposes to disable check for provides.


[a]
```
1643314 Apr03                      |       \_ /bin/sh -c rm -rf /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/rhel8_amd64_gcc10/external/py3-scipy/1.7.1-22a1fd70843dd38e845cebe744fde86f/pkgtools-pkg-src-move2git /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/rhel8_amd64_gcc10/external/py3-scipy/1.7.1-22a1fd70843dd38e845cebe744fde86f/cmsdist-tmp; export _CMSBUILD_BUILD_ENV_=1; mkdir -p /data/cmsbld/jenkins/wor
1643333 Apr03                      |           \_ rpmbuild --buildroot /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/22a1fd70843dd38e845cebe744fde86f -ba --define _topdir /data/cmsbld/jenkins/workspace/build-any-ib/w --define compiling_processes 16 --define cmsdist_directory /data/cmsbld/jenkins/workspace/build-any-ib/CMSDIST --define compilerv 1030 --define cmscompilerv 10 --define cmsos rhel8_amd64 --def
1804650 Apr03                      |               \_ /bin/sh /data/cmsbld/jenkins/workspace/build-any-ib/w/rhel8_amd64_gcc10/external/rpm/4.15.0-1ee7aa6de94e59b133286d272a598131/libx/rpm/find-provides
1804652 Apr03                      |                   \_ /data/cmsbld/jenkins/workspace/build-any-ib/w/rhel8_amd64_gcc10/external/rpm/4.15.0-1ee7aa6de94e59b133286d272a598131/libx/rpm/rpmdeps --define=_use_internal_dependency_generator 1 --provides
1804683 Apr03                      |                       \_ bzip2 -cd
1804684 Apr03                      |                       \_ [gzip] <defunct>
1804685 Apr03                      |                       \_ [gzip] <defunct>
1804686 Apr03                      |                       \_ gzip -cd
```