### PR TITLE
Enable triton-client python interface

### DIFF
--- a/python_tools.spec
+++ b/python_tools.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 Source: none
 
-Requires: root curl python3 xrootd llvm hdf5 yoda opencv
+Requires: root curl python3 xrootd llvm hdf5 yoda opencv triton-inference-client
 Requires: professor2 rivet frontier_client onnxruntime openldap pacparser
 
 Requires: py3-anyio

--- a/rapidjson.spec
+++ b/rapidjson.spec
@@ -1,0 +1,24 @@
+### RPM external rapidjson 1.1.0
+## INCLUDE cpp-standard
+Source: https://github.com/Tencent/rapidjson/archive/refs/tags/v%{realversion}.tar.gz
+BuildRequires: cmake gmake
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build ; mkdir ../build ; cd ../build
+cmake ../%{n}-%{realversion} \
+    -DCMAKE_INSTALL_PREFIX="%{i}" \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
+    -DRAPIDJSON_BUILD_TESTS=OFF \
+    -DRAPIDJSON_BUILD_DOC=OFF \
+    -DRAPIDJSON_BUILD_EXAMPLES=OFF
+  
+make %{makeprocesses}
+
+%install
+cd ../build
+make install
+


### PR DESCRIPTION
This enables the triton client python interface. Code like [a] runs in cmssw env with this change.

[a]
```
bash-4.4$ python3
Python 3.9.14 (main, Jun 21 2023, 12:13:52) 
[GCC 12.3.1 20230527] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from tritonclient import grpc
>>> from google.protobuf import text_format, message, descriptor
>>> model = grpc.model_config_pb2.ModelConfig()
>>> config='/cvmfs/cms.cern.ch/share/cms/data-HeterogeneousCore-SonicTriton/V00-02-00/HeterogeneousCore/SonicTriton/data/models/gat_test/config.pbtxt'
>>> with open(config,'r') as infile:
...   text_format.Parse(infile.read(), model)
... 
name: "gat_test"
platform: "pytorch_libtorch"
input {
  name: "x__0"
  data_type: TYPE_FP32
  dims: -1
  dims: 1433
}
input {
  name: "edgeindex__1"
  data_type: TYPE_INT64
  dims: 2
  dims: -1
}
output {
  name: "logits__0"
  data_type: TYPE_FP32
  dims: -1
  dims: 7
}

>>> 
```