### PR TITLE
Drop py3-Theano, py3-downhill and py3-hep_ml

### DIFF
--- a/pip/Theano.file
+++ b/pip/Theano.file
@@ -1,1 +1,0 @@
-Requires: py3-scipy py3-six

--- a/pip/downhill.file
+++ b/pip/downhill.file
@@ -1,1 +1,0 @@
-Requires: py3-Theano py3-Click

--- a/pip/hep_ml.file
+++ b/pip/hep_ml.file
@@ -1,2 +1,0 @@
-Requires: py3-Theano
-Requires: py3-pandas py3-scikit-learn

--- a/pip/keras.file
+++ b/pip/keras.file
@@ -1,3 +1,3 @@
 %define PipDownloadSourceType none
-Requires: py3-PyYAML py3-six py3-Theano
+Requires: py3-PyYAML py3-six
 Requires: py3-h5py py3-keras-applications py3-keras-preprocessing

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -91,7 +91,6 @@ distlib==0.3.6
 distro==1.8.0
 docopt==0.6.2
 docutils==0.19
-downhill==0.4.0
 dulwich==0.21.3
 editables==0.3
 entrypoints==0.4
@@ -128,7 +127,6 @@ hatchling==1.14.0
 h5py==3.8.0
 hepdata-lib==0.12.0
 hepdata-validator==0.3.3
-hep_ml==0.7.2
 hist==2.6.3
 histbook==1.2.5
 histoprint==2.4.0
@@ -350,7 +348,6 @@ terminado==0.17.1
 testpath==0.6.0
 #NO_AUTO_UPDATE: Below is a dummy test package to show how to use custom download command to download a package source.
 test-download==7.44.1
-Theano==1.0.5
 tinycss2==1.2.1
 toml==0.10.2
 tomli==2.0.1

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -9,7 +9,6 @@ Requires: py3-anyio
 Requires: py3-sniffio
 Requires: py3-scipy
 Requires: py3-keras
-Requires: py3-Theano
 Requires: py3-scikit-learn
 #save for the end
 Requires: py3-tensorflow
@@ -22,9 +21,7 @@ Requires: py3-numexpr
 Requires: py3-histogrammar
 Requires: py3-pandas
 Requires: py3-Bottleneck
-Requires: py3-downhill
 Requires: py3-xgboost
-Requires: py3-hep_ml
 Requires: py3-uncertainties
 Requires: py3-seaborn
 Requires: py3-h5py


### PR DESCRIPTION
These packages are unmaintaned and incompatible with newer versions of py3-numpy