### PR TITLE
Explicitly use the GNU binutils ld.bfd linker

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -40,6 +40,9 @@ GCC_CXXFLAGS="$GCC_CXXFLAGS -fvisibility-inlines-hidden"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -fno-math-errno --param vect-max-version-for-alias-checks=50"
 GCC_CXXFLAGS="$GCC_CXXFLAGS -Xassembler --compress-debug-sections"
 
+# Explicitly use the GNU binutils ld.bfd linker
+GCC_CXXFLAGS="$GCC_CXXFLAGS -fuse-ld=bfd"
+
 case $(uname -m) in
   aarch64 ) GCC_CXXFLAGS="$GCC_CXXFLAGS -fsigned-char -fsigned-bitfields" ;;
   ppc64le ) GCC_CXXFLAGS="$GCC_CXXFLAGS -fsigned-char -fsigned-bitfields" ;;


### PR DESCRIPTION
As we configure them, gcc and clang already use the GNU bfd linker by default (`ld` or `ld.bfd`, they are the same in our externals).

Instead `hipcc` uses its version of `ld.lld` by default.

This can cause inker problems in some corner cases, for example when linking objects with weak `V` symbols with objects with unique `u` symbols: `ld.bfd` and `ld.gold` seem to handle that, while `ld.lld` fails with a duplicate symbol error.

Rather than changing how gcc and clang generate symbols, it looks like the problem can be fixed instructing `hipcc` to use the GNU bfd linker.
This improves consistency with the rest of our build system, possibly avoiding other corner cases.

Setting the flag for gcc should propagate automatically to clang and hipcc, making sure all compilers consistently use the same linker.