### PR TITLE
Update GitPython to version 3.1.37

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -113,7 +113,7 @@ funcsigs==1.0.2
 future==0.18.3
 gast==0.5.3
 gitdb==4.0.10
-GitPython==3.1.35
+GitPython==3.1.37
 google-auth==2.17.2
 google-auth-oauthlib==1.0.0
 google-pasta==0.2.0


### PR DESCRIPTION
New version contains the `Blind local file inclusion` issue
```
In order to resolve some git references, GitPython reads files from the .git directory, 
in some places the name of the file being read is provided by the user, GitPython 
doesn't check if this file is located outside the .git directory. This allows an attacker 
to make GitPython read any file from the system.
```