### PR TITLE
Numpy version 1.23

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -65,7 +65,7 @@ cryptography==37.0.2
 cryptography==3.2.1 ; cmsos_name=='slc7'
 cx-Oracle==8.2.1
 cycler==0.10.0
-cython==0.29.24
+cython==0.29.30
 decorator==5.0.9
 debugpy==1.5.1
 defusedxml==0.7.1

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -174,7 +174,7 @@ node-semver==0.8.0
 notebook==6.4.12
 numba==0.54.0
 numexpr==2.8.1
-numpy==1.21.2
+numpy==1.23.0
 onnx==1.10.1
 onnxmltools==1.9.1
 onnxconverter-common==1.8.1


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmsdist/security/dependabot/130 (Incorrect Comparison in `NumPy <= 1.21.6` )
- `numpy 1.23.0`
- `cython 0.29.30` ( needed by new numpy)