### PR TITLE
add clang-uml for making class diagrams

### DIFF
--- a/clang-uml.spec
+++ b/clang-uml.spec
@@ -1,0 +1,41 @@
+### RPM external clang-uml 0.4.1
+
+%define tag 429e1c47a9669438651076a719de29c00fd18f7b
+%define branch master
+
+%define github_user bkryza
+Source: git+https://github.com/%{github_user}/clang-uml.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+BuildRequires: cmake ninja 
+Requires: yaml-cpp llvm
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+#GIT_VERSION can be a random string with the correct set of fields
+#it is required as the current default in clang-uml cmake system is not
+#correctly formated (issue opened)
+
+CMAKE_PREFIX_PATH=${YAML_CPP_ROOT}/lib64/cmake/yaml-cpp/ cmake ../%{n}-%{realversion} \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX:PATH="%i" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS="" \
+  -DCMAKE_EXE_LINKER_FLAGS="" \
+  -DLLVM_VERSION= \
+  -DCMAKE_VERBOSE_MAKEFILE=true \
+  -DGIT_VERSION="0.4.1-9-g205d6de" \
+  -DLLVM_CONFIG_PATH= 
+
+ninja -v %{makeprocesses}
+
+%install
+cd ../build
+ninja %{makeprocesses} install
+
+%post
+%{relocateConfig}share/pkgconfig/yaml-cpp.pc

--- a/clang-uml.spec
+++ b/clang-uml.spec
@@ -24,12 +24,10 @@ CMAKE_PREFIX_PATH=${YAML_CPP_ROOT}/lib64/cmake/yaml-cpp/ cmake ../%{n}-%{realver
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS="" \
-  -DCMAKE_EXE_LINKER_FLAGS="" \
-  -DLLVM_VERSION= \
-  -DCMAKE_VERBOSE_MAKEFILE=true \
-  -DGIT_VERSION="0.4.1-9-g205d6de" \
-  -DLLVM_CONFIG_PATH= 
+%ifarch aarch64
+-DCMAKE_CXX_FLAGS="-Wno-sign-compare" \
+%endif
+  -DGIT_VERSION="0.4.1-9-g205d6de" 
 
 ninja -v %{makeprocesses}
 

--- a/clang-uml.spec
+++ b/clang-uml.spec
@@ -28,7 +28,7 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_CXX_FLAGS="-Wno-sign-compare" \
 %endif
   -DGIT_VERSION="%{realversion}" \
-  -DCMAKE_PREFIX_PATH="${YAML_CPP_ROOT}/lib64/cmake/yaml-cpp:${ZLIB_ROOT}"
+  -DCMAKE_PREFIX_PATH="${YAML_CPP_ROOT}/lib64/cmake/yaml-cpp;${ZLIB_ROOT}"
 
 ninja -v %{makeprocesses}
 

--- a/clang-uml.spec
+++ b/clang-uml.spec
@@ -6,7 +6,7 @@
 %define github_user bkryza
 Source: git+https://github.com/%{github_user}/clang-uml.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 BuildRequires: cmake ninja 
-Requires: yaml-cpp llvm
+Requires: yaml-cpp llvm zlib
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -20,20 +20,18 @@ cd ../build
 #it is required as the current default in clang-uml cmake system is not
 #correctly formated (issue opened)
 
-CMAKE_PREFIX_PATH=${YAML_CPP_ROOT}/lib64/cmake/yaml-cpp/ cmake ../%{n}-%{realversion} \
+cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
   -DCMAKE_BUILD_TYPE=Release \
 %ifarch aarch64
--DCMAKE_CXX_FLAGS="-Wno-sign-compare" \
+  -DCMAKE_CXX_FLAGS="-Wno-sign-compare" \
 %endif
-  -DGIT_VERSION="0.4.1-9-g205d6de" 
+  -DGIT_VERSION="%{realversion}" \
+  -DCMAKE_PREFIX_PATH="${YAML_CPP_ROOT}/lib64/cmake/yaml-cpp:${ZLIB_ROOT}"
 
 ninja -v %{makeprocesses}
 
 %install
 cd ../build
 ninja %{makeprocesses} install
-
-%post
-%{relocateConfig}share/pkgconfig/yaml-cpp.pc

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -15,6 +15,7 @@ Requires: alpgen
 Requires: boost
 Requires: bz2lib
 Requires: cepgen
+Requires: clang-uml
 Requires: classlib
 Requires: clhep
 Requires: conifer

--- a/scram-tools.file/tools/clang-uml/clang-uml.xml
+++ b/scram-tools.file/tools/clang-uml/clang-uml.xml
@@ -1,0 +1,10 @@
+<tool name="clang-uml" version="@TOOL_VERSION@">
+  <info url="https://github.com/jbeder/clang-uml/"/>
+  <lib name="clang-utml"/>
+  <client>
+    <environment name="CLANG_UML_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CLANG_UML_BASE/lib64"/>
+  </client>
+  <runtime name="PATH" value="$CLANG_UML_BASE/bin" type="path"/>
+  <use name="yaml-cpp"/>
+</tool>

--- a/scram-tools.file/tools/clang-uml/clang-uml.xml
+++ b/scram-tools.file/tools/clang-uml/clang-uml.xml
@@ -1,10 +1,9 @@
 <tool name="clang-uml" version="@TOOL_VERSION@">
-  <info url="https://github.com/jbeder/clang-uml/"/>
-  <lib name="clang-utml"/>
+  <info url="https://github.com/bkryza/clang-uml/"/>
   <client>
     <environment name="CLANG_UML_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CLANG_UML_BASE/lib64"/>
   </client>
   <runtime name="PATH" value="$CLANG_UML_BASE/bin" type="path"/>
   <use name="yaml-cpp"/>
+  <use name="zlib"/>
 </tool>


### PR DESCRIPTION
Has proven useful for building class diagrams from cmssw
https://clang-uml.github.io

pretty lightweight to keep around. Depends on yaml-cpp which we already have. I'm using close to the tip of the master branch as it contains a bug fix for discovering libraries (eg, yaml-cpp) in non-standard locations (eg, the cmssw use case)