### PR TITLE
[SCRAM] Prefer user env over project env if explicilt ignored via .scramrc

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_45
+### RPM lcg SCRAMV1 V3_00_46
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 65fcc4ad6429620c2be617f1d81893bd2bf37525
+%define tag fbfceadf49a3c3b9a765e9bd66b330f5041b257a
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
CMSSW env sets some env variables e.g. `LANG=C`  which can break user tool e.g. see https://github.com/cms-sw/SCRAM/issues/30 . New SCRAMV3 now allows user to instruct scram to not set env if explicitly ignored via `~/.scramrc/runtime` file e.g.

```
ignore: LANG
ignore: LC_ALL LC_CTYPE
```
entries in `~/.scramrc/runtime` file will instruct scram to not set `LANG, LC_ALL and LC_CTYPE` env 

Fixes https://github.com/cms-sw/SCRAM/issues/30