### PR TITLE
[BuildRules] set TMPDIR so that hipcc can create temp file in cmssw/tmp/package directory

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-03
+%define configtag       V07-05-04
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-02
+%define configtag       V07-05-03
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
this avoids hipcc creating a lot temp directories under /tmp