### PR TITLE
Added support to enable debug mode for root/llvm

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -41,7 +41,11 @@ export CXXFLAGS="${CXXFLAGS} %{arch_build_flags}"
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
+%if %{is_debug_build root/llvm}
+  -DLLVM_BUILD_TYPE=Debug \
+%else
   -DLLVM_BUILD_TYPE=Release \
+%endif
   -DCMAKE_INSTALL_PREFIX="%{i}" \
   -DCMAKE_C_COMPILER=gcc \
   -DCMAKE_CXX_COMPILER=g++ \

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -306,12 +306,12 @@ fi
 
 #Enable debug mode for cmssw packages, e.g debug root, geant4, etc
 %if "%{?cms_debug_packages:set}" == "set"
-%define is_debug_build %(if echo %{cms_debug_packages} | tr , '\\n' | grep -q '^%{pkgname}$' ; then echo 1 ; else echo 0; fi)
+%define is_debug_build() %(if echo %{cms_debug_packages} | tr , '\\n' | grep -q '^%{1}$' ; then echo 1 ; else echo 0; fi)
 %else
 %define is_debug_build 0
 %endif
 
-%if %{is_debug_build}
+%if %{is_debug_build %{pkgname}}
 %define cmake_build_type Debug
 %else
 %define cmake_build_type Release


### PR DESCRIPTION
This allows to build root llvm in `Debug` mode if `cms_debug_packages` contains `root/llvm`