### PR TITLE
TF: keep read cpp-standard first

### DIFF
--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -1,9 +1,9 @@
 ##Tensorflow Common build files
 BuildRequires: bazel java-env git
 #Keep all requires in separate file, so that can be included in py-tensorflow too
+## INCLUDE cpp-standard
 ## INCLUDE tensorflow-requires
 ## INCLUDE compilation_flags
-## INCLUDE cpp-standard
 
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}.tgz
 


### PR DESCRIPTION
If TF cuda is disabled (e.g. in GCC12 branch due to cuda 12) then cpp-standard read via cuda-flag does not set cms_cxx_standard. This change makes sure that  cpp-standard is loaded first