### PR TITLE
Update tag for RecoEgamma-EgammaPhotonProducers to V00-03-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,8 +3,8 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-EgammaPhotonProducers=V00-03-00
 Geometry-TestReference=V00-11-00
-RecoEgamma-EgammaPhotonProducers=V00-02-00
 RecoEcal-EgammaClusterProducers=V00-03-00
 HeterogeneousCore-SonicTriton=V00-02-00
 RecoTracker-DisplacedRegionalTracking=V00-01-00


### PR DESCRIPTION
Move RecoEgamma-EgammaPhotonProducers data to new tag, see 
https://github.com/cms-data/RecoEgamma-EgammaPhotonProducers/pull/3
