### PR TITLE
add RecoTracker-DisplacedRegionalTracking V00-01-00 data

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoTracker-DisplacedRegionalTracking=V00-01-00
 RecoTracker-MkFit=V00-12-00
 RecoTauTag-TrainingFiles=V00-07-00
 PhysicsTools-NanoAOD=V01-03-00


### PR DESCRIPTION
needed in context of testing cms-sw/cmssw#40643 

I'm guessing that the external was not propagated to the cmsdist because that part was still manual 2 years ago; but perhaps also because the underlying PR cms-sw/cmssw#32806 was not merged back then