### PR TITLE
[BuildRules] More updates for unit tests

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-08-00
+%define configtag       V07-09-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Using separate test directory is not optional any more. Each tests should run in its own sub-directory.
- Running `unittests/runtests` without `-v` option is not going to dump the unit tests output on stdout/stderr. Without `-v`  build rules will generate output like [a]. Behaviour with `-v` remains same i.e. you will see the output of each test on terminal along with these new extra `Pass|Fail` lines

[a]
```
Pass 4s    ... testA
Pass 2s    ... testB
Fail 1s    ... testC
Pass 1s    ... testD
```