### PR TITLE
Update CICADA version

### DIFF
--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,4 +1,4 @@
-### RPM external CICADA 1.1.1
+### RPM external CICADA 1.2.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updates the CICADA version to make available two 2023 models (CICADA2p1 and CICADA1p1) that have been added to the overall CICADA makefile.

These models are meant for eventual emulator production and this PR is being introduced to begin the process of more completely integrating the CICADA emulator