### PR TITLE
pypi: Update cryptography 42.0.2

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -75,7 +75,7 @@ coverage==7.2.2
 cppy==1.2.1
 # Newer versions of py3-cryptography require OpenSSL 1.1.0+, see https://github.com/pyca/cryptography/issues/5906
 cryptography==3.2.1 ; cmsos_name=='slc7'
-cryptography==41.0.7
+cryptography==42.0.2
 cx-Oracle==8.3.0
 cycler==0.11.0
 cython==0.29.35


### PR DESCRIPTION
Python Cryptography package vulnerable to Bleichenbacher timing oracle attack (https://github.com/cms-sw/cmsdist/security/dependabot/300)