### PR TITLE
Update stomp.py package from 4.1.21 to 7.0.0 - required for CMSMonitoring

### DIFF
--- a/py3-stomp.spec
+++ b/py3-stomp.spec
@@ -1,4 +1,4 @@
-### RPM external py3-stomp 4.1.21
+### RPM external py3-stomp 7.0.0
 ## IMPORT build-with-pip3
 
 Requires: py3-docopt


### PR DESCRIPTION
Should have gone together with: https://github.com/cms-sw/cmsdist/pull/7983