### PR TITLE
GCC 11.4; CUDA 11.8; cleanup for cmsplatf/cmsos use

### DIFF
--- a/archive/python.spec
+++ b/archive/python.spec
@@ -85,9 +85,7 @@ sed -ibak "s|LIBFFI_INCLUDEDIR=.*|LIBFFI_INCLUDEDIR=\"${LIBFFI_ROOT}/include\"|g
 # in CMSSW and pyconfig.h is not smart enough to detect already defined
 # macros on Linux. The following problem does not exists on BSD machines as
 # cdefs.h does not define these macros.
-case %cmsplatf in
-  osx*);;
-  *)
+%ifnos darwin
     rm -f cms_configtest.cpp
     cat <<CMS_EOF > cms_configtest.cpp
 #include <features.h>
@@ -106,8 +104,7 @@ CMS_EOF
 
     sed -ibak "s/\(#define _POSIX_C_SOURCE \)\(.*\)/\1${POSIX_C_SOURCE}/g" pyconfig.h
     sed -ibak "s/\(#define _XOPEN_SOURCE \)\(.*\)/\1${XOPEN_SOURCE}/g" pyconfig.h
-  ;;
-esac
+%endif
 
 # Modify pyconfig.h to disable GCC format attribute as it is used incorrectly.
 # Triggers an error if -Werror=format is used with GNU GCC 4.8.0+.
@@ -127,8 +124,7 @@ export LIBFFI_ROOT
 make install
 %define pythonv %(echo %realversion | cut -d. -f 1,2)
 
-case %cmsplatf in
-  osx*)
+%ifos darwin
    make install prefix=%i 
    (cd Misc; /bin/rm -rf RPM)
    mkdir -p %i/share/doc/%n
@@ -145,8 +141,7 @@ case %cmsplatf in
     perl -p -i -e 's|-fno-common||g' Makefile)
 
    find %i/lib/python%{pythonv}/config -name 'libpython*' -exec mv -f {} %i/lib \;
-  ;;
-esac
+%endif
 
  perl -p -i -e "s|^#!.*python|#!/usr/bin/env python|" %{i}/bin/idle \
                      %{i}/bin/pydoc \

--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -51,16 +51,9 @@ packagesWithBuildProvides=""
 platformSeeds+=" libaio"
 %endif
 
-case %cmsplatf in
-slc*)
-#  platformBuildSeeds+=" perl-Switch"
-  true
-  ;;
-*)
-  #platformSeeds+=" perl-IO"
+%if "%{rhel}" != "7"
   platformSeeds+=" libxcrypt perl-libs"
-  ;;
-esac
+%endif
 
 defaultPkgs="cms+cms-common+1.0 cms+fakesystem+1.0"
 

--- a/bz2lib.spec
+++ b/bz2lib.spec
@@ -1,7 +1,5 @@
 ### RPM external bz2lib 1.0.6
 Source: http://www.bzip.org/%{realversion}/bzip2-%{realversion}.tar.gz
-%define cpu %(echo "%{cmsplatf}" | cut -f2 -d_)
-
 
 %prep
 %setup -n bzip2-%{realversion}

--- a/cmake.spec
+++ b/cmake.spec
@@ -29,15 +29,11 @@ EOF
 export CMAKE_PREFIX_PATH=$CURL_ROOT:$ZLIB_ROOT:$EXPAT_ROOT:$BZ2LIB_ROOT
 # For OS X 10.8 ("Mountain Lion") do not use Objective-C in
 # C and C++ code.
-case %cmsplatf in
-  osx108_*)
-    CXXFLAGS="-DOS_OBJECT_USE_OBJC=0" CFLAGS="-DOS_OBJECT_USE_OBJC=0" \
-      ./configure --prefix=%i --init=build-flags.cmake --parallel=%compiling_processes
-  ;;
-  *)
-    ./configure --prefix=%i --init=build-flags.cmake --parallel=%compiling_processes
-  ;;
-esac
+%ifos darwin
+  CXXFLAGS="-DOS_OBJECT_USE_OBJC=0" CFLAGS="-DOS_OBJECT_USE_OBJC=0" \
+%endif
+  ./configure --prefix=%{i} --init=build-flags.cmake --parallel=%{compiling_processes}
+
 make %makeprocesses
 
 %install

