### PR TITLE
save crab-prod as crab-pre, then bump to v3.231101

### DIFF
--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -3,8 +3,8 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.230612
+%define crabclient_version v3.231010
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
-%define crabserver_version v3.230609
+%define crabserver_version v3.231006
 
 ## IMPORT crab-build

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.231010
+%define crabclient_version v3.231101
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.231006
 


### PR DESCRIPTION
after v3.231101 client was validated on all CMSSW release series in our list https://github.com/dmwm/CRABClient/issues/5271