### PR TITLE
[10_6_X-gcc820] Added cepgen 1.2.1patch1 to standard CMSSW tools

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,0 +1,40 @@
+### RPM external cepgen 1.2.1patch1
+
+Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
+
+BuildRequires: cmake ninja
+Requires: gsl OpenBLAS hepmc lhapdf pythia6 root bz2lib zlib xz
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+export GSL_DIR=${GSL_ROOT}
+export OPENBLAS_DIR=${OPENBLAS_ROOT}
+export HEPMC_DIR=${HEPMC_ROOT}
+export HEPMC3_DIR=${HEPMC3_ROOT}
+export LHAPDF_PATH=${LHAPDF_ROOT}
+export PYTHIA6_DIR=${PYTHIA6_ROOT}
+export ROOTSYS=${ROOT_ROOT}
+
+cmake ../%{n}-%{realversion} \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX:PATH="%i" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="${BZ2LIB_ROOT};${ZLIB_ROOT};${XZ_ROOT}"
+
+ninja -v %{makeprocesses}
+
+%install
+cd ../build
+ninja %{makeprocesses} install
+
+case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
+rm -f %i/lib/libCepGen*-[A-Z]*-%realversion.$so
+
+%post
+%{relocateConfig}bin/cepgen

--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.17.2
+### RPM external cmake 3.25.2
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib

--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -18,6 +18,7 @@ Requires: starlight-toolfile
 Requires: alpgen-toolfile
 Requires: boost-toolfile
 Requires: bz2lib-toolfile
+Requires: cepgen
 Requires: charybdis-toolfile
 Requires: classlib-toolfile
 Requires: clhep-toolfile

--- a/ninja.spec
+++ b/ninja.spec
@@ -1,4 +1,4 @@
-### RPM external ninja 1.8.2
+### RPM external ninja 1.10.0
 Source0: git://github.com/ninja-build/ninja.git?obj=release/v%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: python re2c

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,0 +1,20 @@
+<tool name="cepgen" version="@TOOL_VERSION@">
+  <info url="https://cepgen.hepforge.org/"/>
+  <lib name="CepGen"/>
+  <lib name="CepGenHepMC2"/>
+  <lib name="CepGenLHAPDF"/>
+  <lib name="CepGenProcesses"/>
+  <lib name="CepGenPythia6"/>
+  <client>
+    <environment name="CEPGEN_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$CEPGEN_BASE/lib64"/>
+    <environment name="INCLUDE" default="$CEPGEN_BASE/include"/>
+  </client>
+  <runtime name="PATH" value="$CEPGEN_BASE/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$CEPGEN_BASE/share/CepGen"/>
+  <use name="gsl"/>
+  <use name="OpenBLAS"/>
+  <use name="hepmc"/>
+  <use name="lhapdf"/>
+  <use name="pythia6"/>
+</tool>


### PR DESCRIPTION
This attempts to build CepGen 1.2.1patch1 using gcc820, as #9042 shows an important refactoring is needed to be able to build with gcc700.

Main features:

- cloned from CLHEP spec-file
- with interfacing libraries for HepMC2/3 (event output), LHAPDF (partonic photon PDF), and Pythia 6 ("legacy" proton remnant dissociation)
- requires GSL, OpenBLAS, bzlib2
- collateral damages: CMake bumped to version 3.25.2, Ninja bumped to version 1.10.0

Backport of https://github.com/cms-sw/cmsdist/pull/8023, https://github.com/cms-sw/cmsdist/pull/8089, https://github.com/cms-sw/cmsdist/pull/8319, https://github.com/cms-sw/cmsdist/pull/8329, https://github.com/cms-sw/cmsdist/pull/9030, https://github.com/cms-sw/cmsdist/pull/9033
FYI: @bbilin