### PR TITLE
scram-tools: Fix for replacing `@VAR@` in toolfile; remove PGO-Profiles subdir

### DIFF
--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -21,6 +21,6 @@ for xml in $(find $SCRAM_TOOL_SOURCE_DIR -type f -name "*.xml") ; do
     [ -f ${TOOLFILES_INSTALL_DIR}/tools/selected/$bxml ] && continue
     [ -f ${TOOLFILES_INSTALL_DIR}/tools/available/$bxml ] && continue
     cp $xml ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
-    perl -p -i -e 's|\@([^@]*)\@|$ENV{$1}|g' ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
+    perl -p -i -e 's|\@([a-zA-Z0-9_-]*)\@|$ENV{$1}|g' ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
     echo "  Copied $bxml"
 done

--- a/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
@@ -26,8 +26,8 @@
     <flags CXXFLAGS="@GCC_WARNINGS@"/>
     <flags LTO_FLAGS="@LTO_FLAGS@"/>
     <flags PGO_FLAGS="-fprofile-prefix-path=$(LOCALTOP) -fprofile-update=prefer-atomic -fprofile-correction"/>
-    <flags PGO_GENERATE_FLAGS="-fprofile-generate=%q{CMSSW_PGO_DIRECTORY}/PGO-Profiles/cmssw/%q{CMSSW_CPU_TYPE}"/>
-    <flags PGO_USE_FLAGS="-fprofile-use=@{CMSSW_PGO_DIRECTORY}/PGO-Profiles/cmssw/@{CMSSW_CPU_TYPE} -fprofile-partial-training"/>
+    <flags PGO_GENERATE_FLAGS="-fprofile-generate=%q{CMSSW_PGO_DIRECTORY}/cmssw/%q{CMSSW_CPU_TYPE}"/>
+    <flags PGO_USE_FLAGS="-fprofile-use=@{CMSSW_PGO_DIRECTORY}/cmssw/@{CMSSW_CPU_TYPE} -fprofile-partial-training"/>
     <flags LDFLAGS="@GCC_LDFLAGS@"/>
     <flags CXXSHAREDFLAGS="@GCC_SHAREDFLAGS@"/>
     <flags LD_UNIT="@GCC_LD_UNIT@"/>

--- a/scram-tools.file/tools/icc/intel-license.xml
+++ b/scram-tools.file/tools/icc/intel-license.xml
@@ -1,3 +1,3 @@
   <tool name="intel-license" version="@TOOL_VERSION@">
-    <runtime name="INTEL_LICENSE_FILE" value="28518@AT@lxlicen01.cern.ch,28518@AT@lxlicen02.cern.ch,28518@AT@lxlicen03.cern.ch" handler="warn"/>
+    <runtime name="INTEL_LICENSE_FILE" value="28518@lxlicen01.cern.ch,28518@lxlicen02.cern.ch,28518@lxlicen03.cern.ch" handler="warn"/>
   </tool>


### PR DESCRIPTION
Thsi fixes the PGO issue where existing regexp was changing `@{CMSSW_PGO_DIRECTORY}/PGO-Profiles/cmssw/@{CMSSW_CPU_TYPE}` to `{CMSSW_CPU_TYPE}`