### PR TITLE
Add the ROCm SMI library

### DIFF
--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -2,6 +2,7 @@
   <info url="https://docs.amd.com/"/>
   <lib name="amdhip64"/>
   <lib name="hsa-runtime64"/>
+  <lib name="rocm_smi64"/>
   <client>
     <environment name="ROCM_BASE" default="@TOOL_ROOT@"/>
     <environment name="HIPCC"     default="$ROCM_BASE/bin/hipcc"/>


### PR DESCRIPTION
Add the ROCm SMI library (`librocm_smi64.so`) to the ROCm tools.