### PR TITLE
Update gcc 12 builds to CUDA 12.1

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 11.5.2
+### RPM external cuda 12.1.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 495.29.05
+%define driversversion 530.30.02
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
@@ -96,12 +96,15 @@ mkdir -p %{i}/drivers
 mv %_builddir/build/drivers/libcuda.so.%{driversversion}                    %{i}/drivers/
 ln -sf libcuda.so.%{driversversion}                                         %{i}/drivers/libcuda.so.1
 ln -sf libcuda.so.1                                                         %{i}/drivers/libcuda.so
+mv %_builddir/build/drivers/libcudadebugger.so.%{driversversion}            %{i}/drivers/
+ln -sf libcudadebugger.so.%{driversversion}                                 %{i}/drivers/libcudadebugger.so.1
+ln -sf libcudadebugger.so.1                                                 %{i}/drivers/libcudadebugger.so
 mv %_builddir/build/drivers/libnvidia-ptxjitcompiler.so.%{driversversion}   %{i}/drivers/
 ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                        %{i}/drivers/libnvidia-ptxjitcompiler.so.1
 ln -sf libnvidia-ptxjitcompiler.so.1                                        %{i}/drivers/libnvidia-ptxjitcompiler.so
-cp %{i}/nvvm/lib64/libnvvm.so.4.0.0                                         %{i}/drivers/
-ln -sf libnvvm.so.4.0.0                                                     %{i}/drivers/libnvvm.so.4
-ln -sf libnvvm.so.4                                                         %{i}/drivers/libnvvm.so
+mv %_builddir/build/drivers/libnvidia-nvvm.so.%{driversversion}             %{i}/drivers/
+ln -sf libnvidia-nvvm.so.%{driversversion}                                  %{i}/drivers/libnvidia-nvvm.so.4
+ln -sf libnvidia-nvvm.so.4                                                  %{i}/drivers/libnvidia-nvvm.so
 
 %post
 # let nvcc find its components when invoked from the command line

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,7 +1,7 @@
 ### RPM external cudnn 8.8.0.121
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define cudaver 11
+%define cudaver 12
 
 # NVIDIA uses sbsa for aarch64, and the standard architecture name for ppc64le and x86_64
 %ifarch aarch64

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,8 +1,8 @@
-### RPM external onnxruntime 1.10.0
+### RPM external onnxruntime 1.14.1
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 %define github_user cms-externals
 %define branch cms/v%{realversion}
-%define tag 7a6355a2780cd18ed0cb3f4a1ceb664391a0bf0c
+%define tag 6402abbe53d1a90879fbf25b28f582eb0a4898cd
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 %define github_user cms-externals
 %define branch cms/v%{realversion}
-%define tag 6402abbe53d1a90879fbf25b28f582eb0a4898cd
+%define tag e4c6aa2984c7c71409f4c6d0db865117afa66932
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja


### PR DESCRIPTION
Update to
  - CUDA version 12.1.0, with the compatibility NVIDIA drivers version 530.30.02
  - cuDNN version 8.8.0.121 for CUDA 12.x
  - ONNX Runtime version 1.14.1