### PR TITLE
Update OpenMPI, UCX and related libraries

### DIFF
--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.3
+### RPM external gdrcopy 2.4.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 4.1.5
+### RPM external openmpi 4.1.6
 ## INITENV SET OPAL_PREFIX %{i}
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -1,4 +1,4 @@
-### RPM external rdma-core 39.1
+### RPM external rdma-core 50.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 
 Source: https://github.com/linux-rdma/%{n}/releases/download/v%{realversion}/rdma-core-%{realversion}.tar.gz

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,4 +1,4 @@
-### RPM external ucx 1.14.1
+### RPM external ucx 1.15.0
 Source: https://github.com/openucx/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: autotools
 Requires: cuda gdrcopy


### PR DESCRIPTION
Update:
  - OpenMPI to v4.1.6
  - UCX to v1.15.0
  - RDMA Core to v50.0
  - NVIDIA gdrcopy to v2.4.1
