### PR TITLE
Bug fix: Added back scram build runtests_TESTNAME support

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-03-16
+%define configtag       V07-03-17
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Build rules V07-03-16 has accidentally  dropped the support for `scram build runtests_TestNAME`. This PR fix the issue and restore the support for `scram build runtests_TestNAME`