### PR TITLE
Update tag for RecoTauTag-TrainingFiles to V00-06-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,7 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
-RecoTauTag-TrainingFiles=V00-05-00
+RecoTauTag-TrainingFiles=V00-06-00
 RecoEgamma-ElectronIdentification=V01-10-00
 Validation-HGCalValidation=V00-03-00
 L1Trigger-L1TMuon=V01-06-00


### PR DESCRIPTION
Move RecoTauTag-TrainingFiles data to new tag, see 
https://github.com/cms-data/RecoTauTag-TrainingFiles/pull/10
