### PR TITLE
Add missing rocm deps on zstd

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -1,5 +1,4 @@
 ### RPM external rocm 5.6.0
-## NOCOMPILER
 
 %if "%{rhel}" == "7"
 # allow rpm2cpio dependency on the bootstrap bundle

--- a/rocm.spec
+++ b/rocm.spec
@@ -25,7 +25,7 @@ Source7: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.50600-
 Source8: https://%{repository}/%{repoversion}/main/rocm-llvm-16.0.0.23243.50600-67.el%{rhel}.%{_arch}.rpm
 Source9: https://%{repository}/%{repoversion}/main/rocm-smi-lib-5.0.0.50600-67.el%{rhel}.%{_arch}.rpm
 Source10: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.50600-67.el%{rhel}.%{_arch}.rpm
-Requires: numactl
+Requires: numactl zstd
 Requires: python3
 
 %prep


### PR DESCRIPTION
fwlite IBs failed due to missing deps. things worked for cmssw as zstd was explicitly installed via `cmssw-tool-conf` and that is why rpm did not complain
```
Singularity> ./common/cmspkg -a el8_amd64_gcc11 env -- rpm -q --requires external+rocm+5.6.0-b3e8e46972b3112a27027ca2f3ea0e1b | grep zstd
libzstd.so.1()(64bit)
```