### PR TITLE
[BuildRules] Export cuda/rocm static libs from the base release

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-03-06
+%define configtag       V09-03-07
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/44626

SCRAM was looking in wrong path `.SCRAM/$SCRAM_ARCH/MakeData/dlink` instead of `.SCRAM/$SCRAM_ARCH/MakeData/{cuda|rocm}_dlink` thatis why static libs for cuda/rocm were not properly exported in dev area.