### PR TITLE
[BuildRules] cuda/rocm tests and multi-vec env selection

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V08-00-01
+%define configtag       V08-00-02
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V08-00-02
+%define configtag       V08-00-03
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
- Use `cudaIsEnabled` for `cuda` and `alpaka-cuda`
- Use `rocmIsEnabled` for `rocm` and `alpaka-rocm`
- Allow USER_SCRAM_TARGET env to set the cpu family for multi-vectorizations IB/releases e.g.
  - `USER_SCRAM_TARGET=default cmsenv` to select cmssw default i.e. `sse3` 
  - `USER_SCRAM_TARGET=haswell cmsenv` to select `haswell` cpu family libraries