### PR TITLE
CepGen 1.2.1

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.2.0
+### RPM external cepgen 1.2.1
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 


### PR DESCRIPTION
This PR bumps the CepGen version to 1.2.1.
It allows to fix the issue observed with the production architecture currently using ROOT version 6.26, along with introducing a few patches to simplify the BuildFile of the new `GeneratorInterface/CepGenInterface` introduced in https://github.com/cms-sw/cmssw/pull/44072.

Changelog available at https://github.com/cepgen/cepgen/releases/tag/1.2.1.