### PR TITLE
sqlite: use zlib from cms externals

### DIFF
--- a/sqlite.spec
+++ b/sqlite.spec
@@ -1,10 +1,12 @@
 ### RPM external sqlite 3.36.0
+Requires: zlib
 Source: https://www.sqlite.org/2021/sqlite-autoconf-3360000.tar.gz
 
 %prep
 %setup -n sqlite-autoconf-3360000
 
 %build
+CFLAGS=-I${ZLIB_ROOT}/include LDFLAGS=-L${ZLIB_ROOT}/lib \
 ./configure --build="%{_build}" --host="%{_host}" --prefix=%{i} \
             --disable-static --disable-dependency-tracking
 make %{makeprocesses}


### PR DESCRIPTION
Make sure to build sqlite with zlib from CMS externals
**NOTE**: As sqlite is used by `python3`, so this change rebuilds nearly all the externals. so Do not merge it yet. May be when we have to update the GCC 11 compiler or python3 version then this change can go it. 

For GCC12 and GCC13, we can already include this change