### PR TITLE
[GCC Flags] drop -Wstrict-overflow which has been deprecated since gcc8

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -35,7 +35,6 @@ source ${SCRAM_TOOLS_BIN_DIR}/os_libdir.sh
 
 GCC_CXXFLAGS=""
 GCC_CXXFLAGS="$GCC_CXXFLAGS -std=c++1z -ftree-vectorize"
-GCC_CXXFLAGS="$GCC_CXXFLAGS -Wstrict-overflow"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -fvisibility-inlines-hidden"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50"

--- a/scram-tools.file/tools/icc/icc-cxxcompiler.xml
+++ b/scram-tools.file/tools/icc/icc-cxxcompiler.xml
@@ -7,7 +7,6 @@
     </client>
     <flags REM_CXXFLAGS="-felide-constructors"/>
     <flags REM_CXXFLAGS="-ftree-vectorize"/>
-    <flags REM_CXXFLAGS="-Wstrict-overflow"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-Wno-non-template-friend"/>
     <flags REM_CXXFLAGS="-Wno-psabi"/>

--- a/scram-tools.file/tools/icx/icx-cxxcompiler.xml
+++ b/scram-tools.file/tools/icx/icx-cxxcompiler.xml
@@ -7,7 +7,6 @@
     </client>
     <flags REM_CXXFLAGS="-felide-constructors"/>
     <flags REM_CXXFLAGS="-ftree-vectorize"/>
-    <flags REM_CXXFLAGS="-Wstrict-overflow"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-Wno-non-template-friend"/>
     <flags REM_CXXFLAGS="-Wno-psabi"/>


### PR DESCRIPTION
`-Wstrict-overflow` is deprecated and using `-fsanitize=signed-integer-overflow` is now the preferred way to audit code (see https://github.com/cms-sw/cmssw/issues/38679#issuecomment-1217060226 )

This PR proposes to drop this flag