### PR TITLE
cms-common: Added scram runtime site hook for xrootd

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1226
+## REVISION 1227
 ## NOCOMPILER
 
-%define tag 9c6c3803c5d21f1b5da88eceb4f76f0145c163e1
+%define tag 89c5e262026a8623f033fc78008d2fe9decd3d3f
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep
@@ -37,7 +37,9 @@ if [ -f $RPM_INSTALL_PREFIX/cmsset_default.csh ] && [ -f $RPM_INSTALL_PREFIX/etc
   fi
 fi
 
-for file in $(find . -name '*'); do
+mkdir -p $RPM_INSTALL_PREFIX/etc/scramrc
+[ -d ./etc/scramrc/SCRAM ] && rsync -a --delete ./etc/scramrc/SCRAM/ $RPM_INSTALL_PREFIX/etc/scramrc/SCRAM/
+for file in $(find . -name '*' | grep -v '^./etc/scramrc/SCRAM' ); do
   if [ -d $file ] ; then
     mkdir -p $RPM_INSTALL_PREFIX/$file
   else


### PR DESCRIPTION
This change deploys a new scram runtime hook under  `$CMS_PATH/etc/scramrc/SCRAM/hooks` which should set `XrdSecPROTOCOL=gsi,ztn,unix` env variable for cmssw releases where

- `XrdSecPROTOCOL` is not already set
- `JOB_GLIDEIN_Factory` env is set i.e. for grid jobs
- `xrootd` version is < 5.1 and > 4.5 ( see [GGUS Ticket](https://ggus.eu/index.php?mode=ticket_info&ticket_id=162582) )
- No valid Kerberos ticket is available