### PR TITLE
Update the OpenMPI configure options

### DIFF
--- a/openmpi.spec
+++ b/openmpi.spec
@@ -2,14 +2,20 @@
 ## INITENV SET OPAL_PREFIX %{i}
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools
-Requires: zlib cuda hwloc ucx
+Requires: cuda
+Requires: hwloc
+Requires: rdma-core
+Requires: xpmem
+Requires: ucx
+Requires: zlib
+AutoReq: no
+
 # external libraries are needed for additional protocols:
 #   --with-ofi:         Open Fabric Interface's libfabric
-#   --with-mxm:         Mellanox Messaging
+#   --with-mxm:         Mellanox Messaging (depracated, use UCX instead)
 #   --with-fca:         Mellanox Fabric Collective Accelerator
 #   --with-hcoll:       Mellanox Hierarchical Collectives
-#   --with-lsf:         LSF job scheduler
-#   --with-lustre:      Lustre filesystem
+#   --with-knem:        High-Performance Intra-Node MPI Communication
 # etc.
 
 %prep
@@ -28,7 +34,15 @@ Requires: zlib cuda hwloc ucx
   --with-zlib=$ZLIB_ROOT \
   --with-cuda=$CUDA_ROOT \
   --with-hwloc=$HWLOC_ROOT \
+  --without-ofi \
+  --without-portals4 \
+  --without-psm \
+  --without-psm2 \
+  --with-verbs=$RDMA_CORE_ROOT \
   --with-ucx=$UCX_ROOT \
+  --with-cma \
+  --without-knem \
+  --with-xpmem=$XPMEM_ROOT \
   --without-x \
   --with-pic \
   --with-gnu-ld


### PR DESCRIPTION
Enable additional protocols:
  - RDMA Core libverbs
  - XPMEM and CMA shared memory

Explicitly disable the unsupported protocols:
  - OpenFabrics libfabric
  - Portals 4
  - Intel PSM/PSM2
  - KNEM shared memory

Mellanox Hierarchical Collectives (HCOLL), Fabric Collective Accelerator (FCA), and Messaging (MXM) are disabled by default, since the corresponding libraries are not available.