### PR TITLE
Update tag for RecoEgamma-PhotonIdentification to V01-06-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-PhotonIdentification=V01-06-00
 Alignment-OfflineValidation=V00-03-00
 RecoTracker-FinalTrackSelectors=V01-04-00
 L1Trigger-L1TGlobal=V00-04-00
@@ -15,7 +16,6 @@ Validation-HGCalValidation=V00-05-00
 DQM-Integration=V00-02-00
 L1Trigger-CSCTriggerPrimitives=V00-12-00
 RecoMET-METPUSubtraction=V01-02-00
-RecoEgamma-PhotonIdentification=V01-05-00
 RecoBTag-Combined=V01-14-00
 MagneticField-Interpolation=V01-02-00
 RecoEcal-EgammaClusterProducers=V00-02-00


### PR DESCRIPTION
Move RecoEgamma-PhotonIdentification data to new tag, see 
https://github.com/cms-data/RecoEgamma-PhotonIdentification/pull/13
