### PR TITLE
Update dasgoclient to use revXX as version suffix, fix for finding correct exec

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,8 +1,10 @@
-### RPM cms dasgoclient v02.04.49
+### RPM cms dasgoclient v20221125.0
 ## NOCOMPILER
-Source0: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_amd64
-Source1: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_aarch64
-Source2: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/dasgoclient_ppc64le
+## NO_VERSION_SUFFIX
+%define dasgoclient_tag v02.04.49
+Source0: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_amd64
+Source1: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_aarch64
+Source2: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_ppc64le
 
 %prep
 %build
@@ -10,14 +12,15 @@ Source2: https://github.com/dmwm/dasgoclient/releases/download/%{realversion}/da
 mkdir %{i}/etc %{i}/bin
 cat << \EOF > %{i}/etc/dasgoclient
 #!/bin/sh
-# VERSION:%{cmsplatf}/%{v}
+# CMSDIST_FILE_REVISION=1
 # Clean-up CMSSW environment
 if [ -f %{instroot}/common/scram ] ; then
   eval `%{instroot}/common/scram unsetenv -sh`
 fi
 # Sourcing dasclient environment
 SHARED_ARCH=`%{instroot}/common/cmsos`
-LATEST_VERSION=`cd %{instroot}; ls ${SHARED_ARCH}_*/%{pkgcategory}/%{pkgname}/v*/bin/dasgoclient | sed 's|.*/%{pkgcategory}/%{pkgname}/||' | sort | tail -1`
+[ $(ls %{instroot}/${SHARED_ARCH}_*/cms/dasgoclient 2>/dev/null | wc -l) -eq 0 ] && SHARED_ARCH=$(echo $SCRAM_ARCH | cut -d_ -f1,2)
+LATEST_VERSION=`ls %{instroot}/${SHARED_ARCH}_*/%{pkgcategory}/%{pkgname}/v*/bin/dasgoclient | sed 's|.*/%{pkgcategory}/%{pkgname}/||' | sort | tail -1`
 DASGOCLIENT=`ls %{instroot}/${SHARED_ARCH}_*/%{pkgcategory}/%{pkgname}/${LATEST_VERSION} | sort | tail -1`
 $DASGOCLIENT "$@"
 EOF
@@ -31,10 +34,7 @@ chmod +x %{i}/bin/dasgoclient
 
 # copy wrapper script into common if latest version is same as this version
 mkdir -p $RPM_INSTALL_PREFIX/common
-if [ "`ls ${RPM_INSTALL_PREFIX}/*/%{pkgcategory}/%{pkgname}/v*/etc/profile.d/init.sh | sed 's|.*/%{pkgcategory}/%{pkgname}/||;s|/etc/profile.d/init.sh||' | sort | tail -1`" = "%v" ] ; then
-  /bin/cp -f ${RPM_INSTALL_PREFIX}/%{pkgrel}/etc/dasgoclient $RPM_INSTALL_PREFIX/common/dasgoclient.tmp
-  mv $RPM_INSTALL_PREFIX/common/dasgoclient.tmp $RPM_INSTALL_PREFIX/common/dasgoclient
-fi
+%common_revision_script ${RPM_INSTALL_PREFIX}/%{pkgrel}/etc/dasgoclien $RPM_INSTALL_PREFIX/common/dasgoclient
 
 # make das_client point to dasgoclient in overrides/bin area
 mkdir -p $RPM_INSTALL_PREFIX/share/overrides/bin

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -4,7 +4,7 @@
 ##########################################
 %define version_suffix 00
 %define dasgoclient_tag v02.04.49
-### RPM cms crab-dev %{dasgoclient_tag}.rev%{version_suffix}
+### RPM cms dasgoclient %{dasgoclient_tag}.rev%{version_suffix}
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,11 +1,13 @@
-### RPM cms dasgoclient v20221125.0
+############## IMPORTANT #################
+#For new dasgoclient_tag, set the version_suffix to 00
+#For any other change, increment version_suffix
+##########################################
+%define version_suffix 00
+%define dasgoclient_tag v02.04.49
+### RPM cms crab-dev %{dasgoclient_tag}.rev%{version_suffix}
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
-####### NOTE ########
-# For any changes in this file (e.g. updating dasgoclient_tag or build recipe changes) please
-# always use the latest date as version in first line
-#####################
-%define dasgoclient_tag v02.04.49
+
 Source0: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_amd64
 Source1: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_aarch64
 Source2: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_ppc64le

--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -1,6 +1,10 @@
 ### RPM cms dasgoclient v20221125.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
+####### NOTE ########
+# For any changes in this file (e.g. updating dasgoclient_tag or build recipe changes) please
+# always use the latest date as version in first line
+#####################
 %define dasgoclient_tag v02.04.49
 Source0: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_amd64
 Source1: https://github.com/dmwm/dasgoclient/releases/download/%{dasgoclient_tag}/dasgoclient_aarch64

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -268,7 +268,7 @@ fi
   OLD_REV=0 \
   if [ -f %{2} ] ; then OLD_REV=$(grep '^\s*#\s*CMSDIST_FILE_REVISION\s*=' %{2} | tail -1 | sed 's|.*=||;s| ||g') ; fi \
   NEW_REV=$(grep '^\s*#\s*CMSDIST_FILE_REVISION\s*=' %{1} | tail -1 | sed 's|.*=||;s| ||g') \
-  if [ ${OLD_REV} -lt ${NEW_REV} ] ; then rm -f %{2} ; cp %{1} %{2} ; fi
+  if [ ${OLD_REV} -lt ${NEW_REV} ] ; then cp %{1} %{2}.tmp; mv %{2}.tmp %{2} ; fi
 
 %define cms_python2_major_minor_version %(echo %{allpkgreqs} | tr ' ' '\\n' | grep /python/ | cut -d/ -f3 | cut -f1,2 -d.)
 %define cms_python2_major_minor $(echo %{cms_python2_major_minor_version} | sed 's|[.]||')


### PR DESCRIPTION
- Use `dasgoclient_tag.revXX` as dasgoclient package directory to make sure we get the latest build of it.
- Drop extra hash from the install path
- Use `CMSDIST_FILE_REVISION` feature of cmsdist to copy the latest script back to cms_path/common 