### PR TITLE
Update tag for RecoEgamma-ElectronIdentification to V01-12-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-ElectronIdentification=V01-12-00
 L1Trigger-TrackFindingTracklet=V00-03-00
 RecoTracker-MkFit=V00-10-00
 RecoEgamma-PhotonIdentification=V01-06-00
@@ -22,7 +23,6 @@ RecoBTag-Combined=V01-14-00
 MagneticField-Interpolation=V01-02-00
 RecoEcal-EgammaClusterProducers=V00-02-00
 L1Trigger-TrackTrigger=V00-02-00
-RecoEgamma-ElectronIdentification=V01-11-00
 RecoTauTag-TrainingFiles=V00-06-00
 RecoEgamma-EgammaPhotonProducers=V00-01-00
 L1TriggerConfig-L1TConfigProducers=V00-01-00


### PR DESCRIPTION
Move RecoEgamma-ElectronIdentification data to new tag, see 
https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/27
