### PR TITLE
[G12] Update GCC and UCX

### DIFF
--- a/gcc.spec
+++ b/gcc.spec
@@ -4,7 +4,7 @@
 # Use the git repository for fetching the sources. This gives us more control while developing
 # a new platform so that we can compile yet to be released versions of the compiler.
 # See: https://gcc.gnu.org/viewcvs/gcc/branches/gcc-8-branch/?view=log
-%define gccTag 8e3dab275007e0f66ee7b63bfdf0410ba07bf6ac
+%define gccTag e11513c7688f583d1f4d0961d79d8aa775add03d
 %define gccBranch releases/gcc-12
 
 %define moduleName %{n}-%{realversion}
@@ -17,11 +17,13 @@ Source0: git+https://github.com/gcc-mirror/%{n}.git?obj=%{gccBranch}/%{gccTag}&e
 %define mpcVersion 1.2.1
 %define islVersion 0.24
 %define zlibVersion 1.2.11
+%define zstdVersion 1.4.5
 Source1: https://gmplib.org/download/gmp/gmp-%{gmpVersion}.tar.bz2
 Source2: http://www.mpfr.org/mpfr-%{mpfrVersion}/mpfr-%{mpfrVersion}.tar.bz2
 Source3: https://ftp.gnu.org/gnu/mpc/mpc-%{mpcVersion}.tar.gz
 Source4: http://isl.gforge.inria.fr/isl-%{islVersion}.tar.bz2
 Source12: http://zlib.net/zlib-%{zlibVersion}.tar.gz
+Source13: https://github.com/facebook/zstd/releases/download/v%{zstdVersion}/zstd-%{zstdVersion}.tar.gz
 
 %ifos linux
 %define bisonVersion 3.8.2
@@ -94,6 +96,7 @@ EOF_CMS_H
 %setup -D -T -b 3 -n mpc-%{mpcVersion}
 %setup -D -T -b 4 -n isl-%{islVersion}
 %setup -D -T -b 12 -n zlib-%{zlibVersion}
+%setup -D -T -b 13 -n zstd-%{zstdVersion}
 
 %ifos linux
 %setup -D -T -b 7 -n bison-%{bisonVersion}
@@ -137,6 +140,10 @@ CFLAGS="${CONF_FLAGS}" ./configure --static --prefix=%{i}/tmp/sw
 make %{makeprocesses}
 make install
 
+#Build and install zstd static library
+make -C ../zstd-%{zstdVersion}/lib %{makeprocesses} \
+  install-static install-includes prefix=%{i}/tmp/sw \
+  CPPFLAGS="-fPIC" CFLAGS="-fPIC"
 %ifos linux
   CONF_BINUTILS_OPTS="--enable-ld=default --enable-lto --enable-plugins --enable-threads"
   CONF_GCC_WITH_LTO="--enable-ld=default --enable-lto"
@@ -164,19 +171,12 @@ make install
   # Build Flex (for building)
   cd ../flex-%{flexVersion}
   ./configure --disable-nls --prefix=%{i}/tmp/sw \
+              --enable-static --disable-shared \
               --build=%{_build} --host=%{_host} \
               CC="$CC" CXX="$CXX"
   make %{makeprocesses}
   make install
   hash -r
-
-  # Build Flex
-  cd ../flex-%{flexVersion}
-  ./configure --disable-nls --prefix=%{i} \
-              --build=%{_build} --host=%{_host} \
-              CC="$CC" CXX="$CXX"
-  make %{makeprocesses}
-  make install
 
   # Build elfutils
   cd ../elfutils-%{elfutilsVersion}
@@ -261,13 +261,15 @@ export LD_LIBRARY_PATH=%{i}/lib64:%{i}/lib:$LD_LIBRARY_PATH
              $CONF_GCC_OS_SPEC $CONF_GCC_WITH_LTO --with-gmp=%{i} --with-mpfr=%{i} --enable-bootstrap \
              --with-mpc=%{i} --with-isl=%{i} --enable-checking=release \
              --build=%{_build} --host=%{_host} --enable-libstdcxx-time=rt $CONF_GCC_ARCH_SPEC \
-             --enable-shared --disable-libgcj CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" \
+             --enable-shared --disable-libgcj \
+             --with-zstd=%{i}/tmp/sw \
+             CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" \
              CFLAGS="-I%{i}/tmp/sw/include" CXXFLAGS="-I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/tmp/sw/lib"
 
 make %{makeprocesses} profiledbootstrap
 
 %install
-cd %_builddir/%{moduleName}/obj && make install 
+cd %_builddir/%{moduleName}/obj && make install
 
 ln -s gcc %{i}/bin/cc
 find %{i}/lib %{i}/lib64 -name '*.la' -exec rm -f {} \; || true

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,5 +1,7 @@
-### RPM external ucx 1.14.0
-Source: https://github.com/openucx/%{n}/archive/refs/tags/v%{realversion}.tar.gz
+### RPM external ucx 1.14.x
+%define branch v1.14.x
+%define tag bb39346ac1aebc67cb88c4419429de78a1260bda
+Source: git+https://github.com/openucx/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/v%{realversion}.tar.gz
 BuildRequires: autotools
 Requires: cuda gdrcopy
 Requires: numactl


### PR DESCRIPTION
Update gcc12 to tip of release branch to fix gcc bux (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593) that affects onnxruntime (https://github.com/microsoft/onnxruntime/issues/14923); also enable zstd compression of sections (https://github.com/cms-sw/cmsdist/pull/8219).

Update UCX to tip of 1.14 branch to add Cuda 12 support (https://github.com/openucx/ucx/pull/8938).