### PR TITLE
Disable aggressive compiler optimizations for VecGeom

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -23,6 +23,7 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_AR=$(which gcc-ar) \
   -DCMAKE_RANLIB=$(which gcc-ranlib) \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG" \
   -DCMAKE_VERBOSE_MAKEFILE=TRUE \
 %if "%{?arch_build_flags}"
   -DCMAKE_CXX_FLAGS="%{arch_build_flags}" \


### PR DESCRIPTION
It seems that gcc10 miscompiles (some of) the VecGeom code at `-O3`. In my tests, switching back to `-O2` fixes the crashes. More details and discussion if that is indeed a compiler problem or an issue in the code in https://sft.its.cern.ch/jira/projects/VECGEOM/issues/VECGEOM-600