### PR TITLE
update to 9.8.0 to update visDQMImportDaemon

### DIFF
--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.7.9
+### RPM cms dqmgui 9.8.0
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}


### PR DESCRIPTION
We updated visDQMImportDaemon in dqmgui_prod release 9.8.0 so to add an additional input argument min_run for prioritizing file indexing.

This pull request in cmsdist must be deployed either before or together with [the PR in dmwm/deployment #1276](https://github.com/dmwm/deployment/pull/1276).

Information about the update of visDQMImportDaemon could be found here:
https://github.com/cms-DQM/dqmgui_prod/pull/16