--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -1,8 +1,16 @@
 ### FILE cuda-flags
 # define the CUDA compilation flags in a way that can be shared by SCRAM-based and regular tools
 
-# build support for Pascal, Volta, Turing, Ampere, Lovelace and Hopper
-%define cuda_arch 60 70 75 80 86 89 90
+# on X86 and Power, build support for Pascal, Volta and Turing
+%ifarch x86_64 ppc64le
+%define cuda_arch 60 70 75
+%endif
+
+# on ARM, build support for Volta, Xavier SoC and Turing
+%ifarch aarch64
+%define cuda_arch 70 72 75
+%endif
+
 
 # LLVM style for listing the supported CUDA compute architectures
 %define llvm_cuda_arch %(echo $(for ARCH in %cuda_arch; do echo "$ARCH"; done) | sed -e"s/ /,/g")

--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -1,16 +1,8 @@
 ### FILE cuda-flags
 # define the CUDA compilation flags in a way that can be shared by SCRAM-based and regular tools
 
-# on X86 and Power, build support for Pascal, Volta and Turing
-%ifarch x86_64 ppc64le
-%define cuda_arch 60 70 75
-%endif
-
-# on ARM, build support for Volta, Xavier SoC and Turing
-%ifarch aarch64
-%define cuda_arch 70 72 75
-%endif
-
+# build support for Pascal, Volta, Turing, Ampere, Lovelace and Hopper
+%define cuda_arch 60 70 75 80 86 89 90
 
 # LLVM style for listing the supported CUDA compute architectures
 %define llvm_cuda_arch %(echo $(for ARCH in %cuda_arch; do echo "$ARCH"; done) | sed -e"s/ /,/g")

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 11.5.2
+### RPM external cuda 11.8.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 495.29.05
+%define driversversion 520.61.05
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/curl.spec
+++ b/curl.spec
@@ -6,10 +6,11 @@ Requires: zlib
 %setup -n %{n}-%{realversion}
 
 %build
-case %{cmsplatf} in
-  osx*) KERBEROS_ROOT=/usr/heimdal ;;
-  *) KERBEROS_ROOT=/usr ;;
-esac
+%ifos darwin
+  KERBEROS_ROOT=/usr/heimdal
+%else
+  KERBEROS_ROOT=/usr
+%endif
 
 ./configure \
   --prefix=%{i} \
@@ -27,10 +28,6 @@ make %{makeprocesses}
 
 %install
 make install
-case %{cmsos} in 
-  osx*) SONAME=dylib ;;
-  *) SONAME=so ;;
-esac
 
 # Trick to get our version of curl pick up our version of its associated shared
 # library (which is different from the one coming from the system!).

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -30,12 +30,6 @@ rm -rf ../build
 mkdir ../build
 cd ../build
 
-
-case %cmsplatf in
-  osx*)
-  ;;
-esac
-
 cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../%{n}-%{realversion} \
       -DEVTGEN_HEPMC3:BOOL=OFF -DHEPMC2_ROOT_DIR:PATH=$HEPMC_ROOT \
       -DEVTGEN_PYTHIA:BOOL=ON  -DPYTHIA8_ROOT_DIR:PATH=$PYTHIA8_ROOT \
@@ -43,11 +37,9 @@ cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../%{n}-%{realversion} \
       -DEVTGEN_TAUOLA:BOOL=ON  -DTAUOLAPP_ROOT_DIR:PATH=$TAUOLAPP_ROOT
 
 # One more fix-up for OSX (in addition to the patch above)
-case %cmsplatf in
-  osx*)
-perl -p -i -e "s|-shared|-dynamiclib -undefined dynamic_lookup|" make.inc
-  ;;
-esac
+%ifos darwin
+ perl -p -i -e "s|-shared|-dynamiclib -undefined dynamic_lookup|" make.inc
+%endif
 
 make
 

