### PR TITLE
[HDF5] disable cxx and enable threadsafe

### DIFF
--- a/hdf5.spec
+++ b/hdf5.spec
@@ -16,7 +16,7 @@ LDFLAGS="-L${OPENMPI_ROOT}/lib -lmpi" \
 ./configure --prefix %{i} \
             --disable-sharedlib-rpath \
             --enable-parallel \
-            --enable-threadsafe --disable-hl \
+            --enable-threadsafe --enable-unsupported \
             --with-zlib=${ZLIB_ROOT}
 
 make %{makeprocesses} V=1
@@ -27,4 +27,5 @@ make install V=1
 %post
 %{relocateConfig}bin/h5pcc
 %{relocateConfig}share/hdf5_examples/c*/run-*-ex.sh
+%{relocateConfig}share/hdf5_examples/hl/c*/run-*-ex.sh
 %{relocateConfig}lib/libhdf5.settings

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -15,9 +15,9 @@ CXXFLAGS=-I${OPENMPI_ROOT}/include \
 LDFLAGS="-L${OPENMPI_ROOT}/lib -lmpi" \
 ./configure --prefix %{i} \
             --disable-sharedlib-rpath \
-            --disable-static--enable-shared \
             --enable-parallel \
-            --enable-cxx --enable-unsupported --with-zlib=${ZLIB_ROOT}
+            --enable-threadsafe --disable-hl \
+            --with-zlib=${ZLIB_ROOT}
 
 make %{makeprocesses} V=1
 
@@ -26,7 +26,5 @@ make install V=1
 
 %post
 %{relocateConfig}bin/h5pcc
-%{relocateConfig}bin/h5c++
 %{relocateConfig}share/hdf5_examples/c*/run-*-ex.sh
-%{relocateConfig}share/hdf5_examples/hl/c*/run-*-ex.sh
 %{relocateConfig}lib/libhdf5.settings

--- a/scram-tools.file/tools/hdf5/hdf5-cpp.xml
+++ b/scram-tools.file/tools/hdf5/hdf5-cpp.xml
@@ -1,5 +1,0 @@
-<tool name="hdf5-cpp" version="@TOOL_VERSION@">
-  <use name="hdf5"/>
-  <lib name="hdf5_cpp"/>
-  <lib name="hdf5_hl_cpp"/>
-</tool>

--- a/scram-tools.file/tools/hdf5/hdf5.xml
+++ b/scram-tools.file/tools/hdf5/hdf5.xml
@@ -1,6 +1,7 @@
 <tool name="hdf5" version="@TOOL_VERSION@">
   <info url="https://support.hdfgroup.org/HDF5/"/>
   <lib name="hdf5"/>
+  <lib name="hdf5_hl"/>
   <client>
     <environment name="HDF5_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$HDF5_BASE/lib"/>

--- a/scram-tools.file/tools/hdf5/hdf5.xml
+++ b/scram-tools.file/tools/hdf5/hdf5.xml
@@ -1,7 +1,6 @@
 <tool name="hdf5" version="@TOOL_VERSION@">
   <info url="https://support.hdfgroup.org/HDF5/"/>
   <lib name="hdf5"/>
-  <lib name="hdf5_hl"/>
   <client>
     <environment name="HDF5_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$HDF5_BASE/lib"/>


### PR DESCRIPTION
Fixes #8569

- Remove unused `--disable-static-enable-shared` flag
- enable threadsafe which requires
  - disabling CXX interface
  - enable unsupported to make sure that we build high level libs which are required by h5py python module
- Remove hdf5-cpp toolfile

FYI @Dr15Jones