### PR TITLE
clhep: Build with c++17 i.e. default std used for building cmssw

### DIFF
--- a/clhep.spec
+++ b/clhep.spec
@@ -1,5 +1,5 @@
 ### RPM external clhep 2.4.7.1
-
+## INCLUDE cpp-standard
 %define tag bfc29493e1b4928b1e6b0dff5f754565bcfd4795
 %define branch cms/v%{realversion}
 %define github_user cms-externals
@@ -17,6 +17,7 @@ cd ../build
 
 cmake ../%{n}-%{realversion} \
   -G Ninja \
+  -DCMAKE_CXX_STANDARD:STRING="%{cms_cxx_standard}" \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo
 

--- a/clhep.spec
+++ b/clhep.spec
@@ -17,7 +17,7 @@ cd ../build
 
 cmake ../%{n}-%{realversion} \
   -G Ninja \
-  -DCMAKE_CXX_STANDARD:STRING="%{cms_cxx_standard}" \
+  -DCLHEP_BUILD_CXXSTD="-std=c++%{cms_cxx_standard}" \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo
 


### PR DESCRIPTION
Fixes  cms-sw/cmssw#43063