--- a/gcc.spec
+++ b/gcc.spec
@@ -1,10 +1,10 @@
-### RPM external gcc 11.2.1
+### RPM external gcc 11.4.1
 ## USE_COMPILER_VERSION
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 # Use the git repository for fetching the sources. This gives us more control while developing
 # a new platform so that we can compile yet to be released versions of the compiler.
 # See: https://gcc.gnu.org/viewcvs/gcc/branches/gcc-8-branch/?view=log
-%define gccTag a0a0499b8bb920fdd98e791804812f001f0b4fe8
+%define gccTag d41085966d842e54fd4b528c719ed5af2e51c473
 %define gccBranch releases/gcc-11
 
 %define moduleName %{n}-%{realversion}
@@ -13,20 +13,22 @@ Source0: git+https://github.com/gcc-mirror/%{n}.git?obj=%{gccBranch}/%{gccTag}&e
 %define keep_archives true
 
 %define gmpVersion 6.2.1
-%define mpfrVersion 4.1.0
-%define mpcVersion 1.2.1
-%define islVersion 0.24
-%define zlibVersion 1.2.11
+%define mpfrVersion 4.2.0
+%define mpcVersion 1.3.1
+%define islVersion 0.26
+%define zlibVersion 1.2.13
+%define zstdVersion 1.4.5
 Source1: https://gmplib.org/download/gmp/gmp-%{gmpVersion}.tar.bz2
 Source2: http://www.mpfr.org/mpfr-%{mpfrVersion}/mpfr-%{mpfrVersion}.tar.bz2
 Source3: https://ftp.gnu.org/gnu/mpc/mpc-%{mpcVersion}.tar.gz
-Source4: http://isl.gforge.inria.fr/isl-%{islVersion}.tar.bz2
+Source4: https://libisl.sourceforge.io/isl-%{islVersion}.tar.bz2
 Source12: http://zlib.net/zlib-%{zlibVersion}.tar.gz
+Source13: https://github.com/facebook/zstd/releases/download/v%{zstdVersion}/zstd-%{zstdVersion}.tar.gz
 
 %ifos linux
-%define bisonVersion 3.7.6
-%define binutilsVersion 2.36.1
-%define elfutilsVersion 0.183
+%define bisonVersion 3.8.2
+%define binutilsVersion 2.40
+%define elfutilsVersion 0.189
 %define m4Version 1.4.19
 %define flexVersion 2.6.4
 Source7: http://ftp.gnu.org/gnu/bison/bison-%{bisonVersion}.tar.gz
@@ -38,12 +40,10 @@ Source11: https://github.com/westes/flex/releases/download/v%{flexVersion}/flex-
 
 Patch0: gcc-flex-nonfull-path-m4
 Patch1: gcc-flex-disable-doc
-Patch2: gcc-03af8492bee6243a9d10e78fea1a3e423bd5f9cd
 
 %prep
 
 %setup -T -b 0 -n %{moduleName}
-%patch2 -p1
 
 # Filter out private stuff from RPM requires headers.
 cat << \EOF > %{name}-req
@@ -96,6 +96,7 @@ EOF_CMS_H
 %setup -D -T -b 3 -n mpc-%{mpcVersion}
 %setup -D -T -b 4 -n isl-%{islVersion}
 %setup -D -T -b 12 -n zlib-%{zlibVersion}
+%setup -D -T -b 13 -n zstd-%{zstdVersion}
 
 %ifos linux
 %setup -D -T -b 7 -n bison-%{bisonVersion}
@@ -139,6 +140,10 @@ CFLAGS="${CONF_FLAGS}" ./configure --static --prefix=%{i}/tmp/sw
 make %{makeprocesses}
 make install
 
