### PR TITLE
Update alpaka to pickup fix for C++20

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
-### RPM external alpaka develop-20230215
+### RPM external alpaka develop-20230621
 ## NOCOMPILER
 
-%define git_commit b849ce43dbfb6d5e1d4279c0025e3b15eddffc32
+%define git_commit 3838fbcd1694b461eb3a3d1b64f2cd24d9cf8bd7
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost


### PR DESCRIPTION
Backport from #8561, as requested by @smuzaffar