### PR TITLE
[Build Rules] Auto link alpaka backend libraries

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_43
+### RPM lcg SCRAMV1 V3_00_44
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 0bf0512e3a856f69e31b00eb1ed22bdf59e13ff2
+%define tag f5ae77c5498fb6dae4e9931cf0c488fc9a810d4a
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-02-06
+%define configtag       V07-02-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-02-05
+%define configtag       V07-02-06
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
with this change `<use name="A/B"/>` will automatically does the following
- For normal library/plugin/binary: It adds dependency on `A/B`
- For aplaka/cuda backend library/plugin/binary: It adds dependency on `A/B/alpaka/cuda`
- For aplaka/serial backend library/plugin/binary: It adds dependency on `A/B/alpaka/serial`

So after this change there is no need to has dependencies likes
```
<use name="A/B/aplaka/cuda" for="alpaka/cuda"/>
```