### PR TITLE
BuildRule: Fix emdplugin cache for multiarch builds

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-02-04
+%define configtag       V09-02-05
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-02-05
+%define configtag       V09-03-00
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
We had stopped building cuda/romc backends of alpaka for extra micro-archs of MULTIARCHS/SKYLAKE IBs. Thsi caused runtime issue as the `lib/arch/microarch/.edmplugin` is a symlink to `lib/arch/.edmplugin` and CMS FW was trying to load the `CudaAsync.so` libs from the ``lib/arch/microarch` ( as the `lib/arch/microarch/.edmplugin`  still had the ref to it). The buildrule update fixes these issue and instead of creaing symlink it now properly creates a separate `.edmplugincache` file for each  `lib/arch/microarch/.edmplugin`