### PR TITLE
crab-setup - support zsh login shell

### DIFF
--- a/crab/crab-setup.sh.file
+++ b/crab/crab-setup.sh.file
@@ -12,7 +12,7 @@ esac
 export CRABCLIENT_TYPE
 crab_shared_dir="@CMS_PATH@/share/cms/crab/@CRAB_COMMON_VERSION@"
 export PYTHONPATH="${crab_shared_dir}/lib/${CRABCLIENT_TYPE}${PYTHONPATH:+:$PYTHONPATH}"
-if [ "$(ps -p$$ -ocmd=)" = "zsh" ] ; then
+if [[ "$(ps -p$$ -ocmd=)" = *"zsh" ]] ; then
   autoload -U +X compinit && compinit
   autoload -U +X bashcompinit && bashcompinit
 fi

--- a/crab/crab-setup.sh.file
+++ b/crab/crab-setup.sh.file
@@ -1,5 +1,5 @@
 #!/bin/bash
-#CMSDIST_FILE_REVISION=5
+#CMSDIST_FILE_REVISION=6
 case "X$1Y" in
   XprodY|XdevY|XpreY) CRABCLIENT_TYPE="$1" ;;
   XY ) CRABCLIENT_TYPE="prod" ;;


### PR DESCRIPTION
### problem

Current `crab-setup.sh` does not support zsh on login shells.

### description

When opening a shell on lxplus, the shell is of type "login", so 

```plaintext
> [15:24] lxplus909 ~
> ps -p$$ -ocmd=
-zsh
```

which makes the check ` [ "$(ps -p$$ -ocmd=)" = "zsh" ]` in `crab-setup.sh` to return false, and

```plaintext
autoload -U +X compinit && compinit
autoload -U +X bashcompinit && bashcompinit
```

are not executed, so zsh does not know about the function `complete`, and we ultimately can not import bash completions into zsh.

### solution

change the condition to match also zsh login shell, something like the following should do the job.

```diff
- [ "$(ps -p$$ -ocmd=)" = "zsh" ]
+ [[ "$(ps -p$$ -ocmd=)" = *"zsh" ]]
```

I tested it and it works.

fyi @belforte @novicecpp , I know you use bash, but maybe a user asks for it