### PR TITLE
Update to CUDA 12.0.0 and NVIDIA drivers 525.60.13

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 11.5.2
+### RPM external cuda 12.0.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 495.29.05
+%define driversversion 525.60.13
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
@@ -96,12 +96,15 @@ mkdir -p %{i}/drivers
 mv %_builddir/build/drivers/libcuda.so.%{driversversion}                    %{i}/drivers/
 ln -sf libcuda.so.%{driversversion}                                         %{i}/drivers/libcuda.so.1
 ln -sf libcuda.so.1                                                         %{i}/drivers/libcuda.so
+mv %_builddir/build/drivers/libcudadebugger.so.%{driversversion}            %{i}/drivers/
+ln -sf libcudadebugger.so.%{driversversion}                                 %{i}/drivers/libcudadebugger.so.1
+ln -sf libcudadebugger.so.1                                                 %{i}/drivers/libcudadebugger.so
 mv %_builddir/build/drivers/libnvidia-ptxjitcompiler.so.%{driversversion}   %{i}/drivers/
 ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                        %{i}/drivers/libnvidia-ptxjitcompiler.so.1
 ln -sf libnvidia-ptxjitcompiler.so.1                                        %{i}/drivers/libnvidia-ptxjitcompiler.so
-cp %{i}/nvvm/lib64/libnvvm.so.4.0.0                                         %{i}/drivers/
-ln -sf libnvvm.so.4.0.0                                                     %{i}/drivers/libnvvm.so.4
-ln -sf libnvvm.so.4                                                         %{i}/drivers/libnvvm.so
+mv %_builddir/build/drivers/libnvidia-nvvm.so.%{driversversion}             %{i}/drivers/
+ln -sf libnvidia-nvvm.so.%{driversversion}                                  %{i}/drivers/libnvidia-nvvm.so.4
+ln -sf libnvidia-nvvm.so.4                                                  %{i}/drivers/libnvidia-nvvm.so
 
 %post
 # let nvcc find its components when invoked from the command line

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,7 +1,7 @@
-### RPM external cudnn 8.3.3.40
+### RPM external cudnn 8.7.0.84
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define cudaver 11.5
+%define cudaver 11.8
 %define cudnnver_maj %(echo %{realversion} | cut -f1,2,3 -d.)
 
 # NVIDIA uses sbsa for aarch64, and the standard architecture name for ppc64le and x86_64
@@ -12,7 +12,7 @@
 %endif
 
 # cuDNN archive base name and unpacked name
-%define archive cudnn-linux-%{nvarch}-%{realversion}_cuda%{cudaver}-archive
+%define archive cudnn-linux-%{nvarch}-%{realversion}_cuda11-archive
 
 Source: https://developer.download.nvidia.com/compute/redist/cudnn/v%{cudnnver_maj}/local_installers/%{cudaver}/%{archive}.tar.xz
 Requires: cuda
@@ -20,10 +20,10 @@ Requires: cuda
 %prep
 %setup -n %{archive}
 
-if [ "${CUDA_VERSION%.*}" != %{cudaver} ]; then
-    echo 'Incompatible CUDA version in cudnn.spec!'
-    exit 1
-fi
+#if [ "${CUDA_VERSION%.*}" != %{cudaver} ]; then
+#    echo 'Incompatible CUDA version in cudnn.spec!'
+#    exit 1
+#fi
 
 %build
 

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -226,7 +226,7 @@ pybind11==2.10.0
 pybrain==0.3.3
 pycodestyle==2.9.1
 pycparser==2.21
-pycuda==2022.1
+pycuda==2022.2.2
 pycurl==7.45.1
 pydot==1.4.2
 pyflakes==2.5.0


### PR DESCRIPTION
The main changes since CUDA 11.5.x are
  - support for Lovelace (sm_87) and Hopper (sm_90) architectures (since CUDA 11.8)
  - support for GCC 12
  - support for C++20 (with GCC 10 and later)

See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html for the full CUDA 12.0.x release notes and change log.