### PR TITLE
[SCRAMV1] Fix for PGO/Multivec env setup

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_62
+### RPM lcg SCRAMV1 V3_00_63
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag d643e4e242a699ed8fea5c14ce5640390f263906
+%define tag de3b7c8b5aae73b098929a05bc5c6ac9a3d7b5ac
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
This fixes the issue [a] where scram sets/reset env variable value if it generated multiple time from the hook script. This only effects multi-vectorizations latest builds where `CMSSW_CPU_TYPE` is generated multiple time for PGO build

[a]
```
> export USER_SCRAM_TARGET=auto   
> cmsenv
> echo $CMSSW_CPU_TYPE $SCRAM_TARGET
scram_haswell auto
> cmsenv
> echo $CMSSW_CPU_TYPE $SCRAM_TARGET
default auto
> cmsenv
> echo $CMSSW_CPU_TYPE $SCRAM_TARGET
scram_haswell auto
```