### PR TITLE
Rivet 3.1.7 & YODA 1.9.7, disentagle from Sherpa

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -61,4 +61,3 @@ sed -i -e 's|^#!.*python.*|#!/usr/bin/env python3|' %{i}/bin/*
 %{relocateConfig}bin/rivet-config
 %{relocateConfig}bin/rivet-buildplugin
 %{relocateConfig}bin/rivet-build
-%{relocateConfig}lib/python*/site-packages/rivet-*egg-info/SOURCES.txt

--- a/rivet.spec
+++ b/rivet.spec
@@ -1,4 +1,4 @@
-### RPM external rivet 3.1.6
+### RPM external rivet 3.1.7
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -3,7 +3,7 @@
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-%{realversion}.tar.gz
-Requires: hepmc lhapdf blackhat sqlite python3 fastjet openmpi rivet
+Requires: hepmc lhapdf blackhat sqlite python3 fastjet openmpi
 BuildRequires: mcfm swig autotools
 Patch0: sherpa-2.2.10-hepmcshort
 
@@ -34,7 +34,6 @@ export PYTHON=$(which python3)
 ./configure --prefix=%i --enable-analysis --disable-silent-rules \
             --enable-fastjet=$FASTJET_ROOT \
             --enable-hepmc2=$HEPMC_ROOT \
-            --enable-rivet=$RIVET_ROOT \
             --enable-lhapdf=$LHAPDF_ROOT \
             --enable-blackhat=$BLACKHAT_ROOT \
             --enable-pyext \

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,4 +1,4 @@
-### RPM external yoda 1.9.6
+### RPM external yoda 1.9.7
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 
 Source: git+https://gitlab.com/hepcedar/yoda.git?obj=main/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz

--- a/yoda.spec
+++ b/yoda.spec
@@ -13,9 +13,6 @@ autoreconf -fiv
 
 %build
 
-sed -i -e "s|lPyROOT|lcppyyX.X|" ./pyext/setup.py.in
-
-sed -i -e "s|lcppyy...|lcppyy$(echo %{cms_python3_major_minor_version} | tr . _)|" ./pyext/setup.py.in
 PYTHON=$(which python3) ./configure --prefix=%i --enable-root
 sed -i "s|env python|env python3|" bin/*
 make %{makeprocesses} all

--- a/yoda.spec
+++ b/yoda.spec
@@ -22,4 +22,3 @@ make install
 
 %post
 %{relocateConfig}bin/yoda-config
-%{relocateConfig}lib/python*/site-packages/yoda*egg-info/SOURCES.txt


### PR DESCRIPTION
Hi, this is a new try for the Rivet update (originally https://github.com/cms-sw/cmsdist/pull/8109).
I propose to deactivate the Sherpa Rivet interface to disentangle them from each other so that we can update them separately (needed to have the latest Rivet analyses available in CMSSW).
Sherpa+Rivet can still be run through the CMSSW RivetInterface.

I checked that workflow 534.0 runs fine now, no more crashes like those reported in https://github.com/cms-sw/cmssw/issues/39914.

```
534.0_sherpa_ZtoLL_2j_MEPSatNLO_13TeV_MASTER+sherpa_ZtoLL_2j_MEPSatNLO_13TeV_MASTER+HARVESTGEN Step0-PASSED Step1-PASSED  - time date Thu Nov 24 14:14:32 2022-date Thu Nov 24 14:09:43 2022; exit: 0 0
1 1 tests passed, 0 0 failed
```

Best,
Markus