### PR TITLE
[13_0_X] Bump cepgen to 1.2.1patch1

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.2.1
+### RPM external cepgen 1.2.1patch1
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,9 +1,9 @@
-### RPM external cepgen 1.0.2patch1
+### RPM external cepgen 1.2.1
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
 BuildRequires: cmake ninja
-Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root
+Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib zlib xz
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -24,7 +24,8 @@ export ROOTSYS=${ROOT_ROOT}
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
-  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="${BZ2LIB_ROOT};${ZLIB_ROOT};${XZ_ROOT}"
 
 ninja -v %{makeprocesses}
 

--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.18.2
+### RPM external cmake 3.25.2
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib


### PR DESCRIPTION
Bump of CepGen to version 1.2.1patch1 (to be in sync with #9042 and #9040)

- additionally requires bzlib2
- collateral damage: CMake bumped to version 3.25.2

Backport of #8329, #9030, #9033
FYI: @bbilin