### PR TITLE
[BuildRules] Added support to skip header consistency checks for selected files

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-03-10
+%define configtag       V07-03-11
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
See https://github.com/cms-sw/cmssw/pull/39710
Some times we need to keep the headers in the release to properly print the error and suggest a proper solution to developers. With this new build rule now one should be able to add `<flags IGNORE_HEADER_CHECK="file1 file2"/>` (where `file1` and `file2` are relative file path inder package's interface directory) to instruct scram to not run header consistency checks for these files.