### PR TITLE
[BuildRules] allow to enable disable dedicated unit test directory

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V08-00-03
+%define configtag       V09-00-00
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Build rules ` V08` series has dedicated unit test directory disabled by default. `V08` series is for CMSSW release where unit tests are not updated and still need to be run from `package/test` directory.

`V09` series of build rules has  dedicated unit test directory  enabled by default. This should be used for cmssw where unit tests has been fixed e.g. CMSSW_13_1_X and above