### PR TITLE
cmssw-elN: Drop -i option to not run in interactive mode

### DIFF
--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 240110.0
+### RPM cms cmssw-osenv 240213.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit 5b0a846d3885a9037893eb628da5f2e9e444b6f6
+%define commit 0593460f625758bbb9e1bc90b39fd17ab687c756
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.


### PR DESCRIPTION
See https://cms-talk.web.cern.ch/t/problem-with-running-cmssw-singularity-images-on-lxplus9/34577/9