### PR TITLE
Update tag for CalibTracker-SiPixelESProducers to V02-03-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+CalibTracker-SiPixelESProducers=V02-03-00
 RecoHGCal-TICL=V00-03-00
 L1Trigger-Phase2L1ParticleFlow=V00-04-00
 Validation-HGCalValidation=V00-05-00
@@ -49,7 +50,6 @@ L1Trigger-DTTriggerPhase2=V00-02-00
 EgammaAnalysis-ElectronTools=V00-03-01
 HeterogeneousCore-SonicTriton=V00-01-00
 RecoTracker-TkSeedGenerator=V00-02-00
-CalibTracker-SiPixelESProducers=V02-02-00
 Geometry-DTGeometryBuilder=V00-01-00
 L1Trigger-TrackFindingTMTT=V00-02-00
 L1Trigger-L1TCalorimeter=V01-01-00


### PR DESCRIPTION
Move CalibTracker-SiPixelESProducers data to new tag, see 
https://github.com/cms-data/CalibTracker-SiPixelESProducers/pull/3
