### PR TITLE
WMAgent release candidate 2.1.0.pre2; spec for docker image too

### DIFF
--- a/wmagentpy3-dev.spec
+++ b/wmagentpy3-dev.spec
@@ -1,4 +1,4 @@
-### RPM cms wmagentpy3-dev 2.0.4
+### RPM cms wmagentpy3-dev 2.1.0.pre2
 
 # This is a meta-package to group development tool dependencies
 Requires: wmagentpy3 rotatelogs wmcorepy3-devtools

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -1,4 +1,4 @@
-### RPM cms wmagentpy3 2.0.4.patch1
+### RPM cms wmagentpy3 2.1.0.pre2
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
This release will be used to build a new WMCore docker image as well.