### PR TITLE
Add tf_cuda_support tool if TF is build with cuda support

### DIFF
--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -1,6 +1,17 @@
 #!/bin/bash -ex
 #Usage: get_tool <tool-install-dir> <tool-version> <directory-to-install-toolfiles> <toolname>
 
+function copy_tools (){
+    for xml in $(find $1 -type f -name "*.xml") ; do
+        bxml=$(basename $xml)
+        [ -f ${TOOLFILES_INSTALL_DIR}/tools/selected/$bxml ] && continue
+        [ -f ${TOOLFILES_INSTALL_DIR}/tools/available/$bxml ] && continue
+        cp $xml ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
+        perl -p -i -e 's|\@([a-zA-Z0-9_-]*)\@|$ENV{$1}|g' ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
+        echo "  Copied $bxml"
+    done
+}
+
 export TOOL_ROOT=$1
 export TOOL_VERSION=$2
 export TOOLFILES_INSTALL_DIR=$3
@@ -16,11 +27,7 @@ if [ -f $tool_script ]; then source $tool_script; fi
 
 #Copy all tools and replace the env placeholders @VARIABLES@
 [ -d ${TOOLFILES_INSTALL_DIR}/tools/selected ] || mkdir -p ${TOOLFILES_INSTALL_DIR}/tools/selected
-for xml in $(find $SCRAM_TOOL_SOURCE_DIR -type f -name "*.xml") ; do
-    bxml=$(basename $xml)
-    [ -f ${TOOLFILES_INSTALL_DIR}/tools/selected/$bxml ] && continue
-    [ -f ${TOOLFILES_INSTALL_DIR}/tools/available/$bxml ] && continue
-    cp $xml ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
-    perl -p -i -e 's|\@([a-zA-Z0-9_-]*)\@|$ENV{$1}|g' ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
-    echo "  Copied $bxml"
-done
+copy_tools $SCRAM_TOOL_SOURCE_DIR
+if [ -d ${TOOL_ROOT}/etc/scram.d ] ; then
+    copy_tools ${TOOL_ROOT}/etc/scram.d
+fi

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -29,7 +29,7 @@ tar xfz ${%{tf_root}}/libtensorflow_cc.tar.gz -C %{i}
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/tf_cuda_support.xml
   <tool name="tf_cuda_support" version="1.0">
-  <tool>
+  </tool>
 EOF_TOOLFILE
 %endif
 

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -25,6 +25,13 @@ esac
 %install
 
 tar xfz ${%{tf_root}}/libtensorflow_cc.tar.gz -C %{i}
+%if %{enable_gpu}
+mkdir -p %{i}/etc/scram.d
+cat << \EOF_TOOLFILE >%{i}/etc/scram.d/tf_cuda_support.xml
+  <tool name="tf_cuda_support" version="1.0">
+  <tool>
+EOF_TOOLFILE
+%endif
 
 %post
 %{relocateConfig}lib/lib*.params


### PR DESCRIPTION
backport of #9066

Following up https://github.com/cms-sw/cmssw/pull/44376 , this PR adds a new tool `tf_cuda_support` which will only be available in cmssw if TF is build with cuda/gpu support. One can use this tools to conditionally build/run cmssw tests which require TF GPU support.