### PR TITLE
BuildRule: set env SCRAM_ALPAKA_BACKEND for unit tests

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-03-02
+%define configtag       V09-03-03
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-03-01
+%define configtag       V09-03-02
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
New build rules now can set `SCRAM_ALPAKA_BACKEND` env to one of the valid `alpaka` backends e.g `SerialSync, CudaAsync, ROCmAsync`  during the `scram build runtests`.