### PR TITLE
Set `ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128` [12.5.x]

### DIFF
--- a/scram-tools.file/tools/alpaka/alpaka.xml
+++ b/scram-tools.file/tools/alpaka/alpaka.xml
@@ -5,4 +5,8 @@
     <environment name="INCLUDE"     default="$ALPAKA_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <!-- set ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 for host, device, and dictionaries -->
+  <flags CXXFLAGS="-DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128"/>
+  <flags CUDA_FLAGS="-DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128"/>
+  <flags GENREFLEX_CPPFLAGS="-DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128"/>
 </tool>


### PR DESCRIPTION
Backport of #8107 to 12.5.x .