### PR TITLE
CepGen 1.1.0, CMake 3.25.2

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.0.2patch1
+### RPM external cepgen 1.1.0
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 

--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.18.2
+### RPM external cmake 3.25.2
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib


### PR DESCRIPTION
This PR bumps the version of CepGen to 1.1.0. Changelog in https://cepgen.hepforge.org/changelog.html.

As a collateral damage, the CMake version is bumped to 3.25.2.