### PR TITLE
Move 14.0.X to ROOT 6.30

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -1,9 +1,9 @@
-### RPM external dd4hep v01-25x
+### RPM external dd4hep v01-26x
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
 
-%define tag b07fa115c59d80d37154cf205cf00dff8137ee36
+%define tag 8715c52c1c8b3c714d80896cb8540f3f8f888786
 %define branch master
 %define github_user AIDASoft
 %define keep_archives true

--- a/root.spec
+++ b/root.spec
@@ -1,10 +1,10 @@
-### RPM lcg root 6.26.15
+### RPM lcg root 6.30.03
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag d4ff830a3be0f77ca2d7a3ed19e69eac7f1685ee
-%define branch cms/v6-26-00-patches/e8ff650e67
+%define tag 630493ea6a716fb08d9fd2e8ddc9f33cf62f59c7
+%define branch cms/v6-30-00-patches/33f75f0044
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
@@ -178,7 +178,7 @@ ninja -v %{makeprocesses} install
 
 find %{i} -type f -name '*.py' | xargs chmod -x
 grep -rlI '#!.*python' %{i} | xargs chmod +x
-for p in $(grep -rlI -m1 '^#\!.*python' %i/bin) ; do
+for p in $(grep -rlI -m1 '^#\!.*python' %i/bin %i/etc) ; do
   lnum=$(grep -n -m1 '^#\!.*python' $p | sed 's|:.*||')
   sed -i -e "${lnum}c#!/usr/bin/env python3" $p
 done


### PR DESCRIPTION
This moves 14.0.X IBs to ROOT 6.30. I also have created IB/CMSSW_14_0_X/root626 branch which I will use to keep on build 14.0.X.ROOT626 IBs ( just in case we have to revert back)