### PR TITLE
Rivet: use eigen flags; update rivet analysis path for multi-arch

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -3,6 +3,7 @@
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source99: scram-tools.file/tools/eigen/env
 Patch0: rivet-analysis
 
 Requires: hepmc fastjet fastjet-contrib yoda
@@ -13,6 +14,8 @@ BuildRequires: python3 py3-cython autotools
 %setup -n %{n}-%{realversion}
 %patch0 -p1
 
+%build
+source %{_sourcedir}/env
 # Update config.{guess,sub} to detect aarch64 and ppc64le
 rm -f %{_tmppath}/config.{sub,guess}
 %get_config_guess %{_tmppath}/config.guess
@@ -36,7 +39,7 @@ autoreconf -fiv
 %ifarch aarch64
 sed -i -e 's|^ax_openmp_flags=".*"|ax_openmp_flags="none"|' ./configure
 %endif
-CXXFLAGS="-std=c++%{cms_cxx_standard}"
+CXXFLAGS="-std=c++%{cms_cxx_standard} $CMS_EIGEN_CXX_FLAGS"
 %ifarch x86_64
     CXXFLAGS="${CXXFLAGS} -msse3"
 %endif
@@ -50,8 +53,8 @@ PYTHON=$(which python3) \
 # The following hack insures that the bins with the library linked explicitly
 # rather than indirectly, as required by the gold linker
 perl -p -i -e "s|LIBS = $|LIBS = -lHepMC|g" bin/Makefile
-%build
-make %{makeprocesses} all 
+make %{makeprocesses} all
+
 %install
 make install 
 sed -i -e 's|^#!.*python.*|#!/usr/bin/env python3|' %{i}/bin/*

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-00
+%define configtag       V09-04-01
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-tools.file/tools/cmssw/cmssw.xml
+++ b/scram-tools.file/tools/cmssw/cmssw.xml
@@ -9,6 +9,7 @@
   </client>
   <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/biglib/$SCRAM_ARCH" type="path"/>
   <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="RIVET_ANALYSIS_PATH"      value="$LOCALTOP/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
   <runtime name="PYTHON3PATH" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$CMSSW_BASE/src" type="path"/>

--- a/scram-tools.file/tools/rivet/rivet.xml
+++ b/scram-tools.file/tools/rivet/rivet.xml
@@ -6,7 +6,6 @@
 <environment name="INCLUDE" default="$RIVET_BASE/include"/>
 </client>
 <runtime name="PATH" value="$RIVET_BASE/bin" type="path"/>
-<runtime name="RIVET_ANALYSIS_PATH" value="$RIVET_BASE/lib/Rivet" type="path"/>
 <runtime name="RIVET_DATA_PATH" value="$RIVET_BASE/share/Rivet" type="path"/>
 <runtime name="PDFPATH" default="$RIVET_BASE/share" type="path"/>
 <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>


### PR DESCRIPTION
Rivet tests are failing in multi-arch build. Looks like rivet internally has a copyif eigen but in `RivetEigen` namespace. Just to make sure that we use consistent egien flags I have updated river spec to use `CMS_EIGEN_CXX_FLAGS` build flags. 

Rivet tool sets `RIVET_ANALYSIS_PATH` pointing to `rivet/lib/Rivet`. This causes runtime errors for multu-arch builds. Looks like rivet already knows this path. so no need to set it for `rivet` itself

[a]
```
python3: ../../include/Rivet/Math/eigen3/src/Core/DenseStorage.h:128: RivetEigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 32>::plain_array() [with T = double; int Size = 4; int MatrixOrArrayOptions = 0]: Assertion `(internal::UIntPtr(eigen_unaligned_array_assert_workaround_gcc47(array)) & (31)) == 0 && "this assertion is explained here: " "http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html" " **** READ THIS WEB PAGE !!! ****"' failed.
```