### PR TITLE
SCRAMV2: Allow to query TOOLVERSION

### DIFF
--- a/SCRAMV2.spec
+++ b/SCRAMV2.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV2 V2_2_9_pre17
+### RPM lcg SCRAMV2 V2_2_9_pre18
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -9,7 +9,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag fce83e9b457c3c34373e4e2c1eec7854f33e17fa
+%define tag 158cdbe2c93768caf002fdb06e9c51ce6c5c1b56
 %define branch SCRAMV2
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
with `SCRAMV3` , once can run `scram tool tag <toolname> TOOLVERSION` to get the version of the tool but this feature does not work for old SCRAMV2. https://github.com/cms-sw/SCRAM/commit/158cdbe2c93768caf002fdb06e9c51ce6c5c1b56 enable this for old `SCRAMV2` releases.