### PR TITLE
crab-prod v3.230124, crab-pre v3.221018

### DIFF
--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -3,9 +3,9 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.220823
+%define crabclient_version v3.221018
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
-%define crabserver_version v3.220822
-%define dbs_version        3.14.0
+%define crabserver_version v3.221027
+%define dbs_version        3.16.0
 
 ## IMPORT crab-build

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -3,9 +3,9 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.221018
+%define crabclient_version v3.230124
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
-%define crabserver_version v3.221027
+%define crabserver_version v3.221205
 %define dbs_version        3.16.0
 
 ## IMPORT crab-build


### PR DESCRIPTION
affecting: crab-prod, crab-pre

- crab-pre: Bump crabclient to v3.221018, crabserver to v3.221027, dbs to 3.16.0
- crab-prod: Bump crabclient to v3.230124, crabserver to v3.221205

fyi: @belforte @novicecpp 
