### PR TITLE
Update tag for PhysicsTools-NanoAOD to V01-01-00-01-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+PhysicsTools-NanoAOD=V01-01-00-01-00
 DataFormats-Scouting=V00-02-00
 Configuration-Generator=V01-06-00
 L1Trigger-Phase2L1ParticleFlow=V00-06-00
@@ -22,7 +23,6 @@ HeterogeneousCore-SonicTriton=V00-02-00
 RecoTracker-DisplacedRegionalTracking=V00-01-00
 RecoTracker-MkFit=V00-12-00
 RecoTauTag-TrainingFiles=V00-07-00
-PhysicsTools-NanoAOD=V01-03-00
 CalibTracker-SiStripDCS=V01-01-00
 RecoEgamma-ElectronIdentification=V01-12-00
 L1Trigger-TrackFindingTracklet=V00-03-00


### PR DESCRIPTION
Move PhysicsTools-NanoAOD data to new tag, see 
https://github.com/cms-data/PhysicsTools-NanoAOD/pull/15
