### PR TITLE
cmssw-osenv: Fix for KRB5 file

### DIFF
--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 240213.0
+### RPM cms cmssw-osenv 240326.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit 0593460f625758bbb9e1bc90b39fd17ab687c756
+%define commit 66f2c940250704189c2f1b536639c8e33835b01a
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.


### PR DESCRIPTION
Mount /run/user inside the container if krb5 token file exists under this e.g. on updated [lxplus8/9 nodes](https://cern.service-now.com/service-portal?id=outage&n=OTG0149056)
