### PR TITLE
[TEST] Revert "TF: Use consistent abseil version in TensorFlow"

### DIFF
--- a/abseil-cpp.spec
+++ b/abseil-cpp.spec
@@ -1,7 +1,10 @@
-### RPM external abseil-cpp 20230125.3
+### RPM external abseil-cpp 20230125.4
 ## INCLUDE cpp-standard
 
-Source: https://github.com/abseil/abseil-cpp/archive/%{realversion}.tar.gz
+%define tag c2435f8342c2d0ed8101cb43adfd605fdc52dca2
+%define branch lts_2023_01_25
+%define github_user abseil
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tar.gz
 
 BuildRequires: cmake gmake
 

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,5 +1,5 @@
 ### RPM external tensorflow-sources 2.12.0
-%define tag         75e38ccee85313ae89c01c4810e8188a27020efb
+%define tag         bb361a0a183d45222d8ff7dbf4a04c44c0e094bd
 %define branch      cms/v%{realversion}
 %define github_user cms-externals
 %define python_cmd python3

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,4 +1,6 @@
 ### RPM external tensorflow-sources 2.12.0
+
+
 %define tag         bb361a0a183d45222d8ff7dbf4a04c44c0e094bd
 %define branch      cms/v%{realversion}
 %define github_user cms-externals

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,7 +1,5 @@
 ### RPM external tensorflow-sources 2.12.0
-
-
-%define tag         bb361a0a183d45222d8ff7dbf4a04c44c0e094bd
+%define tag         75e38ccee85313ae89c01c4810e8188a27020efb
 %define branch      cms/v%{realversion}
 %define github_user cms-externals
 %define python_cmd python3


### PR DESCRIPTION
Reverts cms-sw/cmsdist#8675

