### PR TITLE
Update tensorflow to version 2.6.4

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -279,9 +279,9 @@ subprocess32==3.5.4
 sympy==1.8
 tables==3.6.1
 tenacity==8.0.1
-#NO_AUTO_UPDATE:3: Force to use tensorflow 2.6.3; this should match the version in tensorflow-sources.spec
+#NO_AUTO_UPDATE:1: Force to use tensorflow 2.6.4; this should match the version in tensorflow-sources.spec
+tensorflow==2.6.4
 tensorboard==2.6.0
-tensorflow==2.6.3
 tensorflow-estimator==2.6.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -4,9 +4,6 @@ BuildRequires: bazel java-env git
 ## INCLUDE tensorflow-requires
 ## INCLUDE compilation_flags
 
-%define tag         693f6e9b877899f3234e9b8790117c4b99e0470f
-%define branch      cms/v%{realversion}
-%define github_user cms-externals
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}.tgz
 
 %if "%{?build_type:set}" != "set"

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,4 +1,7 @@
-### RPM external tensorflow-sources 2.6.3
+### RPM external tensorflow-sources 2.6.4
+%define tag         0b5069862cb4347fcb482f285a323b26d6453a98
+%define branch      cms/v%{realversion}
+%define github_user cms-externals
 %define python_cmd python3
 %define python_env PYTHON3PATH
 %define build_type opt

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -1,4 +1,4 @@
-### RPM external tensorflow 2.6.3
+### RPM external tensorflow 2.6.4
 %if "%{?vectorized_package:set}" != "set"
 %define source_package tensorflow-sources
 %else


### PR DESCRIPTION
This PR update TF to version 2.6.4. github bot shows over 20 security issues (https://github.com/cms-sw/cmsdist/security/dependabot?q=is%3Aopen+package%3Atensorflow ) and suggested to move to TF 2.6.4 