### PR TITLE
Update cms-tfaot and test models.

### DIFF
--- a/pip/cms-tfaot.file
+++ b/pip/cms-tfaot.file
@@ -2,7 +2,7 @@ BuildRequires: py3-pip py3-setuptools py3-wheel
 Requires: py3-PyYAML py3-cmsml
 
 %define github_user cms-externals
-%define tag a03ccef81c610e051d3d7d172d675fe6c1ff17e2
+%define tag df4bfd35dfed51d7c6ff0367ebc78093dfcc7d1d
 %define branch master
 %define source0 git+https://github.com/%{github_user}/cms-tfaot.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -57,7 +57,7 @@ cleo==2.0.1
 click==8.1.3
 clikit==0.6.2
 cmsml==0.2.5
-cms-tfaot==1.0.0
+cms-tfaot==1.0.1
 contourpy==1.0.7
 correctionlib==2.2.2
 crashtest==0.4.1

--- a/tfaot-model-test-multi.spec
+++ b/tfaot-model-test-multi.spec
@@ -1,4 +1,4 @@
-### RPM external tfaot-model-test-multi 1.0.0
+### RPM external tfaot-model-test-multi 1.0.1
 
 %define aot_config $PY3_CMS_TFAOT_ROOT/share/test_models/multi/aot_config.yaml
 

--- a/tfaot-model-test-simple.spec
+++ b/tfaot-model-test-simple.spec
@@ -1,4 +1,4 @@
-### RPM external tfaot-model-test-simple 1.0.0
+### RPM external tfaot-model-test-simple 1.0.1
 
 %define aot_config $PY3_CMS_TFAOT_ROOT/share/test_models/simple/aot_config.yaml
 


### PR DESCRIPTION
This PR updates the [cms-tfaot](https://github.com/cms-externals/cms-tfaot) python tools, which slightly update the AOT compilation workflow.

- Remove redundant wrapper header.
- Fix typo in dev workflow instructions.
- Header parsing contains input / output types.