### PR TITLE
[FWLite] added hepmc3 deps needed due to cms-sw/cmssw#37187

### DIFF
--- a/fwlite-tool-conf.spec
+++ b/fwlite-tool-conf.spec
@@ -20,6 +20,7 @@ Requires: gdbm
 Requires: gmake
 Requires: gsl
 Requires: hepmc
+Requires: hepmc3
 Requires: hls
 Requires: libjpeg-turbo
 Requires: libpng


### PR DESCRIPTION
cms-sw/cmssw#37187 added hepmc3 dependency for SimDataFormats/GeneratorProducts package ( which is part of fwlite), so this change will add `hepmc3` for fwlite 