### PR TITLE
[14.0][BuildRules] Export cuda/rocm static libs from the base release

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-02-09
+%define configtag       V09-02-10
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of #9115

This is bug fix for build rules. 