### PR TITLE
ReqMgr2MS version 2.1.5.1 with a fix to Rucio ConMon

### DIFF
--- a/reqmgr2ms.spec
+++ b/reqmgr2ms.spec
@@ -1,9 +1,9 @@
-### RPM cms reqmgr2ms 1.1.5rc7
+### RPM cms reqmgr2ms 1.1.5.1
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}
 ## INITENV +PATH PYTHONPATH %i/x${PYTHON_LIB_SITE_PACKAGES}
 
-%define wmcorever 2.1.5rc7
+%define wmcorever 2.1.5.1
 
 Source: git+https://github.com/dmwm/WMCore.git?obj=master/%wmcorever&export=%n&output=/%n.tar.gz
 Requires: py3-cherrypy py3-pycurl py3-httplib2 py3-rucio-clients py3-retry py3-future


### PR DESCRIPTION
Only MSUnmerged was affected by the change of Rucio ConMon URL and the other microservices need no redeployment at this moment.
FYI @todor-ivanov