### PR TITLE
PGO: CMSSW_PGO_DIRECTORY only for pgo generation

### DIFF
--- a/pgo/cmsdist_packages.py
+++ b/pgo/cmsdist_packages.py
@@ -11,7 +11,7 @@ def packages(virtual_packages, *args):
     spec  = "  echo '%%define pgo_path_prefix  %s'" % ('@LOCALTOP@' if pkg in ["cmssw-tool-conf"] else '%{_builddir}')
     spec += "; echo '%%define pgo_package_name %s'" % ('cmssw' if pkg in ["cmssw-tool-conf"] else pkg)
     spec += "; echo '%%define %s 1'" % ('pgo_generate' if opts.PGOGenerate else 'pgo_use')
-    spec += "; echo '## INCLUDE compilation_flags_pgo'"
+    spec += "; echo '## INCLUDE pgo/compilation_flags_pgo'"
     spec += "; cat %s/%s.spec" % (opts.cmsdist, pkg)
     virtual_packages[pkg] = spec
   return

--- a/pgo/compilation_flags_pgo.file
+++ b/pgo/compilation_flags_pgo.file
@@ -10,9 +10,9 @@
 # pgo_generate: Set if package is build in pgo generate mode
 # pgo_use: Set if package is build in pgo use mode
 
-%define cmsdist_package_initenv export CMSSW_PGO_DIRECTORY=%{cmsroot}/%{tempprefix}
 %define pgo_common -fprofile-prefix-path=%{pgo_path_prefix} -fprofile-update=prefer-atomic -fprofile-correction
 %if "%{?pgo_generate:set}" == "set"
+%define cmsdist_package_initenv export CMSSW_PGO_DIRECTORY=%{cmsroot}/%{tempprefix}
 %define pgo_build_flags %{pgo_common} -fprofile-generate -fprofile-dir=%%q{CMSSW_PGO_DIRECTORY}/pgo/%%p/%{pgo_package_name}
 %endif
 %if "%{?pgo_use:set}" == "set"


### PR DESCRIPTION
- `compilation_flags_pgo.file` moved to `pgo` directory
- set `CMSSW_PGO_DIRECTORY` only for PGO generation step