### PR TITLE
[12.3.X] added L1TriggerConfig-L1TConfigProducers V00-01-00

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -60,6 +60,7 @@ Requires: data-RecoBTag-CTagging
 Requires: data-L1Trigger-L1TMuon
 Requires: data-L1Trigger-L1TGlobal
 Requires: data-L1Trigger-L1THGCal
+Requires: data-L1TriggerConfig-L1TConfigProducers
 Requires: data-SLHCUpgradeSimulations-Geometry
 Requires: data-CalibTracker-SiStripDCS
 Requires: data-SimTracker-SiStripDigitizer

--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -48,6 +48,7 @@ Geometry-DTGeometryBuilder=V00-01-00
 L1Trigger-TrackFindingTMTT=V00-02-00
 L1Trigger-Phase2L1ParticleFlow=V00-03-00
 L1Trigger-L1TCalorimeter=V01-01-00
+L1TriggerConfig-L1TConfigProducers=V00-01-00
 SimTransport-PPSProtonTransport=V00-02-00
 DQM-SiStripMonitorClient=V01-01-00
 RecoMET-METPUSubtraction=V01-01-00


### PR DESCRIPTION
backport of #7823
Move L1TriggerConfig-L1TConfigProducers data to new tag, see
https://github.com/cms-data/L1TriggerConfig-L1TConfigProducers/pull/1