### PR TITLE
update to 9.7.9 to update visDQMImportDaemon

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.7.8
+### RPM cms dqmgui 9.7.9
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
Update the release to 9.7.9 so to use the updated visDQMImportDaemon (which prioritize 2023 runs over 2022 runs)
The updated code is this one: 
https://github.com/cms-DQM/dqmgui_prod/blob/index128/bin/visDQMImportDaemon