### PR TITLE
cepgen: add dependency on bzlib2

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -2,8 +2,8 @@
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
-BuildRequires: cmake ninja bz2lib
-Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root
+BuildRequires: cmake ninja
+Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib
 
 %prep
 %setup -n %{n}-%{realversion}

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -3,7 +3,7 @@
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
 BuildRequires: cmake ninja
-Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib
+Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib zlib xz
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -24,7 +24,8 @@ export ROOTSYS=${ROOT_ROOT}
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
-  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="${BZ2LIB_ROOT};${ZLIB_ROOT};${XZ_ROOT}"
 
 ninja -v %{makeprocesses}
 

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -2,7 +2,7 @@
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
-BuildRequires: cmake ninja
+BuildRequires: cmake ninja bz2lib
 Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root
 
 %prep


### PR DESCRIPTION
This fixes the following error:

```
02:37:07 RpmInstallFailed: Failed to install package cepgen. Reason:
02:37:07 error: Failed dependencies:
02:37:07 	libbz2.so.1()(64bit) is needed by external+cepgen+1.1.0-f16bfcee94054c9329075aefb119b6cc-1-1.aarch64
02:37:07 
```

The library is used to handle compressed HepMC3 files.

@forthommel 