### PR TITLE
[BuildRules] Enabled alpaka build rules

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-01-07
+%define configtag       V07-02-03
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
backport of #7942 
Enable alpaka build rules for `cuda and serial` backends. This has been tested in DEVEL IBs