### PR TITLE
add Utilities/OpenSSL in fwlite build set

### DIFF
--- a/fwlite_build_set.file
+++ b/fwlite_build_set.file
@@ -143,4 +143,5 @@ SimDataFormats/TrackingAnalysis
 SimDataFormats/TrackingHit
 SimDataFormats/Vertex
 Utilities/General
+Utilities/OpenSSL
 Utilities/ReleaseScripts


### PR DESCRIPTION
This PR fixes fwlite build errors [a] , this is due to https://github.com/cms-sw/cmssw/pull/37629 change which now requires Utilities/OpenSSL.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/fwlite/slc7_amd64_gcc10/CMSSW_12_4_X_2022-05-02-1100/PhysicsTools/SelectorUtils 
```
PhysicsTools/SelectorUtils/interface/VersionedSelector.h:37:10: fatal error: 'Utilities/OpenSSL/interface/openssl_init.h' file not found
#include "Utilities/OpenSSL/interface/openssl_init.h"
```
FYI @perrotta @qliphy @iarspider  , this should fix the FWLite build errors