+#Build and install zstd static library
+make -C ../zstd-%{zstdVersion}/lib %{makeprocesses} \
+  install-static install-includes prefix=%{i}/tmp/sw \
+  CPPFLAGS="-fPIC" CFLAGS="-fPIC"
 %ifos linux
   CONF_BINUTILS_OPTS="--enable-ld=default --enable-lto --enable-plugins --enable-threads"
   CONF_GCC_WITH_LTO="--enable-ld=default --enable-lto"
@@ -166,19 +171,12 @@ make install
   # Build Flex (for building)
   cd ../flex-%{flexVersion}
   ./configure --disable-nls --prefix=%{i}/tmp/sw \
+              --enable-static --disable-shared \
               --build=%{_build} --host=%{_host} \
               CC="$CC" CXX="$CXX"
   make %{makeprocesses}
   make install
   hash -r
-
-  # Build Flex
-  cd ../flex-%{flexVersion}
-  ./configure --disable-nls --prefix=%{i} \
-              --build=%{_build} --host=%{_host} \
-              CC="$CC" CXX="$CXX"
-  make %{makeprocesses}
-  make install
 
   # Build elfutils
   cd ../elfutils-%{elfutilsVersion}
@@ -263,13 +261,15 @@ export LD_LIBRARY_PATH=%{i}/lib64:%{i}/lib:$LD_LIBRARY_PATH
              $CONF_GCC_OS_SPEC $CONF_GCC_WITH_LTO --with-gmp=%{i} --with-mpfr=%{i} --enable-bootstrap \
              --with-mpc=%{i} --with-isl=%{i} --enable-checking=release \
              --build=%{_build} --host=%{_host} --enable-libstdcxx-time=rt $CONF_GCC_ARCH_SPEC \
-             --enable-shared --disable-libgcj CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" \
+             --enable-shared --disable-libgcj \
+             --with-zstd=%{i}/tmp/sw \
+             CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" \
              CFLAGS="-I%{i}/tmp/sw/include" CXXFLAGS="-I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/tmp/sw/lib"
 
 make %{makeprocesses} profiledbootstrap
 
 %install
-cd %_builddir/%{moduleName}/obj && make install 
+cd %_builddir/%{moduleName}/obj && make install
 
 ln -s gcc %{i}/bin/cc
 find %{i}/lib %{i}/lib64 -name '*.la' -exec rm -f {} \; || true

--- a/gcc.spec
+++ b/gcc.spec
@@ -282,3 +282,13 @@ find %{i}/lib %{i}/lib64 -name '*.la' -exec rm -f {} \; || true
 %define keep_archives yes
 # This avoids having a dependency on the system pkg-config.
 rm -rf %{i}/lib/pkg-config
+
+%post
+%{relocateConfig}bin/eu-make-debug-archive
+%{relocateConfig}etc/profile.d/debuginfod.*sh
+%{relocateConfig}lib/gcc/*/%{realversion}/plugin/include/auto-host.h
+%{relocateConfig}lib/gcc/*/%{realversion}/plugin/include/configargs.h
+%{relocateConfig}lib64/libstdc++*-gdb.py
+%{relocateConfig}libexec/gcc/*/%{realversion}/install-tools/mkheaders
+%{relocateConfig}libexec/gcc/*/%{realversion}/liblto_plugin.la
+for f in $(find $RPM_INSTALL_PREFIX/%{pkgrel}/*/lib/ldscripts -type f) ; do %{relocateCmsFiles} $f || true ; done

--- a/gdbm.spec
+++ b/gdbm.spec
@@ -1,5 +1,6 @@
 ### RPM external gdbm 1.10
 Source: http://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
+BuildRequires: gmake
 
 %prep
 %setup -n %{n}-%{realversion}

--- a/gnuplot.spec
+++ b/gnuplot.spec
@@ -1,10 +1,13 @@
 ### RPM external gnuplot 5.2.8
 Source: http://downloads.sourceforge.net/project/gnuplot/gnuplot/%{realversion}/gnuplot-%{realversion}.tar.gz
+Requires: zlib
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
+CFLAGS=-I${ZLIB_ROOT}/include \
+LDFLAGS=-L${ZLIB_ROOT}/lib \
 ./configure \
   --prefix %{i} \
   --disable-wxt \

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -18,4 +18,7 @@ make install
 
 %post
 %{relocateConfig}bin/h5pcc
+%{relocateConfig}bin/h5c++
+%{relocateConfig}share/hdf5_examples/c*/run-*-ex.sh
+%{relocateConfig}share/hdf5_examples/hl/c*/run-*-ex.sh
 %{relocateConfig}lib/libhdf5.settings

--- a/hector.spec
+++ b/hector.spec
@@ -13,9 +13,9 @@ mkdir -p obj lib
 %build
 # Correct link path for root.
 #perl -p -i -e "s|^ROOTLIBS.*$|ROOTLIBS=-L$ROOT_ROOT/lib -lCore -lRint -lMatrix -lPhysics -lCling -lMathCore -pthread -lm -ldl -rdynamic|" Makefile
-case %cmsplatf in
-  osx*) perl -p -i -e 's|-rdynamic||g' Makefile ;;
-esac
+%ifos darwin
+  perl -p -i -e 's|-rdynamic||g' Makefile
+%endif
 
 # Add CXX and CXXFLAGS to Makefile and increase output versbose level
 sed -ibak "s/@g++/\$(CXX) \$(CXXFLAGS)/g" Makefile

