### PR TITLE
[BuildRules] Add CMSSW_BASE/tmp to CMSSW_SEARCH_PATH for unit tests

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-07-07
+%define configtag       V07-07-08
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
This change allows unit tests to create tmp data files under cmssw/tmp path and use FileInPath to search/load.