### PR TITLE
Fix gsl-config so that by default it uses openblas lib

### DIFF
--- a/gsl.spec
+++ b/gsl.spec
@@ -51,6 +51,9 @@ rm -f %{i}/lib/*.la
 #https://github.com/cms-sw/cmsdist/issues/5528
 mkdir %i/cblas
 mv  %i/lib/libgslcblas* %i/cblas/
+
+#Make sure openblas library exists
+test ${OPENBLAS_ROOT}/lib/libopenblas.%{dynamic_lib_ext}
 sed -i -e "s|-lgslcblas|-L${OPENBLAS_ROOT}/lib -lopenblas|" %{i}/bin/gsl-config
 
 %post

--- a/gsl.spec
+++ b/gsl.spec
@@ -1,5 +1,4 @@
 ### RPM external gsl 2.6
-## INITENV SET GSL_CBLAS_LIB -L${OPENBLAS_ROOT}/lib -lopenblas
 Source: ftp://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
 Requires: OpenBLAS
 %define runpath_opts -m cblas
@@ -52,6 +51,7 @@ rm -f %{i}/lib/*.la
 #https://github.com/cms-sw/cmsdist/issues/5528
 mkdir %i/cblas
 mv  %i/lib/libgslcblas* %i/cblas/
+sed -i -e "s|-lgslcblas|-L${OPENBLAS_ROOT}/lib -lopenblas|" %{i}/bin/gsl-config
 
 %post
 %{relocateConfig}bin/gsl-config


### PR DESCRIPTION
This fixes the `gsl-config` script to by default use openblas library (see https://github.com/cms-sw/cmssw/issues/42716 for details)