### PR TITLE
Update to ROCm 5.4.3

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -1,4 +1,4 @@
-### RPM external rocm 5.4.2
+### RPM external rocm 5.4.3
 ## NOCOMPILER
 Source: none
 Provides: libamd_comgr.so.2()(64bit)


### PR DESCRIPTION
In ROCm v5.4.3, improvements to the compiler address errors with the following signatures: 
  - error: unhandled SGPR spill to memory
  - cannot scavenge register without an emergency spill slot!
  - error: ran out of registers during register allocation

See https://docs.amd.com/bundle/ROCm-Release-Notes-v5.4.3 for the full release notes.