### PR TITLE
for multi-arch set SCRAM_TARGET to auto MULTIARCH/SKYLAKE otherwise to default

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_68
+### RPM lcg SCRAMV1 V3_00_69
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 15a8797db3180ba786e6e131a9c4e3011b53bc68
+%define tag f06afeba5ec011dd62e723a6490513bfddec7012
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/cmssw-queue-override.file
+++ b/cmssw-queue-override.file
@@ -50,3 +50,10 @@ Source20: CXXModules.mk
 %define patchsrc20     cp %{_sourcedir}/CXXModules.mk config/SCRAM/GMake/CXXModules.mk
 %endif
 
+%if "%(case %realversion in (*MULTIARCH*) echo true ;; (*) echo false ;; esac)" == "true"
+%define scram_target_default auto
+%endif
+
+%if "%(case %realversion in (*SKYLAKE*) echo true ;; (*) echo false ;; esac)" == "true"
+%define scram_target_default auto
+%endif

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -6,11 +6,16 @@
 %define cmssw_libs biglib/%{cmsplatf} lib/%{cmsplatf}
 %define scram_home_suffix %(echo %{directpkgreqs} | grep -q /SCRAMV1/V2_ && echo /src || true)
 %define scram_script_prefix %(echo %{directpkgreqs} | grep -q /SCRAMV1/V2_ && echo .pl || echo .py)
+
 %if "%{?pkgname}" != "coral"
 %if "%{?package_vectorization}" != ""
 %define vectorized_build yes
+%if "%{?scram_target_default:set}" != "set"
+%define scram_target_default default
 %endif
 %endif
+%endif
+
 %if "%{?pgo_generate}"
 %undefine runGlimpse
 %undefine saveDeps
@@ -55,7 +60,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-03
+%define configtag       V09-04-04
 %endif
 
 %if "%{?buildarch:set}" != "set"
@@ -123,10 +128,12 @@ echo %{configtag} > %_builddir/config/config_tag
 %else
   --keys ENABLE_PGO=0
 %endif
+
 %if "%{?vectorized_build:set}" == "set"
 sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS="%{package_vectorization}"|' %_builddir/config/Self.xml
-sed -i -e 's|</tool>|<runtime name="SCRAM_TARGET" value="auto"/><runtime name="USER_TARGETS_ALL" value="1"/></tool>|' %_builddir/config/Self.xml
+sed -i -e 's|</tool>|<runtime name="SCRAM_TARGET" value="%{scram_target_default}"/><runtime name="USER_TARGETS_ALL" value="1"/></tool>|' %_builddir/config/Self.xml
 %endif
+
 %if "%{?release_usercxxflags:set}" == "set"
 echo '<flags CXXFLAGS="%{release_usercxxflags}"/>' >> %_builddir/config/BuildFile.xml
 %endif


### PR DESCRIPTION
This PR contains the following updates

- For special `MULTIARCH/SKYLAKE` IB/releases: set `SCRAM_TARGET` to `auto` so that scram can automatically select the best set of libraries at runtime. This is what current MULTIARCHS IBs do (so no change in env logic for MULTIARCH/SKYLAKE builds)
- For default IB with multi-arch support enabled (e.g. 14.1.0.pre3): set `SCRAM_TARGET` to `default` so that scram only set default (`sse3`) set libraries at runtime.
- SCRAM: Update document about SCRAM_TARGET selection and extra scram help on project specific build targets (https://github.com/cms-sw/SCRAM/commit/f06afeba5ec011dd62e723a6490513bfddec7012)
- Build rules: [scram/project/hook](https://github.com/cms-sw/cmssw-config/commit/ba4e63e664e1d074975839dc39694e3ca89f5e79) has been updated to only enable multi-arch builds in developers' area if release is built with `SCRAM_TARGET=auto`. With this change, scram will build multi-arch libs for `MULTIARCH/SKYLAKE` IB/releases but will only build default (`sse3`) set of libraries for other IBs/releases.

FYI @makortel , @fwyzard 

