### PR TITLE
Update conifer version

### DIFF
--- a/conifer.spec
+++ b/conifer.spec
@@ -1,4 +1,4 @@
-### RPM external conifer 1.2
+### RPM external conifer 1.3
 ## NOCOMPILER
 
 Source: https://github.com/thesps/%{n}/archive/v%{realversion}.tar.gz


### PR DESCRIPTION
The conifer external was introduced in #8780. Compiling the external with `scram build` yielded errors. These have been fixed upstream in the external and a new version tagged. This PR updates the external spec to the new version.

I've tested (compiled and executed) this version with a producer in `CMSSW_13_3_X_2023-10-25-2300` that uses the external.