### PR TITLE
Revert lhapdf to 6.4.0 but keep lhapdh_dataset 6.5.1c

### DIFF
--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -1,14 +1,10 @@
-### RPM external lhapdf 6.5.4
+### RPM external lhapdf 6.4.0
 %define setsversion 6.5.1c
 
 Source: http://www.hepforge.org/archive/lhapdf/LHAPDF-%{realversion}.tar.gz
-
 Source1: lhapdf_makeLinks
-
 Source2: http://www.hepforge.org/archive/lhapdf/pdfsets/6.1/MSTW2008nlo68cl.tar.gz
-
 Source3: lhapdf_pdfsetsindex
-
 Requires: python3
 BuildRequires: py3-cython
 


### PR DESCRIPTION
See https://github.com/cms-sw/cmssw/issues/43526 for detail on this revert.