### PR TITLE
[py-crytograpghy] use version 3.0 for slc7

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -62,7 +62,7 @@ contextvars==2.4
 coverage==5.5
 # Newer versions of py3-cryptography require OpenSSL 1.1.0+, see https://github.com/pyca/cryptography/issues/5906
 cryptography==37.0.2
-cryptography==3.2.1 ; cmsos_name=='slc7'
+cryptography==3.0 ; cmsos_name=='slc7'
 cx-Oracle==8.2.1
 cycler==0.10.0
 cython==0.29.24


### PR DESCRIPTION
version ">= 3.1, < 3.3.2" has `Symmetrically encrypting large values can lead to integer overflow` bug (https://github.com/cms-sw/cmsdist/security/dependabot/39 )