### PR TITLE
Update Alpaka and add support for ROCm

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
-### RPM external alpaka develop-20220902
+### RPM external alpaka develop-20230201
 ## NOCOMPILER
 
-%define git_commit b518e8c943a816eba06c3e12c0a7e1b58c8faedc
+%define git_commit a68c866cc6c3019748cf127b4eac61be38e7f687
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost

--- a/scram-tools.file/tools/alpaka/alpaka-rocm.xml
+++ b/scram-tools.file/tools/alpaka/alpaka-rocm.xml
@@ -1,0 +1,9 @@
+<tool name="alpaka-rocm" version="@TOOL_VERSION@">
+  <use name="alpaka"/>
+  <use name="rocm"/>
+  <!-- host comiplation should run with ALPAKA_HOST_ONLY defined -->
+  <flags CXXFLAGS="-DALPAKA_ACC_GPU_HIP_ENABLED -DALPAKA_HOST_ONLY"/>
+  <flags GENREFLEX_CPPFLAGS="-DALPAKA_ACC_GPU_HIP_ENABLED -DALPAKA_HOST_ONLY"/>
+  <!-- device comiplation should run without ALPAKA_HOST_ONLY defined -->
+  <flags ROCM_FLAGS="-DALPAKA_ACC_GPU_HIP_ENABLED -UALPAKA_HOST_ONLY"/>
+</tool>


### PR DESCRIPTION
Update the version of alpaka to the HEAD of the develop branch as of 2023.02.01, corresponding to the commit alpaka-group/alpaka@a68c866cc6c .

Major changes:
  - remove the functions to pin/unpin an existing buffer; host memory buffers pinned/mapped for a particular accelerator platform can be obtained with `allocMappedBuf(...)`;
  - implement accelerator tags, to list all available accelerators;
  - drop the Boost.Fiber back-end;
  - add support for newer CUDA and ROCm back-ends;
  - add optional support for mdspan

Other changes:
  - add deduction guide for `Vec`;
  - add element-wise_min and max functions;
  - make CUDA/ROCm mangled kernel names as short as possible;
  - add math hyperbolic functions;
  - refactor `ConcurrentExecPool` and `QueueGenericThreadsNonBlocking`.
  - implement trait constants.

Add support for the HIP/ROCm alpaka back-end.