### PR TITLE
[BuildRules] Fixed code and header checks for alpaka

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_44
+### RPM lcg SCRAMV1 V3_00_45
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag f5ae77c5498fb6dae4e9931cf0c488fc9a810d4a
+%define tag 65fcc4ad6429620c2be617f1d81893bd2bf37525
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-02-08
+%define configtag       V07-02-09
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-02-07
+%define configtag       V07-02-08
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- `header checks`: add `alpaka-serial` dependnecy if package depend on alpaka
- Only run `clang-tidy` checks for `alpaka/serial` products