### PR TITLE
[13.2] Backport scram/buildrules/gsl env changes

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV1 V3_00_61
+### RPM lcg SCRAMV1 V3_00_62
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -66,7 +66,6 @@ if [ ! -d $RPM_INSTALL_PREFIX/etc/scramrc ] ; then
   echo 'CMSSW=$SCRAM_ARCH/cms/cmssw/CMSSW_*'       > $RPM_INSTALL_PREFIX/etc/scramrc/cmssw.map
   echo 'CMSSW=$SCRAM_ARCH/cms/cmssw-patch/CMSSW_*' > $RPM_INSTALL_PREFIX/etc/scramrc/cmssw-patch.map
   echo 'CORAL=$SCRAM_ARCH/cms/coral/CORAL_*'       > $RPM_INSTALL_PREFIX/etc/scramrc/coral.map
-  [ ! -f $RPM_INSTALL_PREFIX/%{OldDB} ] || grep '%{OldDB} *$' $RPM_INSTALL_PREFIX/%{OldDB} | awk '{print $2}' | sed 's|%{OldDB}.*||' > $RPM_INSTALL_PREFIX/etc/scramrc/links.db
 fi
 
 touch $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg

--- a/SCRAMV2.spec
+++ b/SCRAMV2.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV2 V2_2_9_pre17
+### RPM lcg SCRAMV2 V2_2_9_pre19
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -9,7 +9,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag fce83e9b457c3c34373e4e2c1eec7854f33e17fa
+%define tag 158cdbe2c93768caf002fdb06e9c51ce6c5c1b56
 %define branch SCRAMV2
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
@@ -62,14 +62,6 @@ echo "SCRAMV1_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgr
 echo "SCRAMV1_VERSION='%v'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
 echo "set SCRAMV1_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
 echo "set SCRAMV1_VERSION='%v'" >> $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh
-
-if [ ! -d $RPM_INSTALL_PREFIX/etc/scramrc ] ; then
-  mkdir -p $RPM_INSTALL_PREFIX/etc/scramrc
-  touch $RPM_INSTALL_PREFIX/etc/scramrc/links.db
-  echo 'CMSSW=$SCRAM_ARCH/cms/cmssw/CMSSW_*'       > $RPM_INSTALL_PREFIX/etc/scramrc/cmssw.map
-  echo 'CMSSW=$SCRAM_ARCH/cms/cmssw-patch/CMSSW_*' > $RPM_INSTALL_PREFIX/etc/scramrc/cmssw-patch.map
-  echo 'CORAL=$SCRAM_ARCH/cms/coral/CORAL_*'       > $RPM_INSTALL_PREFIX/etc/scramrc/coral.map
-fi
 
 if [ ! -d $RPM_INSTALL_PREFIX/%{cmsplatf}/%{scramv1_dir} ] ; then
   mkdir -p $RPM_INSTALL_PREFIX/%{cmsplatf}/%{scramv1_dir}

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-00-02
+%define configtag       V09-01-03
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
@@ -24,7 +24,10 @@
     <flags CXXFLAGS="-Werror=switch -fdiagnostics-show-option"/>
     <flags CXXFLAGS="-Wno-unused-local-typedefs -Wno-attributes -Wno-psabi"/>
     <flags LTO_FLAGS="@LTO_FLAGS@"/>
-    <flags PGO_FLAGS="@PGO_FLAGS@"/>
+    <flags PGO_FLAGS="-fprofile-prefix-path=$(LOCALTOP) -fprofile-update=prefer-atomic -fprofile-correction"/>
+    <flags PGO_FLAGS="-fprofile-dir=%q{CMSSW_PGO_DIRECTORY}/PGO-Profiles/cmssw/%q{CMSSW_CPU_TYPE}"/>
+    <flags PGO_GENERATE_FLAGS="-fprofile-generate"/>
+    <flags PGO_USE_FLAGS="-fprofile-use -fprofile-partial-training -Wno-missing-profile"/>
     <flags LDFLAGS="@GCC_LDFLAGS@"/>
     <flags CXXSHAREDFLAGS="@GCC_SHAREDFLAGS@"/>
     <flags LD_UNIT="@GCC_LD_UNIT@"/>

--- a/scram-tools.file/tools/gsl/gsl.xml
+++ b/scram-tools.file/tools/gsl/gsl.xml
@@ -7,6 +7,7 @@
     <environment name="INCLUDE" default="$GSL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="PATH" value="$GSL_BASE/bin" type="path"/>
   <use name="OpenBLAS"/>
   <use name="root_cxxdefaults"/>
 </tool>


### PR DESCRIPTION
- GSL:
  - Backport the GSL env fix: https://github.com/cms-sw/cmsdist/pull/8711
- SCRAM:
  - SCRAMV3: Fix for scram links.db: https://github.com/cms-sw/cmsdist/pull/8638
  - SCRAMV2: Fix for scramrc files https://github.com/cms-sw/cmsdist/pull/8622 , fix for toolversion search https://github.com/cms-sw/cmsdist/pull/8607
- BuildRules:
  - Fix for alpaka dictionary header/xml flags https://github.com/cms-sw/cmsdist/pull/8705
  - Improved PGO builds https://github.com/cms-sw/cmsdist/pull/8720
  - Support for alpaka backend selection inverted logic https://github.com/cms-sw/cmsdist/pull/8721