### PR TITLE
[BuildRules] Fix findDependency whcih was broken due to python compile rules changes

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-01-05
+%define configtag       V07-01-06
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Build rules in 12.5.X were updated to not create `cmssw/python/Package` symlink point to `cmssw/src/Package/Python`. This broke the https://github.com/cms-sw/cmssw-config/blob/scramv3/SCRAM/findDependencies.py for python dependency checking. New build rules tag `V07-01-06` should fix this issue