### PR TITLE
Force rebuild toolfile is scram-tools.file is update

### DIFF
--- a/scram-tools.file/toolfile.file
+++ b/scram-tools.file/toolfile.file
@@ -1,7 +1,7 @@
 ## NOCOMPILER
 ## NO_AUTO_RUNPATH
 ## NO_AUTO_DEPENDENCY
-Source: none
+Source: scram-tools
 %define tool   %(echo %{n} | sed 's|-toolfile$||')
 %define uctool %(echo %{tool} | tr '[a-z-]' '[A-Z_]')
 


### PR DESCRIPTION
`cmsBuild` does not rebuild `<tool>-toolfile` even if one has explicitly update a toolfile under `scram-tools.file`. This change forces every toolfile package to depend on the contents of `scram-tools.file` which allows `cmsBuild` to rebuild the toolfile