### PR TITLE
[14.0.X] Buildrule: Fix emdplugin cache for multiarch builds

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-02-03
+%define configtag       V09-02-06
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/8990

Buf fix for Multi-arch/skylake IBs