### PR TITLE
Change hls4ml emulator extra version to avoid segfault

### DIFF
--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.1.2
+### RPM external hls4mlEmulatorExtras 1.1.3
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 

--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.1.1
+### RPM external hls4mlEmulatorExtras 1.1.2
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 


### PR DESCRIPTION
This PR upgrades the version of hls4mlEmulatorExtras to avoid a segfault on failure to load model needed for AXO error handling in https://github.com/cms-sw/cmssw/pull/44054

The new release can be seen here: https://github.com/cms-hls4ml/hls4mlEmulatorExtras/releases/tag/v1.1.2

the only changed introduced is this https://github.com/cms-hls4ml/hls4mlEmulatorExtras/pull/4

A backport will be required to 14_0 for AXO's backport to this same release