### PR TITLE
Update dqmgui.spec to use 9.7.6

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.7.4
+### RPM cms dqmgui 9.7.6
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
Up to 9.7.6 to fix following warnings:
*** DQMStore: WARNING: cannot extract object 'CPUvsGPU RecHits SizeY Barrel Layer4' of type 'TObjString'