### PR TITLE
Update tag for RecoEgamma-EgammaPhotonProducers to V00-02-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-EgammaPhotonProducers=V00-02-00
 RecoEcal-EgammaClusterProducers=V00-03-00
 HeterogeneousCore-SonicTriton=V00-02-00
 RecoTracker-DisplacedRegionalTracking=V00-01-00
@@ -28,7 +29,6 @@ RecoMET-METPUSubtraction=V01-02-00
 RecoBTag-Combined=V01-14-00
 MagneticField-Interpolation=V01-02-00
 L1Trigger-TrackTrigger=V00-02-00
-RecoEgamma-EgammaPhotonProducers=V00-01-00
 L1TriggerConfig-L1TConfigProducers=V00-01-00
 RecoMuon-TrackerSeedGenerator=V00-04-00
 RecoMuon-MuonIdentification=V01-14-00


### PR DESCRIPTION
Move RecoEgamma-EgammaPhotonProducers data to new tag, see 
https://github.com/cms-data/RecoEgamma-EgammaPhotonProducers/pull/2
