### PR TITLE
[10_6_X] Added cepgen 1.2.1patch1 to standard CMSSW tools

### DIFF
--- a/cepgen-toolfile.spec
+++ b/cepgen-toolfile.spec
@@ -1,0 +1,33 @@
+### RPM external cepgen-toolfile 1.0
+Requires: cepgen
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/cepgen.xml
+<tool name="cepgen" version="@TOOL_VERSION@">
+  <info url="https://cepgen.hepforge.org/"/>
+  <lib name="CepGen"/>
+  <lib name="CepGenHepMC2"/>
+  <lib name="CepGenLHAPDF"/>
+  <lib name="CepGenProcesses"/>
+  <lib name="CepGenPythia6"/>
+  <client>
+    <environment name="CEPGEN_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CEPGEN_BASE/lib64"/>
+    <environment name="INCLUDE" default="$CEPGEN_BASE/include"/>
+  </client>
+  <runtime name="PATH" value="$CEPGEN_BASE/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$CEPGEN_BASE/share/CepGen"/>
+  <use name="gsl"/>
+  <use name="OpenBLAS"/>
+  <use name="hepmc"/>
+  <use name="lhapdf"/>
+  <use name="pythia6"/>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,0 +1,39 @@
+### RPM external cepgen 1.2.1patch1_gcc700
+
+Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
+Patch: cepgen_nopython_noroot
+
+BuildRequires: cmake gmake
+Requires: gsl OpenBLAS hepmc lhapdf pythia6 bz2lib zlib xz
+
+%prep
+%setup -n %{n}-%{realversion}
+%patch -p1
+
+%build
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+export GSL_DIR=${GSL_ROOT}
+export OPENBLAS_DIR=${OPENBLAS_ROOT}
+export HEPMC_DIR=${HEPMC_ROOT}
+export LHAPDF_PATH=${LHAPDF_ROOT}
+export PYTHIA6_DIR=${PYTHIA6_ROOT}
+
+cmake ../%{n}-%{realversion} \
+  -DCMAKE_INSTALL_PREFIX:PATH="%i" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="${BZ2LIB_ROOT};${ZLIB_ROOT};${XZ_ROOT}"
+
+make %{makeprocesses}
+
+%install
+cd ../build
+make install
+
+case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
+rm -f %i/lib/libCepGen*-[A-Z]*-%realversion.$so
+
+%post
+%{relocateConfig}bin/cepgen

--- a/cepgen_nopython_noroot.patch
+++ b/cepgen_nopython_noroot.patch
@@ -1,0 +1,15 @@
+diff --git a/CepGenAddOns/CMakeLists.txt b/CepGenAddOns/CMakeLists.txt
+index 27ac884a..9eb9d422 100644
+--- a/CepGenAddOns/CMakeLists.txt
++++ b/CepGenAddOns/CMakeLists.txt
+@@ -14,10 +14,8 @@ add_subdirectory(PhotosTauolaWrapper)
+ add_subdirectory(ProMCWrapper)
+ add_subdirectory(Pythia6Wrapper)
+ add_subdirectory(Pythia8Wrapper)
+-add_subdirectory(PythonWrapper)
+ add_subdirectory(REvolverWrapper)
+ add_subdirectory(RivetWrapper)
+-add_subdirectory(ROOTWrapper)
+ add_subdirectory(TopdrawerWrapper)
+
+ add_subdirectory(Functionals)

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -18,6 +18,7 @@ Requires: starlight-toolfile
 Requires: alpgen-toolfile
 Requires: boost-toolfile
 Requires: bz2lib-toolfile
+Requires: cepgen-toolfile
 Requires: charybdis-toolfile
 Requires: classlib-toolfile
 Requires: clhep-toolfile


### PR DESCRIPTION
- cloned from CLHEP spec-file
- with interfacing libraries for HepMC2/3 (event output), LHAPDF (partonic photon PDF), and Pythia 6 ("legacy" proton remnant dissociation)
- dropped HepMC3/Python/ROOT support for now (most likely not needed in 10_6_X workflows)
- requires GSL, OpenBLAS, bzlib2

Backport of https://github.com/cms-sw/cmsdist/pull/8023, https://github.com/cms-sw/cmsdist/pull/8089, https://github.com/cms-sw/cmsdist/pull/8319, https://github.com/cms-sw/cmsdist/pull/8329, https://github.com/cms-sw/cmsdist/pull/9030, https://github.com/cms-sw/cmsdist/pull/9033
FYI: @bbilin