### PR TITLE
Update SCRAM and build rules

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_38
+### RPM lcg SCRAMV1 V3_00_39
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 275eaca6bb20a21204e555dd101eeab5e2b829a6
+%define tag a2e3050e750443aa7a16507ebe5e1f94317b6b2f
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-00-06
+%define configtag       V07-00-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
SCRAM V2 had support for adding special flags for individual files e.g. `<flags CPPDEFINE="FOOBAR" file="somefile.xx"/>` but during the SCRAM V3 migration this feature was left out. This PR includes newer version of SCRAM which support this feature.