### PR TITLE
drop G4GEOM_USE_USOLIDS flag to fix G4 compilation warnings in cmssw

### DIFF
--- a/scram-tools.file/tools/geant4/env.sh
+++ b/scram-tools.file/tools/geant4/env.sh
@@ -1,6 +1,6 @@
 GEANT4_VECGEOM=""
 if grep VECGEOM_ROOT ${TOOL_ROOT}/etc/profile.d/dependencies-setup.sh >/dev/null 2>&1  ; then
-  GEANT4_VECGEOM='<use name="vecgeom"/><flags CXXFLAGS="-DG4GEOM_USE_USOLIDS"/>'
+  GEANT4_VECGEOM='<use name="vecgeom"/>'
 fi
 export GEANT4_VECGEOM
 


### PR DESCRIPTION
Geant4 (with vecgeom) is built with `-DGEANT4_USE_USOLIDS="all"`  flag. So when scram use it again in CMSSW then we get compilation warnings like. G4 developers has asked to not re-set this macro when compiling client code (like cmssw).

This PR proposes to drop the macro for cmssw build and should fix the warnings [a]

[a]
```
In file included from geant4/11.1.1-ab4f12342e16e7a64ea68657061b0a37/include/Geant4/G4GeomTypes.hh:34,
                 from geant4/11.1.1-ab4f12342e16e7a64ea68657061b0a37/include/Geant4/G4Trap.hh:96,
                 from cmssw/SimG4CMS/Calo/plugins/CaloSteppingAction.cc:53:
  geant4/11.1.1-ab4f12342e16e7a64ea68657061b0a37/include/Geant4/G4GeomConfig.hh:34: warning: "G4GEOM_USE_USOLIDS" redefined
    34 | #define G4GEOM_USE_USOLIDS
```