### PR TITLE
[BuildRules] Changes for running unit tests from separate test dirs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-07-03
+%define configtag       V07-07-04
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- properly cleanup up top level unit test directory
- add test directories of release/full release in path
- Run test scripts using full path e.g. for `<test name="FOO" command="bar.sh"/>`  test will be run as `$CMSSW_BASE/src/Package/Name/test/bar.sh`

These changes will allow to run unit tests from their separate test paths. This will avoid the issue if two or more tests writing in to same file in $CMSSW_BASE