### PR TITLE
[10_6_X] Bumped CepGen version to 1.2.3

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,7 +1,7 @@
 ### RPM external cepgen 1.2.3_gcc710
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
-Patch: cepgen_nopython_noroot
+Patch: cepgen_noroot
 
 BuildRequires: cmake gmake
 Requires: gsl OpenBLAS hepmc lhapdf pythia6 bz2lib zlib xz

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.2.1patch1_gcc700
+### RPM external cepgen 1.2.3_gcc710
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 Patch: cepgen_nopython_noroot

--- a/cepgen_noroot.patch
+++ b/cepgen_noroot.patch
@@ -1,15 +1,12 @@
 diff --git a/CepGenAddOns/CMakeLists.txt b/CepGenAddOns/CMakeLists.txt
-index 27ac884a..9eb9d422 100644
+index 9b7db4e..4bf730a 100644
 --- a/CepGenAddOns/CMakeLists.txt
 +++ b/CepGenAddOns/CMakeLists.txt
-@@ -14,10 +14,8 @@ add_subdirectory(PhotosTauolaWrapper)
- add_subdirectory(ProMCWrapper)
- add_subdirectory(Pythia6Wrapper)
+@@ -17,7 +17,6 @@ add_subdirectory(Pythia6Wrapper)
  add_subdirectory(Pythia8Wrapper)
--add_subdirectory(PythonWrapper)
  add_subdirectory(REvolverWrapper)
  add_subdirectory(RivetWrapper)
 -add_subdirectory(ROOTWrapper)
  add_subdirectory(TopdrawerWrapper)
-
+ 
  add_subdirectory(Functionals)


### PR DESCRIPTION
This PR bumps the gcc7x version of CepGen to 1.2.3.
Changelog is available [here](https://cepgen.hepforge.org/changelog).