### PR TITLE
CepGen spec-file

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,9 +1,6 @@
 ### RPM external cepgen 1.0.1
 
-%define tag 8bb7a41787b4efb2b765e1de5d39da6bce6a2b25
-%define branch %{realversion}
-%define github_user cepgen
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
 BuildRequires: cmake ninja
 

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.0.1patch1
+### RPM external cepgen 1.0.2
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -3,7 +3,7 @@
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
 BuildRequires: cmake ninja
-Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6
+Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -19,6 +19,7 @@ export HEPMC_DIR=${HEPMC_ROOT}
 export HEPMC3_DIR=${HEPMC3_ROOT}
 export LHAPDF_PATH=${LHAPDF_ROOT}
 export PYTHIA6_DIR=${PYTHIA6_ROOT}
+export ROOTSYS=${ROOT_ROOT}
 
 cmake ../%{n}-%{realversion} \
   -G Ninja \

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,9 +1,9 @@
-### RPM external cepgen 1.0.1
+### RPM external cepgen 1.0.1patch1
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
 BuildRequires: cmake ninja
-Requires: gsl hepmc hepmc3 lhapdf pythia6
+Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -14,6 +14,7 @@ mkdir ../build
 cd ../build
 
 export GSL_DIR=${GSL_ROOT}
+export OPENBLAS_DIR=${OPENBLAS_ROOT}
 export HEPMC_DIR=${HEPMC_ROOT}
 export HEPMC3_DIR=${HEPMC3_ROOT}
 export LHAPDF_PATH=${LHAPDF_ROOT}

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -2,7 +2,8 @@
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
-BuildRequires: cmake ninja hepmc hepmc3 lhapdf pythia6
+BuildRequires: cmake ninja
+Requires: gsl hepmc hepmc3 lhapdf pythia6
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -12,6 +13,7 @@ rm -rf ../build
 mkdir ../build
 cd ../build
 
+export GSL_DIR=${GSL_ROOT}
 export HEPMC_DIR=${HEPMC_ROOT}
 export HEPMC3_DIR=${HEPMC3_ROOT}
 export LHAPDF_PATH=${LHAPDF_ROOT}

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -14,7 +14,7 @@ cd ../build
 
 export HEPMC_DIR=${HEPMC_ROOT}
 export HEPMC3_DIR=${HEPMC3_ROOT}
-export LHAPDF_DIR=${LHAPDF_ROOT}
+export LHAPDF_PATH=${LHAPDF_ROOT}
 export PYTHIA6_DIR=${PYTHIA6_ROOT}
 
 cmake ../%{n}-%{realversion} \

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -2,7 +2,7 @@
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
-BuildRequires: cmake ninja
+BuildRequires: cmake ninja hepmc hepmc3 lhapdf pythia6
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -11,6 +11,11 @@ BuildRequires: cmake ninja
 rm -rf ../build
 mkdir ../build
 cd ../build
+
+export HEPMC_DIR=${HEPMC_ROOT}
+export HEPMC3_DIR=${HEPMC3_ROOT}
+export LHAPDF_DIR=${LHAPDF_ROOT}
+export PYTHIA6_DIR=${PYTHIA6_ROOT}
 
 cmake ../%{n}-%{realversion} \
   -G Ninja \
@@ -24,7 +29,7 @@ cd ../build
 ninja %{makeprocesses} install
 
 case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
-rm -f %i/lib/libCepGen-[A-Z]*-%realversion.$so
+rm -f %i/lib/libCepGen*-[A-Z]*-%realversion.$so
 
 %post
 %{relocateConfig}bin/cepgen

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,0 +1,33 @@
+### RPM external cepgen 1.0.1
+
+%define tag 8bb7a41787b4efb2b765e1de5d39da6bce6a2b25
+%define branch %{realversion}
+%define github_user cepgen
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+
+BuildRequires: cmake ninja
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+cmake ../%{n}-%{realversion} \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX:PATH="%i" \
+  -DCMAKE_BUILD_TYPE=Release
+
+ninja -v %{makeprocesses}
+
+%install
+cd ../build
+ninja %{makeprocesses} install
+
+case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
+rm -f %i/lib/libCepGen-[A-Z]*-%realversion.$so
+
+%post
+%{relocateConfig}bin/cepgen

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -12,6 +12,7 @@ Requires: starlight
 Requires: alpgen
 Requires: boost
 Requires: bz2lib
+Requires: cepgen
 Requires: classlib
 Requires: clhep
 Requires: coral

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,0 +1,9 @@
+<tool name="cepgen" version="@TOOL_VERSION@">
+  <lib name="CepGen"/>
+  <client>
+    <environment name="CEPGEN_PATH" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CEPGEN_PATH/lib"/>
+    <environment name="INCLUDE" default="$CEPGEN_PATH/include"/>
+  </client>
+  <flags SYSTEM_INCLUDE="1"/>
+</tool>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -8,7 +8,7 @@
   <lib name="CepGenPythia6"/>
   <client>
     <environment name="CEPGEN_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CEPGEN_BASE/lib"/>
+    <environment name="LIBDIR" default="$CEPGEN_BASE/lib64"/>
     <environment name="INCLUDE" default="$CEPGEN_BASE/include"/>
   </client>
   <runtime name="PATH" value="$CEPGEN_BASE/bin" type="path"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -4,6 +4,7 @@
   <lib name="CepGenHepMC2"/>
   <lib name="CepGenHepMC3"/>
   <lib name="CepGenLHAPDF"/>
