### PR TITLE
[13_0_X] Bumped CepGen version to 1.2.3

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.2.1patch1
+### RPM external cepgen 1.2.3
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 


### PR DESCRIPTION
This PR bumps the version of CepGen to 1.2.3.
Changelog is available [here](https://cepgen.hepforge.org/changelog).