### PR TITLE
[BuildRules] Fix for multiple DROP_DEPS

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-03-09
+%define configtag       V07-03-10
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
this should fix the issue with multiple `DROP_DEP` packages e.g. see https://github.com/cms-sw/cmssw/pull/39736#discussion_r1015422223