### PR TITLE
Replace c++1z with c++17

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -34,7 +34,7 @@ source ${SCRAM_TOOLS_BIN_DIR}/os_libdir.sh
 # optimizations as they become available in gcc.
 
 GCC_CXXFLAGS=""
-GCC_CXXFLAGS="$GCC_CXXFLAGS -std=c++1z -ftree-vectorize"
+GCC_CXXFLAGS="$GCC_CXXFLAGS -std=c++17 -ftree-vectorize"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -fvisibility-inlines-hidden"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50"


### PR DESCRIPTION
Replace the legacy flag `-std=c++1z` with the official flag `-std=c++17`.

According to the `gcc` man page `c++1z` is deprecated:
> **-std=**
>     Determine the language standard.   This option is currently only supported when compiling C or C++.
>   - **c++17**
>   - **c++1z**
>       The 2017 ISO C++ standard plus amendments.  The name **c++1z** is deprecated.

`nvcc` does not support `c++1z`:
> **--std** {**c++03**|**c++11**|**c++14**|**c++17**|**c++20**}           (**-std**)                          
>         Select a particular C++ dialect.  Note that this flag also turns on the corresponding
>         dialect flag for the host compiler.
>         Allowed values for this option:  'c++03','c++11','c++14','c++17','c++20'.

`clang` does documents only `c++17` and does not mention `c++1z`, but it accepts it for compatibility.

As `-std=c++1z` is now an alias for `-std=c++17`, no changes are expected.
