### PR TITLE
Upgrade pip-based HTCondor from 8.9.7 to 10.2.3

### DIFF
--- a/py3-htcondor.spec
+++ b/py3-htcondor.spec
@@ -1,26 +1,36 @@
-### RPM external py3-htcondor 8.9.7
+### RPM external py3-htcondor 10.2.3
 ## IMPORT build-with-pip3
 
 # dependencies required by 8.9.7
-Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0)(64bit)
-Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0d)(64bit)
-Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0f)(64bit)
-Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0i)(64bit)
-Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_1)(64bit)
+#Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0)(64bit)
+#Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0d)(64bit)
+#Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0f)(64bit)
+#Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_0i)(64bit)
+#Provides: libcrypto-d47fc050.so.1.1(OPENSSL_1_1_1)(64bit)
+
 # dependencies required by 9.2.0
-#Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0)(64bit)
-#Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0d)(64bit)
-#Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0f)(64bit)
-#Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_0i)(64bit)
-#Provides: libcrypto-b8807daa.so.1.1(OPENSSL_1_1_1)(64bit)
-Provides: libglobus_gssapi_gsi-46531449.so.4.10.9(globus_gssapi_gsi)(64bit)
-Provides: libgomp-3300acd3.so.1.0.0(GOMP_1.0)(64bit)
-Provides: libgomp-3300acd3.so.1.0.0(OMP_1.0)(64bit)
-Provides: libk5crypto-622ef25b.so.3.1(k5crypto_3_MIT)(64bit)
-Provides: libkeyutils-1-ff31573b.2.so(KEYUTILS_0.3)(64bit)
-Provides: libkrb5-fb0d2caa.so.3.3(krb5_3_MIT)(64bit)
-Provides: libkrb5support-d7ce89d4.so.0.1(krb5support_0_MIT)(64bit)
-Provides: libssl-6536aedd.so.1.1(OPENSSL_1_1_0)(64bit)
+#Provides: libglobus_gssapi_gsi-46531449.so.4.10.9(globus_gssapi_gsi)(64bit)
+#Provides: libgomp-3300acd3.so.1.0.0(GOMP_1.0)(64bit)
+#Provides: libgomp-3300acd3.so.1.0.0(OMP_1.0)(64bit)
+#Provides: libk5crypto-622ef25b.so.3.1(k5crypto_3_MIT)(64bit)
+#Provides: libkeyutils-1-ff31573b.2.so(KEYUTILS_0.3)(64bit)
+#Provides: libkrb5-fb0d2caa.so.3.3(krb5_3_MIT)(64bit)
+#Provides: libkrb5support-d7ce89d4.so.0.1(krb5support_0_MIT)(64bit)
+#Provides: libssl-6536aedd.so.1.1(OPENSSL_1_1_0)(64bit)
+
+# dependencies required by 10.2.3
+Provides: libcrypto-19957f5b.so.1.0.2k(OPENSSL_1.0.1_EC)(64bit)
+Provides: libcrypto-19957f5b.so.1.0.2k(libcrypto.so.10)(64bit)
+Provides: libgomp-a34b3233.so.1.0.0(GOMP_4.0)(64bit)
+Provides: libgomp-a34b3233.so.1.0.0(OMP_1.0)(64bit)
+Provides: libk5crypto-b1f99d5c.so.3.1(k5crypto_3_MIT)(64bit)
+Provides: libkeyutils-dfe70bd6.so.1.5(KEYUTILS_0.3)(64bit)
+Provides: libkeyutils-dfe70bd6.so.1.5(KEYUTILS_1.0)(64bit)
+Provides: libkeyutils-dfe70bd6.so.1.5(KEYUTILS_1.5)(64bit)
+Provides: libkrb5-fcafa220.so.3.3(krb5_3_MIT)(64bit)
+Provides: libkrb5support-d0bcff84.so.0.1(krb5support_0_MIT)(64bit)
+Provides: libssl-2a9eae6f.so.1.0.2k(libssl.so.10)(64bit)
+Provides: libuuid-f64cda11.so.1.3.0(UUID_1.0)(64bit)
 
 %define PipDownloadSourceType none
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11464

It is important to mention that this `py3-htcondor` package isn't the only HTCondor package available in COMP (comp_gcc630), we have:
* `py3-htcondor` is used by `crabserver` and `wmagentpy3`
* `condorpy3` is used by `crabtaskworker` and `t0`

See https://github.com/dmwm/WMCore/issues/11402#issuecomment-1553151443 for further details.

Having said that:
1) @belforte @mapellidario I wanted to check with you whether it's okay to get this change in (it will affect crabserver)? In addition, should we also update crabtaskworker spec to start depending on `py3-htcondor` instead of `condorpy3`?
2) @germanfgv and @LinaresToine should we update the `t0` spec to also start depending on this spec instead of `condorpy3`? 