--- a/pip/pillow.file
+++ b/pip/pillow.file
@@ -1,4 +1,4 @@
 %define PipBuildOptions --global-option="build_ext" --global-option="--disable-xcb"
-Requires: libjpeg-turbo zlib libtiff 
-%define PipPreBuild export LDFLAGS="-L${LIBJPEG_TURBO_ROOT}/lib64 -L${ZLIB_ROOT}/lib -L${LIBTIFF_ROOT}/lib"; \
-                    export CFLAGS="-I${LIBJPEG_TURBO_ROOT}/include -I${ZLIB_ROOT}/include -I${LIBTIFF_ROOT}/include"
+Requires: libjpeg-turbo zlib libtiff freetype 
+%define PipPreBuild export LDFLAGS="-L${LIBJPEG_TURBO_ROOT}/lib64 -L${ZLIB_ROOT}/lib -L${LIBTIFF_ROOT}/lib -L${FREETYPE_ROOT}/lib"; \
+                    export CFLAGS="-I${LIBJPEG_TURBO_ROOT}/include -I${ZLIB_ROOT}/include -I${LIBTIFF_ROOT}/include -I${FREETYPE_ROOT}/include"

--- a/pythia6.spec
+++ b/pythia6.spec
@@ -4,20 +4,6 @@ Source: http://cern.ch/service-spi/external/MCGenerators/distribution/%{n}/%{n}-
 %define keep_archives true
 
 %prep
-PLATF_CONF_OPTS="--disable-shared --enable-static"
-F77="$(which gfortran) -fPIC"
-
-# Notice we need to define LDFLAGS like this to avoid dropping 
-# the dynamic linker options on slc5_amd64_gcc434
-case %cmsplatf in
-  osx*) 
-    PLATF_LDFLAGS="LDFLAGS='-Wl,-commons,use_dylibs -Wl,-flat_namespace'"
-    PLATF_LDFLAGS=""
-    PLATF_LD="LD='$(which gcc)'" ;;
-  *)
-    PLATF_LD="" ;;
-esac
-
 %setup -q -n %{n}/%{realversion}
 
 # Update to detect aarch64 and ppc64le
@@ -26,18 +12,10 @@ rm -f ./config/config.{sub,guess}
 %get_config_guess ./config/config.guess
 chmod +x ./config/config.{sub,guess}
 
