### PR TITLE
Python tools versions with security fixes updates

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -106,14 +106,14 @@ flit-scm==1.7.0
 flake8==6.0.0
 flatbuffers==23.3.3
 flawfinder==2.0.19
-fonttools==4.39.3
+fonttools==4.47.2
 frozenlist==1.3.3
 fsspec==2023.4.0
 funcsigs==1.0.2
 future==0.18.3
 gast==0.5.3
 gitdb==4.0.10
-GitPython==3.1.37
+GitPython==3.1.41
 google-auth==2.17.2
 google-auth-oauthlib==1.0.0
 google-pasta==0.2.0
@@ -148,7 +148,7 @@ jaraco-classes==3.2.3
 jax==0.4.12
 jedi==0.18.2
 jeepney==0.8.0
-Jinja2==3.1.2
+Jinja2==3.1.3
 jinja2-time==0.2.0
 joblib==1.2.0
 jsonpickle==3.0.1


### PR DESCRIPTION
Updated following python packages which contains security fixes
- fonttools 4.47.2
- GitPython 3.1.41
- Jinja2 3.1.3