### PR TITLE
Update Alpaka to the development branch as of 2023.02.15 [13.0.x]

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,9 +1,9 @@
-### RPM external alpaka develop-20230209
+### RPM external alpaka develop-20230215
 ## NOCOMPILER
 
-%define git_commit d1855b1b0d0a2877b06147eacf0ddda56e40d661
+%define git_commit b849ce43dbfb6d5e1d4279c0025e3b15eddffc32
 
-Source: https://github.com/cms-patatrack/%{n}/archive/%{git_commit}.tar.gz
+Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost
 
 %prep


### PR DESCRIPTION
Update the version of alpaka to the HEAD of the develop branch as of 2023.02.15, corresponding to the commit alpaka-group/alpaka@b849ce43dbf .

Major changes:
  - replace `BOOST_LANG_HIP` with `HIP_VERSION`: the former is available only when compiling HIP code with `hipcc` or `clang`, while the latter is available also while using the HIP host API with other compilers.

Other changes:
  - fix HIP/ROCm compilation warnings;
  - make `ALPAKA_FN_INLINE` always inline;
  - remove old clang-cuda workarounds.