### PR TITLE
Disable LTO for CLANG IBs

### DIFF
--- a/compilation_flags_lto.file
+++ b/compilation_flags_lto.file
@@ -1,5 +1,5 @@
 #Enable/disable LTO builds
-%define enable_lto 1
+%define enable_lto 0
 
 #LTO related flags
 %ifarch ppc64le


### PR DESCRIPTION
We are disabling LTO for CLANG IBs since we cannot link against external libraries, e.g., dd4hep, built with gcc.