### PR TITLE
[BuildRules] Enable usage of separate unit tests directory at project level

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-07-08
+%define configtag       V07-08-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
[This change](https://github.com/cms-sw/cmssw-config/commit/67d792f8e587323d68802f3660791515c357fd17) allows scram to create separate unit test directories (e.g. `$CMSSW/BASE/unit_tests/<test_name>`) for each tests. This protects unit test against generating the same file names. Note that SCRAM  will add `$CMSSW/BASE/unit_tests/<test_name>` in to `CMSSW_SEARCH_PATH` , so tests can create data files under this path and load it via `FileInPath`