### PR TITLE
Revert "Revert "[Coral] Fixes to complete FrontierAccess plugin thread-safety""

### DIFF
--- a/coral.spec
+++ b/coral.spec
@@ -1,5 +1,5 @@
 ### RPM cms coral CORAL_2_3_21
-%define tag c5ddd97499d6a76f24cba6800e5cb88887764bcb
+%define tag 2ac0d2a14fe877702f5491fe66702a5d32039262
 %define branch cms/%{realversion}py3
 %define github_user cms-externals
 


### PR DESCRIPTION
Reverts cms-sw/cmsdist#7747, thus restoring the very same CMSSW_12_2_X HEAD as it was in CMSSW_12_2_3_patch1