### PR TITLE
improved unit test message

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-09-00
+%define configtag       V07-09-01
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
- Short status of test now includes the package name too e.g.
```
Pass    0s ... Utilities/General/CudaGCCSupport
Skip    0s ... Utilities/StorageFactory/test_StorageFactory_Any
Pass    0s ... Utilities/General/test_precomputed_value_sort
Skip    0s ... Utilities/StorageFactory/test_StorageFactory_Ftp
Skip    0s ... Utilities/StorageFactory/test_StorageFactory_Ftp2
Pass    1s ... Utilities/ReleaseScripts/test-clang-tidy
```

- Remove extra package level messages during unit tests