### PR TITLE
Update to CUDA 12.4.0

### DIFF
--- a/celeritas.spec
+++ b/celeritas.spec
@@ -9,6 +9,7 @@ Source: git+https://github.com/celeritas-project/celeritas?obj=develop/%{tag}&ex
 BuildRequires: cmake
 
 %define build_flags -Wall -Wextra -pedantic %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}
+Requires: python3
 Requires: json
 Requires: geant4
 Requires: vecgeom

--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.25.2
+### RPM external cmake 3.28.3
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib
@@ -20,6 +20,7 @@ cat > build-flags.cmake <<- EOF
 	SET(BUILD_CursesDialog FALSE CACHE BOOL "" FORCE)
 
 	# Use system libraries, not cmake bundled ones.
+	SET(CMAKE_USE_OPENSSL TRUE CACHE BOOL "" FORCE)
 	SET(CMAKE_USE_SYSTEM_LIBRARY_CURL TRUE CACHE BOOL "" FORCE)
 	SET(CMAKE_USE_SYSTEM_LIBRARY_ZLIB TRUE CACHE BOOL "" FORCE)
 	SET(CMAKE_USE_SYSTEM_LIBRARY_BZIP2 TRUE CACHE BOOL "" FORCE)

--- a/cuda-compatible-runtime.spec
+++ b/cuda-compatible-runtime.spec
@@ -11,11 +11,11 @@ Requires: cuda
 
 %build
 ## INCLUDE cuda-flags
-# defines nvcc_stdcxx and cuda_flags_4
+# defines nvcc_flags_stdcxx and nvcc_flags_cuda_archs
 
 rm -rf %{_builddir}/build && mkdir %{_builddir}/build
 if
-  $CUDA_ROOT/bin/nvcc %{nvcc_stdcxx} -O2 -g %{cuda_flags_4} test.cu -I $CUDA_ROOT/include -L $CUDA_ROOT/lib64 -L $CUDA_ROOT/lib64/stubs --cudart static -ldl -lrt --compiler-options '-Wall -pthread' -o %{_builddir}/build/cuda-compatible-runtime
+  $CUDA_ROOT/bin/nvcc %{nvcc_flags_stdcxx} -O2 -g %{nvcc_flags_cuda_archs} test.cu -I $CUDA_ROOT/include -L $CUDA_ROOT/lib64 -L $CUDA_ROOT/lib64/stubs --cudart static -ldl -lrt --compiler-options '-Wall -pthread' -o %{_builddir}/build/cuda-compatible-runtime
 then
   true
 else

--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -5,32 +5,39 @@
 # build support for Pascal (6.x), Volta (7.0), Turing (7.5), Ampere (8.x) and Lovelace (8.9)
 %define cuda_arch 60 70 75 80 89
 
+# LIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES style for listing the supported CUDA compute architectures
+%define omptarget_cuda_archs %(echo $(for ARCH in %cuda_arch; do echo "$ARCH"; done) | sed -e"s/ /,/g")
+
 # LLVM style for listing the supported CUDA compute architectures
-%define llvm_cuda_arch %(echo $(for ARCH in %cuda_arch; do echo "$ARCH"; done) | sed -e"s/ /,/g")
+%define llvm_flags_cuda_archs %(echo $(for ARCH in %cuda_arch; do echo "--offload-arch=sm_$ARCH"; done)) -Wunknown-cuda-version
 
 # C++ standard to use for building host and device code with nvcc
-%define nvcc_stdcxx -std=c++%{cms_cxx_standard}
+%define nvcc_flags_stdcxx -std=c++%{cms_cxx_standard}
 
 # generate optimised code
-%define cuda_flags_0 -O3
+%define nvcc_flags_opt -O3
 
 # generate debugging information for device code
-%define cuda_flags_1 --generate-line-info --source-in-ptx --display-error-number
+%define nvcc_flags_debug --generate-line-info --source-in-ptx --display-error-number
 
 # imply __host__, __device__ attributes in constexpr functions
-%define cuda_flags_2 --expt-relaxed-constexpr
+%define nvcc_flags_constexpr --expt-relaxed-constexpr
 
 # allow __host__, __device__ attributes in lambda declaration
-%define cuda_flags_3 --extended-lambda
+%define nvcc_flags_lambda --extended-lambda
 
 # build support for the various compute architectures
