### PR TITLE
Add fix for segfault in Min Bias

### DIFF
--- a/herwig7.spec
+++ b/herwig7.spec
@@ -18,12 +18,14 @@ BuildRequires: autotools
 Patch0: herwig_Matchbox_mg_py3
 Patch1: herwig7-fxfx-fix
 Patch2: LHEEventNumFxFx
+Patch3: herwig_MB
 
 %prep
 %setup -q -n Herwig-%{realversion}
 %patch0 -p1
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 
 # Regenerate build scripts
 autoreconf -fiv

--- a/herwig_MB.patch
+++ b/herwig_MB.patch
@@ -1,0 +1,24 @@
+diff -ur Herwig-7.2.1/MatrixElement/Hadron/MEDiffraction.cc Herwig-7.2.1_patched/MatrixElement/Hadron/MEDiffraction.cc
+--- Herwig-7.2.1/MatrixElement/Hadron/MEDiffraction.cc	2023-10-19 19:10:16.254957366 +0200
++++ Herwig-7.2.1_patched/MatrixElement/Hadron/MEDiffraction.cc	2023-10-19 19:14:18.639389061 +0200
+@@ -620,7 +620,7 @@
+   // given by the MPIHandler. 
+   
+   // First get the eventhandler to get the current cross sections. 
+-  static Ptr<StandardEventHandler>::tptr eh =
++  Ptr<StandardEventHandler>::tptr eh =
+   dynamic_ptr_cast<Ptr<StandardEventHandler>::tptr>(generator()->eventHandler());
+ 
+   // All diffractive processes make use of this ME. 
+diff -ur Herwig-7.2.1/MatrixElement/MEMinBias.cc Herwig-7.2.1_patched/MatrixElement/MEMinBias.cc
+--- Herwig-7.2.1/MatrixElement/MEMinBias.cc	2023-10-19 19:08:46.414751420 +0200
++++ Herwig-7.2.1_patched/MatrixElement/MEMinBias.cc	2023-10-19 19:14:19.199390134 +0200
+@@ -113,7 +113,7 @@
+   // given by the MPIHandler. 
+   
+   // First get the eventhandler to get the current cross sections. 
+-  static Ptr<StandardEventHandler>::tptr eh =
++  Ptr<StandardEventHandler>::tptr eh =
+   dynamic_ptr_cast<Ptr<StandardEventHandler>::tptr>(generator()->eventHandler());
+ 
+   // All diffractive processes make use of this ME. 


### PR DESCRIPTION
A segfault was reported for generating Min Bias events with Herwig. The root cause seems to be that both the "read" and "run" steps are run in a single job (whereas in standalone Herwig they are run in two different jobs). This leads to issues as two static pointers are made to an object which is deleted and recreated between the steps, removing the static keyword seems to resolve the issue (tested in CMSSW_10_6). Herwig authors agree this seems a reasonable fix, and they plan to include it in future versions of Herwig, this patch resolves the issue in CMSSW in the meantime