### PR TITLE
[SCRAM] Allow conditional dependency

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_40
+### RPM lcg SCRAMV1 V3_00_41
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 8111f5f92f9478647c50cd09fda95936eace77ac
+%define tag 6e7f7f48df4cfdfccb08da423da587ba4f3c6dbb
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
SCRAM needs to support conditional dependencies e.g. add dependency on one set of cmssw packages when alpaka backend is cuda. Now scram allows to add `<use name="Foo/Bar" when="alpaka-cuda"/>`