-# Unfortunately we need the two cases because LDFLAGS= does not work on linux
-# and I couldn't get the space between use_dylibs and -Wl, preseved if
-# I tried to have the whole "LDFLAGS=foo" in a variable.
-case %cmsplatf in
-  osx*)
-    ./configure $PLATF_CONF_OPTS --with-hepevt=4000 F77="$F77" \
-		LD='$(which gcc)' LDFLAGS='-Wl,-commons,use_dylibs -Wl,-flat_namespace'
-  ;;
-  *)
-    ./configure $PLATF_CONF_OPTS --with-hepevt=4000 F77="$F77" 
-  ;;
-esac
+%ifos darwin
+  LD="$(which gcc)" LDFLAGS='-Wl,-commons,use_dylibs -Wl,-flat_namespace'  \
+%endif
+  ./configure --disable-shared --enable-static --with-hepevt=4000 F77="$(which gfortran) -fPIC"
 
 perl -p -i -e 's|^CC=.*$|CC="gcc -fPIC"|' libtool
 

--- a/python3.spec
+++ b/python3.spec
@@ -68,6 +68,5 @@ echo "       site.addsitedir(p)">> %i/lib/python%{pythonv}/sitecustomize.py
 
 %post
 %{relocateConfig}bin/python*-config
-%{relocateConfig}lib/pkgconfig/python*.pc
 %{relocateConfig}lib/python*/config-*/Makefile
 %{relocateConfig}lib/python*/_sysconfigdata*.py

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -137,8 +137,10 @@
 # Define the variable name for dynamic linker search path.
 %ifos darwin
 %define dynamic_path_var DYLD_FALLBACK_LIBRARY_PATH
+%define dynamic_lib_ext  dylib
 %else
 %define dynamic_path_var LD_LIBRARY_PATH
+%define dynamic_lib_ext  so
 %endif
 
 # We are now done with locations.  Move to other things.

--- a/sqlite.spec
+++ b/sqlite.spec
@@ -1,10 +1,12 @@
 ### RPM external sqlite 3.36.0
 Source: https://www.sqlite.org/2021/sqlite-autoconf-3360000.tar.gz
+Requires: zlib
 
 %prep
 %setup -n sqlite-autoconf-3360000
 
 %build
+CFLAGS=-I${ZLIB_ROOT}/include LDFLAGS=-L${ZLIB_ROOT}/lib \
 ./configure --build="%{_build}" --host="%{_host}" --prefix=%{i} \
             --disable-static --disable-dependency-tracking
 make %{makeprocesses}

--- a/starlight.spec
+++ b/starlight.spec
@@ -20,10 +20,7 @@ mkdir ../build
 cd ../build
 
 export CLHEP_PARAM_PATH=${CLHEP_ROOT}
-CXXFLAGS="-Wno-error=deprecated-declarations"
-case %cmsplatf in
-  *_gcc9*|*_gcc1[0-9]*) CXXFLAGS="$CXXFLAGS -Wno-error=deprecated-copy";;
-esac
+CXXFLAGS="-Wno-error=deprecated-declarations -Wno-error=deprecated-copy"
 
 cmake ../%{n}-%{realversion} \
  -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \

--- a/swig.spec
+++ b/swig.spec
@@ -3,11 +3,14 @@
 ## INITENV SET SWIG_LIB %{i}/share/swig/%{realversion}
 
 Source: http://prdownloads.sourceforge.net/swig/swig-%{realversion}.tar.gz
+Requires: zlib
 
 %prep
 %setup -n swig-%{realversion}
 
 %build
+CFLAGS=-I${ZLIB_ROOT}/include \
+LDFLAGS=-L${ZLIB_ROOT}/lib \
 ./configure \
   --prefix=%{i} \
   --without-pcre

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,5 +1,5 @@
 ### RPM external tensorflow-sources 2.6.4
-%define tag         0b5069862cb4347fcb482f285a323b26d6453a98
+%define tag         88c18549eb072773f551e3332f718b33db67a46d
 %define branch      cms/v%{realversion}
 %define github_user cms-externals
 %define python_cmd python3

