### PR TITLE
Update frontier_client to 2.10.1

### DIFF
--- a/frontier_client.spec
+++ b/frontier_client.spec
@@ -1,7 +1,7 @@
-### RPM external frontier_client 2.9.1
+### RPM external frontier_client 2.10.1
 ## INITENV +PATH PYTHON3PATH %{i}/python/lib
 
-%define tag 9a63575736ae2da49b51e630796a3b3a65e9bd37
+%define tag cec9524564c7541168fd0a6408ff9e6fed6709d4
 %define branch cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/frontier_client.spec
+++ b/frontier_client.spec
@@ -1,7 +1,7 @@
 ### RPM external frontier_client 2.10.1
 ## INITENV +PATH PYTHON3PATH %{i}/python/lib
 
-%define tag cec9524564c7541168fd0a6408ff9e6fed6709d4
+%define tag a8ea14344c937daf926813cf32a689f545be4af0
 %define branch cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
v2_10_1 - 7 Apr 2023 
  - Add Python bindings and related patch that CMS has been using.
  - Fix to compile with gcc 10.1's new default -f-no-common option.
  - Update fnget.py to its version 1.10, to work with the python3 on EL9.