### PR TITLE
 Update ROCm to version 5.6.1 [14.0.x]

### DIFF
--- a/rocm-rocrand.spec
+++ b/rocm-rocrand.spec
@@ -1,4 +1,4 @@
-### RPM external rocm-rocrand 5.6.0
+### RPM external rocm-rocrand 5.6.1
 ## NOCOMPILER
 
 %if "%{rhel}" == "7"
@@ -14,9 +14,10 @@
 # without any .0 in the directory name
 %define repoversion %(echo %{realversion} | sed -e's/\.0$//')
 
-Source0: https://%{repository}/%{repoversion}/main/rocrand-2.10.17.50600-67.el%{rhel}.%{_arch}.rpm
-Source1: https://%{repository}/%{repoversion}/main/rocrand-devel-2.10.17.50600-67.el%{rhel}.%{_arch}.rpm
+Source0: https://%{repository}/%{repoversion}/main/rocrand-2.10.17.50601-93.el%{rhel}.%{_arch}.rpm
+Source1: https://%{repository}/%{repoversion}/main/rocrand-devel-2.10.17.50601-93.el%{rhel}.%{_arch}.rpm
 Requires: rocm
+AutoReq: no
 
 %prep
 

--- a/rocm.spec
+++ b/rocm.spec
@@ -24,6 +24,9 @@ Source7: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.50600-
 Source8: https://%{repository}/%{repoversion}/main/rocm-llvm-16.0.0.23243.50600-67.el%{rhel}.%{_arch}.rpm
 Source9: https://%{repository}/%{repoversion}/main/rocm-smi-lib-5.0.0.50600-67.el%{rhel}.%{_arch}.rpm
 Source10: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.50600-67.el%{rhel}.%{_arch}.rpm
+Source11: https://%{repository}/%{repoversion}/main/openmp-extras-devel-16.56.0.50600-67.el%{rhel}.%{_arch}.rpm
+Source12: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-16.56.0.50600-67.el%{rhel}.%{_arch}.rpm
+Source13: https://%{repository}/%{repoversion}/main/rocm-openmp-sdk-5.6.0.50600-67.el%{rhel}.%{_arch}.rpm
 Requires: numactl zstd
 Requires: python3
 
@@ -41,6 +44,9 @@ rpm2cpio %{SOURCE7} | cpio -idmv
 rpm2cpio %{SOURCE8} | cpio -idmv
 rpm2cpio %{SOURCE9} | cpio -idmv
 rpm2cpio %{SOURCE10} | cpio -idmv
+rpm2cpio %{SOURCE11} | cpio -idmv
+rpm2cpio %{SOURCE12} | cpio -idmv
+rpm2cpio %{SOURCE13} | cpio -idmv
 
 %install
 rmdir %{i}

--- a/rocm.spec
+++ b/rocm.spec
@@ -1,4 +1,4 @@
-### RPM external rocm 5.6.0
+### RPM external rocm 5.6.1
 
 %if "%{rhel}" == "7"
 # allow rpm2cpio dependency on the bootstrap bundle
@@ -13,24 +13,25 @@
 # without any .0 in the directory name
 %define repoversion %(echo %{realversion} | sed -e's/\.0$//')
 
