### PR TITLE
Update/rename CouchDB from 3.1.2 to 3.2.2

### DIFF
--- a/acdcserver.spec
+++ b/acdcserver.spec
@@ -4,7 +4,7 @@
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
 Source: git+https://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=%n&output=/%n.tar.gz
-Requires: python3 py3-future py3-httplib2 rotatelogs couchdb31
+Requires: python3 py3-future py3-httplib2 rotatelogs couchdb
 BuildRequires: py3-sphinx
 
 %prep

--- a/comp.spec
+++ b/comp.spec
@@ -20,7 +20,7 @@ Requires: wmarchive
 # Python3
 BuildRequires: wmcorepy3-devtools wmagentpy3-dev
 ### List of services that are likely no longer needed, but nobody could confirm that..
-BuildRequires: gitweb compsec couchdb31
+BuildRequires: gitweb compsec couchdb
 ### List of obsolete services (or under deprecation), stop building them!
 #BuildRequires: filemover PHEDEX-combined-web PHEDEX-combined-agents PHEDEX-lifecycle
 #BuildRequires: overview happyface sreadiness lifecycle-das webtools

--- a/couchdb.spec
+++ b/couchdb.spec
@@ -1,22 +1,5 @@
-### RPM external couchdb31 3.1.2
+### RPM external couchdb 3.2.2
 Source0: https://downloads.apache.org/couchdb/source/%{realversion}/apache-couchdb-%{realversion}.tar.gz
-Source1: couchdb31_cms_auth.erl
-Patch0: couchdb31-ssl-cert-patch
-Patch1: couchdb31-fix-rep-streaming
-
-# Patch explanation
-#   couchdb31-ssl-client-cert:
-#     Passes cacert_file too for the ssl context in the replicator
-#     code. Otherwise, it cannot use proxy certificates.
-#   couchdb31-fix-rep-streaming:
-#     Fixes or at least avoids the obscure bug of couch replicator
-#     client where it does not process chunked requests correctly
-#     when replicating from (but not to) a remote couch behind
-#     a SSL (Apache) proxy. On this very specific case (which happens only
-#     when replicating big documents), it seems couch is not reading
-#     the very last received data in the SSL connection buffer.
-#     We tell ibrowse to handle the (pace of) reading of incoming data buffer
-#     instead of couch. Not clear if the bug is in couch or in ibrowse.
 
 # Although there is no technical software dependency,
 # couchapp was included because all CMS applications will need it.
@@ -25,9 +8,6 @@ BuildRequires: autotools
 
 %prep
 %setup -n apache-couchdb-%{realversion}
-%patch0 -p0
-%patch1 -p0
-cp %_sourcedir/couchdb31_cms_auth.erl %_builddir/apache-couchdb-%{realversion}/src/couch/src/couch_cms_auth.erl
 
 %build
 export CURL_ROOT SPIDERMONKEY_ROOT ICU4C_ROOT ERLANG22_ROOT AUTOTOOLS_ROOT

--- a/reqmgr2.spec
+++ b/reqmgr2.spec
@@ -10,7 +10,7 @@ Source: git+https://github.com/dmwm/WMCore.git?obj=master/%realversion&export=%n
 
 Requires: python3 py3-httplib2 py3-cherrypy py3-cheetah3 py3-pycurl py3-dbs3-client
 Requires: py3-future py3-retry py3-psutil py3-cmsmonitoring
-Requires: jemalloc rotatelogs couchdb31
+Requires: jemalloc rotatelogs couchdb
 BuildRequires: py3-sphinx
 
 %prep

--- a/t0.spec
+++ b/t0.spec
@@ -15,7 +15,7 @@ Source1: git+https://github.com/dmwm/WMCore.git?obj=master/%wmcver&export=%{wmcp
 Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
 Requires: py3-mysqlclient py3-cx-oracle py3-cheetah3 py3-pyOpenSSL py3-retry
 Requires: py3-dbs3-client py3-pyzmq py3-psutil py3-future py3-cmsmonitoring py3-pyjwt
-Requires: yui libuuid couchdb31 condorpy3 jemalloc
+Requires: yui libuuid couchdb condorpy3 jemalloc
 
 BuildRequires: py3-sphinx py3-sphinxcontrib-websupport couchskel
 

--- a/wmagentpy3.spec
+++ b/wmagentpy3.spec
@@ -5,7 +5,7 @@
 
 Source: git+https://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=WMCore-%{realversion}&output=/WMCore-%{realversion}.tar.gz
 
-Requires: yui libuuid couchdb31 jemalloc mariadb
+Requires: yui libuuid couchdb jemalloc mariadb
 Requires: python3 py3-sqlalchemy py3-httplib2 py3-pycurl py3-rucio-clients
 Requires: py3-cx-oracle py3-jinja2 py3-pyOpenSSL py3-htcondor
 Requires: py3-pyzmq py3-psutil py3-future py3-retry py3-cheetah3

--- a/workqueue.spec
+++ b/workqueue.spec
@@ -6,7 +6,7 @@
 Source: git+https://github.com/dmwm/WMCore.git?obj=master/%{realversion}&export=%n&output=/%n.tar.gz
 Requires: python3 py3-httplib2 py3-dbs3-client py3-cherrypy py3-pycurl
 Requires: py3-future py3-retry py3-psutil py3-rucio-clients py3-cmsmonitoring
-Requires: jemalloc rotatelogs couchdb31 yui
+Requires: jemalloc rotatelogs couchdb yui
 BuildRequires: py3-sphinx
 
 %prep


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11222
Requires https://github.com/dmwm/deployment/pull/1169

This PR updates the spec name `couchdb31.spec` to simply `couchdb.spec`. It also updates the CouchDB version from 3.1.2 to 3.2.2. Last but not least, it no longer adds any of the CMS-specific patches when building this software.