### PR TITLE
Update tag for RecoEgamma-EgammaPhotonProducers to V00-05-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoEgamma-EgammaPhotonProducers=V00-05-00
 RecoMuon-MuonIdentification=V01-16-00
 DataFormats-L1Scouting=V00-01-00
 DataFormats-L1ScoutingRawData=V00-01-00
@@ -17,7 +18,6 @@ RecoTauTag-TrainingFiles=V00-08-00
 IOPool-Input=V00-03-00
 RecoBTag-Combined=V01-19-00
 DQM-Integration=V00-05-00
-RecoEgamma-EgammaPhotonProducers=V00-04-00
 DataFormats-DetId=V00-01-00
 RecoTracker-TkSeedGenerator=V00-03-00
 DataFormats-SiStripCluster=V00-01-00


### PR DESCRIPTION
Move RecoEgamma-EgammaPhotonProducers data to new tag, see 
https://github.com/cms-data/RecoEgamma-EgammaPhotonProducers/pull/5
