### PR TITLE
Revert config tag to V07-08-00

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-09-00
+%define configtag       V07-08-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
looks like new build rules caused few unit tests for fail in IBs. Lets revert it and first test it in devel IB