### PR TITLE
[12_4_X] Added cepgen 1.2.1patch1 to standard CMSSW tools

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,0 +1,40 @@
+### RPM external cepgen 1.2.1
+
+Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
+
+BuildRequires: cmake ninja
+Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib zlib xz
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+export GSL_DIR=${GSL_ROOT}
+export OPENBLAS_DIR=${OPENBLAS_ROOT}
+export HEPMC_DIR=${HEPMC_ROOT}
+export HEPMC3_DIR=${HEPMC3_ROOT}
+export LHAPDF_PATH=${LHAPDF_ROOT}
+export PYTHIA6_DIR=${PYTHIA6_ROOT}
+export ROOTSYS=${ROOT_ROOT}
+
+cmake ../%{n}-%{realversion} \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX:PATH="%i" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="${BZ2LIB_ROOT};${ZLIB_ROOT};${XZ_ROOT}"
+
+ninja -v %{makeprocesses}
+
+%install
+cd ../build
+ninja %{makeprocesses} install
+
+case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
+rm -f %i/lib/libCepGen*-[A-Z]*-%realversion.$so
+
+%post
+%{relocateConfig}bin/cepgen

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -3,7 +3,7 @@
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
 BuildRequires: cmake ninja
-Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib zlib xz
+Requires: gsl OpenBLAS hepmc lhapdf pythia6 root bz2lib zlib xz
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -16,7 +16,6 @@ cd ../build
 export GSL_DIR=${GSL_ROOT}
 export OPENBLAS_DIR=${OPENBLAS_ROOT}
 export HEPMC_DIR=${HEPMC_ROOT}
-export HEPMC3_DIR=${HEPMC3_ROOT}
 export LHAPDF_PATH=${LHAPDF_ROOT}
 export PYTHIA6_DIR=${PYTHIA6_ROOT}
 export ROOTSYS=${ROOT_ROOT}

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.2.1
+### RPM external cepgen 1.2.1patch1
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 

--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.18.2
+### RPM external cmake 3.25.2
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -12,6 +12,7 @@ Requires: starlight
 Requires: alpgen
 Requires: boost
 Requires: bz2lib
+Requires: cepgen
 Requires: classlib
 Requires: clhep
 Requires: coral

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,0 +1,22 @@
+<tool name="cepgen" version="@TOOL_VERSION@">
+  <info url="https://cepgen.hepforge.org/"/>
+  <lib name="CepGen"/>
+  <lib name="CepGenHepMC2"/>
+  <lib name="CepGenHepMC3"/>
+  <lib name="CepGenLHAPDF"/>
+  <lib name="CepGenProcesses"/>
+  <lib name="CepGenPythia6"/>
+  <client>
+    <environment name="CEPGEN_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CEPGEN_BASE/lib64"/>
+    <environment name="INCLUDE" default="$CEPGEN_BASE/include"/>
+  </client>
+  <runtime name="PATH" value="$CEPGEN_BASE/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$CEPGEN_BASE/share/CepGen"/>
+  <use name="gsl"/>
+  <use name="OpenBLAS"/>
+  <use name="hepmc"/>
+  <use name="hepmc3"/>
+  <use name="lhapdf"/>
+  <use name="pythia6"/>
+</tool>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -2,7 +2,6 @@
   <info url="https://cepgen.hepforge.org/"/>
   <lib name="CepGen"/>
   <lib name="CepGenHepMC2"/>
-  <lib name="CepGenHepMC3"/>
   <lib name="CepGenLHAPDF"/>
   <lib name="CepGenProcesses"/>
   <lib name="CepGenPythia6"/>
@@ -16,7 +15,6 @@
   <use name="gsl"/>
   <use name="OpenBLAS"/>
   <use name="hepmc"/>
-  <use name="hepmc3"/>
   <use name="lhapdf"/>
   <use name="pythia6"/>
 </tool>


### PR DESCRIPTION
- cloned from CLHEP spec-file
- with interfacing libraries for HepMC2/3 (event output), LHAPDF (partonic photon PDF), and Pythia 6 ("legacy" proton remnant dissociation)
- requires GSL, OpenBLAS, bzlib2
- collateral damage: CMake bumped to version 3.25.2

Backport of #8023, #8089, #8319, #8329, #9030, #9033
FYI: @bbilin