### PR TITLE
[BuildRules] Reorder Rocm flags so that those can override compilers flags

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-05
+%define configtag       V07-05-06
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-04
+%define configtag       V07-05-05
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-tools.file/tools/cuda/cuda.xml
+++ b/scram-tools.file/tools/cuda/cuda.xml
@@ -12,8 +12,8 @@
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
   <flags CUDA_FLAGS="@CUDA_FLAGS@"/>
-  <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
-  <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>
+  <flags REM_CUDA_HOST_CXXFLAGS="-std=%"/>
+  <flags REM_CUDA_HOST_CXXFLAGS="%potentially-evaluated-expression"/>
   <flags CUDA_HOST_CXXFLAGS="@CUDA_HOST_CXXFLAGS@"/>
   <lib name="cudadevrt" type="cuda"/>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>


### PR DESCRIPTION
- Reorder Rocm flags so that those can override compilers flags
- Make ROCM_HOST and CUDA_HOST  flags to match the other flags names e.g 
  - REM_ROCM_HOST instead of ROCM_HOST_REM
  - REM_CUDA_HOST instead of CUDA_HOST_REM
- Allow to add/remove cuda/rocm host flags via project config/BuildFile e.g. to remove special flags for ASAN/UBSAN which does bot work with rocm/cuda