-%define cuda_flags_4 %(echo $(for ARCH in %cuda_arch; do echo "-gencode arch=compute_$ARCH,code=[sm_$ARCH,compute_$ARCH]"; done)) -Wno-deprecated-gpu-targets
+%define nvcc_flags_cuda_archs %(echo $(for ARCH in %cuda_arch; do echo "-gencode arch=compute_$ARCH,code=[sm_$ARCH,compute_$ARCH]"; done)) -Wno-deprecated-gpu-targets
 
 # disable warnings about attributes on defaulted methods
-%define cuda_flags_5 -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+%define nvcc_flags_cudafe_diag -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+
+# override the version of GCC passed to cudafe++
+%define override_gnu_version $(gcc -dumpfullversion | { IFS=.; read MAJOR MINOR PATCH; echo $(((MAJOR * 100 + MINOR) * 100)); })
+%define nvcc_flags_gnu_version -Xcudafe --gnu_version=%{override_gnu_version}
 
 # link the CUDA runtime shared library
-%define cuda_flags_6 --cudart shared
+%define nvcc_flags_cudart --cudart shared
 
 # collect all CUDA flags
-%define nvcc_cuda_flags %{nvcc_stdcxx} %{cuda_flags_0} %{cuda_flags_1} %{cuda_flags_2} %{cuda_flags_3} %{cuda_flags_4} %{cuda_flags_5} %{cuda_flags_6}
+%define nvcc_cuda_flags %{nvcc_flags_stdcxx} %{nvcc_flags_opt} %{nvcc_flags_debug} %{nvcc_flags_constexpr} %{nvcc_flags_lambda} %{nvcc_flags_cuda_archs} %{nvcc_flags_cudafe_diag} %{nvcc_flags_gnu_version} %{nvcc_flags_cudart}

--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 12.2.1
+### RPM external cuda 12.4.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 535.86.10
+%define driversversion 550.54.14
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,4 +1,4 @@
-### RPM external cudnn 8.8.0.121
+### RPM external cudnn 8.9.7.29
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define cudaver 12

--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.3
+### RPM external gdrcopy 2.4.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda

--- a/geant4.spec
+++ b/geant4.spec
@@ -2,7 +2,7 @@
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
-%define tag 2d5992376773d172321f01710a82943ead5bb435
+%define tag 0f1b33cb3d004830d88b4f9fab2c12b31ed69164
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz

--- a/llvm.spec
+++ b/llvm.spec
@@ -29,7 +29,7 @@ sed -ibak '/add_clang_subdirectory(libclang)/a add_subdirectory(include-what-you
 
 %build
 ## INCLUDE cuda-flags
-# defines llvm_cuda_arch
+# defines omptarget_cuda_archs
 
 rm -rf %{_builddir}/build
 mkdir -p %{_builddir}/build
@@ -51,7 +51,7 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -DLLVM_HOST_TRIPLE=$(gcc -dumpmachine) \
   -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64;NVPTX" \
   -DLIBOMPTARGET_NVPTX_ALTERNATE_HOST_COMPILER=/usr/bin/gcc \
-  -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES="%llvm_cuda_arch" \
+  -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES="%omptarget_cuda_archs" \
   -DCMAKE_REQUIRED_INCLUDES="${ZLIB_ROOT}/include" \
   -DCMAKE_PREFIX_PATH="${ZLIB_ROOT}"
 

--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -1,9 +1,9 @@
-### RPM external onnxruntime 1.14.1
+### RPM external onnxruntime 1.17.1
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## INCLUDE cuda-flags
 %define github_user cms-externals
 %define branch cms/v%{realversion}
-%define tag e4c6aa2984c7c71409f4c6d0db865117afa66932
+%define tag 5353412812a6f0409a15faff9a18640456ab1ff8
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake ninja
@@ -35,6 +35,7 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -Donnxruntime_USE_CUDA=${USE_CUDA} \
    -Donnxruntime_CUDA_HOME="${CUDA_ROOT}" \
    -Donnxruntime_CUDNN_HOME="${CUDNN_ROOT}" \
+   -Donnxruntime_NVCC_THREADS=0 \
    -Donnxruntime_BUILD_CSHARP=OFF \
    -Donnxruntime_USE_OPENMP=OFF \
    -Donnxruntime_USE_TVM=OFF \
@@ -53,10 +54,12 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
    -DCMAKE_TRY_COMPILE_PLATFORM_VARIABLES="CMAKE_CUDA_RUNTIME_LIBRARY" \
    -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${LIBPNG_ROOT};${PROTOBUF_ROOT};${PY3_PYBIND11_ROOT};${RE2_ROOT}" \
    -DRE2_INCLUDE_DIR="${RE2_ROOT}/include" \
-   -DCMAKE_CXX_FLAGS="-Wno-error=stringop-overflow"
+   -DCMAKE_CXX_FLAGS="-Wno-error=stringop-overflow -Wno-error=maybe-uninitialized"
 
