### PR TITLE
Pytroch: Build ATEN with static cuda to avoid cuda extra deps

### DIFF
--- a/pytorch.spec
+++ b/pytorch.spec
@@ -27,11 +27,10 @@ cp %{_sourcedir}/FindEigen3.cmake %{_sourcedir}/FindFMT.cmake cmake/Modules/
 rm -rf ../build && mkdir ../build && cd ../build
 
 USE_CUDA=OFF
-%if "%{cmsos}" != "slc7_aarch64"
 if [ "%{cuda_gcc_support}" = "true" ] ; then
 USE_CUDA=ON
+export ATEN_STATIC_CUDA=1
 fi
-%endif
 
 cmake ../%{n}-%{realversion} \
     -G Ninja \


### PR DESCRIPTION
To avoid dependency on non-distributable part of cuda [a], build pyTrouch `ATEN` with static cuda. This should fix the packaging errors for CUDART IBs

[a]
```
libcusolver.so.11()(64bit) is needed by external+pytorch+2.1.1-c6a4f9ac7bbb65863cf04f0ff3195323-1-1.x86_64
libcusparse.so.12()(64bit) is needed by external+pytorch+2.1.1-c6a4f9ac7bbb65863cf04f0ff3195323-1-1.x86_64
libnvrtc.so.12()(64bit) is needed by external+pytorch+2.1.1-c6a4f9ac7bbb65863cf04f0ff3195323-1-1.x86_64
```
