### PR TITLE
HDF5: Version 1.14.1 with hdf5 cxx library enabled

### DIFF
--- a/hdf5.spec
+++ b/hdf5.spec
@@ -1,20 +1,28 @@
-### RPM external hdf5 1.10.6
-Source: git+https://github.com/HDFGroup/%{n}.git?obj=master/5b9cf732caab9daa6ed1e00f2df4f5a792340196&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+### RPM external hdf5 1.14.1
+%define hdf5_tag hdf5-%(echo %realversion | tr '.' '_')
+Source: https://github.com/HDFGroup/hdf5/archive/refs/tags/%{hdf5_tag}.tar.gz
 Requires: zlib openmpi
 
 %prep
-%setup -n %{n}-%{realversion}
+%setup -n %{n}-%{hdf5_tag}
 
 %build
 rm -f ./bin/config.{sub,guess}
 %get_config_sub ./bin/config.sub
 %get_config_guess ./bin/config.guess
 chmod +x ./bin/config.{sub,guess}
-./configure --enable-shared --enable-parallel --with-zlib=${ZLIB_ROOT} --prefix %{i}
-make %{makeprocesses} VERBOSE=1
+CXXFLAGS=-I${OPENMPI_ROOT}/include \
+LDFLAGS="-L${OPENMPI_ROOT}/lib -lmpi" \
+./configure --prefix %{i} \
+            --disable-sharedlib-rpath \
+            --disable-static--enable-shared \
+            --enable-parallel \
+            --enable-cxx --enable-unsupported --with-zlib=${ZLIB_ROOT}
+
+make %{makeprocesses} V=1
 
 %install
-make install
+make install V=1
 
 %post
 %{relocateConfig}bin/h5pcc

--- a/scram-tools.file/tools/hdf5/hdf5-cpp.xml
+++ b/scram-tools.file/tools/hdf5/hdf5-cpp.xml
@@ -1,0 +1,5 @@
+<tool name="hdf5-cpp" version="@TOOL_VERSION@">
+  <use name="hdf5"/>
+  <lib name="hdf5_cpp"/>
+  <lib name="hdf5_hl_cpp"/>
+</tool>


### PR DESCRIPTION
Resolves https://github.com/cms-sw/cmsdist/issues/8530
- New HDF5 version 1.14.1
- Enabled CXX Interface
- SCRAM `hdf5-cpp` tool added