### PR TITLE
Update rucio-clients to 1.29.10 and all its dependencies

### DIFF
--- a/py3-attrs.spec
+++ b/py3-attrs.spec
@@ -1,2 +1,2 @@
-### RPM external py3-attrs 20.3.0
+### RPM external py3-attrs 22.1.0
 ## IMPORT build-with-pip3

--- a/py3-certifi.spec
+++ b/py3-certifi.spec
@@ -1,2 +1,2 @@
-### RPM external py3-certifi 2021.5.30
+### RPM external py3-certifi 2022.9.24
 ## IMPORT build-with-pip3

--- a/py3-charset-normalizer.spec
+++ b/py3-charset-normalizer.spec
@@ -1,4 +1,4 @@
-### RPM external py3-charset-normalizer 2.0.4
+### RPM external py3-charset-normalizer 2.0.12
 ## IMPORT build-with-pip3
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-cmsmonitoring.spec
+++ b/py3-cmsmonitoring.spec
@@ -1,10 +1,10 @@
-### RPM external py3-cmsmonitoring 0.6.9
+### RPM external py3-cmsmonitoring 0.6.10
 ## IMPORT build-with-pip3
 
 %define pip_name cmsmonitoring
 Requires: py3-stomp py3-jsonschema py3-genson
 
 # Relax dependency on jsonschema to avoid incompatibilities with rucio-clients
-%define PipPreBuild perl -p -i -e "s|^jsonschema>=4|jsonschema>=3.2|" %{i}/src/*
+# %define PipPreBuild perl -p -i -e "s|^jsonschema>=4|jsonschema>=3.2|" %{i}/src/*
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-cmsmonitoring.spec
+++ b/py3-cmsmonitoring.spec
@@ -4,4 +4,7 @@
 %define pip_name cmsmonitoring
 Requires: py3-stomp py3-jsonschema py3-genson
 
+# Relax dependency on jsonschema to avoid incompatibilities with rucio-clients
+%define PipPreBuild perl -p -i -e "s|^jsonschema>=4|jsonschema>=3.2|" %{i}/src/*
+
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-decorator.spec
+++ b/py3-decorator.spec
@@ -1,2 +1,2 @@
-### RPM external py3-decorator 4.4.2
+### RPM external py3-decorator 5.1.1
 ## IMPORT build-with-pip3

--- a/py3-dogpile-cache.spec
+++ b/py3-dogpile-cache.spec
@@ -1,5 +1,6 @@
 ### RPM external py3-dogpile-cache 1.1.5
 ## IMPORT build-with-pip3
+Requires: py3-decorator py3-stevedore
 
 %define pip_name dogpile.cache
 

--- a/py3-dogpile-cache.spec
+++ b/py3-dogpile-cache.spec
@@ -1,4 +1,4 @@
-### RPM external py3-dogpile-cache 0.6.7
+### RPM external py3-dogpile-cache 1.1.5
 ## IMPORT build-with-pip3
 
 %define pip_name dogpile.cache

--- a/py3-idna.spec
+++ b/py3-idna.spec
@@ -1,4 +1,4 @@
-### RPM external py3-idna 3.2
+### RPM external py3-idna 3.4
 ## IMPORT build-with-pip3
 
 Requires: py3-certifi py3-urllib3

--- a/py3-pbr.spec
+++ b/py3-pbr.spec
@@ -1,4 +1,4 @@
-### RPM external py3-pbr 5.5.1
+### RPM external py3-pbr 5.11.0
 ## IMPORT build-with-pip3
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-pyrsistent.spec
+++ b/py3-pyrsistent.spec
@@ -1,3 +1,3 @@
-### RPM external py3-pyrsistent 0.17.3
+### RPM external py3-pyrsistent 0.19.2
 ## IMPORT build-with-pip3
 

--- a/py3-requests.spec
+++ b/py3-requests.spec
@@ -1,4 +1,4 @@
-### RPM external py3-requests 2.26.0
+### RPM external py3-requests 2.27.1
 ## IMPORT build-with-pip3
 
 Requires: py3-certifi py3-urllib3 py3-idna py3-charset-normalizer

--- a/py3-rucio-clients.spec
+++ b/py3-rucio-clients.spec
@@ -1,4 +1,4 @@
-### RPM external py3-rucio-clients 1.25.5
+### RPM external py3-rucio-clients 1.29.10
 ## IMPORT build-with-pip3
 ## INITENV SET RUCIO_HOME %i/
 

--- a/py3-stevedore.spec
+++ b/py3-stevedore.spec
@@ -1,0 +1,2 @@
+### RPM external py3-stevedore 4.1.1
+## IMPORT build-with-pip3

--- a/py3-stevedore.spec
+++ b/py3-stevedore.spec
@@ -1,2 +1,3 @@
 ### RPM external py3-stevedore 4.1.1
 ## IMPORT build-with-pip3
+Requires: py3-pbr

--- a/py3-tabulate.spec
+++ b/py3-tabulate.spec
@@ -1,4 +1,4 @@
-### RPM external py3-tabulate 0.8.7
+### RPM external py3-tabulate 0.8.10
 ## IMPORT build-with-pip3
 
 %define PipPostBuild perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/*

--- a/py3-urllib3.spec
+++ b/py3-urllib3.spec
@@ -1,2 +1,2 @@
-### RPM external py3-urllib3 1.26.6
+### RPM external py3-urllib3 1.26.8
 ## IMPORT build-with-pip3


### PR DESCRIPTION
This PR updates `rucio-clients` to version `1.29.10`. Note that the `cmsmonitoring` package requires `jsonschema>4`, so I am trying to patch it to actually accept jsonschema >= 3.2

It includes the following dependencies, tested with a Dockerfile:
```
Successfully installed attrs-22.1.0 certifi-2022.9.24 charset-normalizer-2.0.12 decorator-5.1.1 dogpile.cache-1.1.5 idna-3.4 jsonschema-3.2.0
 pbr-5.11.0 pyrsistent-0.19.2 requests-2.27.1 rucio-clients-1.29.10 six-1.16.0 stevedore-4.1.1 tabulate-0.8.10 urllib3-1.26.8
```