### PR TITLE
[LTO] Improve link time by using multiple process for linking

### DIFF
--- a/compilation_flags_lto.file
+++ b/compilation_flags_lto.file
@@ -7,7 +7,7 @@
 %define enable_lto 0
 %endif
 %if "%{enable_lto}" == "1"
-%define lto_build_flags -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr
+%define lto_build_flags -flto=2 -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr
 %else
 %define lto_build_flags %{nil}
 %endif

--- a/compilation_flags_lto.file
+++ b/compilation_flags_lto.file
@@ -7,7 +7,7 @@
 %define enable_lto 0
 %endif
 %if "%{enable_lto}" == "1"
-%define lto_build_flags -flto=2 -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr
+%define lto_build_flags -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr
 %else
 %define lto_build_flags %{nil}
 %endif

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-01-05
+%define configtag       V09-01-06
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This should avoid the warnings like [a] and also it should use the GNU Make job server[b] to run multiple processes for at link step

[a]
```
lto-wrapper: warning: using serial compilation of 6 LTRANS jobs
lto-wrapper: note: see the '-flto' option documentation for more information
```

[b]
```
Use -flto=auto to use GNU make’s job server, if available, or otherwise fall back to autodetection of the number of CPU threads present in your system. 
```