### PR TITLE
Update UTM to 0.11.1

### DIFF
--- a/utm.spec
+++ b/utm.spec
@@ -1,4 +1,4 @@
-### RPM external utm utm_0.10.0
+### RPM external utm utm_0.11.1
 Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake
 Requires: xerces-c boost


### PR DESCRIPTION
An updated utm library (version 0.11.1) is available: https://gitlab.cern.ch/cms-l1t-utm/utm/-/tree/utm_0.11.1/

Follow up of https://github.com/cms-sw/cmsdist/pull/8352.