### PR TITLE
GCC 11.3.1: use zstd for compressing LTO data

### DIFF
--- a/gcc.spec
+++ b/gcc.spec
@@ -179,14 +179,6 @@ make -C ../zstd-%{zstdVersion}/lib %{makeprocesses} \
   make install
   hash -r
 
-  # Build Flex
-  cd ../flex-%{flexVersion}
-  ./configure --disable-nls --prefix=%{i} \
-              --build=%{_build} --host=%{_host} \
-              CC="$CC" CXX="$CXX"
-  make %{makeprocesses}
-  make install
-
   # Build elfutils
   cd ../elfutils-%{elfutilsVersion}
   ./configure --disable-static --with-zlib --without-bzlib --without-lzma \

--- a/gcc.spec
+++ b/gcc.spec
@@ -40,12 +40,10 @@ Source11: https://github.com/westes/flex/releases/download/v%{flexVersion}/flex-
 
 Patch0: gcc-flex-nonfull-path-m4
 Patch1: gcc-flex-disable-doc
-Patch2: gcc-03af8492bee6243a9d10e78fea1a3e423bd5f9cd
 
 %prep
 
 %setup -T -b 0 -n %{moduleName}
-%patch2 -p1
 
 # Filter out private stuff from RPM requires headers.
 cat << \EOF > %{name}-req

--- a/gcc.spec
+++ b/gcc.spec
@@ -1,10 +1,10 @@
-### RPM external gcc 11.2.1
+### RPM external gcc 11.3.1
 ## USE_COMPILER_VERSION
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 # Use the git repository for fetching the sources. This gives us more control while developing
 # a new platform so that we can compile yet to be released versions of the compiler.
 # See: https://gcc.gnu.org/viewcvs/gcc/branches/gcc-8-branch/?view=log
-%define gccTag a0a0499b8bb920fdd98e791804812f001f0b4fe8
+%define gccTag d0291465936b556b4f76bf78af45a2ed49ac5a05
 %define gccBranch releases/gcc-11
 
 %define moduleName %{n}-%{realversion}

--- a/gcc.spec
+++ b/gcc.spec
@@ -173,6 +173,7 @@ make -C ../zstd-%{zstdVersion}/lib %{makeprocesses} \
   # Build Flex (for building)
   cd ../flex-%{flexVersion}
   ./configure --disable-nls --prefix=%{i}/tmp/sw \
+              --enable-static --disable-shared \
               --build=%{_build} --host=%{_host} \
               CC="$CC" CXX="$CXX"
   make %{makeprocesses}


### PR DESCRIPTION
Notice: I have tried building gcc with static libzstd, but it didn't work (missing symbols at link-time)