### PR TITLE
backport Alpaka updates to 12.4.x

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
-### RPM external alpaka develop-20220811
+### RPM external alpaka develop-20220902
 ## NOCOMPILER
 
-%define git_commit 30d205f46d7f9235dd49b4cccd4d2daaa25e0f04
+%define git_commit b518e8c943a816eba06c3e12c0a7e1b58c8faedc
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost

--- a/scram-tools.file/tools/alpaka/alpaka.xml
+++ b/scram-tools.file/tools/alpaka/alpaka.xml
@@ -5,4 +5,8 @@
     <environment name="INCLUDE"     default="$ALPAKA_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <!-- set ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 for host, device, and dictionaries -->
+  <flags CXXFLAGS="-DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128"/>
+  <flags CUDA_FLAGS="-DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128"/>
+  <flags GENREFLEX_CPPFLAGS="-DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128"/>
 </tool>


### PR DESCRIPTION
Update the version of alpaka to the HEAD of the develop branch as of 2022.09.02, corresponding to the commit [b518e8c943a8](https://github.com/alpaka-group/alpaka/commit/b518e8c943a816eba06c3e12c0a7e1b58c8faedc) .

Major changes:
  - change the interface of `allocMappedBuf()` to identify the platform with an explicit template parameter instead of deducing it from an (unused) device argument;
  - use `CUDART_VERSION` instead of `BOOST_LANG_CUDA`.

Other changes:
  - document new memory functionality;
  - add missing template parameters.

Set `ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128`.