### PR TITLE
Roll back to CUDA 12.0.1 [gcc 12]

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 12.1.1
+### RPM external cuda 12.0.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 530.30.02
+%define driversversion 525.85.12
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,7 +1,5 @@
-### RPM external ucx 1.14.x
-%define branch v1.14.x
-%define tag bb39346ac1aebc67cb88c4419429de78a1260bda
-Source: git+https://github.com/openucx/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/v%{realversion}.tar.gz
+### RPM external ucx 1.14.1
+Source: https://github.com/openucx/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: autotools
 Requires: cuda gdrcopy
 Requires: numactl


### PR DESCRIPTION
Roll back to CUDA 12.0.1, as CUDA 12.1.1 fails to build the `RecoPixelVertexing/PixelTriplets package` (the `cicc` CUDA compiler crashes).