### PR TITLE
[el9][oracle] explicitly use unzip instead of setup

### DIFF
--- a/bazel.spec
+++ b/bazel.spec
@@ -20,10 +20,7 @@ Patch0: bazel-3.7.0-patches
 Patch1: bazel-3.7.2-gcc11
 
 %prep
-
-%define __unzip unzip -d bazel-%{realversion}
-
-%setup -q -n bazel-%{realversion}
+%setup -q -c -n bazel-%{realversion}
 
 %patch0 -p1
 %patch1 -p1

--- a/oracle.spec
+++ b/oracle.spec
@@ -24,45 +24,45 @@ AutoReq: no
 %define http_mirror https://download.oracle.com/otn_software/linux/instantclient/%{ver_num}
 %define client_dir instantclient_%(echo %{oc_ver} | cut -d. -f1,2 | tr '.' '_')
 
-# zip files contains overlapping files, use -o to avoid human input
-%define __unzip unzip -o
+%define source0 instantclient-basic-linux.%{client_arch}-%{realversion}.zip
+%define source1 instantclient-basiclite-linux.%{client_arch}-%{realversion}.zip
+%define source2 instantclient-jdbc-linux.%{client_arch}-%{realversion}.zip
+%define source3 instantclient-odbc-linux.%{client_arch}-%{realversion}.zip
+%define source4 instantclient-sdk-linux.%{client_arch}-%{realversion}.zip
+%define source5 instantclient-sqlplus-linux.%{client_arch}-%{realversion}.zip
+%define source6 instantclient-tools-linux.%{client_arch}-%{realversion}.zip
+%define source7 libocci.so.%{occi_lib}.zip
 
-%define source0 %{http_mirror}/instantclient-basic-linux.%{client_arch}-%{realversion}.zip
-%define source1 %{http_mirror}/instantclient-basiclite-linux.%{client_arch}-%{realversion}.zip
-%define source2 %{http_mirror}/instantclient-jdbc-linux.%{client_arch}-%{realversion}.zip
-%define source3 %{http_mirror}/instantclient-odbc-linux.%{client_arch}-%{realversion}.zip
-%define source4 %{http_mirror}/instantclient-sdk-linux.%{client_arch}-%{realversion}.zip
-%define source5 %{http_mirror}/instantclient-sqlplus-linux.%{client_arch}-%{realversion}.zip
-%define source6 %{http_mirror}/instantclient-tools-linux.%{client_arch}-%{realversion}.zip
-%define source7 http://cmsrep.cern.ch/cmssw/download/oracle-mirror/x64/libocci.so.%{occi_lib}.zip
-
-Source0: %{source0}
-Source1: %{source1}
-Source2: %{source2}
-Source3: %{source3}
-Source4: %{source4}
-Source5: %{source5}
-Source6: %{source6}
-Source7: %{source7}
+Source0: %{http_mirror}/%{source0}
+Source1: %{http_mirror}/%{source1}
+Source2: %{http_mirror}/%{source2}
+Source3: %{http_mirror}/%{source3}
+Source4: %{http_mirror}/%{source4}
+Source5: %{http_mirror}/%{source5}
+Source6: %{http_mirror}/%{source6}
+Source7: http://cmsrep.cern.ch/cmssw/download/oracle-mirror/x64/%{source7}
 Source10: oracle-license
 
 %prep
 rm -rf instantclient_*
-
-%setup -D -T -b 0 -n %{client_dir} %(echo %{source0} | sed 's|.*/||)
-%setup -D -T -b 1 -n %{client_dir} %(echo %{source1} | sed 's|.*/||)
-%setup -D -T -b 2 -n %{client_dir} %(echo %{source2} | sed 's|.*/||)
-%setup -D -T -b 3 -n %{client_dir} %(echo %{source3} | sed 's|.*/||)
-%setup -D -T -b 4 -n %{client_dir} %(echo %{source4} | sed 's|.*/||)
-%setup -D -T -b 5 -n %{client_dir} %(echo %{source5} | sed 's|.*/||)
-%setup -D -T -b 6 -n %{client_dir} %(echo %{source6} | sed 's|.*/||)
+#RPM 4.18 does not allow to override build-in %%__unzip, so we explicitly use it instead of calling %%setup
+%{__unzip} -o -x %{_sourcedir}/%{source0}
+%{__unzip} -o -x %{_sourcedir}/%{source1}
+%{__unzip} -o -x %{_sourcedir}/%{source2}
+%{__unzip} -o -x %{_sourcedir}/%{source3}
+%{__unzip} -o -x %{_sourcedir}/%{source4}
+%{__unzip} -o -x %{_sourcedir}/%{source5}
+%{__unzip} -o -x %{_sourcedir}/%{source6}
 
 %ifarch x86_64
 #OCCI lib with new C++ ABI (GCC 5 and above)
-%setup -D -T -c -a 7 -n %{client_dir} %(echo %{source7} | sed 's|.*/||)
+%{__unzip} -o -x %{_sourcedir}/%{source7} -d %{client_dir}
 %endif
 
+chmod -Rf a+rX,u+w,g-w,o-w %{client_dir}
+
 %build
+cd %{client_dir}
 chmod a-x sdk/include/*.h *.sql
 %ifarch x86_64
 chmod +x libocci_gcc53.so.%{occi_lib}
@@ -70,6 +70,7 @@ ln -sf libocci_gcc53.so.%{occi_lib} libocci.so.%{occi_lib}
 %endif
 
 %install
+cd %{client_dir}
 mkdir -p %{i}/{bin,lib,java,demo,include,doc,etc}
 cp %{_sourcedir}/oracle-license   %{i}/etc/LICENSE
 mv *_LICENSE                      %{i}/etc


### PR DESCRIPTION
RPM 4.18 and above now user new tool `rpmuncompress` for unpacking the sources. It does not allow to override build-in macros e.g. `__unzip`. This break the build of oracle client as multiple sources provide same directory and without `unzip -o` it hangs. This PR proposes to explicitly use `%{__unzip} -o` instead of `%setup`