### PR TITLE
[BuildRules] Do not create python/package symlink to src/package/python

### DIFF
--- a/cmssw-patch-build.file
+++ b/cmssw-patch-build.file
@@ -34,7 +34,7 @@
 %endif
 
 %define PatchReleaseLink \
-  for SUBSYS in `ls -d %{parent_release_fpath}/$DIR/*`; do \
+  for SUBSYS in `ls -d %{parent_release_fpath}/$DIR/* | grep -v /__pycache__`; do \
     if [ -d $SUBSYS ] ; then \
       S=`basename $SUBSYS`; \
       if [ -d $DIR/$S ] ; then \

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-00-07
+%define configtag       V07-01-05
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
There was a long pending request to not generate __init__.py under src tree (https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html ). New build rules implement this and now it not only generate any __init__.py file but also still allows developers to create/modify and use src/Package/python/*.py files without re-running `scram build`. New build rules has been tested in special `PY_X` IBs