### PR TITLE
move sanitizer flags in to toolfile; drop sanitizer deps for rocm prod

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_58
+### RPM lcg SCRAMV1 V3_00_59
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 6654963f322524cb9560b6e46e7d9807c2cec9cf
+%define tag e8f47d278bafb41f8ea16e2ae7247c709ee9d591
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-05-11
+%define configtag       V07-06-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-06-00
+%define configtag       V07-06-01
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-tools.file/tools/gcc/sanitizer-flags-asan.xml
+++ b/scram-tools.file/tools/gcc/sanitizer-flags-asan.xml
@@ -1,0 +1,7 @@
+  <tool name="sanitizer-flags-asan" version="1.0">
+    <ifrelease name="ASAN">
+      <flags CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address"/>
+      <!-- See https://github.com/cms-sw/cmssw/issues/36480 <flags CXXFLAGS="-fsanitize=pointer-compare"/> -->
+      <flags CXXFLAGS="-fsanitize=pointer-subtract"/>
+    </ifrelease>
+  </tool>

--- a/scram-tools.file/tools/gcc/sanitizer-flags-ubsan.xml
+++ b/scram-tools.file/tools/gcc/sanitizer-flags-ubsan.xml
@@ -1,0 +1,8 @@
+  <tool name="sanitizer-flags-ubsan" version="1.0">
+    <ifrelease name="UBSAN">
+      <flags CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>
+      <flags CXXFLAGS="-fsanitize=builtin -fsanitize=pointer-overflow"/>
+      <flags REM_BOOST_SERIALIZATION_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>
+      <flags REM_BOOST_SERIALIZATION_CXXFLAGS="-fsanitize=builtin -fsanitize=pointer-overflow"/>
+    </ifrelease>
+  </tool>


### PR DESCRIPTION
backport of #8311

Move ASAN and UBSAN sanitizer flags in to toolfiles which are added in to dependency chain via cmssw/config/BuildFile.xml. Drop sanitizer tool deps from rocm products. Hopefully this can fix the ASAN/UBSAN build issues