### PR TITLE
Update hwloc to version 2.8.0

### DIFF
--- a/hwloc.spec
+++ b/hwloc.spec
@@ -1,5 +1,5 @@
-### RPM external hwloc 2.7.1
-Source: https://download.open-mpi.org/release/%{n}/v2.7/%{n}-%{realversion}.tar.bz2
+### RPM external hwloc 2.8.0
+Source: https://download.open-mpi.org/release/%{n}/v2.8/%{n}-%{realversion}.tar.bz2
 
 BuildRequires: autotools
 Requires: cuda libpciaccess libxml2 numactl

--- a/hwloc.spec
+++ b/hwloc.spec
@@ -3,6 +3,9 @@ Source: https://download.open-mpi.org/release/%{n}/v2.8/%{n}-%{realversion}.tar.
 
 BuildRequires: autotools
 Requires: cuda libpciaccess libxml2 numactl
+%ifarch x86_64
+Requires: rocm
+%endif
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -13,17 +16,24 @@ Requires: cuda libpciaccess libxml2 numactl
   --disable-static \
   --disable-dependency-tracking \
   --enable-cpuid \
-  --enable-cuda \
-  --enable-nvml \
   --enable-libxml2 \
   --disable-cairo \
   --disable-doxygen \
+  --disable-opencl \
+  --with-cuda=$CUDA_ROOT \
+  --enable-cuda \
+  --enable-nvml \
   --enable-plugins=cuda,nvml \
+%ifarch x86_64
+  --with-rocm=$ROCM_ROOT \
+  --enable-rsmi \
+  --enable-plugins=cuda,nvml,rsmi \
+%else
+  --enable-plugins=cuda,nvml \
+%endif
   --with-pic \
   --with-gnu-ld \
   --without-x \
-  CPPFLAGS="-I$CUDA_ROOT/include" \
-  LDFLAGS="-L$CUDA_ROOT/lib64 -L$CUDA_ROOT/lib64/stubs" \
   HWLOC_PCIACCESS_CFLAGS="-I$LIBPCIACCESS_ROOT/include" \
   HWLOC_PCIACCESS_LIBS="-L$LIBPCIACCESS_ROOT/lib -lpciaccess" \
   HWLOC_LIBXML2_CFLAGS="-I$LIBXML2_ROOT/include/libxml2" \


### PR DESCRIPTION
API changes:
  - Add HWLOC_TOPOLOGY_FLAG_NO_DISTANCES, _NO_MEMATTRS and _NO_CPUKINDS
    to reduce the overhead when unneeded.
  - Add separate Read/Write Bandwidth/Latency memory attributes and
    implement them on Linux.

Backends changes:
  - NUMA nodes may now have a subtype such as DRAM, HBM, SPM, or NVM
    on heterogeneous memory platforms on Linux.
    - Add DAXType and DAXParent attributes on Linux to tell where a
      DAX device or its corresponding NUMA node come from (SPM for
      Specific-Purpose or NVM for Non-Volatile Memory).
  - Detect heterogeneous caches in hybrid CPUs on MacOS X,
    thanks to Paul Bone for the help.
  - Max frequencies are not ignored in Linux cpukinds anymore (they were
    ignored in hwloc 2.7.0), but they may be slightly adjusted to avoid
    reporting hybrid CPUs because Intel Turbo Boost Max 3.0.
    - See the documentation of environment variable HWLOC_CPUKINDS_MAXFREQ.
  - Hardwire the PCI locality of HPE Cray EX235a nodes.

Tools:
  - lstopo and other tools may now load Linux and x86 cpuid topology files
    from a tarball.
  - lstopo may now replace the P# and L# index prefixes with custom strings
    thanks to --os-index-prefix and --logical-index-prefix options.

Misc:
  - Add --disable-readme to avoid regenerating the top-level hwloc README
    file from the documentation.

Other change:
  - Enable ROCm support
  - Rework CUDA support 