### PR TITLE
Set `HWLOC_PLUGINS_PATH`

### DIFF
--- a/scram-tools.file/tools/hwloc/hwloc.xml
+++ b/scram-tools.file/tools/hwloc/hwloc.xml
@@ -6,4 +6,5 @@
     <environment name="LIBDIR"      default="$HWLOC_BASE/lib"/>
   </client>
   <runtime name="PATH" value="$HWLOC_BASE/bin" type="path"/>
+  <runtime name="HWLOC_PLUGINS_PATH" value="$HWLOC_BASE/lib/hwloc" type="path"/>
 </tool>


### PR DESCRIPTION
Set the `HWLOC_PLUGINS_PATH` variable to `$HWLOC_BASE/lib/hwloc`, in order to find the hwloc plugins when the library is installed in a different directory than the build one.