### PR TITLE
[hepmc3] Update to version 3.2.7

### DIFF
--- a/hepmc3.spec
+++ b/hepmc3.spec
@@ -1,6 +1,6 @@
 ### RPM external hepmc3 3.2.7
 
-Source: https://gitlab.cern.ch/hepmc/HepMC3/-/archive/3.2.5/HepMC3-%{realversion}.tar.gz
+Source: https://gitlab.cern.ch/hepmc/HepMC3/-/archive/%{realversion}/HepMC3-%{realversion}.tar.gz
 
 BuildRequires: cmake
 

--- a/hepmc3.spec
+++ b/hepmc3.spec
@@ -1,5 +1,5 @@
 ### RPM external hepmc3 3.2.7
-
+## INCLUDE cpp-standard
 Source: https://gitlab.cern.ch/hepmc/HepMC3/-/archive/%{realversion}/HepMC3-%{realversion}.tar.gz
 
 BuildRequires: cmake
@@ -18,6 +18,7 @@ cmake ../HepMC3-%{realversion} \
   -DHEPMC3_ENABLE_ROOTIO:BOOL=OFF -DHEPMC3_ENABLE_TEST:BOOL=OFF \
   -DHEPMC3_INSTALL_INTERFACES:BOOL=ON -DHEPMC3_ENABLE_PYTHON:BOOL=OFF \
   -DHEPMC3_BUILD_STATIC_LIBS:BOOL=OFF -DHEPMC3_BUILD_DOCS:BOOL=OFF \
+  -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} -DHEPMC3_CXX_STANDARD=%{cms_cxx_standard} \
   -DCMAKE_INSTALL_PREFIX:PATH="%i"
 
 make %{makeprocesses}

--- a/hepmc3.spec
+++ b/hepmc3.spec
@@ -1,4 +1,4 @@
-### RPM external hepmc3 3.2.5
+### RPM external hepmc3 3.2.7
 
 Source: https://gitlab.cern.ch/hepmc/HepMC3/-/archive/3.2.5/HepMC3-%{realversion}.tar.gz
 


### PR DESCRIPTION
@mkirsano any progress on migrating to hepmc3 ? By the waym we still have both hepme2 and hepmc3 in cmssw distribution