### PR TITLE
Update gbl to V03-01-01 and millepede to V04-16-00

### DIFF
--- a/gbl.spec
+++ b/gbl.spec
@@ -1,6 +1,6 @@
-### RPM external gbl V02-04-01
+### RPM external gbl V03-01-01
 ## INCLUDE cpp-standard
-%define tag 31e726d777fe93cdbed0c363dc15f803f7767f40
+%define tag 59c2d99ea96bc739321fd251096504c91467be24
 Source: git+https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake

--- a/gbl.spec
+++ b/gbl.spec
@@ -8,6 +8,8 @@ Requires: eigen
 
 %prep
 %setup -q -n %{n}-%{realversion}
+grep -q 'CMAKE_CXX_STANDARD  *11' cpp/CMakeLists.txt
+sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' cpp/CMakeLists.txt
 
 %build
 rm -rf build
@@ -21,11 +23,10 @@ cmake ../cpp \
   -DEIGEN3_INCLUDE_DIR=${EIGEN_ROOT}/include/eigen3 \
   -DSUPPORT_ROOT=False \
   %ifarch x86_64
-  -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64 -msse3" \
+  -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64 -msse3" 
   %else
-  -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64" \
+  -DCMAKE_CXX_FLAGS="-DEIGEN_MAX_ALIGN_BYTES=64" 
   %endif
-  -DCMAKE_CXX_STANDARD=%{cms_cxx_standard}
 
 make %{makeprocesses}
 

--- a/millepede.spec
+++ b/millepede.spec
@@ -1,4 +1,4 @@
-### RPM external millepede V04-14-00
+### RPM external millepede V04-16-00
 Source: https://gitlab.desy.de/claus.kleinwort/millepede-ii/-/archive/%{realversion}/%{n}-ii-%{realversion}.tar.gz
 Requires: zlib
 


### PR DESCRIPTION
- Update of GBL software version for tracker alignment calibration with a fix for logic reported in [comment](https://github.com/cms-sw/cmssw/issues/44188#issuecomment-1971881496)
- Update of Millepede II version for Tracker Alignment

Backport to 14.0 will also be needed. Supersedes #8976 