### PR TITLE
[13.1.X] Update llvm.spec with latest hash

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -7,7 +7,7 @@ Requires: gcc zlib python3
 Requires: cuda
 AutoReq: no
 
-%define llvmCommit d88fe2a1cafb6621210a7a0ae968c1e8e797d2bb
+%define llvmCommit 7304230013170b813b38c0df73f47e3c1538794a
 %define llvmBranch cms/release/14.x/f28c006
 %define iwyuCommit d888efc52646dcf3e4e3a56af13aa23dd26abde0
 %define iwyuBranch master


### PR DESCRIPTION
Update to clang static analyzer core to use scoped named for variable when calculating issue hash

backport of #8537