### PR TITLE
Update crab-dev to v3.230925

### DIFF
--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -3,8 +3,8 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 01
-%define crabclient_version v3.230612
+%define crabclient_version v3.230925
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
-%define crabserver_version v3.230609
+%define crabserver_version v3.230921
 
 ## IMPORT crab-build


### PR DESCRIPTION
Update crab-dev to [v3.230925](https://github.com/dmwm/CRABClient/releases/tag/v3.230925), also bump crabserver dependency to [v3.230921](https://github.com/dmwm/CRABServer/releases/tag/v3.230921).

cc: @belforte @mapellidario 