### PR TITLE
Update Py3 CMSMonitoring package to version 0.6.8

### DIFF
--- a/py3-cmsmonitoring.spec
+++ b/py3-cmsmonitoring.spec
@@ -1,4 +1,4 @@
-### RPM external py3-cmsmonitoring 0.6.7
+### RPM external py3-cmsmonitoring 0.6.8
 ## IMPORT build-with-pip3
 
 %define pip_name cmsmonitoring


### PR DESCRIPTION
Fixes the log verbosity of stomp.py