### PR TITLE
[DO NOT MERGE] Test making Eigen alignment setting consistent

### DIFF
--- a/lwtnn.spec
+++ b/lwtnn.spec
@@ -1,4 +1,4 @@
-### RPM external lwtnn 2.13
+### RPM external lwtnn 2.14.1
 ## INCLUDE cpp-standard
 
 Source: https://github.com/lwtnn/lwtnn/archive/v%{realversion}.tar.gz

--- a/lwtnn.spec
+++ b/lwtnn.spec
@@ -17,7 +17,11 @@ cd ../build
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_CXX_COMPILER="g++" \
-  -DCMAKE_CXX_FLAGS="-fPIC" \
+  %ifarch x86_64
+  -DCMAKE_CXX_FLAGS="-fPIC -DEIGEN_MAX_ALIGN_BYTES=64 -msse3" \
+  %else
+  -DCMAKE_CXX_FLAGS="-fPIC -DEIGEN_MAX_ALIGN_BYTES=64" \
+  %endif
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILTIN_BOOST=OFF \

--- a/opencv.spec
+++ b/opencv.spec
@@ -23,6 +23,11 @@ cmake ../%{n}-%{realversion} \
     -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DWITH_EIGEN=ON \
+    %ifarch x86_64
+    -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64 -msse3" \
+    %else
+    -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64" \
+     %endif
     -DBUILD_EXAMPLES=OFF \
     -DWITH_QT=OFF \
     -DWITH_GTK=OFF \

--- a/pytorch.spec
+++ b/pytorch.spec
@@ -74,6 +74,11 @@ cmake ../%{n}-%{realversion} \
     -DUSE_SYSTEM_FXDIV=ON \
     -DUSE_SYSTEM_PYBIND11=ON \
     -DUSE_SYSTEM_BENCHMARK=ON \
+    %ifarch x86_64
+    -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64 -msse3" \
+    %else
+    -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64" \
+    %endif
     -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
     -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3
 


### PR DESCRIPTION
Following https://github.com/cms-sw/cmssw/issues/44188#issuecomment-1971628271 This PR attempts to use consistent alignment options for Eigen in the remaining externals depending on Eigen.

I skipped `professor2` because of not feeling proficient enough in RPM spec syntax, and it not being linked against in CMSSW.

I think we'd also want a better way to propagate these settings.