### PR TITLE
[G4] Update geant4 version to v11.1.0

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,6 +1,6 @@
-### RPM external geant4 11.0.10
+### RPM external geant4 11.1.0
 ## INCLUDE compilation_flags
-%define tag fdd5cd70ae299ffa162cf274eba2638bd9b008aa
+%define tag 9f34590941fb8a3f7ad139731089ec3794947545
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Fixes https://github.com/cms-externals/geant4/issues/66
- Update Geant4 to version v11.1.0