### PR TITLE
Update crab-prod to v3.220823

### DIFF
--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -3,9 +3,9 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.220714
+%define crabclient_version v3.220823
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
-%define crabserver_version v3.220713
+%define crabserver_version v3.220822
 %define dbs_version        3.14.0
 
 ## IMPORT crab-build


### PR DESCRIPTION
Bump crab-prod to [v3.220823](https://github.com/dmwm/CRABClient/releases/tag/v3.220823), also bump crabserver dependency to [v3.220822](https://github.com/dmwm/CRABServer/compare/v3.220713...v3.220822). Fix `crab checkwrite`.

cc: @mapellidario @belforte 