### PR TITLE
Fix compilation warnings related to HIP/ROCm in Alpaka

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,9 +1,9 @@
-### RPM external alpaka develop-20230201
+### RPM external alpaka develop-20230209
 ## NOCOMPILER
 
-%define git_commit a68c866cc6c3019748cf127b4eac61be38e7f687
+%define git_commit d1855b1b0d0a2877b06147eacf0ddda56e40d661
 
-Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
+Source: https://github.com/cms-patatrack/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost
 
 %prep

--- a/scram-tools.file/tools/rocm/rocm-rocrand.xml
+++ b/scram-tools.file/tools/rocm/rocm-rocrand.xml
@@ -5,7 +5,5 @@
   <lib name="rocrand"/>
   <client>
     <environment name="ROCM_ROCRAND_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$ROCM_ROCRAND_BASE/include/hiprand"/>
-    <environment name="INCLUDE" default="$ROCM_ROCRAND_BASE/include/rocrand"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -9,7 +9,7 @@
     <environment name="INCLUDE"   default="$ROCM_BASE/include"/>
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
-  <flags ROCM_FLAGS="-fgpu-rdc --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
+  <flags ROCM_FLAGS="-fgpu-rdc --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
   <!-- use -isystem instead of -I to silence warnings in the HIP/ROCm headers -->
   <flags SYSTEM_INCLUDE="1"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -10,6 +10,8 @@
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
   <flags ROCM_FLAGS="-fgpu-rdc --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
+  <!-- use -isystem instead of -I to silence warnings in the HIP/ROCm headers -->
+  <flags SYSTEM_INCLUDE="1"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>
   <runtime name="PATH" value="$ROCM_BASE/bin" type="path"/>
 </tool>


### PR DESCRIPTION
Fix compilation warnings related to HIP/ROCm in Alpaka.
Use `-isystem` instead of `-I` to silence warnings in HIP/ROCm headers.

Other changes:
  - add support for MI200/MI210/MI250 CDNA2 GPUs;
  - include rocrand/hiprand headers from the main include directory (since ROCm 5.2.0).