### PR TITLE
Improve protobuf text_format output

### DIFF
--- a/protobuf.spec
+++ b/protobuf.spec
@@ -14,6 +14,8 @@
 Source: https://github.com/protocolbuffers/protobuf/archive/v%{realversion}.zip
 Requires: zlib
 BuildRequires: cmake ninja
+# improves text_format printing
+Patch0: protobuf_text_format
 
 %prep
 %setup -n %{n}-%{realversion}

--- a/protobuf.spec
+++ b/protobuf.spec
@@ -19,6 +19,7 @@ Patch0: protobuf_text_format
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 # Make sure the default c++sdt stand is c++11
 grep -q 'CMAKE_CXX_STANDARD  *11' CMakeLists.txt
 sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt

--- a/protobuf_text_format.patch
+++ b/protobuf_text_format.patch
@@ -1,0 +1,15 @@
+diff --git a/python/google/protobuf/text_format.py b/python/google/protobuf/text_format.py
+index a6d8bcf64..24da4cac5 100644
+--- a/python/google/protobuf/text_format.py
++++ b/python/google/protobuf/text_format.py
+@@ -470,9 +470,7 @@ class _Printer(object):
+           entry_submsg = value.GetEntryClass()(key=key, value=value[key])
+           self.PrintField(field, entry_submsg)
+       elif field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
+-        if (self.use_short_repeated_primitives
+-            and field.cpp_type != descriptor.FieldDescriptor.CPPTYPE_MESSAGE
+-            and field.cpp_type != descriptor.FieldDescriptor.CPPTYPE_STRING):
++        if self.use_short_repeated_primitives:
+           self._PrintShortRepeatedPrimitivesValue(field, value)
+         else:
+           for element in value:


### PR DESCRIPTION
This PR applies a small patch to protobuf so that text output from the `text_format` Python API avoids repetition for both primitive types and message types. This is used to get more concise printouts from the `cmsTritonConfigTool` (see https://github.com/cms-sw/cmssw/issues/43695 and https://github.com/cms-sw/cmssw/pull/43696).