### PR TITLE
AXOL1TL v3.0.2

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 3.0.0
+### RPM external AXOL1TL 3.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 3.0.1
+### RPM external AXOL1TL 3.0.2
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
This updates AXOL1TL to v3.0.2 adding namespace protection to weights, biases, and model function as done for CICADA in #9087 to prevent symbol name clashes.