### PR TITLE
[BuildRules] More fixes for running tests in individual dirs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-07-06
+%define configtag       V07-07-07
 %endif
 
 %if "%{?cvssrc:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-07-05
+%define configtag       V07-07-06
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
Base on https://github.com/cms-sw/cmssw-config/commit/f269ce29610230ffc6424aeae96ae70079fc8c8b
- use full path of top level unit test directory
- create hard links instead of full copy of tests dependencies
- ignore copy of dependency contents if its directory does not exists e.g. if the test was skipped