### PR TITLE
[14.0.x][BuildRules] backport changes from 14.1.X

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-02-07
+%define configtag       V09-02-08
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
- Set SCRAM_ALPAKA_BACKEND to one of SerialSync, CudaAsync, ROCmAsync
- Copy all CFIPYTHON_PACKAGE_FILES files to cfipython store if available
- Updated scram build help message