### PR TITLE
Update OpenMPI to version 4.1.5

### DIFF
--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 4.1.4
+### RPM external openmpi 4.1.5
 ## INITENV SET OPAL_PREFIX %{i}
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools


### PR DESCRIPTION
The Open MPI community is pleased to announce the Open MPI v4.1.5 release. This release is a bug fix release.

Open MPI v4.1.5 can be downloaded from the Open MPI website:

  https://www.open-mpi.org/software/ompi/v4.1/

Changes to v4.1.5 compared to v4.1.4:

  - fix crash in one-sided applications for certain process layouts.
  - update embedded OpenPMIx to version 3.2.4
  - fix issue building with ifort on MacOS.
  - backport patches to Libevent for CVE-2016-10195, CVE-2016-10196, and CVE-2016-10197.  Note that Open MPI's internal libevent does not use the impacted portions of the Libevent code base.
  - SHMEM improvements:
    - fix initializer bugs in SHMEM interface.
    - fix unsigned type comparisons generating warnings.
    - fix use after clear issue in shmem_ds_reset.
  - UCX improvements:
    - fix memory registration bug that could occur when UCX was built but not selected.
    - reduce overhead of add_procs with intercommunicators.
    - enable multi_send_nb by default.
    - call opal_progress while waiting for a UCX fence to complete.
  - fix data corruption bug in osc/rdma component.
  - fix overflow bug in alltoall collective
  - fix crash when displaying topology.
  - add some MPI_F_XXX constants that were missing from mpi.h.
  - coll/ucc bug fixes.