### PR TITLE
Update ROOT 6.14 to include forward-compatibility patch

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHONPATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
 %define tag c99f334c8d6bd505f4f0e453dcc654a938020e10
-%define branch cms/v6-14-00-patches/94610d9
+%define branch cms/v6-14-00-patches/65ed49a
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 


### PR DESCRIPTION
Update ROOT 6.14 ref to include forward-compatibility patch for root files created by versions >=6.30.

Discussion [here](https://github.com/cms-sw/cmssw/issues/43590).

Initial issue [here](https://github.com/cms-DQM/dqmgui_prod/issues/18)

@smuzaffar Are there any other changes that need to be included?