### PR TITLE
[BuildRules] Do not set multi-arch env if not enabled

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-03-04
+%define configtag       V07-03-05
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Setting CMSSW env for multi-target first and then setting env for non-multi-target cmssw release causes scram to set wrong LD_LIBRARY_PATH. New cmssw-config tag makes sure to ignore `SCRAM_TARGET` env ( which could be set by multi-trget release) for a non-multi-target release 