### PR TITLE
Update xrootd to version 5.5.4

### DIFF
--- a/scram-tools.file/tools/xrootd/xrootd.xml
+++ b/scram-tools.file/tools/xrootd/xrootd.xml
@@ -10,5 +10,4 @@
   <runtime name="PATH" value="$XROOTD_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
-  <use name="scitokens-cpp"/>
 </tool>

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.5.3
+### RPM external xrootd 5.5.4
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 
@@ -12,7 +12,6 @@ BuildRequires: cmake gmake autotools
 Requires: zlib libuuid curl davix
 Requires: python3 py3-setuptools
 Requires: libxml2
-Requires: scitokens-cpp
 
 %define soext so
 %ifarch darwin
@@ -46,8 +45,7 @@ cmake ../%n-%{realversion} \
   -DCMAKE_CXX_FLAGS="-I${LIBUUID_ROOT}/include -I${DAVIX_ROOT}/include" \
   -DUUID_INCLUDE_DIR="${LIBUUID_ROOT}/include" \
   -DUUID_LIBRARY="${LIBUUID_ROOT}/lib64/libuuid.%{soext}" \
-  -DSCITOKENS_CPP_DIR="${SCITOKENS_CPP_ROOT}" \
-  -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${PYTHON3_ROOT};${LIBXML2_ROOT};${LIBUUID_ROOT};${SCITOKENS_CPP_ROOT};${CURL_ROOT};${DAVIX_ROOT}"
+  -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${PYTHON3_ROOT};${LIBXML2_ROOT};${LIBUUID_ROOT};${CURL_ROOT};${DAVIX_ROOT}"
 
 make %makeprocesses VERBOSE=1
 


### PR DESCRIPTION
This version builts the `Secztn` plugin for default (previously it was not build when xrootd was build with `XRDCL_ONLY`.
Dropped `scitokens-cpp` dependency which is only needed when xrootd is build for server side scitoken support.

https://github.com/xrootd/xrootd/blob/master/docs/ReleaseNotes.txt
```
+ **Minor bug fixes**
 **[SSI]** Avoid file system+SSI feature interference that caused problems
 **[Server]** Fix dropped connections when link is reused (issue 1928)
 **[Server]** Limit max number of sockets in poller (issue 1962)
 **[Tests]** Fix intermittent failure of SocketTest
 **[XrdApps]** Fix crashes and deadlocks in xrdreplay tool (issue 1937)
 **[XrdCl]** Remove interference between sessions in the client (issue 1942)
 **[XrdCrypto]** Allow ASN1 GeneralizedTime in certificates (issue 1969)
 **[XrdCrypto]** Fix handling of daylight savings time (issues 985, 1955)
 **[XrdHttp]** Avoid sending empty headers in the HTTP response
 **[XrdHttp]** Clear digest header between requests (issue 1956)
 **[XrdHttp]** Fix for HTTP requests with open-ended byte range
 **[XrdHttp]** Fix handling of SSL shutdown during cleanup (issue 1967)
 **[XrdHttp]** Fix parsing of configuration with weighted checksums (issue 1944)
 **[XrdHttp]** Only call ERR_print_errors() if an error occurred
 **[XrdPfc]** Fix HTTP request failures with direct read mode enabled
 **[XrdTls]** Fix intermittent clients disconnections on login (issue 1952)

+ **Miscellaneous**
 **[XrdHttp]** Map authentication failure to HTTP 401 instead of 500
 **[XrdSecztn]** Enable ZTN plugin by default
```