### PR TITLE
[json] Explicitly added cmake and gmake deps

### DIFF
--- a/json.spec
+++ b/json.spec
@@ -2,7 +2,7 @@
 ## NOCOMPILER
 
 Source: https://github.com/nlohmann/json/archive/refs/tags/v%{realversion}.tar.gz
-
+BuildRequires: cmake gmake
 %prep
 %setup -n %{n}-%{realversion}
 


### PR DESCRIPTION
This fixes the build issues for slc7 where cmake is not part of cmssw-el7 container