### PR TITLE
Update CICADA external to v1.2.1

### DIFF
--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,4 +1,4 @@
-### RPM external CICADA 1.2.0
+### RPM external CICADA 1.2.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
This upgrade fixes several firmware emulator mismatches via added models v2.1.1 and v1.1.1, and synchronizes the two architecture output types.