### PR TITLE
Update py-pillow to 10.2.0

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -237,7 +237,7 @@ pathspec==0.11.1
 pbr==5.11.1
 pexpect==4.8.0
 pickleshare==0.7.5
-pillow==10.2.1
+pillow==10.2.0
 pkgconfig==1.5.5
 plac==1.3.5
 platformdirs==3.2.0

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -237,7 +237,7 @@ pathspec==0.11.1
 pbr==5.11.1
 pexpect==4.8.0
 pickleshare==0.7.5
-pillow==10.0.1
+pillow==10.2.1
 pkgconfig==1.5.5
 plac==1.3.5
 platformdirs==3.2.0


### PR DESCRIPTION
Pillow through 10.1.0 allows PIL.ImageMath.eval Arbitrary Code Execution via the environment parameter, a different vulnerability than https://github.com/advisories/GHSA-8vj2-vxx3-667w (which was about the expression parameter).