### PR TITLE
Update alpaka to the devel branch as of 2022.05.03 / c493040fe0b

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
-### RPM external alpaka develop-20220427
+### RPM external alpaka develop-20220503
 ## NOCOMPILER
 
-%define git_commit 879b95ffce2da499c9cc6e12d4cfd5545effa701
+%define git_commit c493040fe0b3ef9416bb0bbb8d45550c184a67e0
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost


### PR DESCRIPTION
Update alpaka to the HEAD of the devel branch as of 2022.05.03, corresponding to the commit c493040fe0b3ef9416bb0bbb8d45550c184a67e0 .

Relevant changes:
  - add braces around aggregate initializer.