### PR TITLE
[13_0_X] bumping up sherpa to 2.2.15

### DIFF
--- a/sherpa.spec
+++ b/sherpa.spec
@@ -1,7 +1,4 @@
-### RPM external sherpa 2.2.12
-%define tag 600078cc741021be898f15563235cf6c809ca5ff
-%define branch cms/v%realversion
-%define github_user cms-externals
+### RPM external sherpa 2.2.15
 Source: http://www.hepforge.org/archive/sherpa/SHERPA-MC-%{realversion}.tar.gz
 Requires: hepmc lhapdf blackhat sqlite python3 fastjet openmpi
 BuildRequires: mcfm swig autotools


### PR DESCRIPTION
Bumping up Sherpa to 2.2.15 based on the discussion [here](https://cms-talk.web.cern.ch/t/sherpa-event-generation-segfault-with-privately-generated-sherpack-for-z-jets/23629/9). Also, this is a backport of https://github.com/cms-sw/cmsdist/pull/8450.