### PR TITLE
[hls] Fix for uninitialized/maybe-uninitialized warnings

### DIFF
--- a/hls-fix-uninitialized.patch
+++ b/hls-fix-uninitialized.patch
@@ -1,0 +1,19 @@
+--- a/include/etc/ap_private.h	2022-05-16 15:05:19.000000000 +0200
++++ b/include/etc/ap_private.h	2023-11-23 14:53:55.052958667 +0100
+@@ -1590,7 +1590,7 @@
+   }
+ 
+  public:
+-  INLINE ap_private() {
++  INLINE ap_private(): VAL(0) {
+     set_canary();
+     clearUnusedBits();
+     check_canary();
+@@ -3302,6 +3302,7 @@
+   ///  for object deserialization (pair this with the static method Read).
+   INLINE ap_private() {
+     set_canary();
++    memset(pVal, 0, _AP_N * sizeof(uint64_t));
+     clearUnusedBits();
+     check_canary();
+   }

--- a/hls.spec
+++ b/hls.spec
@@ -4,10 +4,12 @@
 %define github_user Xilinx
 %define runpath_opts -m examples
 Source: git+https://github.com/%{github_user}/HLS_arbitrary_Precision_Types.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Patch0: hls-fix-uninitialized
 Requires: gmake
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 


### PR DESCRIPTION
Apply patch to explicitly initialize ap_private data member to avoid warning likes [a]. Fixes https://github.com/cms-sw/cmssw/issues/43040

[a]
```
In member function 'clearUnusedBits',
    inlined from '__ct ' at hls//include/etc/ap_private.h:1595:20,
    inlined from '__ct_base ' at hls//include/ap_common.h:248:18,
    inlined from '__ct ' at hls//include/ap_int_base.h:208:3,
    inlined from 'operator&' at hls//include/ap_int_base.h:1436:1,
    inlined from 'clusterEnergy' at cmssw/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:872:54,
    inlined from 'compareClusterET' at cmssw/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:962:52:
  hls//include/etc/ap_private.h:2109:27: warning: 'MEM[(volatile struct ap_private *)&D.9255].VAL' is used uninitialized [-Wuninitialized]
  2109 |             ? ((((int64_t)VAL) << (excess_bits)) >> (excess_bits))
```
```
In member function 'clearUnusedBits',
    inlined from '__ct ' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hls/2019.08-b8a1533230929513077d97b1507ff465/include/etc/ap_private.h:3305:20,
    inlined from '__ct_base ' at hls/include/ap_common.h:248:18,
    inlined from '__ct ' at hls/include/ap_int_base.h:179:61,
    inlined from 'operator-' at hls/include/ap_int_base.h:1321:1:
  hls/include/etc/ap_private.h:3397:33: warning: 'MEM[(volatile struct ap_private *)&lhs].pVal[1]' is used uninitialized [-Wuninitialized]
  3397 |         _AP_S ? ((((int64_t)pVal[_AP_N - 1]) << (excess_bits)) >> excess_bits)

```