### PR TITLE
update monit tools version

### DIFF
--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -1,4 +1,4 @@
-### RPM cms cmsmon-tools 0.5.35
+### RPM cms cmsmon-tools go-0.6.3
 ## NOCOMPILER
 
 %define arch amd64
@@ -11,7 +11,7 @@
 %define heyver 0.0.2
 %define k8s_info_ver 0.0.1
 %define gocurlver 0.0.4
-%define monit_commands monit ggus_parser alert annotationManager nats-sub nats-pub dbs_vm
+%define monit_commands monit alert annotationManager nats-sub nats-pub dbs_vm
 %define common_commands promtool amtool prometheus hey stern trivy k8s_info gocurl
 %define flags -ldflags="-s -w -extldflags -static" -p %{compiling_processes}
 Source0: https://github.com/dmwm/CMSMonitoring/releases/download/%{realversion}/cmsmon-tools.tar.gz

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -1,4 +1,4 @@
-### RPM cms cmsmon-tools go-0.6.3
+### RPM cms cmsmon-tools 0.6.3
 ## NOCOMPILER
 
 %define arch amd64
@@ -14,7 +14,7 @@
 %define monit_commands monit alert annotationManager nats-sub nats-pub dbs_vm
 %define common_commands promtool amtool prometheus hey stern trivy k8s_info gocurl
 %define flags -ldflags="-s -w -extldflags -static" -p %{compiling_processes}
-Source0: https://github.com/dmwm/CMSMonitoring/releases/download/%{realversion}/cmsmon-tools.tar.gz
+Source0: https://github.com/dmwm/CMSMonitoring/releases/download/go-%{realversion}/cmsmon-tools.tar.gz
 Source1: https://github.com/prometheus/prometheus/releases/download/v%promv/prometheus-%promv.linux-amd64.tar.gz
 Source2: https://github.com/prometheus/alertmanager/releases/download/v%amver/alertmanager-%amver.linux-amd64.tar.gz
 Source3: https://github.com/vkuznet/hey/releases/download/%heyver/hey-tools.tar.gz

--- a/cmsmon-tools.spec
+++ b/cmsmon-tools.spec
@@ -23,7 +23,7 @@ Source5: https://github.com/vkuznet/auth-proxy-server/releases/download/%apsver/
 Source6: https://github.com/vkuznet/k8s_info/releases/download/%k8s_info_ver/k8s_info-tools.tar.gz
 Source7: https://github.com/aquasecurity/trivy/releases/download/v%trivyver/trivy_%{trivyver}_Linux-64bit.tar.gz
 Source8: https://github.com/vkuznet/gocurl/releases/download/%gocurlver/gocurl-tools.tar.gz
-
+AutoReq: no
 BuildRequires: go
 
 # RPM macros documentation


### PR DESCRIPTION
Hi,

thank you for the guidelines, @smuzaffar . If I understand correctly, the version on the first line is then assigned to the `realversion` variable, right?


Changes here:
- update monit tools version
- delete decommissioned service (`ggus_parser`)

FYI @leggerf @brij01 @vkuznet 