### PR TITLE
Fix py3-pyjwt PyPi name

### DIFF
--- a/py3-pyjwt.spec
+++ b/py3-pyjwt.spec
@@ -1,4 +1,5 @@
 ### RPM external py3-pyjwt 2.4.0
 ## IMPORT build-with-pip3
 
+%define pip_name PyJWT
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*


### PR DESCRIPTION
I don't know how it was working, but the correct PyPi name is the one provided in this PR, as can be seen here:
https://pypi.org/project/PyJWT/