### PR TITLE
Update crab-prod to v3.220714

### DIFF
--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,8 +2,8 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 01
-%define crabclient_version v3.220210
+%define version_suffix 00
+%define crabclient_version v3.220323
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define wmcore_version     1.5.3
 %define crabserver_version v3.220107

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,11 +2,10 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 01
-%define crabclient_version v3.220323
+%define version_suffix 00
+%define crabclient_version v3.220714
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
-%define wmcore_version     1.5.3
-%define crabserver_version v3.220107
+%define crabserver_version v3.220713
 %define dbs_version        3.14.0
 
 ## IMPORT crab-build


### PR DESCRIPTION
Bump crab-prod to [v3.220714](https://github.com/dmwm/CRABClient/releases/tag/v3.220714) and move current crab-prod version to crab-pre as usual.