### PR TITLE
[cmssw-osenv] Check and mount for /pool

### DIFF
--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 221009.0
+### RPM cms cmssw-osenv 221027.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit a85902226d6107c61802d01ee1afac13a11a7eb4
+%define commit 85b709c25e613a732ccacc931f99bfe4659873d1
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.


### PR DESCRIPTION
This should fix the `CondCore/CondDB/condTestRegression` unit test  which runs `cmssw-cc7` internally but `/pool` of grid nodes is not mounted under new env
`CondTools/SiStrip/SiStripDAQ_O2O_test` test failure is due to old ~/.netrc file on grid nodes. The fail has been updated on `afs/cmsbuild` so new grid nodes should pick it up.