### PR TITLE
L1METML and TOoLLiP v1.0.1

### DIFF
--- a/L1METML.spec
+++ b/L1METML.spec
@@ -1,4 +1,4 @@
-### RPM external L1METML 1.0.0
+### RPM external L1METML 1.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/TOoLLiP.spec
+++ b/TOoLLiP.spec
@@ -1,4 +1,4 @@
-### RPM external TOoLLiP 1.0.0
+### RPM external TOoLLiP 1.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Similar to #9091 namespace protection to prevent collisions but for Phase-2 Level-1 trigger hls4ml models.

We can separate them into 2 PRs if desired. @aloeliger should we also open a backport to 14_0_X?