### PR TITLE
Fix for llvm-static checks

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-00-00
+%define configtag       V09-00-01
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Set `CCC_OVERRIDE_OPTIONS="^--gcc-toolchain=$(GCC_CXXCOMPILER_BASE)"` for scan-build so that `c++-analyzer` command can find gcc headers