### PR TITLE
Build gbl for multivectorization release due to its eigen dependency

### DIFF
--- a/cmssw-vectorization.file
+++ b/cmssw-vectorization.file
@@ -1,2 +1,2 @@
-%define vectorized_packages zlib fastjet tensorflow-sources tensorflow OpenBLAS rivet
+%define vectorized_packages zlib fastjet tensorflow-sources tensorflow OpenBLAS rivet gbl
 %{expand:%(for t in %{vectorized_packages} ; do echo Requires: $t; for v in %{package_vectorization}; do echo Requires: ${t}_${v}; done; done)}

--- a/gbl.spec
+++ b/gbl.spec
@@ -1,6 +1,6 @@
 ### RPM external gbl V02-04-01
 ## INCLUDE cpp-standard
-
+## INCLUDE cpp-standard
 %define tag 31e726d777fe93cdbed0c363dc15f803f7767f40
 Source: git+https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
@@ -19,8 +19,10 @@ cd build
 cmake ../cpp \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_VERBOSE_MAKEFILE=ON \
   -DEIGEN3_INCLUDE_DIR=${EIGEN_ROOT}/include/eigen3 \
   -DSUPPORT_ROOT=False \
+  -DCMAKE_CXX_FLAGS="-msse3" \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard}
 
 make %{makeprocesses}

--- a/gbl.spec
+++ b/gbl.spec
@@ -1,9 +1,7 @@
 ### RPM external gbl V02-04-01
 ## INCLUDE cpp-standard
-## INCLUDE cpp-standard
 %define tag 31e726d777fe93cdbed0c363dc15f803f7767f40
 Source: git+https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-
 
 BuildRequires: cmake
 Requires: eigen

--- a/gbl.spec
+++ b/gbl.spec
@@ -20,7 +20,7 @@ cmake ../cpp \
   -DCMAKE_VERBOSE_MAKEFILE=ON \
   -DEIGEN3_INCLUDE_DIR=${EIGEN_ROOT}/include/eigen3 \
   -DSUPPORT_ROOT=False \
-  -DCMAKE_CXX_FLAGS="-msse3" \
+  -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64 -msse3" \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard}
 
 make %{makeprocesses}

--- a/scram-tools.file/tools/eigen/eigen.xml
+++ b/scram-tools.file/tools/eigen/eigen.xml
@@ -5,5 +5,6 @@
   </client>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags CPPDEFINES="EIGEN_DONT_PARALLELIZE"/>
+  <flags CPPDEFINES="EIGEN_MAX_ALIGN_BYTES=64"/>
   <flags CUDA_FLAGS="--diag-suppress 20014"/>
 </tool>

--- a/scram-tools.file/tools/gbl/vectorized.tmpl
+++ b/scram-tools.file/tools/gbl/vectorized.tmpl
@@ -1,0 +1,5 @@
+<tool name="gbl_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@">
+  <client>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib" type="path"/>
+  </client>
+</tool>

--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -17,6 +17,7 @@ if machine() == "x86_64":
     "tensorflow",
     "OpenBLAS",
     "rivet",
+    "gbl",
   ]
   VALID_TARGETS = {
     "nehalem":     "-march=nehalem",


### PR DESCRIPTION
Enable GBL multi-arch build CMSSW. See details at https://github.com/cms-sw/cmssw/issues/43801 .