### PR TITLE
update AXOL1TL to 1.0.0

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 0.2.0
+### RPM external AXOL1TL 1.0.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
- update AXOL1TL to 1.0.0 (cleanup and returning model outputs & loss as `std::pair`)
https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v1.0.0