### PR TITLE
[SCRAM] treat rhel and its colnes as same

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_36
+### RPM lcg SCRAMV1 V3_00_37
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 02b0bef849aa8bfc8f9c2afa5b02234221960822
+%define tag ec956d69661ee52b8d1073b7ca03805f0e1338eb
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
SCRAM should not complain like [a], it should treat al rhel and its clones as same

[a]
```
WARNING: Developer's area is created for architecture cs9_amd64_gcc11 while your current OS is el9_amd64.
```