### PR TITLE
fix geant4 cmake files relocation

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -81,7 +81,7 @@ gcc-ar rcs libgeant4-static.a *.o
 find . -name "*.o" -delete
 
 %post
-%{relocateConfig}lib64/Geant4-*/*.cmake
+%{relocateCmsFiles} $(find $RPM_INSTALL_PREFIX/%{pkgrel} -name '*.cmake')
 %{relocateConfig}bin/geant4-config
 %{relocateConfig}bin/geant4.*
-%{relocateConfig}share/Geant4-*/geant4make/geant4make.*
+%{relocateConfig}share/Geant4*/geant4make/geant4make.*


### PR DESCRIPTION
This should fix the build errors in Geant4 IBs which are failing to build `dd4hep` as the geant4 cmake files were not properly relocated. This PR fixes the relocation for current G4 and new G4 version