### PR TITLE
set jemalloc hugepagesize on aarch64 to avoid huge address space allocations

### DIFF
--- a/jemalloc-debug.spec
+++ b/jemalloc-debug.spec
@@ -3,10 +3,10 @@
 
 %build
 XOPTS=""
-case %{cmsplatf} in
-  # set the huge page size to 16M on ARMv8
-  *_aarch64_*) XOPTS="--with-lg-hugepage=24" ;;
-esac
+%ifarch aarch64
+# set the huge page size to 16M ( log2(16M)=24 ) on ARMv8
+XOPTS="--with-lg-hugepage=24"
+%endif
 
 ./autogen.sh ${XOPTS} \
   --enable-shared \

--- a/jemalloc-debug.spec
+++ b/jemalloc-debug.spec
@@ -2,7 +2,13 @@
 ### RPM external jemalloc-debug %{jemalloc_version}
 
 %build
-./autogen.sh \
+XOPTS=""
+case %{cmsplatf} in
+  # set the huge page size to 16M on ARMv8
+  *_aarch64_*) XOPTS="--with-lg-hugepage=24" ;;
+esac
+
+./autogen.sh ${XOPTS} \
   --enable-shared \
   --disable-static \
   --disable-doc \

--- a/jemalloc-prof.spec
+++ b/jemalloc-prof.spec
@@ -6,10 +6,10 @@ Requires: libunwind
 
 %build
 XOPTS=""
-case %{cmsplatf} in
-  # set the huge page size to 16M on ARMv8
-  *_aarch64_*) XOPTS="--with-lg-hugepage=24" ;;
-esac
+%ifarch aarch64
+# set the huge page size to 16M ( log2(16M)=24 ) on ARMv8
+XOPTS="--with-lg-hugepage=24"
+%endif
 
 export CXXFLAGS=-I$LIBUNWIND_ROOT/include
 export CFLAGS=-I$LIBUNWIND_ROOT/include

--- a/jemalloc-prof.spec
+++ b/jemalloc-prof.spec
@@ -5,11 +5,17 @@ Requires: libunwind
 ### RPM external jemalloc-prof %{jemalloc_version}
 
 %build
+XOPTS=""
+case %{cmsplatf} in
+  # set the huge page size to 16M on ARMv8
+  *_aarch64_*) XOPTS="--with-lg-hugepage=24" ;;
+esac
+
 export CXXFLAGS=-I$LIBUNWIND_ROOT/include
 export CFLAGS=-I$LIBUNWIND_ROOT/include
 export LDFLAGS=-L$LIBUNWIND_ROOT/lib
 
-./autogen.sh \
+./autogen.sh ${XOPTS} \
   --enable-shared \
   --disable-static \
   --disable-doc \

--- a/jemalloc.spec
+++ b/jemalloc.spec
@@ -3,10 +3,10 @@
 
 %build
 XOPTS=""
-case %{cmsplatf} in
-  # set the huge page size to 16M on ARMv8
-  *_aarch64_*) XOPTS="--with-lg-hugepage=24" ;;
-esac
+%ifarch aarch64
+# set the huge page size to 16M ( log2(16M)=24 ) on ARMv8
+XOPTS="--with-lg-hugepage=24"
+%endif
 
 ./autogen.sh ${XOPTS} \
   --enable-shared \

--- a/jemalloc.spec
+++ b/jemalloc.spec
@@ -2,7 +2,13 @@
 ### RPM external jemalloc %{jemalloc_version}
 
 %build
-./autogen.sh \
+XOPTS=""
+case %{cmsplatf} in
+  # set the huge page size to 16M on ARMv8
+  *_aarch64_*) XOPTS="--with-lg-hugepage=24" ;;
+esac
+
+./autogen.sh ${XOPTS} \
   --enable-shared \
   --disable-static \
   --disable-doc \


### PR DESCRIPTION
The OpenLab ARM64 systems have Hugepagesize set to 0.5GB.  jemalloc uses the huge page size for its internal arrays and bitmaps, so having a very large value allocates large amounts of address space that often never get used.  For details, see:

https://github.com/cms-sw/cmssw/issues/31306

This PR sets the jemalloc huge page size to the same 16MB value used by the ppc builds.  Even that probably wastes some address space--the jemalloc default if it can't find the pagesize is 2MB.

Completely untested, it has been a long time since I built anything in cmsdist by hand.