### PR TITLE
Update alpaka to pickup fixes for C++20 and alpaka::Vec [13.0.x]

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
-### RPM external alpaka develop-20230215
+### RPM external alpaka develop-20230621
 ## NOCOMPILER
 
-%define git_commit b849ce43dbfb6d5e1d4279c0025e3b15eddffc32
+%define git_commit 3838fbcd1694b461eb3a3d1b64f2cd24d9cf8bd7
 
 Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost

--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,9 +1,9 @@
 ### RPM external alpaka develop-20230621
 ## NOCOMPILER
 
-%define git_commit 3838fbcd1694b461eb3a3d1b64f2cd24d9cf8bd7
+%define git_commit 8d4b8df9f1d0477e685e8d1581326b65707f404d
 
-Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
+Source: https://github.com/cms-patatrack/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost
 
 %prep


### PR DESCRIPTION
Update alpaka to pick up fix for c++20 (backport #8567).
Minimal backport of fixes and updates to `alpaka::Vec` (backport #8645).