### PR TITLE
Fix py-tables issue for aarch64/ppc64le

### DIFF
--- a/pip/tables.file
+++ b/pip/tables.file
@@ -1,5 +1,5 @@
 Requires: py3-numexpr py3-six hdf5 bz2lib py3-mock py3-numpy
 Requires: py3-numexpr py3-six py3-numpy hdf5 bz2lib py3-mock
 Requires: openmpi
-%define PipPreBuild export HDF5_DIR=${HDF5_ROOT} CC="mpicc"; export DISABLE_AVX2=true
+%define PipPreBuild export CFLAGS="-pthread"; export HDF5_DIR=${HDF5_ROOT} CC="mpicc"; export DISABLE_AVX2=true
 %define PipBuildOptions  --global-option="--hdf5=${HDF5_ROOT}" --global-option="--bzip2=${BZ2LIB_ROOT}"


### PR DESCRIPTION
Build with `-pthread` to fix unit tests for aarch64 and ppc64le 
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../py3-tables/3.6.1-0c82929e2e13ad5ec991d01bb7064d7d/lib/python3.9/site-packages/tables/__init__.py", line 99, in <module>
    from .utilsextension import (
ImportError: .../py3-tables/3.6.1-0c82929e2e13ad5ec991d01bb7064d7d/lib/python3.9/site-packages/tables/utilsextension.cpython-39-powerpc64le-linux-gnu.so: undefined symbol: pthread_atfork
```