### PR TITLE
Update NVIDIA gdrcopy to v2.4.1 [14.0.x]

### DIFF
--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.3
+### RPM external gdrcopy 2.4.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda


### PR DESCRIPTION
Changes in v2.4.1:
  - add support for persistent mapping
  - fix bug in src/gdrdrv/Makefile
  - fix compile-time bug when check.h is not found

Changes in v2.4:
  - various bug fixes in the test and benchmark applications
  - prefix all applications with "gdrcopy_"
  - introduce more unit tests in gdrcopy_sanity
  - introduce gdrcopy_pplat benchmark application
  - remove dependency on libcheck and libsubunit
  - introduce gdr_get_info_v2
  - introduce new copy algorithm for device mappings
  - add support for NVIDIA BLUEFIELD-3
  - add support for Linux kernel >= 6.3
  - add support for SLES and OpenSUSE
  - add support for systemd service on RHEL9
  - relicense gdrdrv to Dual MIT/GPL
  - fix bugs in gdrdrv when pinning two small buffers back-to-back
  - add support for coherent platforms such as Grace-Hopper
  - add support for Confidential Computing (CC)

Backport of #9058 to CMSSW 14.0.x.