### PR TITLE
Added CICADA and hls4mlEmulatorExtras specs

### DIFF
--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,4 +1,4 @@
-### RPM external CICADA 1.2.0
+### RPM external CICADA 1.1.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,4 +1,4 @@
-### RPM external CICADA 1.0.0
+### RPM external CICADA 1.2.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,14 +1,14 @@
 ### RPM external CICADA 1.0.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
-Requires: hls4mlEmulatorExtras
+Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
-make %{makeprocesses} EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT}
+make %{makeprocesses} EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT} HLS_ROOT=${HLS_ROOT}
 
 %install
-make PREFIX=%{i} install EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT}
+make PREFIX=%{i} install
 

--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,9 +1,5 @@
-### RPM external CICADA 1.0
-%define tag 7b9dde083a78e75c539bf16741f4085eee8d9412
-%define branch main
-%define github_user smuzaffar
-
-Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+### RPM external CICADA 1.0.0
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras
 BuildRequires: gmake
 

--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,0 +1,18 @@
+### RPM external CICADA 1.0
+%define tag 7b9dde083a78e75c539bf16741f4085eee8d9412
+%define branch main
+%define github_user smuzaffar
+
+Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Requires: hls4mlEmulatorExtras
+BuildRequires: gmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+make %{makeprocesses} EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT}
+
+%install
+make PREFIX=%{i} install EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT}
+

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,9 +1,10 @@
-### RPM cms cmssw-tool-conf 53.0
+### RPM cms cmssw-tool-conf 54.0
 # With cmsBuild, change the above version only when a new tool is added
 
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cmssw-osenv cms-git-tools SCRAMV2
 ## UPLOAD_DEPENDENCIES dqmgui
 
+Requires: CICADA
 Requires: crab
 Requires: cmssw-wm-tools
 Requires: google-benchmark

--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.2.0
+### RPM external hls4mlEmulatorExtras 1.1.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 

--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,10 +1,5 @@
-### RPM external hls4mlEmulatorExtras 1.0
-%define tag a599ccb0ef3afa2852f32dfa91b4faf8a3d606e1
-%define branch main
-%define github_user smuzaffar
-
-Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
-
+### RPM external hls4mlEmulatorExtras 1.0.0
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 
 %prep
@@ -15,4 +10,3 @@ make %{makeprocesses}
 
 %install
 make PREFIX=%{i} install
-

--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,0 +1,18 @@
+### RPM external hls4mlEmulatorExtras 1.0
+%define tag a599ccb0ef3afa2852f32dfa91b4faf8a3d606e1
+%define branch main
+%define github_user smuzaffar
+
+Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+
+BuildRequires: gmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+make %{makeprocesses} 
+
+%install
+make PREFIX=%{i} install
+

--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.0.0
+### RPM external hls4mlEmulatorExtras 1.2.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 

--- a/scram-tools.file/tools/CICADA/cicada.xml
+++ b/scram-tools.file/tools/CICADA/cicada.xml
@@ -1,6 +1,6 @@
 <tool name="cicada" version="@TOOL_VERSION@">
   <client>
     <environment name="CICADA_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$HLS4MLEMULATOREXTRAS_BASE/lib64"/>
+    <environment name="LIBDIR"       default="$CICADA_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/CICADA/cicada.xml
+++ b/scram-tools.file/tools/CICADA/cicada.xml
@@ -1,0 +1,6 @@
+<tool name="cicada" version="@TOOL_VERSION@">
+  <client>
+    <environment name="CICADA_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$HLS4MLEMULATOREXTRAS_BASE/lib64"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
+++ b/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
@@ -1,5 +1,6 @@
 <tool name="hls4mlemulatorextras" version="@TOOL_VERSION@">
   <lib name="emulator_interface"/>
+  <use name="sockets"/>
   <client>
     <environment name="HLS4MLEMULATOREXTRAS_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE"      default="$HLS4MLEMULATOREXTRAS_BASE/include"/>

--- a/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
+++ b/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
@@ -1,4 +1,5 @@
 <tool name="hls4mlemulatorextras" version="@TOOL_VERSION@">
+  <lib name="emulator_interface"/>
   <client>
     <environment name="HLS4MLEMULATOREXTRAS_BASE" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE"      default="$HLS4MLEMULATOREXTRAS_BASE/include"/>

--- a/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
+++ b/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
@@ -1,0 +1,7 @@
+<tool name="hls4mlemulatorextras" version="@TOOL_VERSION@">
+  <client>
+    <environment name="HLS4MLEMULATOREXTRAS_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$HLS4MLEMULATOREXTRAS_BASE/include"/>
+    <environment name="LIBDIR"       default="$HLS4MLEMULATOREXTRAS_BASE/lib64"/>
+  </client>
+</tool>


### PR DESCRIPTION
Follow up on https://github.com/cms-sw/cmssw/pull/40277
This adds two new packages
- hls4mlEmulatorExtras
- CICADA Model with two versions

Currently it is using my forks of these projects but once https://github.com/cms-hls4ml/hls4mlEmulatorExtras/pull/1
https://github.com/cms-hls4ml/CICADA/pull/1 are merged and we have proper tags for these then I will update the PR. For now this is only for testing to see the built