### PR TITLE
tensorflow-xla-runtime: fix for TF 2.15

### DIFF
--- a/tensorflow-xla-runtime.spec
+++ b/tensorflow-xla-runtime.spec
@@ -26,7 +26,7 @@ CXXFLAGS="-fPIC -Wl,-z,defs %{arch_build_flags} ${CMS_EIGEN_CXX_FLAGS}"
 
 pushd tensorflow/xla_aot_runtime_src
   # remove unnecessary implementations that use symbols that are not even existing
-  rm tensorflow/compiler/xla/service/cpu/runtime_fork_join.cc
+  find . -type f -path '*/service/cpu/runtime_fork_join.cc' | xargs rm -f
 
   cmake . \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \


### PR DESCRIPTION
For Tf 2.15, the file `runtime_fork_join.cc` exists under `xla/service/cpu/runtime_fork_join.cc` as compare to 2.12 `tensorflow/compiler/xla/service/cpu/runtime_fork_join.cc`. 