### PR TITLE
Add  -fno-reciprocal-math -mrecip=none to Ofast to solve the AMD/Intel differences

### DIFF
--- a/scram-tools.file/tools/gcc/ofast-flag.xml
+++ b/scram-tools.file/tools/gcc/ofast-flag.xml
@@ -1,8 +1,5 @@
   <tool name="ofast-flag" version="1.0">
-    <flags CXXFLAGS="-Ofast -fno-reciprocal-math"/>
-    <ifcompiler name="gcc">
-      <flags CXXFLAGS="-mno-recip"/>
-    </ifcompiler>
+    <flags CXXFLAGS="-Ofast -fno-reciprocal-math -mrecip=none"/>
     <ifarchitecture name="slc6_">
       <ifcompiler name="llvm">
         <flags CXXFLAGS="-fno-builtin"/>

--- a/scram-tools.file/tools/gcc/ofast-flag.xml
+++ b/scram-tools.file/tools/gcc/ofast-flag.xml
@@ -1,5 +1,5 @@
   <tool name="ofast-flag" version="1.0">
-    <flags CXXFLAGS="-Ofast"/>
+    <flags CXXFLAGS="-Ofast -fno-reciprocal-math -mno-recip"/>
     <ifarchitecture name="slc6_">
       <ifcompiler name="llvm">
         <flags CXXFLAGS="-fno-builtin"/>

--- a/scram-tools.file/tools/gcc/ofast-flag.xml
+++ b/scram-tools.file/tools/gcc/ofast-flag.xml
@@ -1,5 +1,8 @@
   <tool name="ofast-flag" version="1.0">
-    <flags CXXFLAGS="-Ofast -fno-reciprocal-math -mno-recip"/>
+    <flags CXXFLAGS="-Ofast -fno-reciprocal-math"/>
+    <ifcompiler name="gcc">
+      <flags CXXFLAGS="-mno-recip"/>
+    </ifcompiler>
     <ifarchitecture name="slc6_">
       <ifcompiler name="llvm">
         <flags CXXFLAGS="-fno-builtin"/>


### PR DESCRIPTION
About one year ago we discovered differences of few percents between AMD and Intel in few HLT paths when rerunning the HLT [1]. The situation got worse when we added the parking di-electron paths with dZ path, which gave a difference of ~8% [2].

After several failed attempts, @gparida managed to solve the differences following @VinInn suggestion [3] to use `-Ofast  -fno-reciprocal-math -mno-recip`.

@gparida replaced `<use name="ofast-flag"/>` with `<flags   CXXFLAGS="-Ofast  -fno-reciprocal-math -mrecip=none"/>` in all `BuildFiles.xml` (except `test` folders to save compilation time)
```
"RecoEgamma/EgammaElectronAlgos/BuildFile.xml"
"RecoEgamma/EgammaPhotonAlgos/BuildFile.xml"
"RecoPixelVertexing/PixelTriplets/BuildFile.xml"
"RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml"
"RecoTracker/FinalTrackSelectors/BuildFile.xml"
"RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml"
"RecoTracker/TkDetLayers/BuildFile.xml"
"RecoTracker/TkHitPairs/BuildFile.xml"
"RecoVertex/PrimaryVertexProducer/BuildFile.xml"
"TrackingTools/GsfTools/BuildFile.xml"
"TrackingTools/GsfTools/plugins/BuildFile.xml"
"TrackingTools/GsfTracking/BuildFile.xml"
"TrackingTools/KalmanUpdators/BuildFile.xml"
"TrackingTools/MaterialEffects/BuildFile.xml"
"TrackingTools/MaterialEffects/plugins/BuildFile.xml"
"TrackingTools/TrackFitters/BuildFile.xml"
"TrackingTools/TrajectoryState/BuildFile.xml"
```
and found no AMD/Intel differences @gparida please share your results here (which release did you use?).

So I made this PR to implement this change directly at `cmsdist` level 
(but I didn't test it compiling the externals).

I don't know exactly the impact on timing, but I assume it will be much smaller than 1%, that was the impact of the full removal of Ofast [4]

[1] https://its.cern.ch/jira/browse/CMSHLT-2257
[2] https://docs.google.com/spreadsheets/d/1XRu1sfIYJUQ0e7Z_yJWdGrxTDA31zr33uWPFY54-APc
[3] https://its.cern.ch/jira/browse/CMSHLT-2257?focusedCommentId=4686018&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4686018
[4] https://github.com/cms-sw/cmssw/issues/40089

cc @cms-sw/hlt-l2 @cms-sw/reconstruction-l2 @gparida @sanuvarghese @cms-sw/core-l2 
