### PR TITLE
Add heaptrack application

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -154,6 +154,7 @@ Requires: cudnn
 Requires: libunwind
 %ifnarch ppc64le
 Requires: igprof
+Requires: heaptrack
 Requires: openloops
 %endif
 

--- a/heaptrack.spec
+++ b/heaptrack.spec
@@ -1,7 +1,9 @@
 ### RPM external heaptrack 1.4.0
+## NO_AUTO_DEPENDENCY
 Source: https://github.com/KDE/heaptrack/archive/refs/tags/v%{realversion}.tar.gz
-Requires: boost libunwind zstd bz2lib
+Requires: boost libunwind zstd bz2lib zlib
 BuildRequires: cmake
+
 %prep
 %setup -n %{n}-%{realversion}
 
@@ -12,8 +14,9 @@ rm -rf ../build; mkdir ../build; cd ../build
 cmake ../%{n}-%{realversion} \
    -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE \
    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3" \
-   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$BOOST_ROOT;$ZSTD_ROOT;$BZ2LIB_ROOT"
-make DEBUG=1 VERBOSE=1 %makeprocesses 
+   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$BOOST_ROOT;$ZSTD_ROOT;$BZ2LIB_ROOT;$ZLIB_ROOT" \
+   -DHEAPTRACK_BUILD_GUI=off -DHEAPTRACK_USE_LIBUNWIND=on -DHEAPTRACK_BUILD_PRINT=on
+make DEBUG=1 VERBOSE=1 %makeprocesses
 
 %install
 cd ../build

--- a/heaptrack.spec
+++ b/heaptrack.spec
@@ -1,0 +1,21 @@
+### RPM external heaptrack 1.4.0
+Source: https://github.com/KDE/heaptrack/archive/refs/tags/v%{realversion}.tar.gz
+Requires: boost libunwind zstd
+BuildRequires: cmake
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+mkdir -p %i
+rm -rf ../build; mkdir ../build; cd ../build
+
+cmake ../%{n}-%{realversion} \
+   -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+   -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3" \
+   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$BOOST_ROOT;$ZSTD_ROOT"
+make DEBUG=1 VERBOSE=1 %makeprocesses 
+
+%install
+cd ../build
+make %makeprocesses install
+%define drop_files %i/share/man

--- a/heaptrack.spec
+++ b/heaptrack.spec
@@ -1,9 +1,8 @@
 ### RPM external heaptrack 1.4.0
-## NO_AUTO_DEPENDENCY
 Source: https://github.com/KDE/heaptrack/archive/refs/tags/v%{realversion}.tar.gz
 Requires: boost libunwind zstd bz2lib zlib
 BuildRequires: cmake
-
+Provides: libc.so.6(GLIBC_PRIVATE)(64bit)
 %prep
 %setup -n %{n}-%{realversion}
 

--- a/heaptrack.spec
+++ b/heaptrack.spec
@@ -1,6 +1,6 @@
 ### RPM external heaptrack 1.4.0
 Source: https://github.com/KDE/heaptrack/archive/refs/tags/v%{realversion}.tar.gz
-Requires: boost libunwind zstd
+Requires: boost libunwind zstd bz2lib
 BuildRequires: cmake
 %prep
 %setup -n %{n}-%{realversion}
@@ -12,7 +12,7 @@ rm -rf ../build; mkdir ../build; cd ../build
 cmake ../%{n}-%{realversion} \
    -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE \
    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3" \
-   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$BOOST_ROOT;$ZSTD_ROOT"
+   -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$BOOST_ROOT;$ZSTD_ROOT;$BZ2LIB_ROOT"
 make DEBUG=1 VERBOSE=1 %makeprocesses 
 
 %install

--- a/scram-tools.file/tools/heaptrack/heaptrack.xml
+++ b/scram-tools.file/tools/heaptrack/heaptrack.xml
@@ -1,0 +1,8 @@
+  <tool name="heaptrack" version="@TOOL_VERSION@">
+    <info url="https://invent.kde.org/sdk/heaptrack/"/>
+    <client>
+      <environment name="HEAPTRACK_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$HEAPTRACK_BASE/lib"/>
+    </client>
+    <runtime name="PATH" value="$HEAPTRACK_BASE/bin" type="path"/>
+  </tool>


### PR DESCRIPTION
Local build inside cmssw-el8 environment yielded this error after the build completes
```
Build successful heaptrack.
(<function buildPackage at 0x7f6a0d1ab048>, <Package name=heaptrack>, <scheduler.Scheduler object at 0x7f6a0d19b898>) done
Command:
source /build/gartung/testbuild/el8_amd64_gcc11/rpm-env.sh ; rpm -Uvh --prefix /build/gartung/testbuild /build/gartung/testbuild/RPMS/cache/a145626f31e309f552114b0c685fa687/el8_amd64_gcc11/external+heaptrack+1.4.0-a145626f31e309f552114b0c685fa687-1-1.el8_amd64_gcc11.rpm failed with the following message: error: Failed dependencies:
        libc.so.6(GLIBC_PRIVATE)(64bit) is needed by external+heaptrack+1.4.0-a145626f31e309f552114b0c685fa687-1-1.x86_64
Running tasks: []
Trying to install the rpm package external+heaptrack+1.4.0-a145626f31e309f552114b0c685fa687 just built.
Checking local path dependency for rpm package external+heaptrack+1.4.0-a145626f31e309f552114b0c685fa687 just build.
Failed to install RPM for heaptrack
```