### PR TITLE
Update tag for PhysicsTools-NanoAOD to V01-04-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+PhysicsTools-NanoAOD=V01-04-00
 RecoEgamma-PhotonIdentification=V01-07-00
 Validation-HGCalValidation=V00-06-00
 RecoBTag-Combined=V01-21-00
@@ -47,7 +48,6 @@ DataFormats-Common=V00-01-00
 DQM-EcalMonitorClient=V00-03-00
 CondTools-Hcal=V00-01-00
 RecoTracker-DisplacedRegionalTracking=V00-01-00
-PhysicsTools-NanoAOD=V01-03-00
 CalibTracker-SiStripDCS=V01-01-00
 L1Trigger-TrackFindingTracklet=V00-03-00
 Alignment-OfflineValidation=V00-03-00


### PR DESCRIPTION
Move PhysicsTools-NanoAOD data to new tag, see 
https://github.com/cms-data/PhysicsTools-NanoAOD/pull/16
