### PR TITLE
Fix genreflex cppflags

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-01-06
+%define configtag       V07-01-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-tools.file/tools/root/rootrflx.xml
+++ b/scram-tools.file/tools/root/rootrflx.xml
@@ -8,6 +8,7 @@
   </ifarchitecture>
   <flags GENREFLEX_CPPFLAGS="-DCMS_DICT_IMPL -D_REENTRANT -DGNUSOURCE -D__STRICT_ANSI__"/>
   <runtime name="GENREFLEX" value="$ROOTRFLX_BASE/bin/genreflex"/>
+  <flags OVERRIDABLE_FLAGS="GENREFLEX_CPPFLAGS"/>
   <use name="root_interface"/>
   <use name="rootcling"/>
 </tool>


### PR DESCRIPTION
Currentl BuildRules do not allow to include cppflags from tools for building root dictionaries. This change makes `GENREFLEX_CPPFLAGS` an overridable flag so that tools can set 
```
<flags GENREFLEX_CPPFLAGS="-Dflags"/>
```