### PR TITLE
Update CICADA external to v1.3.1 to prevent weight overwrite

### DIFF
--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,4 +1,4 @@
-### RPM external CICADA 1.3.0
+### RPM external CICADA 1.3.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,4 +1,4 @@
-### RPM external CICADA 1.2.1
+### RPM external CICADA 1.3.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
This updates the CICADA external to v1.3.1

The major changes of this migration are the addition of x.1.2 models, designed to better use the output bit range, and more importantly, the addition of namespaces to the weights and types of _all_ model versions, designed to prevent weight overwrite/symbol collision as seen in https://github.com/cms-sw/cmssw/issues/44435 (the changes here can be seen in https://github.com/cms-hls4ml/CICADA/pull/3).

This change _is_ expected to change trigger results for 14_1 and forward, as it will dis-entangle CICADA from AXOL1TL.

@eyigitba, @slaurila, @quinnanm @thesps, FYI.

This PR is expected to be backported, as CICADA is expected to come online for datataking.