### PR TITLE
Update tag for CalibTracker-SiStripDCS to V01-01-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+CalibTracker-SiStripDCS=V01-01-00
 RecoEgamma-ElectronIdentification=V01-12-00
 L1Trigger-TrackFindingTracklet=V00-03-00
 RecoTracker-MkFit=V00-10-00
@@ -75,7 +76,6 @@ GeneratorInterface-ReggeGribovPartonMCInterface=V00-00-02
 #Never update any package here. Always move it to default section.
 [data-build-github]
 Calibration-Tools=V01-00-00
-CalibTracker-SiStripDCS=V01-00-00
 CondFormats-JetMETObjects=V01-00-03
 DQM-DTMonitorClient=V00-01-00
 DQM-PhysicsHWW=V01-00-00


### PR DESCRIPTION
Move CalibTracker-SiStripDCS data to new tag, see 
https://github.com/cms-data/CalibTracker-SiStripDCS/pull/2
