### PR TITLE
deploy new site based os mismatch check hook

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_69
+### RPM lcg SCRAMV1 V3_00_70
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag f06afeba5ec011dd62e723a6490513bfddec7012
+%define tag 121148347412a0362c99139de0aa67e06171909d
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1233
+## REVISION 1234
 ## NOCOMPILER
 
-%define tag 17fc23fb375c04706a08f3f607a35ac6761067e1
+%define tag f1821e6c6953b601cb5501ced2125b15b65d6e26
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -60,7 +60,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-04
+%define configtag       V09-04-05
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This deploys a new site based scram hook to check for scram/host OS mismatch. See https://github.com/cms-sw/cms-common/pull/11 