### PR TITLE
Update Py3 dbs3-client from 4.0.7 to 4.0.8

### DIFF
--- a/py3-dbs3-client.spec
+++ b/py3-dbs3-client.spec
@@ -1,3 +1,3 @@
-### RPM cms py3-dbs3-client 4.0.7
+### RPM cms py3-dbs3-client 4.0.8
 ## IMPORT build-with-pip3
 Requires: py3-pycurl py3-dbs3-pycurl


### PR DESCRIPTION
Fixes https://github.com/dmwm/dbs2go/issues/35

This new version contains a bugfix required for the ReqMgr2 StepChain parentage fix cherrypy thread.