### PR TITLE
[ROCM] avoid creating symlinks

### DIFF
--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -17,6 +17,7 @@
     <environment name="INCLUDE"   default="$ROCM_BASE/hsa/include"/>
     <environment name="INCLUDE"   default="$ROCM_LLVM"/>
   </client>
+  <flags SKIP_TOOL_SYMLINKS="1"/>
   <flags ROCM_FLAGS="-fno-gpu-rdc --amdgpu-target=gfx900 --gcc-toolchain=$COMPILER_PATH -D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__"/>
   <!-- REM_CXXFLAGS from llvm/llvm-cxxcompiler.xml -->
   <flags ROCM_HOST_REM_CXXFLAGS="-Wno-non-template-friend"/>


### PR DESCRIPTION
llvm in rocm does not match llvm from cms externals and this causes cmssw to fail. This change should allow to not create symlinks for rocm libs