### PR TITLE
[BuildRules] Fix for alpaka backend dict header/xml files flags

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-00-02
+%define configtag       V09-00-03
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/40846

- BuildFile's `LCG_DICT_HEADER` and `LCG_DICT_XML` flags are now only used for default dictionary generation. 
- For alpaka backend, scram now looks for `classes_<backend>.h` and `classes_<backend>_def.xml` files. One can override this by adding `ALPAKA_<BACKEND>_LCG_DICT_HEADER` and `ALPAKA_<BACKEND>_LCG_DICT_XML` BuildFile flags. e.g
```
 <flags ALPAKA_CUDA_LCG_DICT_HEADER="classes_cuda_1.h classes_cuda_2.h"/> 
 <flags ALPAKA_CUDA_LCG_DICT_XML="classes_cuda_def_1.xml classes_cuda_def_2.xml"/> 
 <flags ALPAKA_ROCM_LCG_DICT_HEADER="classes_rocm_1.h classes_rocm_2.h"/> 
 <flags ALPAKA_ROCM_LCG_DICT_XML="classes_rocm_def_1.xml classes_rocm_def_2.xml"/> 
```