### PR TITLE
Update OpenMPI to version 4.1.4 [12.4.x]

### DIFF
--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,15 +1,21 @@
-### RPM external openmpi 4.1.3
+### RPM external openmpi 4.1.4
 ## INITENV SET OPAL_PREFIX %{i}
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools
-Requires: zlib cuda hwloc ucx
+Requires: cuda
+Requires: hwloc
+Requires: rdma-core
+Requires: xpmem
+Requires: ucx
+Requires: zlib
+AutoReq: no
+
 # external libraries are needed for additional protocols:
 #   --with-ofi:         Open Fabric Interface's libfabric
-#   --with-mxm:         Mellanox Messaging
+#   --with-mxm:         Mellanox Messaging (depracated, use UCX instead)
 #   --with-fca:         Mellanox Fabric Collective Accelerator
 #   --with-hcoll:       Mellanox Hierarchical Collectives
-#   --with-lsf:         LSF job scheduler
-#   --with-lustre:      Lustre filesystem
+#   --with-knem:        High-Performance Intra-Node MPI Communication
 # etc.
 
 %prep
@@ -28,7 +34,16 @@ Requires: zlib cuda hwloc ucx
   --with-zlib=$ZLIB_ROOT \
   --with-cuda=$CUDA_ROOT \
   --with-hwloc=$HWLOC_ROOT \
+  --without-ofi \
+  --without-portals4 \
+  --without-psm \
+  --without-psm2 \
+  --with-verbs=$RDMA_CORE_ROOT \
+  --without-mxm \
   --with-ucx=$UCX_ROOT \
+  --with-cma \
+  --without-knem \
+  --with-xpmem=$XPMEM_ROOT \
   --without-x \
   --with-pic \
   --with-gnu-ld
@@ -40,9 +55,7 @@ make %{makeprocesses}
 make install
 
 # remove the libtool library files
-rm -f %{i}/lib/lib*.la
-rm -f %{i}/lib/pmix/lib*.la
-rm -f %{i}/lib/openmpi/lib*.la
+find %{i}/lib/ -name '*.la' -delete
 
 %post
 %{relocateConfig}share/openmpi/*-wrapper-data.txt


### PR DESCRIPTION
The Open MPI community is pleased to announce the Open MPI v4.1.4 release.
This release contains a number of bug fixes, as well as the UCC collectives component to accelerate collectives on systems with the UCC library installed.

Open MPI v4.1.4 can be downloaded from the Open MPI website:

  https://www.open-mpi.org/software/ompi/v4.1/

Changes to v4.1.4 compared to v4.1.3:

  - fix possible length integer overflow in numerous non-blocking collective operations;
  - fix segmentation fault in UCX if MPI Tool interface is finalized before `MPI_Init` is called;
  - remove `/usr/bin/python` dependency in configure;
  - fix OMPIO issue with long double etypes;
  - update treematch topology component to fix numerous correctness issues;
  - fix memory leak in UCX MCA parameter registration;
  - fix long operation closing file descriptors on non-Linux systems that can appear as a hang to users;
  - fix for attribute handling on GCC 11 due to pointer aliasing;
  - fix multithreaded race in UCX PML's datatype handling;
  - fix a correctness issue in CUDA Reduce algorithm;
  - fix compilation issue with CUDA GPUDirect RDMA support;
  - fix to make `shmem_calloc(..., 0)` conform to the OpenSHMEM specification;
  - add UCC collectives component;
  - fix divide by zero issue in OMPI IO component;
  - fix compile issue with libnl when not in standard search locations.