-# False positive string overflow
-# https://github.com/google/flatbuffers/issues/7366
+# -Wno-error=stringop-overflow is needed to work around a false positive string overflow,
+# see https://github.com/google/flatbuffers/issues/7366
+
+# -Wno-error=maybe-uninitialized is needed for ONNX runtime 1.17.1 with cuDNN 8.9 or 9.0
 
 ninja -v %{makeprocesses}
 python3 ../%{n}-%{realversion}/setup.py build

--- a/pytorch.spec
+++ b/pytorch.spec
@@ -2,10 +2,10 @@
 ## INCLUDE cuda-flags
 
 %define cuda_arch_float $(echo %{cuda_arch} | tr ' ' '\\n' | sed -E 's|([0-9])$|.\\1|' | tr '\\n' ' ')
-%define tag v%{realversion}
-%define branch release/2.1
+%define tag bb938bbe9f53414dda1e1159795b7536dbffd041
+%define branch cms/v%{realversion}
 
-Source: git+https://github.com/pytorch/pytorch.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
+Source: git+https://github.com/cms-externals/pytorch.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 Source1: FindEigen3.cmake
 Source2: FindFMT.cmake
 Patch0: pytorch-ignore-different-cuda-include-dir

--- a/scram-tools.file/tool-env.file
+++ b/scram-tools.file/tool-env.file
@@ -13,7 +13,7 @@ export COMPILER_CXXFLAGS="%{arch_build_flags}"
 export COMPILER_WARNINGS="%{?warning_flags}"
 export ORACLE_ENV_ROOT=""
 export CUDA_FLAGS="%{nvcc_cuda_flags}"
-export CUDA_HOST_CXXFLAGS="%{nvcc_stdcxx}"
+export CUDA_HOST_CXXFLAGS="%{nvcc_flags_stdcxx}"
 export LTO_FLAGS="%{?lto_build_flags}"
 export PGO_FLAGS="%{?pgo_build_flags}"
 if [ $(echo ' %requiredtools ' | grep ' python3 ' |wc -l) -gt 0 ] ; then export PYTHON3_LIB_SITE_PACKAGES ; fi


### PR DESCRIPTION
### Update CMake to version 3.28.3.
  - backport from Geant4 v11.2.0 a fix for CMake 3.27 and later

### Update to CUDA 12.4.0:
  * CUDA runtime version 12.4.99
  * NVIDIA drivers version 550.54.14

See https://docs.nvidia.com/cuda/archive/12.4.0/cuda-toolkit-release-notes/index.html for the full CUDA 12.4.0 release notes and change log.

Force CUDA to consider only the major/minor version of GCC, to work around a problem in the GCC version checks inside `cudafe++`, where GCC 12.3.1 is not recognised as equivalent to GCC 12.3.0.

Rename the CUDA-related flags used in the spec files to avoid potential problems when adding,
removing or reordering them.

### Update cuDNN to version 8.9:

See https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-897/release-notes/index.html for the release notes and change log.

### Update NVIDIA gdrcopy to v2.4.1

Add support for new hardware (Grace Hopper, BlueField 3 NICs and DPUs).
Add support for recent OS (kernel, RHEL, SUSE).
Various bug fixes.

See https://github.com/NVIDIA/gdrcopy/releases/tag/v2.4 and https://github.com/NVIDIA/gdrcopy/releases/tag/v2.4.1 for the release notes and change log.

### Update ONNX runtime to version 1.17.1:

Older version of ONNX runtime fail to compile with CUDA 12.4.
On the other hand, ONNX 1.17.1 requires CMAKE 3.26 or later, and cuDNN 8.9 or later.

This version requires two more workarounds:
  - `-Wno-error=maybe-uninitialized` is needed to a void a (hopefully false positive) warning about a potentially uninitialised variable with cuDNN 8.9 and 9.0
  - `-Donnxruntime_NVCC_THREADS=0` is needed because the default is `ON`, causing nvcc to be called as `nvcc ... --threads ON ...`, which causes an error.

This version requires an update inside CMSSW, implemented in https://github.com/cms-sw/cmssw/pull/44354.

### Add missing thrust include in PyTorch

Backport of https://github.com/pytorch/pytorch/pull/121421.