### PR TITLE
Geant4: Cleanup unused cmake variables

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -40,8 +40,6 @@ export VecGeom_DIR=${VECGEOM_ROOT}/lib/cmake/VecGeom
 cmake ../%{n}.%{realversion} \
   -DCMAKE_CXX_COMPILER="g++" \
   -DCMAKE_CXX_FLAGS="%{build_flags}" \
-  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="%{build_flags}" \
-  -DCMAKE_STATIC_LIBRARY_C_FLAGS="%{build_flags}" \
   -DCMAKE_AR=$(which gcc-ar) \
   -DCMAKE_RANLIB=$(which gcc-ranlib) \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \


### PR DESCRIPTION
cmake complains [a] for geant4 build

[a]
```
CMake Warning:
Manually-specified variables were not used by the project:

CMAKE_STATIC_LIBRARY_CXX_FLAGS
CMAKE_STATIC_LIBRARY_C_FLAGS
```