### PR TITLE
CepGen v1.0.2patch1

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.0.2
+### RPM external cepgen 1.0.2patch1
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 


### PR DESCRIPTION
This release fixes the CMake installation directive, and in particular the lack of headers observed for the add-ons built in the former release.

@smuzaffar Sorry for the extra work. The CMSSW integration helped spotting this wrong behaviour.