### PR TITLE
Add more libamdhip64.so.5 symbol versions

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -7,6 +7,13 @@ Provides: librocm-core.so.1()(64bit)
 Provides: librocm_smi64.so.5()(64bit)
 Provides: libamdhip64.so.5()(64bit)
 Provides: libamdhip64.so.5(hip_4.2)(64bit)
+Provides: libamdhip64.so.5(hip_4.3)(64bit)
+Provides: libamdhip64.so.5(hip_4.4)(64bit)
+Provides: libamdhip64.so.5(hip_4.5)(64bit)
+Provides: libamdhip64.so.5(hip_5.0)(64bit)
+Provides: libamdhip64.so.5(hip_5.1)(64bit)
+Provides: libamdhip64.so.5(hip_5.2)(64bit)
+Provides: libamdhip64.so.5(hip_5.3)(64bit)
 
 # This rpm packages only symlinks to an installation that is already on CVMFS.
 # Configure pkgtools to keep the static libraries, to avoid actually trying to


### PR DESCRIPTION
The installation of CMSSW 13.0.0/13.1.0-pre1 from RPMs fails complaining about missing symbols, all the way up to hip_5.3:
```
error: Failed dependencies:
        libamdhip64.so.5(hip_5.3)(64bit) is needed by cms+cmssw+CMSSW_13_1_0_pre1-1-1.x86_64
```

This PR includes all symbol versions in the spec file's Provides.

The list of symbol versions supported by the library can be extracted e.g. with
```
nm -D lib/libamdhip64.so --defined-only | cut -s -d @ -f3 | sort -u
```