### PR TITLE
Update tag for RecoEgamma-EgammaPhotonProducers to V00-04-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-EgammaPhotonProducers=V00-04-00
 DataFormats-DetId=V00-01-00
 RecoTracker-TkSeedGenerator=V00-03-00
 DataFormats-SiStripCluster=V00-01-00
@@ -26,7 +27,6 @@ DataFormats-FEDRawData=V00-01-00
 DataFormats-Common=V00-01-00
 DQM-EcalMonitorClient=V00-03-00
 CondTools-Hcal=V00-01-00
-RecoEgamma-EgammaPhotonProducers=V00-03-00
 RecoEcal-EgammaClusterProducers=V00-03-00
 HeterogeneousCore-SonicTriton=V00-02-00
 RecoTracker-DisplacedRegionalTracking=V00-01-00


### PR DESCRIPTION
Move RecoEgamma-EgammaPhotonProducers data to new tag, see 
https://github.com/cms-data/RecoEgamma-EgammaPhotonProducers/pull/4
