### PR TITLE
vecgeom: Testing Vecgeom commit 742eede86

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -2,7 +2,7 @@
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
-%define tag 12fc8ba12efe93de5aaa9ff8e51e093ae93a1633
+%define tag 742eede8679ec8f7ef000d909b2ecfe78d9bc183
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake gmake
 %define keep_archives true


### PR DESCRIPTION
testing vecgeom commit [742eede8679ec8f7ef000d909b2ecfe78d9bc183](https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/742eede8679ec8f7ef000d909b2ecfe78d9bc183)