### PR TITLE
New dasgoclient version

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,4 +1,4 @@
-### RPM cms dasgoclient v02.04.47
+### RPM cms dasgoclient v02.04.48
 ## NOCOMPILER
 Source0: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_amd64
 Source1: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_aarch64


### PR DESCRIPTION
The new version used `--deep` parameter to look-up site information about CMS dataset, see ticket https://github.com/dmwm/das2go/issues/43