### PR TITLE
[BuildRules] Enable alpaka ROCm backend [13.0.x]

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-06-01
+%define configtag       V07-07-03
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Backport of #8346.