### PR TITLE
Update UCX to version 1.12.1

### DIFF
--- a/scram-tools.file/tools/xpmem/xpmem.xml
+++ b/scram-tools.file/tools/xpmem/xpmem.xml
@@ -1,0 +1,8 @@
+<tool name="xpmem" version="@TOOL_VERSION@">
+  <lib name="xpmem"/>
+  <client>
+    <environment name="XPMEM_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"    default="$XPMEM_BASE/include"/>
+    <environment name="LIBDIR"     default="$XPMEM_BASE/lib"/>
+  </client>
+</tool>

--- a/xpmem.spec
+++ b/xpmem.spec
@@ -1,0 +1,35 @@
+### RPM external xpmem v2.6.3-20220308
+%define commit 61c39efdea943ac863037d7e35b236145904e64d
+
+BuildRequires: autotools
+Source: https://github.com/hjelmn/%{n}/archive/%{commit}.tar.gz
+
+%prep
+%setup -n %{n}-%{commit}
+
+./autogen.sh
+./configure \
+  --prefix=%{i} \
+  --enable-shared \
+  --disable-static \
+  --disable-dependency-tracking \
+  --disable-kernel-module \
+  --with-pic \
+  --with-gnu-ld
+
+%build
+make %{makeprocesses}
+
+%install
+make install
+
+# remove kernel module rules
+rm -rf %{i}/etc
+
+# remove the libtool library files
+rm -f %{i}/lib/lib*.la
+
+# remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
+rm -rf %{i}/lib/pkgconfig
+
+%post


### PR DESCRIPTION
Add the xpmem library from the HEAD of the master branch as of 2022.03.08, corresponding to the commit 61c39efdea943ac863037d7e35b236145904e64d.
Based on v2.6.3 with updates for Linux kernel up to 5.17.

Enable additional libraries in UCX:
  - enable the use of xpmem for intra-node communication;
  - enable the use of ROCm for AMD gpus;
  - remove the ROCm GDR module, which is not compatible with GDRCopy v2.x.

Update UCX to version 1.12.1:
  - change the default for UCX_MEM_CUDA_HOOK_MODE from "reloc" to "bistro";
  - various bug fixes for CUDA and ROCm;
  - see https://github.com/openucx/ucx/releases/tag/v1.12.1 for the full change log.