### PR TITLE
fastjet 3.4.1 and fastjet-contrib 1.051

### DIFF
--- a/fastjet-contrib.spec
+++ b/fastjet-contrib.spec
@@ -1,8 +1,8 @@
-### RPM external fastjet-contrib 1.044
-%define tag 03f2fb3c7e26248f5cab3d6c52fab3e112342113
+### RPM external fastjet-contrib 1.051
+%define tag aa1972cd2b3e8aa2c76764f14122e8f728c23712
 %define branch cms/v%{realversion}
 %define github_user cms-externals
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&foo=1&output=/%{n}-%{realversion}.tgz
+Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Requires: fastjet
 %define keep_archives true
 

--- a/fastjet.spec
+++ b/fastjet.spec
@@ -1,10 +1,10 @@
-### RPM external fastjet 3.4.0
+### RPM external fastjet 3.4.1
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## INCLUDE compilation_flags
 
 BuildRequires: autotools
 Requires: python3
-%define tag 2423e8c763b7d7b73f77c5a0c71c8638df362246
+%define tag e843c303828cd0b882d386decc35ad8c1b19df3d
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/fastjet.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
Update [fastjet 3.4.1](https://fastjet.fr/all-releases.html) with bug fixes
```
- Resolved MAJOR BUG that arose with full thread-safety enabled (reported by Ludo Scyboz),
where PseudoJet::reset_momentum and PseudoJet::operator= failed to update internally cached
values of phi() and rap(). In some instances related issues could also lead to race conditions.
- eliminated NaN from square-root of negative mean areas in background estimation (now returns zero) 
```