### PR TITLE
Update Pythia to 8.309

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,9 +1,6 @@
-### RPM external pythia8 306
+### RPM external pythia8 309
 
-%define tag 2859dafb545a8ede707a86b4eff4a329c21cfd6a
-%define branch cms/%{realversion}
-%define github_user cms-externals
-Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}%{realversion}&output=/%{n}-%{realversion}.tgz
+Source: https://pythia.org/download/pythia83/%{n}%{realversion}.tgz
 
 Requires: hepmc hepmc3 lhapdf
 


### PR DESCRIPTION
Propose to update Pythia in master to 8.309 as it includes important fixes to the running of alpha_s:
> Equation (9.5) in the 2006 RPP [[Yao06](https://pythia.org/latest-manual/Bibliography.html#refYao06)] has erroneously been taken as a second-order alpha_strong expression, while actually it is a third-order one. This has been corrected, with separate second- and third-order options now available for matrix elements and showers. In practice the difference between second- and third-order running is minor, and furthermore first-order is default throughout.

Also discussed in today's GEN meeting: https://indico.cern.ch/event/1293969/contributions/5438463/attachments/2668515/4624955/GEN%20Meeting%20190623%20v2.pdf#page=16

The changes in our custom 8.306 were taken from the later Pythia versions, so they are all included.

@cms-sw/generators-l2 @amsimone FYI

@smrenna Would it be possible to get the patch fixing the alpha_s bug, so that we could consider a backport to 10_6 (https://github.com/cms-externals/pythia8/tree/cms/240)?