### PR TITLE
[10.6.X] Add Collier package and use ninja from gosamcontrib for madgraph

### DIFF
--- a/collier.spec
+++ b/collier.spec
@@ -1,0 +1,25 @@
+### RPM external collier 1.2.8
+# Source: http://www.hepforge.org/archive/collier/%{n}-%{realversion}.tar.gz
+Source: https://cmsrep.cern.ch/cmssw/download/collier/%{realversion}/%{n}-%{realversion}.tar.gz
+BuildRequires: gmake cmake
+
+%define keep_archives true
+
+%prep
+%setup -q -n COLLIER-%{realversion}
+sed -i 's;add_definitions(-Dcollierdd -DSING);add_definitions(-Dcollierdd -DSING -fPIC);g' ./CMakeLists.txt
+
+%build
+rm -rf build && mkdir build && cd build
+cmake ../ \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -Dstatic=ON \
+  -DCMAKE_Fortran_FLAGS=-fPIC
+
+make -j1
+
+%install
+mkdir -p %{i}/lib %{i}/include
+cp libcollier.a %{i}/lib
+cp modules/*.mod %{i}/include/

--- a/gosamcontrib.spec
+++ b/gosamcontrib.spec
@@ -4,6 +4,8 @@ Source: http://www.hepforge.org/archive/gosam/gosam-contrib-%{realversion}.tar.g
 Requires: qgraf
 Requires: form
 
+%define keep_archives true
+
 %prep
 %setup -q -n gosam-contrib-2.0
 
@@ -22,7 +24,8 @@ PLATF_CONF_OPTS="--enable-shared --enable-static"
 make %makeprocesses all
 
 %install
-make install 
+make install
+rm %{i}/lib/*.la
 
 %post
 %{relocateConfig}share/gosam-contrib/gosam.conf

--- a/madgraph5amcatnlo-config.patch
+++ b/madgraph5amcatnlo-config.patch
@@ -133,14 +133,14 @@ index c089808..f6b983f 100644
  #! if '' or None: disabling ninja 
  #! if ninja=/PATH/TO/ninja/lib: use that specific installation path for ninja 
 -# ninja = ./HEPTools/lib
-+ninja = @MADGRAPH5AMCATNLO_ROOT@/HEPTools/lib
++ninja = ${GOSAMCONTRIB_ROOT}/lib
  
  #! Set the COLLIER directory containing COLLIER's library
  #! if '' or None: disabling COLLIER 
  #! if ninja=/PATH/TO/ninja/lib: use that specific installation path for COLLIER
  # Note that it is necessary that you have generated a static library for COLLIER
 -# collier = ./HEPTools/lib 
-+collier = @MADGRAPH5AMCATNLO_ROOT@/HEPTools/lib
++collier = ${COLLIER_ROOT}/lib
  
  #! Set how MadLoop dependencies (such as CutTools) should be handled
  #!  > external : ML5 places a link to the MG5_aMC-wide libraries

--- a/madgraph5amcatnlo.spec
+++ b/madgraph5amcatnlo.spec
@@ -18,6 +18,7 @@ Requires: gosamcontrib
 Requires: fastjet
 Requires: pythia8
 Requires: thepeg
+Requires: collier
                    
 %prep
 %setup -n MG5_aMC_v%{versiontag}
@@ -30,6 +31,7 @@ sed -i -e "s|\${LHAPDF_ROOT}|${LHAPDF_ROOT}|g" input/mg5_configuration.txt
 sed -i -e "s|\${FASTJET_ROOT}|${FASTJET_ROOT}|g" input/mg5_configuration.txt
 sed -i -e "s|\${GOSAMCONTRIB_ROOT}|${GOSAMCONTRIB_ROOT}|g" input/mg5_configuration.txt
 sed -i -e "s|\${THEPEG_ROOT}|${THEPEG_ROOT}|g" input/mg5_configuration.txt
+sed -i -e "s|\${COLLIER_ROOT}|${COLLIER_ROOT}|g" input/mg5_configuration.txt
 
 %build
 # Save patched config
@@ -64,6 +66,8 @@ sed -ideleteme 's|#!.*/bin/python|#!/usr/bin/env python|' \
     %{i}/Template/LO/bin/internal/addmasses_optional.py \
     %{i}/madgraph/various/progressbar.py
 find %{i} -name '*deleteme' -delete
+rm -f %{i}/basiceventgeneration/*.log
+rm -f %{i}/basiceventgeneration/Source/StdHEP/log.mcfio.*
 
 %post
 %{relocateConfig}input/mg5_configuration.txt


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/8809 for use in Run2 production - requested by the Madgraph contacts so these packages can be accessed inside CMSSW in the event of hepforge downtime.

Tested with the Herwig+Madgraph matchbox workflow 539 backported in https://github.com/cms-sw/cmssw/pull/43691