### PR TITLE
Update to ROCm 5.4.2 and TBB 2021.8.0

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -6,6 +6,11 @@ Provides: libhsa-runtime64.so.1()(64bit)
 Provides: librocm-core.so.1()(64bit)
 Provides: librocm_smi64.so.5()(64bit)
 
+# This rpm packages only symlinks to an installation that is already on CVMFS.
+# Configure pkgtools to keep the static libraries, to avoid actually trying to
+# delete them from CVMFS.
+%define keep_archives true
+
 %prep
 
 %build
@@ -17,41 +22,29 @@ if ! [ -d $OSDIR ]; then
 fi
 BASEDIR=${OSDIR}/amd/%{n}-%{realversion}
 
-# symlink individual files from ${BASEDIR}/bin/
+# Symlink individual files from ${BASEDIR}/bin/
 mkdir %{i}/bin
 test -d ${BASEDIR}/bin
 test -e ${BASEDIR}/bin/hipcc
 ln -s ${BASEDIR}/bin/* %{i}/bin/
-# remove the OpenCL extra files
-rm -f %{i}/bin/clang-ocl
-# remove the OpenMP extra files
-rm -f %{i}/bin/{aompcc,gputable.txt,mygpu,mymcpu}
-# remove the MIGraphX tools
-rm -f %{i}/bin/migraphx-driver
+# Remove the OpenCL extra files
+rm -f %{i}/bin/{clang-ocl,clinfo}
+# Remove the OpenMP extra files
+rm -f %{i}/bin/{aompcc,mygpu,mymcpu}
+# Remove the Fortran files
+rm -f %{i}/bin/hipfc
+# Remove the MI tools
+rm -f %{i}/bin/{MIOpenDriver,migraphx-driver,runvx}
+# Remove the datacenter tools and validation suite binaries
+rm -f %{i}/bin/{rdcd,rdci,rvs}
+# Remove some of the prebuilt samples
+rm -f %{i}/bin/{sgemmv,simple_dlrm,simple_gemm}
 
 # ROCm/HIP core tools
-DIRECTORIES="amdgcn hip hipcub hsa hsa-amd-aqlprofile include lib libexec llvm rocthrust share"
+DIRECTORIES="amdgcn hip hsa hsa-amd-aqlprofile include lib libexec llvm share"
 
 # rocm-smi
 DIRECTORIES+=" oam rocm_smi"
-
-# hipBLAS / rocBLAS
-DIRECTORIES+=" hipblas rocblas"
-
-# hipSOLVER / rocSOLVER
-DIRECTORIES+=" hipsolver rocsolver"
-
-# hipSPARSE / rocSPARSE
-DIRECTORIES+=" hipsparse rocsparse"
-
-# hipFFT / rocFFT
-DIRECTORIES+=" hipfft rocfft"
-
-# hipRAND / rocRAND
-DIRECTORIES+=" hiprand rocrand"
-
-# ROCm Parallel Primitives (rocPRIM)
-DIRECTORIES+=" rocprim"
 
 # ROCm Tracer Callback/Activity Library (rocTRACER) and profiler library (ROC-profiler)
 DIRECTORIES+=" rocprofiler roctracer"
@@ -64,9 +57,6 @@ DIRECTORIES+=" rocprofiler roctracer"
 
 # ROCm Communication Collectives Library (RCCL)
 #DIRECTORIES+=" rccl"
-
-# iterative sparse solvers for ROCm platform (rocALUTION)
-#DIRECTORIES+=" rocalution"
 
 # Machine Intelligence Libraries
 #DIRECTORIES+=" miopen miopengemm"

--- a/rocm.spec
+++ b/rocm.spec
@@ -1,4 +1,4 @@
-### RPM external rocm 5.0.2
+### RPM external rocm 5.4.2
 ## NOCOMPILER
 Source: none
 Provides: libamd_comgr.so.2()(64bit)
@@ -30,7 +30,7 @@ rm -f %{i}/bin/{aompcc,gputable.txt,mygpu,mymcpu}
 rm -f %{i}/bin/migraphx-driver
 
 # ROCm/HIP core tools
-DIRECTORIES="amdgcn hip hipcub hsa hsa-amd-aqlprofile include lib lib64 llvm rocthrust share"
+DIRECTORIES="amdgcn hip hipcub hsa hsa-amd-aqlprofile include lib libexec llvm rocthrust share"
 
 # rocm-smi
 DIRECTORIES+=" oam rocm_smi"
@@ -60,7 +60,7 @@ DIRECTORIES+=" rocprofiler roctracer"
 #DIRECTORIES+=" atmi"
 
 # OpenCL support
-#DIRECTORIES+=" opencl"
+#DIRECTORIES+=" opencl tests"
 
 # ROCm Communication Collectives Library (RCCL)
 #DIRECTORIES+=" rccl"
@@ -69,7 +69,7 @@ DIRECTORIES+=" rocprofiler roctracer"
 #DIRECTORIES+=" rocalution"
 
 # Machine Intelligence Libraries
-#DIRECTORIES+=" miopen miopengemm mivisionx"
+#DIRECTORIES+=" miopen miopengemm"
 
 # HIP Fortran interface (hipfort)
 #DIRECTORIES+=" hipfort"

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -6,7 +6,6 @@
     <environment name="HIPCC"     default="$ROCM_BASE/bin/hipcc"/>
     <environment name="BINDIR"    default="$ROCM_BASE/bin"/>
     <environment name="LIBDIR"    default="$ROCM_BASE/lib"/>
-    <environment name="LIBDIR"    default="$ROCM_BASE/lib64"/>
     <environment name="INCLUDE"   default="$ROCM_BASE/include"/>
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -9,7 +9,7 @@
     <environment name="INCLUDE"   default="$ROCM_BASE/include"/>
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
-  <flags ROCM_FLAGS="-fgpu-rdc --offload-arch=gfx900 --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
+  <flags ROCM_FLAGS="-fgpu-rdc --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>
   <runtime name="PATH" value="$ROCM_BASE/bin" type="path"/>
 </tool>

--- a/tbb.spec
+++ b/tbb.spec
@@ -1,4 +1,4 @@
-### RPM external tbb v2021.8.0-rc1
+### RPM external tbb v2021.8.0
 
 %define tag %{realversion}
 %define branch onetbb_2021


### PR DESCRIPTION
Update ROCm to version 5.4.2.

Enable support for newer AMD GPUs:
  - AMD Instinct MI50/MI60 (gfx906)
  - AMD Instinct MI100/MI210/MI250 (gfx908)

Update TBB to version 2021.8.0. 