### PR TITLE
Use consistent abseil version in TensorFlow

### DIFF
--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -20,6 +20,8 @@ Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag
 
 %setup -q -n tensorflow-%{realversion}
 sed -i -e 's|lib/python[^/]*/site-packages/|lib/python%{cms_python3_major_minor_version}/site-packages/|'  third_party/systemlibs/pybind11.BUILD
+# must be kept consistent with abseil-cpp.spec and bazel-absl.patch
+sed -i 's/lts_20220623/lts_20230125/g' tensorflow/tools/def_file_filter/def_file_filter.py.tpl
 
 %build
 

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -22,6 +22,12 @@ Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag
 sed -i -e 's|lib/python[^/]*/site-packages/|lib/python%{cms_python3_major_minor_version}/site-packages/|'  third_party/systemlibs/pybind11.BUILD
 # must be kept consistent with abseil-cpp.spec and bazel-absl.patch
 sed -i 's/lts_20220623/lts_20230125/g' tensorflow/tools/def_file_filter/def_file_filter.py.tpl
+# bazel-absl.patch doesn't seem to override local workspace file
+# -> copy changes from upstream https://github.com/tensorflow/tensorflow/commit/ad938db0da16d00d7f14da3de2a4abb97b1bc340
+sed -i '/^    ABSL_COMMIT/c\    ABSL_COMMIT = "c2435f8342c2d0ed8101cb43adfd605fdc52dca2"' third_party/absl/workspace.bzl
+sed -i '/^    ABSL_SHA256/c\    ABSL_SHA256 = "9892836ab0d3f099b8c15076c6f4168144f452d097bd49da215fe0df36a2d48c"' third_party/absl/workspace.bzl
+sed -i '/^        patch_file/c\' third_party/absl/workspace.bzl
+rm third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
 
 %build
 


### PR DESCRIPTION
The change to the abseil version in #8565 introduced an inconsistency in TensorFlow, leading to errors like this:
```
/cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/x86_64-unknown-linux-gnu/11.4.1/../../../../x86_64-unknown-linux-gnu/bin/ld.bfd: tmp/slc7_amd64_gcc11/src/RecoMET/METPUSubtraction/plugins/RecoMETMETPUSubtraction_plugins/ccjAPFCF.ltrans0.ltrans.o: in function `DeepMETProducer::DeepMETProducer(edm::ParameterSet const&, tensorflow::SessionCache const*)':
<artificial>:(.text+0x6d6c): undefined reference to `tensorflow::TensorShapeBase<tensorflow::TensorShape>::TensorShapeBase(absl::lts_20230125::Span<long const>)'
/cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/x86_64-unknown-linux-gnu/11.4.1/../../../../x86_64-unknown-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x6da7): undefined reference to `tensorflow::TensorShapeBase<tensorflow::TensorShape>::TensorShapeBase(absl::lts_20230125::Span<long const>)'
collect2: error: ld returned 1 exit status
gmake: *** [config/SCRAM/GMake/Makefile.rules:1793: tmp/slc7_amd64_gcc11/src/RecoMET/METPUSubtraction/plugins/RecoMETMETPUSubtraction_plugins/libRecoMETMETPUSubtraction_plugins.so] Error 1
```

The problem as I understand it:
1. The TensorFlow shared libraries are linked to the CMSSW abseil library and have the correct symbols, but the TensorFlow *headers* have a different abseil namespace (`lts_20220623` rather than `lts_20230125`).
2. This appears to be because TensorFlow still uses its local Bazel workspace information for abseil, even with our `bazel-absl.patch` file that updates the central Bazel info on this package.

I patched all the places I could find where the Bazel version was hardcoded in the TensorFlow source (based on the upstream abseil version update in TensorFlow 2.13.0, one minor version after ours: https://github.com/tensorflow/tensorflow/commit/ad938db0da16d00d7f14da3de2a4abb97b1bc340) and was able to remove the `DeepMETProducer` workaround from https://github.com/cms-sw/cmssw/pull/42228 (see https://github.com/cms-sw/cmssw/pull/42682). I'm happy to reimplement the patches in whatever way is preferred (but it's going to be ugly no matter what).

attn: @iarspider @yongbinfeng