### PR TITLE
Update alpaka to the devel branch as of 2022.06.21

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
-### RPM external alpaka develop-20220503
+### RPM external alpaka develop-20220621
 ## NOCOMPILER
 
-%define git_commit c493040fe0b3ef9416bb0bbb8d45550c184a67e0
+%define git_commit 5a4691c82676176fd8b71e1f57bb809f8c75a095
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost


### PR DESCRIPTION
Update alpaka to the HEAD of the devel branch as of 2022.06.21, corresponding to the commit 5a4691c82676176fd8b71e1f57bb809f8c75a095.

Major changes:
  - implement const buffers with the ViewConst adaptor;
  - ensure that tasks submitted to async CPU queues are completed even
    after the queue is destroyed;
  - use a callback thread instead of launching a new thread for each
    CUDA asynchronous host function.

Other changes:
  - added demangled type names;
  - introduce alpaka::math::constants.

Update the supported host compilers:
  - add support for gcc 12;
  - drop support for clang 5.

Various bug fixes.