### PR TITLE
updated ROCm tools

### DIFF
--- a/scram-tools.file/tools/rocm/rocm-rocrand.xml
+++ b/scram-tools.file/tools/rocm/rocm-rocrand.xml
@@ -5,7 +5,6 @@
   <lib name="rocrand"/>
   <client>
     <environment name="ROCM_ROCRAND_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"  default="$ROCM_ROCRAND_BASE/lib"/>
     <environment name="INCLUDE" default="$ROCM_ROCRAND_BASE/include/hiprand"/>
     <environment name="INCLUDE" default="$ROCM_ROCRAND_BASE/include/rocrand"/>
   </client>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -13,7 +13,6 @@
     <environment name="INCLUDE"   default="$ROCM_BASE/hip/include"/>
     <environment name="INCLUDE"   default="$ROCM_BASE/hsa/include"/>
   </client>
-  <flags SKIP_TOOL_SYMLINKS="1"/>
   <flags ROCM_FLAGS="-fno-gpu-rdc --amdgpu-target=gfx900 --gcc-toolchain=$COMPILER_PATH -D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__"/>
   <!-- REM_CXXFLAGS from llvm/llvm-cxxcompiler.xml -->
   <flags ROCM_HOST_REM_CXXFLAGS="-Wno-non-template-friend"/>
@@ -28,6 +27,6 @@
   <flags ROCM_HOST_REM_CXXFLAGS="-fno-aggressive-loop-optimizations"/>
   <flags ROCM_HOST_REM_CXXFLAGS="-funroll-all-loops"/>
   <flags ROCM_HOST_CXXFLAGS="-D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>
   <runtime name="PATH" value="$ROCM_BASE/bin" type="path"/>
 </tool>


### PR DESCRIPTION
- No need to define `LIBDIR` for `rocm-rocrand.xml` as it depends on `rocm`
- enable symlink creation for `rocm` libs. Previously this was disabled to avoid getting `rocm/llvm` libs which conflicits with llvm libs from cmssw externals
- Fix `ROOT_INCLUDE_PATH` to have all `INCLUDE` directories. If a tool have multiple include paths then `join="1"` attribute is needed

FYI @fwyzard 