### PR TITLE
TF: Use consistent abseil version in cms externals as used by TensorFlow

### DIFF
--- a/abseil-cpp.spec
+++ b/abseil-cpp.spec
@@ -1,4 +1,4 @@
-### RPM external abseil-cpp 20230125.3
+### RPM external abseil-cpp 20220623.1
 ## INCLUDE cpp-standard
 
 Source: https://github.com/abseil/abseil-cpp/archive/%{realversion}.tar.gz

--- a/fasthadd.spec
+++ b/fasthadd.spec
@@ -5,7 +5,7 @@
 %define user cms-sw
 Source0: https://raw.githubusercontent.com/%user/cmssw/%commit/DQMServices/Components/bin/fastHadd.cc
 Source1: https://raw.githubusercontent.com/%user/cmssw/%commit/DQMServices/Core/src/ROOTFilePB.proto
-Requires: protobuf root abseil-cpp
+Requires: protobuf root
 
 %prep
 
@@ -17,8 +17,7 @@ cp %{_sourcedir}/ROOTFilePB.proto .
 protoc -I ./ --cpp_out=./ ROOTFilePB.proto
 perl -p -i -e 's|DQMServices/Core/interface/||' ROOTFilePB.pb.cc fastHadd.cc
 g++ -O2 -o %i/bin/fastHadd ROOTFilePB.pb.cc ./fastHadd.cc \
-      -I$PROTOBUF_ROOT/include -L$PROTOBUF_ROOT/lib -lprotobuf -L$ABSEIL_CPP_ROOT/lib -labsl_log_internal_check_op \
-      -labsl_log_internal_message \
+      -I$PROTOBUF_ROOT/include -L$PROTOBUF_ROOT/lib -lprotobuf \
       `root-config --cflags --libs`
 
 %install

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,5 +1,5 @@
 ### RPM external tensorflow-sources 2.12.0
-%define tag         75e38ccee85313ae89c01c4810e8188a27020efb
+%define tag         bb361a0a183d45222d8ff7dbf4a04c44c0e094bd
 %define branch      cms/v%{realversion}
 %define github_user cms-externals
 %define python_cmd python3


### PR DESCRIPTION
`Tensorflow 2.12` uses `abseil` version [20220623](https://github.com/abseil/abseil-cpp/commit/273292d1cfc0a94a65082ee350509af1d113344d) while in cms external we have `20230125`. This inconsistency cause cmssw to fail for `aarch64`. TF `2.12` does not build with `abseil 20230125` so this PR proposes to use `abseil` version `20220623` for cms externals too.

We can update `abseil` to `20230125` once we move to TF 2.13 (which uses https://github.com/abseil/abseil-cpp/commit/b971ac5250ea8de900eae9f95e06548d14cd95fe i.e. `lts_2023_01_25` )