### PR TITLE
[TF] backport tensorflow-absl-src patch from gcc12

### DIFF
--- a/tensorflow-absl-src.patch
+++ b/tensorflow-absl-src.patch
@@ -1,0 +1,15 @@
+diff --git a/third_party/absl/workspace.bzl b/third_party/absl/workspace.bzl
+index 183bb7f..5783c67 100644
+--- a/third_party/absl/workspace.bzl
++++ b/third_party/absl/workspace.bzl
+@@ -6,8 +6,8 @@ def repo():
+     """Imports absl."""
+ 
+     # Attention: tools parse and update these lines.
+-    ABSL_COMMIT = "997aaf3a28308eba1b9156aa35ab7bca9688e9f6"
+-    ABSL_SHA256 = "35f22ef5cb286f09954b7cc4c85b5a3f6221c9d4df6b8c4a1e9d399555b366ee"
++    ABSL_COMMIT = "215105818dfde3174fe799600bb0f3cae233d0bf"
++    ABSL_SHA256 = "237e2e6aec7571ae90d961d02de19f56861a7417acbbc15713b8926e39d461ed"
+ 
+     tf_http_archive(
+         name = "com_google_absl",


### PR DESCRIPTION
GCC12 aarch64 IBs build fine, so let try backporting the tensorflow-absl-src patch from GCC12 back to master branch