### PR TITLE
Revert "[vecgeom] Disable aggressive compiler optimizations"

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -24,7 +24,6 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_AR=$(which gcc-ar) \
   -DCMAKE_RANLIB=$(which gcc-ranlib) \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG" \
   -DNO_SPECIALIZATION=ON \
   -DBACKEND=Scalar \
 %ifarch x86_64


### PR DESCRIPTION
Reverts cms-sw/cmsdist#7992
To be merged for CMSSW_12_5_X_2022-07-20-1100 and then re-reverted