### PR TITLE
build cpu_features so that it can be linked into plugins

### DIFF
--- a/cpu_features.spec
+++ b/cpu_features.spec
@@ -9,6 +9,7 @@ BuildRequires: gmake cmake
 %build
 cmake -S. -Bbuild \
     -DBUILD_TESTING=OFF \
+    -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_INSTALL_PREFIX:STRING=%{i}
 
 %install


### PR DESCRIPTION
Code linked into plugins needs to be relocatable.  cpu_features by default builds a static library and doesn't turn on position independent code, so it can't be linked into the CPU plugin.  The CMakeList explains:
```
# cpu_features uses bit-fields which are - to some extends - implementation-defined (see https://en.cppreference.com/w/c/language/bit_field).
# As a consequence it is discouraged to use cpu_features as a shared library because different compilers may interpret the code in different ways.
# Prefer static linking from source whenever possible.
option(BUILD_SHARED_LIBS "Build library as shared." OFF)
```
but that doesn't apply to us since we recompile for every different compiler variant.