### PR TITLE
[14_0_X] Update UTM to 0.12.0

### DIFF
--- a/utm.spec
+++ b/utm.spec
@@ -1,4 +1,4 @@
-### RPM external utm utm_0.11.2
+### RPM external utm utm_0.12.0
 Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake
 Requires: xerces-c boost


### PR DESCRIPTION
An updated utm library (version 0.12.0) is available: https://gitlab.cern.ch/cms-l1t-utm/utm/-/tree/utm_0.12.0/

cms-sw/cmssw#44054 needs the UTM to be updated to this version.

Backport of https://github.com/cms-sw/cmsdist/pull/9029.