### PR TITLE
llvm does not support -fno-fat-lto-objects

### DIFF
--- a/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
@@ -19,6 +19,7 @@
     <flags REM_CXXFLAGS="-funroll-all-loops"/>
     <flags REM_LTO_FLAGS="-fipa-icf"/>
     <flags REM_LTO_FLAGS="-flto-odr-type-merging"/>
+    <flags REM_LTO_FLAGS="-fno-fat-lto-objects"/>
     <flags REM_PGO_FLAGS="-fprofile%"/>
     <flags CXXFLAGS="-Wno-c99-extensions"/>
     <flags CXXFLAGS="-Wno-c++11-narrowing"/>


### PR DESCRIPTION
optimization flag '-fno-fat-lto-objects' is not supported