### PR TITLE
New version of DBS3 and pycurl clients

### DIFF
--- a/py3-dbs3-client.spec
+++ b/py3-dbs3-client.spec
@@ -1,3 +1,3 @@
-### RPM cms py3-dbs3-client 4.0.10
+### RPM cms py3-dbs3-client 4.0.12
 ## IMPORT build-with-pip3
 Requires: py3-pycurl py3-dbs3-pycurl

--- a/py3-dbs3-pycurl.spec
+++ b/py3-dbs3-pycurl.spec
@@ -1,4 +1,4 @@
-### RPM cms py3-dbs3-pycurl 3.17.7
+### RPM cms py3-dbs3-pycurl 3.17.9
 ## IMPORT build-with-pip3
 Requires: py3-pycurl
 


### PR DESCRIPTION
The new version of DBS3 and pycurl clients provide compatibility with new DBS Go server error codes which we need for WMCore services.

FYI: @amaltaro 