### PR TITLE
Minimal backport of Alpaka fixes for ROCm 5.3 and later

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,7 +1,7 @@
 ### RPM external alpaka develop-20230621
 ## NOCOMPILER
 
-%define git_commit 8d4b8df9f1d0477e685e8d1581326b65707f404d
+%define git_commit 0286cd8fa24e50179e24b62a48c89201e51eb80a
 
 Source: https://github.com/cms-patatrack/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost


### PR DESCRIPTION
Updates Alpaka with a minimal backport of https://github.com/alpaka-group/alpaka/pull/2197:

> ROCm 5.3 and later support asynchronous memory operations.