### PR TITLE
Update to head of 1.6 branch to pick up fix for segfault in gdwarf.

### DIFF
--- a/libunwind-dwarf.patch
+++ b/libunwind-dwarf.patch
@@ -1,0 +1,32 @@
+From 1a74cba1ecfe1d12eb67068a84f53fb1ce7b3e72 Mon Sep 17 00:00:00 2001
+From: Saleem Abdulrasool <compnerd@compnerd.org>
+Date: Thu, 31 Mar 2022 17:32:22 +0000
+Subject: [PATCH] DWARF: avoid invalid memory access with invalid CFI
+
+In the case that the CFI is incorrect, the return address column entry
+may be incorrect and point outside of the range of the program.  Add a
+cheap validation to prevent the errant memory access.
+---
+ src/dwarf/Gparser.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/dwarf/Gparser.c b/src/dwarf/Gparser.c
+index 7cfc4e506..cea35b46f 100644
+--- a/src/dwarf/Gparser.c
++++ b/src/dwarf/Gparser.c
+@@ -778,6 +778,15 @@ apply_reg_state (struct dwarf_cursor *c, struct dwarf_reg_state *rs)
+   int i, ret;
+   void *arg;
+ 
++  /* In the case that we have incorrect CFI, the return address column may be
++   * outside the valid range of data and will read invalid data.  Protect
++   * against the errant read and indicate that we have a bad frame.  */
++  if (rs->ret_addr_column >= DWARF_NUM_PRESERVED_REGS) {
++    Dprintf ("%s: return address entry %zu is outside of range of CIE",
++             __FUNCTION__, rs->ret_addr_column);
++    return -UNW_EBADFRAME;
++  }
++
+   prev_ip = c->ip;
+   prev_cfa = c->cfa;
+ 

--- a/libunwind.spec
+++ b/libunwind.spec
@@ -2,11 +2,13 @@
 %define tag e44877a4545d55332a9358f8b9e3468f5c1782f7
 %define branch v1.6-stable
 Source0: git://github.com/%{n}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Patch0: libunwind-dwarf
 BuildRequires: autotools gmake
 Requires: zlib
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 autoreconf -fiv

--- a/libunwind.spec
+++ b/libunwind.spec
@@ -1,5 +1,5 @@
 ### RPM external libunwind 1.6.2
-%define tag b3ca1b59a795a617877c01fe5d299ab7a07ff29d
+%define tag e44877a4545d55332a9358f8b9e3468f5c1782f7
 %define branch v1.6-stable
 Source0: git://github.com/%{n}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 BuildRequires: autotools gmake


### PR DESCRIPTION
Resolves https://github.com/cms-sw/cmssw/issues/37816

Tested locally with same input used in https://github.com/cms-sw/cmssw/issues/37816 that igprof runs without segfault in libunwind.