### PR TITLE
[BuildRules] Re-revert to tag V07-09-00

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-08-00
+%define configtag       V07-09-00
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
unit tests errors in IB are not related to build rules update . unit tests failed due to https://github.com/cms-sw/cmssw/pull/41075 which should be fixed by  https://github.com/cms-sw/cmssw/pull/41116