### PR TITLE
Add patch to disable builting Rivet documentation

### DIFF
--- a/rivet-disable-doc.patch
+++ b/rivet-disable-doc.patch
@@ -1,0 +1,15 @@
+--- Makefile.am.orig	2022-10-31 16:05:58.132999546 +0100
++++ Makefile.am	2022-10-31 16:06:15.565836240 +0100
+@@ -19,11 +19,7 @@
+ 	@rm -rf a.out
+ 
+ install-data-local:
+-	cd doc && $(MAKE) dat json
+-	$(mkdir_p) $(DESTDIR)$(pkgdatadir)
+-	$(install_sh_DATA) doc/analists/analyses.dat $(DESTDIR)$(pkgdatadir)/
+-	$(install_sh_DATA) doc/analists/analyses.json $(DESTDIR)$(pkgdatadir)/
+-
++	@true
+ 
+ ## Upload tarballs to HepForge
+ DEST = login.hepforge.org:rivet/downloads/

--- a/rivet.spec
+++ b/rivet.spec
@@ -7,11 +7,13 @@ Requires: hepmc fastjet fastjet-contrib yoda
 BuildRequires: python3 py3-cython autotools
 
 Patch0: rivet-140-313
+Patch1: rivet-disable-doc
 
 %prep
 ## OLD GENSER: %setup -n rivet/%{realversion}
 %setup -n %{n}-%{realversion}
 %patch0 -p0
+%patch1 -p0
 
 # Update config.{guess,sub} to detect aarch64 and ppc64le
 rm -f %{_tmppath}/config.{sub,guess}


### PR DESCRIPTION
Building `analyses.dat` and `analyses.dat` cause `libRivet.so` to be loaded - which could've been built with vector instructions not supported by build machine. While the failure of command used to generate `doc/analists/analyses.{dat,json}` does not cause built to fail, lack of generated files does fail the build.