### PR TITLE
New spec for Py3 pycodestyle; added to wmcorepy3-devtools

### DIFF
--- a/py3-astroid.spec
+++ b/py3-astroid.spec
@@ -1,4 +1,4 @@
-### RPM external py3-astroid 2.5.0
+### RPM external py3-astroid 2.11.4
 ## IMPORT build-with-pip3
 
-Requires: py3-typed-ast py3-lazy-object-proxy py3-six py3-wrapt
+Requires: py3-typed-ast py3-lazy-object-proxy py3-six py3-wrapt py3-typing-extensions

--- a/py3-cheetah3.spec
+++ b/py3-cheetah3.spec
@@ -1,4 +1,4 @@
-### RPM external py3-cheetah3 3.2.6.post2
+### RPM external py3-cheetah3 3.2.6.post1
 ## IMPORT build-with-pip3
 
 Requires: py3-markdown

--- a/py3-dill.spec
+++ b/py3-dill.spec
@@ -1,4 +1,4 @@
-### RPM external py3-pycodestyle 2.8.0
+### RPM external py3-dill 0.3.4
 ## IMPORT build-with-pip3
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-mccabe.spec
+++ b/py3-mccabe.spec
@@ -1,2 +1,2 @@
-### RPM external py3-mccabe 0.6.1
+### RPM external py3-mccabe 0.7.0
 ## IMPORT build-with-pip3

--- a/py3-pep8.spec
+++ b/py3-pep8.spec
@@ -1,4 +1,0 @@
-### RPM external py3-pep8 1.7.1
-## IMPORT build-with-pip3
-
-%define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-platformdirs.spec
+++ b/py3-platformdirs.spec
@@ -1,0 +1,3 @@
+### RPM external py3-platformdirs 2.5.2
+## IMPORT build-with-pip3
+

--- a/py3-pycodestyle.spec
+++ b/py3-pycodestyle.spec
@@ -1,0 +1,2 @@
+### RPM external py3-pycodestyle 2.8.0
+## IMPORT build-with-pip3

--- a/py3-pylint.spec
+++ b/py3-pylint.spec
@@ -1,7 +1,7 @@
 ### RPM external py3-pylint 2.13.5
 ## IMPORT build-with-pip3
 
-Requires: py3-astroid py3-toml py3-isort py3-mccabe
+Requires: py3-astroid py3-toml py3-isort py3-mccabe py3-dill py3-platformdirs py3-tomli
 
 %define PipPostBuild \
     perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*; \

--- a/py3-pylint.spec
+++ b/py3-pylint.spec
@@ -1,4 +1,4 @@
-### RPM external py3-pylint 2.7.0
+### RPM external py3-pylint 2.13.5
 ## IMPORT build-with-pip3
 
 Requires: py3-astroid py3-toml py3-isort py3-mccabe

--- a/py3-tomli.spec
+++ b/py3-tomli.spec
@@ -1,0 +1,2 @@
+### RPM external py3-tomli 2.0.1
+## IMPORT build-with-pip3

--- a/py3-typing-extensions.spec
+++ b/py3-typing-extensions.spec
@@ -1,0 +1,2 @@
+### RPM external py3-typing-extensions 4.2.0
+## IMPORT build-with-pip3

--- a/py3-wrapt.spec
+++ b/py3-wrapt.spec
@@ -1,3 +1,3 @@
-### RPM external py3-wrapt 1.12.1
+### RPM external py3-wrapt 1.14.1
 ## IMPORT build-with-pip3
 

--- a/wmcorepy3-devtools.spec
+++ b/wmcorepy3-devtools.spec
@@ -1,10 +1,10 @@
-### RPM cms wmcorepy3-devtools 0.2
+### RPM cms wmcorepy3-devtools 0.3
 
 # This is a meta-package to group development tool dependencies
 Requires: yuicompressor
 Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint py3-coverage py3-nose py3-nose2
 Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo py3-future py3-sphinx py3-cherrypy
-Requires: py3-mongomock py3-pyjwt
+Requires: py3-mongomock py3-pyjwt py3-pycodestyle
 
 %prep
 %build

--- a/wmcorepy3-devtools.spec
+++ b/wmcorepy3-devtools.spec
@@ -2,7 +2,7 @@
 
 # This is a meta-package to group development tool dependencies
 Requires: yuicompressor
-Requires: python3 py3-mock py3-pep8 py3-mox3 py3-pylint py3-coverage py3-nose py3-nose2
+Requires: python3 py3-mock py3-mox3 py3-pylint py3-coverage py3-nose py3-nose2
 Requires: py3-psutil py3-memory-profiler py3-retry py3-pymongo py3-future py3-sphinx py3-cherrypy
 Requires: py3-mongomock py3-pyjwt py3-pycodestyle
 


### PR DESCRIPTION
Create a python3 `pycodestyle` spec, which has no other dependencies; remove the `py3-pep8`, which was only used by WMCore; last but not least, update `py3-pylint` to `2.13.5` and bring in all the necessary updates and new specs that it depends on.