### PR TITLE
SCRAM: Allow to create dev area within an existing dev area

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_66
+### RPM lcg SCRAMV1 V3_00_67
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag da05d3bb7d0390df7e04b9e68775a9725201b65c
+%define tag 85a81e2bc84e2af73ae747a89a514b541e14a0ca
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
SCRAM V2 allowed to create cmssw dev area within an existing dev area but SCRAM V3 was failing [a] if the both cmssw versions were not using the same config tag. This was a bug and scram should allow to create cmssw dev area within an existing dev area 

[a]
```
ERROR: Can not setup your current working area for SCRAM_ARCH: el8_amd64_gcc10
Your current development area /tmp/muzaffar/CMSSW_14_1_X_2024-03-26-1100/xx
is using a different config tag then the one used for release
```