### PR TITLE
remove cuda-gcc-support tool if cuda gcc support not available

### DIFF
--- a/scram-tool-conf.file
+++ b/scram-tool-conf.file
@@ -122,6 +122,12 @@ if [ "${DUP_BIN}" != "" ] ; then
   exit 1
 fi
 set -x
+if [ -e %{i}/tools/selected/cuda-gcc-support.xml ] ; then
+  if [ "%{cuda_gcc_support}" != "true" ] ; then
+    rm -f %{i}/tools/selected/cuda-gcc-support.xml
+    echo "WARNING: CUDA does not support this GCC version, removing cuda-gcc-support.xml tool file"
+  fi
+fi
 
 %post
 


### PR DESCRIPTION
Delete `cuda-gcc-support.xml` tool if cuda does not support GCC