### PR TITLE
[cuda-runtime] add extra cuda runtime libs needed by pytorch

### DIFF
--- a/cuda-runtime.spec
+++ b/cuda-runtime.spec
@@ -1,4 +1,4 @@
-%define runtime_libs cublas cublasLt cudart cufft curand nvToolsExt cusolver cusparse nvrtc
+%define runtime_libs cublas cublasLt cudart cufft curand nvToolsExt cusolver cusparse nvrtc nvJitLink
 %define runtime_stubs nvidia-ml cuda
 %define cuda_incs nvrtc.h cufile.h cuda_fp16.h cuda_fp16.hpp cuda_occupancy.h
 Source99: install-cuda.sh

--- a/cuda-runtime.spec
+++ b/cuda-runtime.spec
@@ -1,11 +1,13 @@
-%define runtime_libs cublas cublasLt cudart cufft curand nvToolsExt
+%define runtime_libs cublas cublasLt cudart cufft curand nvToolsExt cusolver cusparse nvrtc
 %define runtime_stubs nvidia-ml cuda
+%define cuda_incs nvrtc.h cufile.h cuda_fp16.h cuda_fp16.hpp cuda_occupancy.h
 Source99: install-cuda.sh
 
 ## INCLUDE cuda-version
 ### RPM external cuda-runtime %{cuda_version}
 
 %install
+#Copy runtime libs
 mkdir -p %i/lib64/stubs
 for lib in %runtime_libs ; do
   cp -P %{cuda_install_dir}/lib64/lib${lib}.so* %i/lib64/
@@ -15,6 +17,14 @@ for lib in %runtime_stubs; do
   soname=$(objdump -p %i/lib64/stubs/lib${lib}.so | grep ' SONAME ' | sed "s|.*lib${lib}|lib${lib}|")
   [ -e %i/lib64/stubs/${soname} ] || ln -sf lib${lib}.so %i/lib64/stubs/${soname}
 done
+
+#copy headers
+mkdir %i/include
+for inc in %{cuda_incs} ; do
+  cp -P %{cuda_install_dir}/include/$inc  %i/include/${inc}
+done
+
+#Copy binary/utils
 mkdir %i/bin
 cp %{cuda_install_dir}/.cms/install-cuda.py %i/bin
 cp %{_sourcedir}/install-cuda.sh %i/bin/install-cuda.sh


### PR DESCRIPTION
CUDART IBs failed to build due to missing [a] cuda libs at packaging/runtime time. As these libraries are all listed under [Attachment A](https://docs.nvidia.com/cuda/eula/index.html#attachment-a) of the License Agreement so this PR proposes to add these in cuda-runtime package.

[a]
```
libcusolver.so.11()(64bit) is needed by external+pytorch+2.1.1-c6a4f9ac7bbb65863cf04f0ff3195323-1-1.x86_64
libcusparse.so.12()(64bit) is needed by external+pytorch+2.1.1-c6a4f9ac7bbb65863cf04f0ff3195323-1-1.x86_64
libnvrtc.so.12()(64bit) is needed by external+pytorch+2.1.1-c6a4f9ac7bbb65863cf04f0ff3195323-1-1.x86_64
```