### PR TITLE
Enable vectorization of lwtnn, opencv and pytorch

### DIFF
--- a/cmssw-vectorization.file
+++ b/cmssw-vectorization.file
@@ -1,2 +1,2 @@
-%define vectorized_packages zlib fastjet tensorflow-sources tensorflow OpenBLAS rivet gbl
+%define vectorized_packages zlib fastjet tensorflow-sources tensorflow OpenBLAS rivet gbl lwtnn opencv pytorch
 %{expand:%(for t in %{vectorized_packages} ; do echo Requires: $t; for v in %{package_vectorization}; do echo Requires: ${t}_${v}; done; done)}

--- a/scram-tools.file/tools/lwtnn/vectorized.tmpl
+++ b/scram-tools.file/tools/lwtnn/vectorized.tmpl
@@ -1,0 +1,5 @@
+<tool name="lwtnn_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@">
+  <client>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/opencv/vectorized.tmpl
+++ b/scram-tools.file/tools/opencv/vectorized.tmpl
@@ -1,0 +1,5 @@
+<tool name="opencv_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@">
+  <client>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/pytorch/vectorized.tmpl
+++ b/scram-tools.file/tools/pytorch/vectorized.tmpl
@@ -1,0 +1,5 @@
+<tool name="pytorch_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@">
+  <client>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+  </client>
+</tool>


### PR DESCRIPTION
This change actually enable the building of vectorization packages for `lwtnn, opencv and pytorch` for multi-arch IB/releases