-Source0: https://%{repository}/%{repoversion}/main/comgr-2.5.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source1: https://%{repository}/%{repoversion}/main/hipcc-1.0.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source2: https://%{repository}/%{repoversion}/main/hip-devel-5.6.31061.50600-67.el%{rhel}.%{_arch}.rpm
-Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-5.6.31061.50600-67.el%{rhel}.%{_arch}.rpm
-Source4: https://%{repository}/%{repoversion}/main/hsa-rocr-1.9.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source5: https://%{repository}/%{repoversion}/main/rocm-core-5.6.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source6: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.70.1.50600-67.el%{rhel}.%{_arch}.rpm
-Source7: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source8: https://%{repository}/%{repoversion}/main/rocm-llvm-16.0.0.23243.50600-67.el%{rhel}.%{_arch}.rpm
-Source9: https://%{repository}/%{repoversion}/main/rocm-smi-lib-5.0.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source10: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source11: https://%{repository}/%{repoversion}/main/openmp-extras-devel-16.56.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source12: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-16.56.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source13: https://%{repository}/%{repoversion}/main/rocm-openmp-sdk-5.6.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source14: https://%{repository}/%{repoversion}/main/rocprim-devel-2.13.0.50600-67.el%{rhel}.%{_arch}.rpm
-Source15: https://%{repository}/%{repoversion}/main/rocthrust-devel-2.18.0.50600-67.el%{rhel}.%{_arch}.rpm
+Source0: https://%{repository}/%{repoversion}/main/comgr-2.5.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source1: https://%{repository}/%{repoversion}/main/hipcc-1.0.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source2: https://%{repository}/%{repoversion}/main/hip-devel-5.6.31062.50601-93.el%{rhel}.%{_arch}.rpm
+Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-5.6.31062.50601-93.el%{rhel}.%{_arch}.rpm
+Source4: https://%{repository}/%{repoversion}/main/hsa-rocr-1.9.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source5: https://%{repository}/%{repoversion}/main/rocm-core-5.6.1.50601-93.el%{rhel}.%{_arch}.rpm
+Source6: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.70.1.50601-93.el%{rhel}.%{_arch}.rpm
+Source7: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source8: https://%{repository}/%{repoversion}/main/rocm-llvm-16.0.0.23332.50601-93.el%{rhel}.%{_arch}.rpm
+Source9: https://%{repository}/%{repoversion}/main/rocm-smi-lib-5.0.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source10: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source11: https://%{repository}/%{repoversion}/main/openmp-extras-devel-16.56.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source12: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-16.56.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source13: https://%{repository}/%{repoversion}/main/rocm-openmp-sdk-5.6.1.50601-93.el%{rhel}.%{_arch}.rpm
+Source14: https://%{repository}/%{repoversion}/main/rocprim-devel-2.13.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source15: https://%{repository}/%{repoversion}/main/rocthrust-devel-2.18.0.50601-93.el%{rhel}.%{_arch}.rpm
 Requires: numactl zstd
 Requires: python3
+AutoReq: no
 
 %prep
 

--- a/rocm.spec
+++ b/rocm.spec
@@ -27,6 +27,8 @@ Source10: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.50600-67.el%{
 Source11: https://%{repository}/%{repoversion}/main/openmp-extras-devel-16.56.0.50600-67.el%{rhel}.%{_arch}.rpm
 Source12: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-16.56.0.50600-67.el%{rhel}.%{_arch}.rpm
 Source13: https://%{repository}/%{repoversion}/main/rocm-openmp-sdk-5.6.0.50600-67.el%{rhel}.%{_arch}.rpm
+Source14: https://%{repository}/%{repoversion}/main/rocprim-devel-2.13.0.50600-67.el%{rhel}.%{_arch}.rpm
+Source15: https://%{repository}/%{repoversion}/main/rocthrust-devel-2.18.0.50600-67.el%{rhel}.%{_arch}.rpm
 Requires: numactl zstd
 Requires: python3
 
@@ -47,6 +49,8 @@ rpm2cpio %{SOURCE10} | cpio -idmv
 rpm2cpio %{SOURCE11} | cpio -idmv
 rpm2cpio %{SOURCE12} | cpio -idmv
 rpm2cpio %{SOURCE13} | cpio -idmv
+rpm2cpio %{SOURCE14} | cpio -idmv
+rpm2cpio %{SOURCE15} | cpio -idmv
 
 %install
 rmdir %{i}


### PR DESCRIPTION
Update ROCm to version 5.6.1:
  - see https://rocm.docs.amd.com/en/docs-5.6.1/release.html for the list of changes and fixes.

Add the ROCm packages to support OpenMP and Thrust:
  -  the OpenMP packages are required to compile any source that uses `#pragma omp ...` with `hipcc`;
  - the Thrust packages are needed for compatibility with CUDA, and are used by the HIP backend of PyTorch.

Backport of #9050 to the data taking release.