+  <lib name="CepGenProcesses"/>
   <lib name="CepGenPythia6"/>
   <client>
     <environment name="CEPGEN_BASE" default="@TOOL_ROOT@"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,10 +1,5 @@
 <tool name="cepgen" version="@TOOL_VERSION@">
   <info url="https://cepgen.hepforge.org/"/>
-  <use name="gsl"/>
-  <use name="hepmc"/>
-  <use name="hepmc3"/>
-  <use name="lhapdf"/>
-  <use name="pythia6"/>
   <lib name="CepGen"/>
   <lib name="CepGenHepMC2"/>
   <lib name="CepGenHepMC3"/>
@@ -17,4 +12,10 @@
   </client>
   <runtime name="PATH" value="$CEPGEN_BASE/bin" type="path"/>
   <runtime name="CEPGEN_PATH" value="$CEPGEN_BASE/share/CepGen"/>
+  <use name="gsl"/>
+  <use name="OpenBLAS"/>
+  <use name="hepmc"/>
+  <use name="hepmc3"/>
+  <use name="lhapdf"/>
+  <use name="pythia6"/>
 </tool>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,5 +1,8 @@
 <tool name="cepgen" version="@TOOL_VERSION@">
   <lib name="CepGen"/>
+  <lib name="CepGenHepMC2"/>
+  <lib name="CepGenLHAPDF"/>
+  <lib name="CepGenPythia6"/>
   <client>
     <environment name="CEPGEN_PATH" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$CEPGEN_PATH/lib"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,5 +1,6 @@
 <tool name="cepgen" version="@TOOL_VERSION@">
   <info url="https://cepgen.hepforge.org/"/>
+  <use name="gsl"/>
   <use name="hepmc"/>
   <use name="hepmc3"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -12,6 +12,6 @@
     <environment name="CEPGEN_DIR" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$CEPGEN_DIR/lib"/>
     <environment name="INCLUDE" default="$CEPGEN_DIR/include"/>
-    <environment name="CEPGEN_PATH" default="$CEPGEN_DIR/share"/>
+    <environment name="CEPGEN_PATH" default="$CEPGEN_DIR/share/CepGen"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -5,9 +5,9 @@
   <lib name="CepGenLHAPDF"/>
   <lib name="CepGenPythia6"/>
   <client>
-    <environment name="CEPGEN_PATH" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CEPGEN_PATH/lib"/>
-    <environment name="INCLUDE" default="$CEPGEN_PATH/include"/>
+    <environment name="CEPGEN_DIR" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CEPGEN_DIR/lib"/>
+    <environment name="INCLUDE" default="$CEPGEN_DIR/include"/>
+    <environment name="CEPGEN_PATH" default="$CEPGEN_DIR/share"/>
   </client>
-  <flags SYSTEM_INCLUDE="1"/>
 </tool>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,4 +1,5 @@
 <tool name="cepgen" version="@TOOL_VERSION@">
+  <info url="https://cepgen.hepforge.org/"/>
   <use name="hepmc"/>
   <use name="hepmc3"/>
   <use name="lhapdf"/>
@@ -12,6 +13,7 @@
     <environment name="CEPGEN_DIR" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$CEPGEN_DIR/lib"/>
     <environment name="INCLUDE" default="$CEPGEN_DIR/include"/>
-    <environment name="CEPGEN_PATH" default="$CEPGEN_DIR/share/CepGen"/>
   </client>
+  <runtime name="PATH" value="$CEPGEN_DIR/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$CEPGEN_DIR/share/CepGen"/>
 </tool>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -10,10 +10,10 @@
   <lib name="CepGenLHAPDF"/>
   <lib name="CepGenPythia6"/>
   <client>
-    <environment name="CEPGEN_DIR" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CEPGEN_DIR/lib"/>
-    <environment name="INCLUDE" default="$CEPGEN_DIR/include"/>
+    <environment name="CEPGEN_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CEPGEN_BASE/lib"/>
+    <environment name="INCLUDE" default="$CEPGEN_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$CEPGEN_DIR/bin" type="path"/>
-  <runtime name="CEPGEN_PATH" value="$CEPGEN_DIR/share/CepGen"/>
+  <runtime name="PATH" value="$CEPGEN_BASE/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$CEPGEN_BASE/share/CepGen"/>
 </tool>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,4 +1,8 @@
 <tool name="cepgen" version="@TOOL_VERSION@">
+  <use name="hepmc"/>
+  <use name="hepmc3"/>
+  <use name="lhapdf"/>
+  <use name="pythia6"/>
   <lib name="CepGen"/>
   <lib name="CepGenHepMC2"/>
   <lib name="CepGenHepMC3"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,6 +1,7 @@
 <tool name="cepgen" version="@TOOL_VERSION@">
   <lib name="CepGen"/>
   <lib name="CepGenHepMC2"/>
+  <lib name="CepGenHepMC3"/>
   <lib name="CepGenLHAPDF"/>
   <lib name="CepGenPythia6"/>
   <client>


### PR DESCRIPTION
Adding a build recipe for [CepGen](https://cepgen.hepforge.org), directly cloned from CLHEP CMake-based spec-file.
Already part of LCG102 release since integration of [lcgcmake#1290](https://gitlab.cern.ch/sft/lcgcmake/-/merge_requests/1290).