### PR TITLE
Update tag for RecoEgamma-PhotonIdentification to V01-08-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,7 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
-RecoEgamma-PhotonIdentification=V01-07-00
+RecoEgamma-PhotonIdentification=V01-08-00
 RecoTauTag-TrainingFiles=V00-09-00
 RecoEgamma-EgammaPhotonProducers=V00-05-00
 RecoMET-METPUSubtraction=V01-03-00


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/9135

Move RecoEgamma-PhotonIdentification data to new tag, see
https://github.com/cms-data/RecoEgamma-PhotonIdentification/pull/15