### PR TITLE
[10.6.X] Fix geneva download url

### DIFF
--- a/geneva.spec
+++ b/geneva.spec
@@ -1,10 +1,12 @@
 ### RPM external geneva 1.0-RC3
 ## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/CT10nnlo_beamfunc.tar.gz?no-cmssdt-cache=1
-Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/MMHT2014nnlo68cl_beamfunc.tar.gz?no-cmssdt-cache=1
-Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/NNPDF31_nnlo_as_0118_beamfunc.tar.gz?no-cmssdt-cache=1
-Source5: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/PDF4LHC15_nnlo_100_beamfunc.tar.gz?no-cmssdt-cache=1
+# no-cmssdt-cache=1 part is used to instruct cmsBuild to not cache these files.
+# no-cmssdt-cache=1 is removed by cmsBuild
+Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/CT10nnlo_beamfunc.tar.gz
+Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/MMHT2014nnlo68cl_beamfunc.tar.gz
+Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/NNPDF31_nnlo_as_0118_beamfunc.tar.gz
+Source5: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/PDF4LHC15_nnlo_100_beamfunc.tar.gz
 
 BuildRequires: cmake gmake
 

--- a/geneva.spec
+++ b/geneva.spec
@@ -3,10 +3,10 @@
 Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 # no-cmssdt-cache=1 part is used to instruct cmsBuild to not cache these files.
 # no-cmssdt-cache=1 is removed by cmsBuild
-Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/CT10nnlo_beamfunc.tar.gz
-Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/MMHT2014nnlo68cl_beamfunc.tar.gz
-Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/NNPDF31_nnlo_as_0118_beamfunc.tar.gz
-Source5: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}no-cmssdt-cache=1/PDF4LHC15_nnlo_100_beamfunc.tar.gz
+Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/no-cmssdt-cache=1/CT10nnlo_beamfunc.tar.gz
+Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/no-cmssdt-cache=1/MMHT2014nnlo68cl_beamfunc.tar.gz
+Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/no-cmssdt-cache=1/NNPDF31_nnlo_as_0118_beamfunc.tar.gz
+Source5: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/no-cmssdt-cache=1/PDF4LHC15_nnlo_100_beamfunc.tar.gz
 
 BuildRequires: cmake gmake
 

--- a/geneva.spec
+++ b/geneva.spec
@@ -1,6 +1,6 @@
 ### RPM external geneva 1.0-RC3
 ## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
-Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 BuildRequires: cmake gmake
 

--- a/geneva.spec
+++ b/geneva.spec
@@ -1,6 +1,11 @@
 ### RPM external geneva 1.0-RC3
 ## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/CT10nnlo_beamfunc.tar.gz
+Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/MMHT2014nnlo68cl_beamfunc.tar.gz
+Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/NNPDF31_nnlo_as_0118_beamfunc.tar.gz
+Source5: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/PDF4LHC15_nnlo_100_beamfunc.tar.gz
 
 BuildRequires: cmake gmake
 
@@ -11,6 +16,8 @@ Requires: openloops
 
 %prep
 %setup -q -n %{n}-%{realversion}
+mkdir -p share/Geneva/beamfunc
+cp %{_sourcedir}/*_beamfunc.tar.gz share/Geneva/beamfunc
 
 %build
 

--- a/geneva.spec
+++ b/geneva.spec
@@ -1,10 +1,10 @@
 ### RPM external geneva 1.0-RC3
 ## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/CT10nnlo_beamfunc.tar.gz
-Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/MMHT2014nnlo68cl_beamfunc.tar.gz
-Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/NNPDF31_nnlo_as_0118_beamfunc.tar.gz
-Source5: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/PDF4LHC15_nnlo_100_beamfunc.tar.gz
+Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/CT10nnlo_beamfunc.tar.gz?no-cmssdt-cache=1
+Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/MMHT2014nnlo68cl_beamfunc.tar.gz?no-cmssdt-cache=1
+Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/NNPDF31_nnlo_as_0118_beamfunc.tar.gz?no-cmssdt-cache=1
+Source5: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/PDF4LHC15_nnlo_100_beamfunc.tar.gz?no-cmssdt-cache=1
 
 BuildRequires: cmake gmake
 

--- a/geneva.spec
+++ b/geneva.spec
@@ -1,7 +1,6 @@
 ### RPM external geneva 1.0-RC3
 ## INITENV +PATH PYTHON27PATH %{i}/${PYTHON_LIB_SITE_PACKAGES}
 Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-Source: git+https://stash.desy.de/scm/geneva/geneva-public.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Source2: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/CT10nnlo_beamfunc.tar.gz
 Source3: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/MMHT2014nnlo68cl_beamfunc.tar.gz
 Source4: http://cmsrep.cern.ch/cmssw/download/%{n}/%{realversion}/NNPDF31_nnlo_as_0118_beamfunc.tar.gz


### PR DESCRIPTION
After latest update to 10.6.X branch, `geneva` failed to build and problem is that it can not download the sources from https://stash.desy.de/scm/geneva/geneva-public. The allows us to download our cached sources.

http://stash.desy.de/ looks down. No idea how long this will remain down. This PR has cached all the sources download from http://stash.desy.de/ in to our cmsrep server