### PR TITLE
fix typo for LTO EDM so fix the LTO IBs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-07
+%define configtag       V07-05-11
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Alpaka/ROCM backend can be enable later