### PR TITLE
[Pythia8] Enable Vincia ME corrections

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -7,7 +7,7 @@ Requires: hepmc hepmc3 lhapdf
 %prep
 %setup -q -n %{n}%{realversion}
 
-./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-hepmc3=${HEPMC3_ROOT} --with-lhapdf6=${LHAPDF_ROOT}
+./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-hepmc3=${HEPMC3_ROOT} --with-lhapdf6=${LHAPDF_ROOT} --enable-mg5mes
 
 %build
 make %makeprocesses


### PR DESCRIPTION
From https://pythia.org/latest-manual/VinciaMECs.html:

> Tree-level Matrix element corrections (MECs) have not yet been re-implemented in the VINCIA shower. This feature will become available in the future. But since both the QCD helicity shower and the EW shower require polarised particles, matrix elements can be used to select helicities for the Born process.
Born-level helicity selection can be enabled by setting the modeMECs and the respective maxMECs switches (see below) to 0. Additionally, Vincia:MEPlugin must be set to a valid plugin library. By default, these plugins are not built and can be enabled with ./configure --enable-mg5mes.

List of MEs currently shipping with Pythia can be found here: https://gitlab.com/Pythia8/releases/-/tree/master/plugins/mg5mes