### PR TITLE
Update utm to v0.11.2

### DIFF
--- a/utm.spec
+++ b/utm.spec
@@ -1,4 +1,4 @@
-### RPM external utm utm_0.11.1
+### RPM external utm utm_0.11.2
 Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake
 Requires: xerces-c boost


### PR DESCRIPTION
This PR is to update the available UTM firmware to v0.11.2

No large change in functionality is expected with respect to the recent v0.11.2 upgrade. This update is just to provide access to a few functions necessary (overloaded constructors) necessary for the debugging effort ongoing in https://github.com/cms-sw/cmssw/pull/41036, please see that thread for details on the plans for this version of the utm firmware.

All differences with respect to v0.11.1 can be seen here: https://gitlab.cern.ch/cms-l1t-utm/utm/-/compare/utm_0.11.1...utm_0.11.2?from_project_id=4792&straight=false

This PR is non urgent (except to facilitate debugging of https://github.com/cms-sw/cmssw/pull/41036), and not expected to be backported for any reason.