### PR TITLE
[do not merge] Disable the use of GNU unique symbols

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -39,6 +39,7 @@ GCC_CXXFLAGS="$GCC_CXXFLAGS -Werror=array-bounds -Werror=format-contains-nul -We
 GCC_CXXFLAGS="$GCC_CXXFLAGS -fvisibility-inlines-hidden"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -Xassembler --compress-debug-sections"
+GCC_CXXFLAGS="$GCC_CXXFLAGS -fno-gnu-unique"
 
 case $(uname -m) in
   aarch64 ) GCC_CXXFLAGS="$GCC_CXXFLAGS -fsigned-char -fsigned-bitfields" ;;

--- a/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
@@ -17,6 +17,7 @@
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-fno-aggressive-loop-optimizations"/>
     <flags REM_CXXFLAGS="-funroll-all-loops"/>
+    <flags REM_CXXFLAGS="-fno-gnu-unique"/>
     <flags REM_LTO_FLAGS="-fipa-icf"/>
     <flags REM_LTO_FLAGS="-flto-odr-type-merging"/>
     <flags CXXFLAGS="-Wno-c99-extensions"/>


### PR DESCRIPTION
From `man gcc`:
> `-fno-gnu-unique`
> On systems with recent GNU assembler and C library, the C++ compiler uses the "STB_GNU_UNIQUE" binding to make sure that definitions of template static data members and static local variables in inline functions are unique even in the presence of "RTLD_LOCAL"; this is necessary to avoid problems with a library used by two different "RTLD_LOCAL" plugins depending on a definition in one of them and therefore disagreeing with the other one about the binding of the symbol.  But this causes "dlclose" to be ignored for affected DSOs; if your program relies on reinitialization of a DSO via "dlclose" and "dlopen", you can use `-fno-gnu-unique`.

Since CMSSW loads plugins using `RTLD_GLOBAL`, not `RTLD_LOCAL`, we could check the impact of disabling the GNU unique extension, that does not seem to be supported by clang.