### PR TITLE
Bump py3 CMSMonitoring to version 0.6.5 - heartbeat support

### DIFF
--- a/py3-cmsmonitoring.spec
+++ b/py3-cmsmonitoring.spec
@@ -1,4 +1,4 @@
-### RPM external py3-cmsmonitoring 0.6.4
+### RPM external py3-cmsmonitoring 0.6.5
 ## IMPORT build-with-pip3
 
 %define pip_name cmsmonitoring


### PR DESCRIPTION
This version 0.6.5 brings in support to send/recv heartbeat, which is a requirements for the CERN IT AMQ system.