### PR TITLE
[Davix] Update to version 0.8.1

### DIFF
--- a/davix.spec
+++ b/davix.spec
@@ -1,4 +1,4 @@
-### RPM external davix 0.7.6
+### RPM external davix 0.8.1
 
 %define tag %(echo R_%{realversion} | tr . _)
 %define branch master
@@ -10,29 +10,24 @@ Source0: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&exp
 %define soext dylib
 %endif
 
-BuildRequires: cmake gmake git
-Requires: libxml2 libuuid
+BuildRequires: cmake gmake
+Requires: libxml2 libuuid curl
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
-# need this until we have the submodule recursive option
-cd ../ ; rm -rf %{n}-%{realversion}
-git clone https://github.com/%{github_user}/%{n}.git %{n}-%{realversion} ; cd %{n}-%{realversion} ; git checkout tags/%{tag}
-git submodule update --recursive --init
-mkdir build ; cd build
-
-cmake -DCMAKE_INSTALL_PREFIX="%{i}" \
- -DLIBXML2_INCLUDE_DIR="${LIBXML2_ROOT}/include/libxml2" \
- -DLIBXML2_LIBRARY="${LIBXML2_ROOT}/lib/libxml2.%{soext}" \
- -DUUID_INCLUDE_DIR="${LIBUUID_ROOT}/include" \
+rm -rf ../build; mkdir ../build; cd ../build
+cmake ../%{n}-%{realversion} \
+ -DCMAKE_INSTALL_PREFIX="%{i}" \
+ -DEMBEDDED_LIBCURL=FALSE \
+ -DDAVIX_TESTS=False \
  -DUUID_LIBRARY="${LIBUUID_ROOT}/lib64/libuuid.%{soext}" \
- ../
+ -DCMAKE_PREFIX_PATH="${LIBXML2_ROOT};${LIBUUID_ROOT};${CURL_ROOT}"
 
 make VERBOSE=1 %{makeprocesses}
 
 %install
-cd build
+cd ../build
 make install
 
 %post


### PR DESCRIPTION
- include latest version 0.8.1
- cleanup build recipe
- enable external curl (disable embedded curl)
- disable tests
