### PR TITLE
Bumping up sherpa to 2.2.12

### DIFF
--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,4 +1,4 @@
-### RPM external sherpa 2.2.11
+### RPM external sherpa 2.2.12
 %define tag 600078cc741021be898f15563235cf6c809ca5ff
 %define branch cms/v%realversion
 %define github_user cms-externals


### PR DESCRIPTION
bumping up sherpa to 2.2.12 for run-3 MC production's need ( see original request https://github.com/cms-sw/cmsdist/pull/7914 )