### PR TITLE
Minimal backport of fixes and updates to alpaka::Vec

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,9 +1,9 @@
 ### RPM external alpaka develop-20230621
 ## NOCOMPILER
 
-%define git_commit 3838fbcd1694b461eb3a3d1b64f2cd24d9cf8bd7
+%define git_commit 8d4b8df9f1d0477e685e8d1581326b65707f404d
 
-Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
+Source: https://github.com/cms-patatrack/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost
 
 %prep


### PR DESCRIPTION
Backport commit alpaka-group/alpaka@8d4b8df9f1d0477e685e8d1581326b65707f404d to the current alpaka branch:

> Implement logical operations on `alpaka::Vec`.
> Protect all `constexpr` comparisons from old NVCC versions.
