### PR TITLE
Add ROCm 5.0.2 for x86_64

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -166,6 +166,7 @@ Requires: oracle
 Requires: icc
 Requires: icx
 Requires: intel-vtune
+Requires: rocm
 Requires: cmsmon-tools
 Requires: dip
 %else

--- a/rocm.spec
+++ b/rocm.spec
@@ -1,0 +1,87 @@
+### RPM external rocm 5.0.2
+## NOCOMPILER
+Source: none
+Provides: libamd_comgr.so.2()(64bit)
+Provides: libhsa-runtime64.so.1()(64bit)
+Provides: librocm-core.so.1()(64bit)
+Provides: librocm_smi64.so.5()(64bit)
+
+%prep
+
+%build
+
+%install
+OSDIR=/cvmfs/patatrack.cern.ch/externals/%{_arch}/rhel%{rhel}
+if ! [ -d $OSDIR ]; then
+  OSDIR=/cvmfs/patatrack.cern.ch/externals/%{_arch}/unknown
+fi
+BASEDIR=${OSDIR}/amd/%{n}-%{realversion}
+
+# symlink individual files from ${BASEDIR}/bin/
+mkdir %{i}/bin
+test -d ${BASEDIR}/bin
+test -e ${BASEDIR}/bin/hipcc
+ln -s ${BASEDIR}/bin/* %{i}/bin/
+# remove the OpenCL extra files
+rm -f %{i}/bin/clang-ocl
+# remove the OpenMP extra files
+rm -f %{i}/bin/{aompcc,gputable.txt,mygpu,mymcpu}
+# remove the MIGraphX tools
+rm -f %{i}/bin/migraphx-driver
+
+# ROCm/HIP core tools
+DIRECTORIES="amdgcn hip hipcub hsa hsa-amd-aqlprofile include lib lib64 llvm rocthrust share"
+
+# rocm-smi
+DIRECTORIES+=" oam rocm_smi"
+
+# hipBLAS / rocBLAS
+DIRECTORIES+=" hipblas rocblas"
+
+# hipSOLVER / rocSOLVER
+DIRECTORIES+=" hipsolver rocsolver"
+
+# hipSPARSE / rocSPARSE
+DIRECTORIES+=" hipsparse rocsparse"
+
+# hipFFT / rocFFT
+DIRECTORIES+=" hipfft rocfft"
+
+# hipRAND / rocRAND
+DIRECTORIES+=" hiprand rocrand"
+
+# ROCm Parallel Primitives (rocPRIM)
+DIRECTORIES+=" rocprim"
+
+# ROCm Tracer Callback/Activity Library (rocTRACER) and profiler library (ROC-profiler)
+DIRECTORIES+=" rocprofiler roctracer"
+
+# Asynchronous Task and Memory Interface (ATMI)
+#DIRECTORIES+=" atmi"
+
+# OpenCL support
+#DIRECTORIES+=" opencl"
+
+# ROCm Communication Collectives Library (RCCL)
+#DIRECTORIES+=" rccl"
+
+# iterative sparse solvers for ROCm platform (rocALUTION)
+#DIRECTORIES+=" rocalution"
+
+# Machine Intelligence Libraries
+#DIRECTORIES+=" miopen miopengemm mivisionx"
+
+# HIP Fortran interface (hipfort)
+#DIRECTORIES+=" hipfort"
+
+# ROCm Data Center Tool (RDC)
+#DIRECTORIES+=" rdc"
+
+# ROCm Validation Suite (RVS)
+#DIRECTORIES+=" rvs"
+
+# symlink the other directories from ${BASEDIR}/
+for D in ${DIRECTORIES}; do
+  ln -s ${BASEDIR}/${D} %{i}/
+  test -L %{i}/${D}
+done

--- a/scram-tools.file/tools/rocm/rocm-rocrand.xml
+++ b/scram-tools.file/tools/rocm/rocm-rocrand.xml
@@ -1,0 +1,12 @@
+<tool name="rocm-rocrand" version="@TOOL_VERSION@">
+  <info url="https://github.com/ROCmSoftwarePlatform/rocRAND"/>
+  <use name="rocm"/>
+  <lib name="hiprand"/>
+  <lib name="rocrand"/>
+  <client>
+    <environment name="ROCM_ROCRAND_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"  default="$ROCM_ROCRAND_BASE/lib"/>
+    <environment name="INCLUDE" default="$ROCM_ROCRAND_BASE/include/hiprand"/>
+    <environment name="INCLUDE" default="$ROCM_ROCRAND_BASE/include/rocrand"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -1,0 +1,36 @@
+<tool name="rocm" version="@TOOL_VERSION@">
+  <info url="https://docs.amd.com/"/>
+  <lib name="amdhip64"/>
+  <client>
+    <environment name="ROCM_BASE" default="@TOOL_ROOT@"/>
+    <environment name="ROCM_LLVM" default="$ROCM_BASE/llvm/lib/clang/14.0.0"/>
+    <environment name="HIPCC"     default="$ROCM_BASE/bin/hipcc"/>
+    <environment name="BINDIR"    default="$ROCM_BASE/bin"/>
+    <environment name="LIBDIR"    default="$ROCM_BASE/lib"/>
+    <environment name="LIBDIR"    default="$ROCM_BASE/lib64"/>
+    <environment name="LIBDIR"    default="$ROCM_BASE/hip/lib"/>
+    <environment name="LIBDIR"    default="$ROCM_BASE/hsa/lib"/>
+    <environment name="LIBDIR"    default="$ROCM_LLVM/lib/linux"/>
+    <environment name="LIBDIR"    default="$ROCM_BASE/llvm/lib"/>
+    <environment name="INCLUDE"   default="$ROCM_BASE/include"/>
+    <environment name="INCLUDE"   default="$ROCM_BASE/hip/include"/>
+    <environment name="INCLUDE"   default="$ROCM_BASE/hsa/include"/>
+    <environment name="INCLUDE"   default="$ROCM_LLVM"/>
+  </client>
+  <flags ROCM_FLAGS="-fno-gpu-rdc --amdgpu-target=gfx900 --gcc-toolchain=$COMPILER_PATH -D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__"/>
+  <!-- REM_CXXFLAGS from llvm/llvm-cxxcompiler.xml -->
+  <flags ROCM_HOST_REM_CXXFLAGS="-Wno-non-template-friend"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-Werror=format-contains-nul"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-Werror=maybe-uninitialized"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-Werror=unused-but-set-variable"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-Werror=return-local-addr"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-fipa-pta"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-frounding-math"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-mrecip"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-fno-crossjumping"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-fno-aggressive-loop-optimizations"/>
+  <flags ROCM_HOST_REM_CXXFLAGS="-funroll-all-loops"/>
+  <flags ROCM_HOST_CXXFLAGS="-D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="PATH" value="$ROCM_BASE/bin" type="path"/>
+</tool>


### PR DESCRIPTION
This PR aims to add AMD ROCm 5.x as an external for CMSSW, without including it in the CMSSW distribution.
Instead, the ROCm tools and libraries are used over CVMFS from the Patatrack repository, similarly to what is done for the Intel tools.

For more information, see the documentation at:
  - ROCm 5.0: https://docs.amd.com/category/ROCm_v5.0;
  - ROCm 5.0.2: https://docs.amd.com/category/ROCm_v5.0.2.