### PR TITLE
Revert "Revert "[vecgeom] Disable aggressive compiler optimizations""

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -24,6 +24,7 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_AR=$(which gcc-ar) \
   -DCMAKE_RANLIB=$(which gcc-ranlib) \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG" \
   -DNO_SPECIALIZATION=ON \
   -DBACKEND=Scalar \
 %ifarch x86_64


### PR DESCRIPTION
Reverts cms-sw/cmsdist#7998
That is: move the compiler flag for VecGeom to the non-aggressive "-O2" from now on in the master release