### PR TITLE
[cms-common] Added scram site runtime hook to add gsl/bin in to PATH

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1229
+## REVISION 1230
 ## NOCOMPILER
 
-%define tag bddc90f7262c8d93d294c95ccc0beba4ad6fc269
+%define tag 2bfaf3cd89a9ddbd552267ae0f227caa40363423
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep


### PR DESCRIPTION
For old releases, CMS distributed `external/gsl/bin` is not added in the PATH which means `gsl-config` is picked up from system while using `libgsl.so` from cms externals. Grid packs makes use of `gsl-config` and fails ( see https://github.com/cms-sw/cmssw/issues/42716 for datails). This PR should fix the old release cycles and already built releases as it adds a `SCRAM` site based runtime hook to add CMS distributed `gsl/bin` in to PATH.