### PR TITLE
[CRAB] Remove deployment of crab/examples

### DIFF
--- a/crab-build.file
+++ b/crab-build.file
@@ -56,6 +56,6 @@ fi
 %post
 cd ${RPM_INSTALL_PREFIX}
 mkdir -p share/%{pkgdir}
-for dir in bin lib etc examples; do
+for dir in bin lib etc; do
   rsync -a %{pkgrel}/${dir}/ share/%{pkgdir}/${dir}/
 done

--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.240110
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.231215

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.231010
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.231006

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.240110
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.231215


### PR DESCRIPTION
This drops the deployment of `crab/examples` directory which was removed in `v3.230417.01`. As this change is in common `crab-build-file` so `version_suffix` for all `crab-[pre|prod|dev]` needs an increment. 

Due to missing `examples` directory we get following error message at install time

```
16:20:31 rsync: change_dir "/cvmfs/cms.cern.ch//el8_amd64_gcc12/cms/crab-prod/v3.240110.00/examples" failed: No such file or directory (2)
16:20:31 rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1189) [sender=3.1.3]

```