### PR TITLE
Add conifer external

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -17,6 +17,7 @@ Requires: bz2lib
 Requires: cepgen
 Requires: classlib
 Requires: clhep
+Requires: conifer
 Requires: coral
 Requires: cppunit
 Requires: cpu_features

--- a/conifer.spec
+++ b/conifer.spec
@@ -1,0 +1,16 @@
+### RPM external conifer 1.2
+## NOCOMPILER
+
+Source: https://github.com/thesps/%{n}/archive/v%{realversion}.tar.gz
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+
+%install
+mkdir -p %{i}/include/
+cp conifer/backends/cpp/include/conifer.h     %{i}/include/
+
+%post
+

--- a/conifer.spec
+++ b/conifer.spec
@@ -2,6 +2,7 @@
 ## NOCOMPILER
 
 Source: https://github.com/thesps/%{n}/archive/v%{realversion}.tar.gz
+Requires: json
 
 %prep
 %setup -n %{n}-%{realversion}

--- a/scram-tools.file/tools/conifer/conifer.xml
+++ b/scram-tools.file/tools/conifer/conifer.xml
@@ -1,7 +1,8 @@
 <tool name="conifer" version="@TOOL_VERSION@">
   <client>
     <environment name="CONIFER_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$CONIFER_BASE/conifer/backends/cpp/include"/>
+    <environment name="INCLUDE" default="$CONIFER_BASE/include"/>
   </client>
+  <use name="json"/>
 </tool>
 

--- a/scram-tools.file/tools/conifer/conifer.xml
+++ b/scram-tools.file/tools/conifer/conifer.xml
@@ -1,0 +1,7 @@
+<tool name="conifer" version="@TOOL_VERSION@">
+  <client>
+    <environment name="CONIFER_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$CONIFER_BASE/conifer/backends/cpp/include"/>
+  </client>
+</tool>
+


### PR DESCRIPTION
This PR adds a new external `conifer` that is to be used for emulation of BDTs in the L1T. We just need to pull in a single header file ([this one](https://github.com/thesps/conifer/blob/master/conifer/backends/cpp/include/conifer.h)).

This is my first time adding an external, so to check: the header file itself does `#include "nlohmann/json.hpp"`, which is already an external. Do I need to add a requirement on `json`?