### PR TITLE
update crab-dev to v3.220714

### DIFF
--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -5,7 +5,7 @@
 %define version_suffix 00
 %define crabclient_version v3.220714
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
-%define crabserver_version v3.220429
+%define crabserver_version v3.220713
 %define dbs_version        3.14.0
 
 ## IMPORT crab-build

--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -3,9 +3,8 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.220504
+%define crabclient_version v3.220714
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
-%define wmcore_version     1.5.3
 %define crabserver_version v3.220429
 %define dbs_version        3.14.0
 


### PR DESCRIPTION
Bump crab-dev to [v3.220714](https://github.com/dmwm/CRABClient/releases/tag/v3.220714).
Also remove unused `wmcore_version`.

cc: @belforte 