Compilation on ARM fails with:
```
ERROR: /data/cmsbld/jenkins_b/workspace/build-any-ib/w/BUILD/el9_aarch64_gcc11/external/tensorflow-sources/2.12.0-044978ac9e50a16db08877520775e250/tensorflow-2.12.0/tensorflow/core/kernels/BUILD:4491:18: Compiling tensorflow/core/kernels/depthtospace_op_gpu.cu.cc failed: (Exit 4): crosstool_wrapper_driver_is_not_gcc failed: error executing command 
  (cd /data/cmsbld/jenkins_b/workspace/build-any-ib/w/BUILD/el9_aarch64_gcc11/external/tensorflow-sources/2.12.0-044978ac9e50a16db08877520775e250/build/f3ae9d2dafcfe5643f514015f93d74cb/execroot/org_tensorflow && \
  exec env - \
    CUDA_TOOLKIT_PATH=/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/cuda/11.8.0-a2db08b624dc4f754031142a3cdb3a9d \
    GCC_HOST_COMPILER_PATH=/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/gcc \
    LD_LIBRARY_PATH=<...>
    PATH=<...>
        PWD=/proc/self/cwd \
    PYTHON_BIN_PATH=/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/python3/3.9.14-e432d7f95f9e22c05899c3205f44ed54/bin/python3 \
    PYTHON_LIB_PATH=/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/python3/3.9.14-e432d7f95f9e22c05899c3205f44ed54/lib/python3.9/site-packages \
    TF2_BEHAVIOR=1 \
    TF_CUDA_COMPUTE_CAPABILITIES=compute_70,compute_72,compute_75 \
    TF_CUDA_PATHS=/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/cuda/11.8.0-a2db08b624dc4f754031142a3cdb3a9d,/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/cudnn/8.8.0.121-03351b77b26a1bb330695b75933b5212 \
    TF_CUDA_VERSION=11.8 \
    TF_SYSTEM_LIBS=absl_py,astor_archive,boringssl,com_github_grpc_grpc,com_google_protobuf,curl,cython,eigen_archive,flatbuffers,functools32_archive,gast_archive,gif,libjpeg_turbo,opt_einsum_archive,org_python_pypi_backports_weakref,org_sqlite,pasta,png,pybind11,six_archive,termcolor_archive,typing_extensions_archive,wrapt,zlib \
  external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -MD -MF bazel-out/aarch64-opt/bin/tensorflow/core/kernels/_objs/depth_space_ops_gpu/depthtospace_op_gpu.cu.pic.d '-frandom-seed=bazel-out/aarch64-opt/bin/tensorflow/core/kernels/_objs/depth_space_ops_gpu/depthtospace_op_gpu.cu.pic.o' -DEIGEN_MPL2_ONLY '-DEIGEN_MAX_ALIGN_BYTES=64' -DHAVE_SYS_UIO_H -DTF_USE_SNAPPY -iquote . -iquote bazel-out/aarch64-opt/bin -iquote external/com_google_absl -iquote bazel-out/aarch64-opt/bin/external/com_google_absl -iquote external/nsync -iquote bazel-out/aarch64-opt/bin/external/nsync -iquote external/eigen_archive -iquote bazel-out/aarch64-opt/bin/external/eigen_archive -iquote external/com_google_protobuf -iquote bazel-out/aarch64-opt/bin/external/com_google_protobuf -iquote external/gif -iquote bazel-out/aarch64-opt/bin/external/gif -iquote external/libjpeg_turbo -iquote bazel-out/aarch64-opt/bin/external/libjpeg_turbo -iquote external/com_googlesource_code_re2 -iquote bazel-out/aarch64-opt/bin/external/com_googlesource_code_re2 -iquote external/farmhash_archive -iquote bazel-out/aarch64-opt/bin/external/farmhash_archive -iquote external/fft2d -iquote bazel-out/aarch64-opt/bin/external/fft2d -iquote external/highwayhash -iquote bazel-out/aarch64-opt/bin/external/highwayhash -iquote external/zlib -iquote bazel-out/aarch64-opt/bin/external/zlib -iquote external/local_config_cuda -iquote bazel-out/aarch64-opt/bin/external/local_config_cuda -iquote external/snappy -iquote bazel-out/aarch64-opt/bin/external/snappy -iquote external/double_conversion -iquote bazel-out/aarch64-opt/bin/external/double_conversion -iquote external/local_config_rocm -iquote bazel-out/aarch64-opt/bin/external/local_config_rocm -iquote external/local_config_tensorrt -iquote bazel-out/aarch64-opt/bin/external/local_config_tensorrt -Ibazel-out/aarch64-opt/bin/external/local_config_cuda/cuda/_virtual_includes/cuda_headers_virtual -Ibazel-out/aarch64-opt/bin/external/local_config_tensorrt/_virtual_includes/tensorrt_headers -isystem external/nsync/public -isystem bazel-out/aarch64-opt/bin/external/nsync/public -isystem external/eigen_archive/include/eigen3 -isystem bazel-out/aarch64-opt/bin/external/eigen_archive/include/eigen3 -isystem external/com_google_protobuf/include -isystem bazel-out/aarch64-opt/bin/external/com_google_protobuf/include -isystem external/gif/include -isystem bazel-out/aarch64-opt/bin/external/gif/include -isystem external/libjpeg_turbo/include -isystem bazel-out/aarch64-opt/bin/external/libjpeg_turbo/include -isystem external/farmhash_archive/src -isystem bazel-out/aarch64-opt/bin/external/farmhash_archive/src -isystem external/zlib/include -isystem bazel-out/aarch64-opt/bin/external/zlib/include -isystem external/local_config_cuda/cuda -isystem bazel-out/aarch64-opt/bin/external/local_config_cuda/cuda -isystem external/local_config_cuda/cuda/cuda/include -isystem bazel-out/aarch64-opt/bin/external/local_config_cuda/cuda/cuda/include -isystem external/local_config_rocm/rocm -isystem bazel-out/aarch64-opt/bin/external/local_config_rocm/rocm -isystem external/local_config_rocm/rocm/rocm/include -isystem bazel-out/aarch64-opt/bin/external/local_config_rocm/rocm/rocm/include -isystem external/local_config_rocm/rocm/rocm/include/rocrand -isystem bazel-out/aarch64-opt/bin/external/local_config_rocm/rocm/rocm/include/rocrand -isystem external/local_config_rocm/rocm/rocm/include/roctracer -isystem bazel-out/aarch64-opt/bin/external/local_config_rocm/rocm/rocm/include/roctracer -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -fPIC -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -Wall -fno-omit-frame-pointer -no-canonical-prefixes -fno-canonical-system-headers -DNDEBUG -g0 -O2 -ffunction-sections -fdata-sections -Wno-all -Wno-extra -Wno-deprecated -Wno-deprecated-declarations -Wno-ignored-attributes -Wno-array-bounds -Wunused-result '-Werror=unused-result' -Wswitch '-Werror=switch' '-Wno-error=unused-but-set-variable' -DAUTOLOAD_DYNAMIC_KERNELS '-march=armv8-a' -mno-outline-atomics -Wno-sign-compare '-std=c++17' '-std=c++17' -x cuda '-DGOOGLE_CUDA=1' '--cuda-include-ptx=sm_70' '--cuda-gpu-arch=sm_70' '--cuda-include-ptx=sm_72' '--cuda-gpu-arch=sm_72' '--cuda-include-ptx=sm_75' '--cuda-gpu-arch=sm_75' '-Xcuda-fatbinary=--compress-all' -DEIGEN_AVOID_STL_ARRAY -Iexternal/gemmlowp -Wno-sign-compare '-ftemplate-depth=900' -fno-exceptions '-DGOOGLE_CUDA=1' '-DTENSORFLOW_USE_NVCC=1' -pthread '-nvcc_options=relaxed-constexpr' '-nvcc_options=ftz=true' -c tensorflow/core/kernels/depthtospace_op_gpu.cu.cc -o bazel-out/aarch64-opt/bin/tensorflow/core/kernels/_objs/depth_space_ops_gpu/depthtospace_op_gpu.cu.pic.o)
# Configuration: 99ba46c2452aa9a5d5b939673c664313b29f97d3839647b88f01d4b3a7436dae
# Execution platform: @local_execution_config_platform//:platform
external/eigen_archive/include/eigen3/unsupported/Eigen/CXX11/../../../Eigen/src/Core/util/IntegralConstant.h(187): warning #1835-D: attribute "__host__" does not apply here

external/com_google_absl/absl/status/status.h(796): warning #2810-D: ignoring return value type with "nodiscard" attribute

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::FilesExist" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::CreateDir" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/env.h(498): warning #611-D: overloaded virtual function "tsl::Env::RegisterFileSystem" is only partially overridden in class "tsl::EnvWrapper"

external/eigen_archive/include/eigen3/unsupported/Eigen/CXX11/../../../Eigen/src/Core/util/IntegralConstant.h(187): warning #1835-D: attribute "__host__" does not apply here

external/com_google_absl/absl/status/status.h(796): warning #2810-D: ignoring return value type with "nodiscard" attribute

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::FilesExist" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::CreateDir" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/env.h(498): warning #611-D: overloaded virtual function "tsl::Env::RegisterFileSystem" is only partially overridden in class "tsl::EnvWrapper"

external/eigen_archive/include/eigen3/unsupported/Eigen/CXX11/../../../Eigen/src/Core/util/IntegralConstant.h(187): warning #1835-D: attribute "__host__" does not apply here

external/com_google_absl/absl/status/status.h(796): warning #2810-D: ignoring return value type with "nodiscard" attribute

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::FilesExist" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::CreateDir" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/env.h(498): warning #611-D: overloaded virtual function "tsl::Env::RegisterFileSystem" is only partially overridden in class "tsl::EnvWrapper"

external/eigen_archive/include/eigen3/unsupported/Eigen/CXX11/../../../Eigen/src/Core/util/IntegralConstant.h(187): warning #1835-D: attribute "__host__" does not apply here

external/com_google_absl/absl/status/status.h(796): warning #2810-D: ignoring return value type with "nodiscard" attribute

./tensorflow/tsl/platform/errors.h(143): warning #2810-D: ignoring return value type with "nodiscard" attribute

./tensorflow/tsl/platform/statusor_internals.h(142): warning #2810-D: ignoring return value type with "nodiscard" attribute

./tensorflow/tsl/platform/statusor_internals.h(152): warning #2810-D: ignoring return value type with "nodiscard" attribute

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::FilesExist" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/file_system.h(574): warning #611-D: overloaded virtual function "tsl::FileSystem::CreateDir" is only partially overridden in class "tsl::WrappedFileSystem"

./tensorflow/tsl/platform/env.h(498): warning #611-D: overloaded virtual function "tsl::Env::RegisterFileSystem" is only partially overridden in class "tsl::EnvWrapper"

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(38): error: identifier "__Int8x8_t" is undefined

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(39): error: identifier "__Int16x4_t" is undefined

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(40): error: identifier "__Int32x2_t" is undefined

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(41): error: identifier "__Int64x1_t" is undefined

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(42): error: identifier "__Float16x4_t" is undefined

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(43): error: identifier "__Float32x2_t" is undefined

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(44): error: identifier "__Poly8x8_t" is undefined

/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el9_aarch64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/aarch64-redhat-linux-gnu/11.4.1/include/arm_neon.h(45): error: identifier "__Poly16x4_t" is undefined

<... for every NEON intrinsic ...>
```