### PR TITLE
Update dd4hep to follow latest version/commits

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -1,6 +1,6 @@
-### RPM external dd4hep v01-19x
+### RPM external dd4hep v01-23x
 
-%define tag cc335b34e9eb2825ab18e20c531be813a92d141f
+%define tag 5c3b494f047ee025b2e32303c16ad854bfbb342d
 %define branch master
 %define github_user AIDASoft
 %define keep_archives true


### PR DESCRIPTION
Hello @cms-sw/simulation-l2, @cms-sw/geometry-l2,

Do you have any objections on `dd4hep` update to latest version `v01-23` (released on Sep 30, 2022)  and latest commit (https://github.com/AIDASoft/DD4hep/tree/5c3b494f047ee025b2e32303c16ad854bfbb342d) in `12.6.X/master`?

See the origin of this discussion at https://github.com/cms-sw/cmsdist/pull/8133#issuecomment-1282687459.

Thank you,
Andrea.