### PR TITLE
drop py3-py package which is now part of pytest

### DIFF
--- a/pip/py.file
+++ b/pip/py.file
@@ -1,1 +1,0 @@
-Requires: py3-setuptools-scm

--- a/pip/pytest.file
+++ b/pip/pytest.file
@@ -1,4 +1,4 @@
-Requires: py3-more-itertools py3-atomicwrites py3-attrs py3-funcsigs py3-pathlib2 py3-pluggy py3-py py3-scandir
+Requires: py3-more-itertools py3-atomicwrites py3-attrs py3-funcsigs py3-pathlib2 py3-pluggy py3-scandir
 Requires: py3-packaging py3-wcwidth
 Requires: py3-iniconfig py3-toml
 Requires: py3-exceptiongroup

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -275,14 +275,13 @@ pyparsing==3.0.9
 pyproject-hooks==1.0.0
 pyproject-metadata==0.7.1
 pyrsistent==0.19.3
-py==1.11.0
 pydantic==1.10.7
 pygithub==1.58.1
 pylev==1.4.0
 PyNaCl==1.5.0
 pysocks==1.7.1
 pysqlite3==0.5.0
-pytest==7.2.2
+pytest==7.4.0
 pytest-cov==4.0.0
 pytest-runner==6.0.0
 python-daemon==3.0.1

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -121,7 +121,6 @@ Requires: py3-autopep8
 Requires: py3-pycodestyle
 Requires: py3-lz4
 Requires: py3-ply
-Requires: py3-py
 Requires: py3-defusedxml
 Requires: py3-atomicwrites
 Requires: py3-attrs


### PR DESCRIPTION
this should fix the [ReDoS in py library when used with subversion](https://github.com/cms-sw/cmsdist/security/dependabot/200) issue