### PR TITLE
Update GBL to V03-01-00

### DIFF
--- a/gbl.spec
+++ b/gbl.spec
@@ -1,6 +1,6 @@
-### RPM external gbl V02-04-01
+### RPM external gbl V03-01-00
 ## INCLUDE cpp-standard
-%define tag 31e726d777fe93cdbed0c363dc15f803f7767f40
+%define tag 45bba8092133fefad57e82e7b91fb783075bb978
 Source: git+https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake


### PR DESCRIPTION
* Update of GBL software version for tracker alignment calibration
* Main implementation in the new GBL version is THICK scatterers at GblPoints
* Works with new MP version in the PR here: https://github.com/cms-sw/cmsdist/pull/8953
* See presentation [here](https://indico.cern.ch/event/1363492/#27-new-mp2-solution-method-par) at TrkAl meeting (09.01.2024) by C. Kleinwort with overview of method and performance summary from test campaign.