### PR TITLE
[DQM] Bump DQMGUI tag + Apply patch for increasing index limits

### DIFF
--- a/dqmgui-index-size.patch
+++ b/dqmgui-index-size.patch
@@ -1,0 +1,15 @@
+diff --git a/src/cpp/DQM/VisDQMIndex.h b/src/cpp/DQM/VisDQMIndex.h
+index bbf1ba0..8b6b971 100644
+--- a/src/cpp/DQM/VisDQMIndex.h
++++ b/src/cpp/DQM/VisDQMIndex.h
+@@ -10,8 +10,8 @@
+ // Define the sizes to be used for the StringAtomTrees
+ 
+ #define OBJECTNAMES 5000000
+-#define PATHNAMES 1000000
+-#define DATASETNAMES 100000
++#define PATHNAMES 1500000   // Mostly affects DQMGUI offline deployment
++#define DATASETNAMES 200000 // Mostly affects DQMGUI dev deployment
+ #define CMSSWNAMES 10000
+ #define STREAMERS 100
+ 

--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -1,4 +1,4 @@
-### RPM cms dqmgui 9.8.1
+### RPM cms dqmgui 9.9.0
 ## INITENV +PATH PATH %i/xbin
 ## INITENV +PATH %{dynamic_path_var} %i/xlib
 ## INITENV +PATH PYTHONPATH %i/${PYTHON_LIB_SITE_PACKAGES}

--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -17,6 +17,7 @@ Source0: git+https://github.com/cms-DQM/dqmgui_prod.git?obj=index128/%realversio
 Source2: svn://rotoglup-scratchpad.googlecode.com/svn/trunk/rtgu/image?module=image&revision=10&scheme=http&output=/rtgu.tar.gz
 Source3: http://opensource.adobe.com/wiki/download/attachments/3866769/numeric.tar.gz
 Patch0: dqmgui-rtgu
+Patch1: dqmgui-index-size
 
 Requires: python cherrypy py2-cheetah yui extjs gmake pcre boost root rootjs libpng libjpg classlib rotatelogs py2-pycurl py2-cjson libuuid d3 protobuf py2-argparse py2-pytest py2-nose jemalloc
 BuildRequires: py2-sphinx

--- a/dqmgui.spec
+++ b/dqmgui.spec
@@ -8,7 +8,7 @@
 %define webdoc_files %{installroot}/%{pkgrel}/128/doc
 %define cvs cvs://:pserver:anonymous@cmscvs.cern.ch:2401/cvs_server/repositories/CMSSW?passwd=AA_:yZZ3e
 
-Source0: git+https://github.com/cms-DQM/dqmgui_prod.git?obj=index128/%realversion&export=Monitoring&output=/Monitoring.tar.gz
+Source0: git+https://github.com/cms-DQM/dqmgui_prod.git?obj=index128_cc7/%realversion&export=Monitoring&output=/Monitoring.tar.gz
 #Source0: git+:///build1/rovere/GUIDevelopment/GHM?obj=RovereDevelopment&export=Monitoring&output=/Monitoring.tar.gz
 #Source0: %{svn}?scheme=svn+ssh&strategy=export&module=Monitoring&output=/src.tar.gz
 # For documentation, please refer to http://cms-sw.github.io/pkgtools/fetching-sources.html


### PR DESCRIPTION
- Bumped DQMGUI version. The [new version](https://github.com/cms-DQM/dqmgui_prod/releases/tag/9.9.0) includes a monitoring script for the index size. 
  - To do so, I updated the git branch in the `spec` file from (`index128_cc7`) which is dedicated to the CC7 deployment. I'm not sure if it's needed. 
- Apply a patch (`dqmgui-index-size.patch`) to increase the limit of `PATHNAMES` (mostly for the `vocms0738` "offline" deployment) and `DATASETNAMES` (mostly for the `vocms0731` "dev" deployment). The patch was created by a simple `git diff` in the root directory of the `dqmgui_prod` source. I am not sure if it will just work, since the build procedure is not exactly clear to me. Let me know if I need to modify it.

This PR is also required for merging this PR: https://github.com/dmwm/deployment/pull/1310

CC: @syuvivida @tjavaid @antoniovagnerini