### PR TITLE
[BuildRules] Disable LTO flags for ROCM products

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-06
+%define configtag       V07-05-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
I think problem is mixing LTO objects build with llvm (hipcc) and gcc. For now lets disable LTO for rocm products. I will check if for rocm products ( where .hip.cc files exists) we can compile default `.cc` files with llvm instead of `gcc`