### PR TITLE
[BuildRules] USe nvidia-drivers LIBDIR for compatibility drivers

### DIFF
--- a/cmssw-drop-tools.file
+++ b/cmssw-drop-tools.file
@@ -1,1 +1,1 @@
-%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp nvidia-drivers intel-vtune icx-cxxcompiler icx-ccompiler icx-f77compiler
+%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp intel-vtune icx-cxxcompiler icx-ccompiler icx-f77compiler

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-00-01
+%define configtag       V09-00-02
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-tools.file/tools/cuda/nvidia-drivers.xml
+++ b/scram-tools.file/tools/cuda/nvidia-drivers.xml
@@ -4,4 +4,5 @@
     <environment name="NVIDIA_DRIVERS_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"              default="$NVIDIA_DRIVERS_BASE/drivers"/>
   </client>
+  <flags SKIP_TOOL_SYMLINKS="1"/>
 </tool>


### PR DESCRIPTION
Updates SCRAM runtime hooks (  https://github.com/cms-sw/cmssw-config/commit/9a096650c348c66882a8bead5f4e83fd75089d6f ) to make use of nvidia-driver LIBDIR to check the compatibility drivers 