### PR TITLE
[BuildRules] Use hipcc to link product which has hip.cc sources

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-00
+%define configtag       V07-05-01
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-01
+%define configtag       V07-05-02
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-04-04
+%define configtag       V07-05-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- use hipcc for linking products ( libs, bin/tests) which have `hit.cc` files
- Bug fix: Avoid duplicate source files e.g. `file="*.cc *.hip.cc"` can have duplicate `hip.cc` files (once matched due to `*.cc` and one due to `*.hip.cc`)
- Fix `_rocm.a` build order 