### PR TITLE
Update tag for RecoEgamma-ElectronIdentification to V01-10-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-ElectronIdentification=V01-10-00
 Validation-HGCalValidation=V00-03-00
 L1Trigger-L1TMuon=V01-06-00
 RecoEgamma-EgammaPhotonProducers=V00-01-00
@@ -23,7 +24,6 @@ RecoParticleFlow-PFProducer=V16-02-00
 RecoEcal-EgammaClusterProducers=V00-01-00
 CondTools-SiPhase2Tracker=V00-02-00
 RecoTracker-FinalTrackSelectors=V01-03-00
-RecoEgamma-ElectronIdentification=V01-09-00
 CalibCalorimetry-CaloMiscalibTools=V01-00-00
 FastSimulation-MaterialEffects=V05-00-00
 L1Trigger-RPCTrigger=V00-15-00


### PR DESCRIPTION
Move RecoEgamma-ElectronIdentification data to new tag, see 
https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/25