--- a/tkonlinesw.spec
+++ b/tkonlinesw.spec
@@ -2,7 +2,6 @@
 %define projectname trackerDAQ
 %define releasename %{projectname}-4.2-tkonline
 Source0: http://cms-trackerdaq-service.web.cern.ch/cms-trackerdaq-service/download/sources/trackerDAQ-%{realversion}.tgz
-Patch0: tkonlinesw-2.7.0-macosx
 Patch1: tkonlinesw-4.0-clang-hash_map
 Patch2: tkonlinesw-bring-pvf
 # NOTE: given how broken the standard build system is
@@ -10,7 +9,8 @@ Patch2: tkonlinesw-bring-pvf
 #       The 4 libraries we need can be built with the
 #       attached 118 lines of cmakefile, at least on macosx 
 #       (and without dependencies on xdaq).
-%if "%(echo %cmsos | grep osx >/dev/null && echo true)" == "true"
+%ifos darwin
+Patch0: tkonlinesw-2.7.0-macosx
 Source1: tkonlinesw-cmake-build
 Requires: cmake
 %endif
@@ -24,11 +24,9 @@ Requires: root
 %setup -q -n %releasename
 %patch1 -p1
 %patch2 -p1
-case %cmsos in 
-  osx*)
+%ifos darwin
 %patch0 -p1
-  ;;
-esac
+%endif
 # Clean up some mysterious old build within the sources that screws
 # up the install by copying in an old libFed9UUtils.so 
 # (this is really needed) 

--- a/valgrind.spec
+++ b/valgrind.spec
@@ -9,11 +9,9 @@ BuildRequires: autotools gmake
 
 %build
 CONF_OPTS="--enable-only64bit"
-case %{cmsplatf} in
-  osx*)
-    CFLAGS="-D__private_extern__=extern"
-    ;;
-esac
+%ifos darwin
+  CFLAGS="-D__private_extern__=extern"
+%endif
 
 ./autogen.sh
 ./configure --prefix=%{i} --without-mpicc --disable-static ${CONF_OPTS}

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -48,6 +48,3 @@ make %{makeprocesses} VERBOSE=1
 %install
 cd ../build
 make %{makeprocesses} install VERBOSE=1
-
-%post
-%{relocateConfig}lib/cmake/VecGeom/*.cmake

--- a/xerces-c.spec
+++ b/xerces-c.spec
@@ -17,13 +17,11 @@ rm -f ./config/config.{sub,guess}
 chmod +x ./config/config.{sub,guess}
 
 export VERBOSE=1
-case %cmsplatf in
-  osx108_*)
-    # For OS X ("Mountain Lion") do not use Objective-C in C and C++ code.
-    export CXXFLAGS="${CXXFLAGS} -DOS_OBJECT_USE_OBJC=0"
-    export CFLAGS="${CXXFLAGS} -DOS_OBJECT_USE_OBJC=0"
-  ;;
-esac
+%ifos darwin
+  # For OS X ("Mountain Lion") do not use Objective-C in C and C++ code.
+  export CXXFLAGS="${CXXFLAGS} -DOS_OBJECT_USE_OBJC=0"
+  export CFLAGS="${CXXFLAGS} -DOS_OBJECT_USE_OBJC=0"
+%endif
 
 ./configure \
   --prefix=%{i} \

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -56,4 +56,4 @@ make install
 
 %post
 %{relocateConfig}bin/xrootd-config
-%{relocateConfig}${PYTHON3_LIB_SITE_PACKAGES}/xrootd-%{realvesion}-*.egg/EGG-INFO/SOURCES.txt
+%{relocateConfig}lib/python*/site-packages/xrootd-%{realversion}-*.egg/EGG-INFO/SOURCES.txt


### PR DESCRIPTION
- Update GCC version to 11.4.1 and its prerequisites and build with zstd support ( changes backported from gcc 12 branch)
- CUDA 11.8 which has GCC 11.4 support
- Fixes to resolve https://github.com/cms-sw/cmsdist/issues/7571 i.e. clean up for the usage of `cmsplatf` and `cmsos`
- Added missing dependencies for sqlite, swig, py3-pillow, gnuplot
