### PR TITLE
use INCLUDE instead of IMPORT: to fix recursive parsing issue

### DIFF
--- a/cmssw-patch.spec
+++ b/cmssw-patch.spec
@@ -9,8 +9,7 @@ Requires: cmssw-patch-tool-conf
 #Set it to -cmsX added by cmsBuild (if any) to the base release
 %define baserel_postfix %{nil}
 
-## INCLUDE cmssw-queue-override
-
-## IMPORT cmssw-patch-build
-## IMPORT scram-project-build
 ## SUBPACKAGE debug IF %subpackageDebug
+## INCLUDE cmssw-queue-override
+## INCLUDE cmssw-patch-build
+## INCLUDE scram-project-build

--- a/cmssw.spec
+++ b/cmssw.spec
@@ -13,5 +13,5 @@ Requires: cmssw-tool-conf
 
 %define source1         git://github.com/cms-sw/cmssw.git?protocol=https&obj=%{branch}/%{gitcommit}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
 
-## IMPORT scram-project-build
 ## SUBPACKAGE debug IF %subpackageDebug
+## INCLUDE scram-project-build

--- a/coral.spec
+++ b/coral.spec
@@ -26,5 +26,5 @@ Requires: coral-tool-conf
 %define patchsrc4       %patch1 -p1
 
 %define source1  git://github.com/%{github_user}/%{n}.git?protocol=https&obj=%{branch}/%{tag}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
-## IMPORT scram-project-build
 ## SUBPACKAGE debug IF %subpackageDebug
+## INCLUDE scram-project-build

--- a/fwlite.spec
+++ b/fwlite.spec
@@ -17,5 +17,5 @@ Requires: fwlite-tool-conf
 
 %define source1 git://github.com/cms-sw/cmssw.git?protocol=https&obj=%{branch}/%{gitcommit}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
 
-## IMPORT cmssw-partial-build
-## IMPORT scram-project-build
+## INCLUDE cmssw-partial-build
+## INCLUDE scram-project-build


### PR DESCRIPTION
cmsBuild does not recursively parse the `IMPORT` file , so use `INCLUDE` instead 