### PR TITLE
[Backport to 13_0] Update UTM to version 0.11.2

### DIFF
--- a/utm.spec
+++ b/utm.spec
@@ -1,4 +1,4 @@
-### RPM external utm utm_0.11.1
+### RPM external utm utm_0.11.2
 Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake
 Requires: xerces-c boost

--- a/utm.spec
+++ b/utm.spec
@@ -1,4 +1,4 @@
-### RPM external utm utm_0.10.0
+### RPM external utm utm_0.11.1
 Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake
 Requires: xerces-c boost


### PR DESCRIPTION
UTM version 0.11.2 is available: https://gitlab.cern.ch/cms-l1t-utm/utm/-/tree/utm_0.11.2/. 

backport of https://github.com/cms-sw/cmsdist/pull/8386