### PR TITLE
Add L1METML extra

### DIFF
--- a/L1METML.spec
+++ b/L1METML.spec
@@ -1,0 +1,14 @@
+### RPM external L1METML 1.0.0
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
+Requires: hls4mlEmulatorExtras hls
+BuildRequires: gmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+make %{makeprocesses} EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT} HLS_ROOT=${HLS_ROOT}
+
+%install
+make PREFIX=%{i} install
+

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tool-conf 57.0
+### RPM cms cmssw-tool-conf 58.0
 # With cmsBuild, change the above version only when a new tool is added
 
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cmssw-osenv cms-git-tools SCRAMV2
@@ -54,6 +54,7 @@ Requires: jemalloc-debug
 Requires: jemalloc-prof
 Requires: json
 Requires: ktjet
+Required: L1METML
 Requires: lhapdf
 Requires: libjpeg-turbo
 Requires: libpng

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -54,7 +54,7 @@ Requires: jemalloc-debug
 Requires: jemalloc-prof
 Requires: json
 Requires: ktjet
-Required: L1METML
+Requires: L1METML
 Requires: lhapdf
 Requires: libjpeg-turbo
 Requires: libpng

--- a/scram-tools.file/tools/L1METML/l1metml.xml
+++ b/scram-tools.file/tools/L1METML/l1metml.xml
@@ -1,0 +1,6 @@
+<tool name="l1metml" version="@TOOL_VERSION@">
+  <client>
+    <environment name="L1METML_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$L1METML_BASE/lib64"/>
+  </client>
+</tool>


### PR DESCRIPTION
This PR adds one new package needed for a forthcoming CMSSW PR for an ML-based Level-1 trigger MET regression algorithm: [L1METML](https://github.com/cms-hls4ml/L1METML).

This follows similar PRs for AXOL1TL https://github.com/cms-sw/cmsdist/pull/8379 and CICADA https://github.com/cms-sw/cmsdist/pull/8307

@quinnanm @vloncar @thesps