### PR TITLE
CepGen 1.2.0

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.1.0
+### RPM external cepgen 1.2.0
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 


### PR DESCRIPTION
This PR bumps the CepGen version to 1.2.0.
This fortunately solves a few issues preventing to proceed in the delivery of an EDFilter to ease the production of central exclusive event samples.

As usual, please have a look at https://github.com/cepgen/cepgen/releases/tag/1.2.0 and https://cepgen.hepforge.org/changelog.html to get an idea of the changelog.