### PR TITLE
[14.0.X] backport of multi-arch and scram os mismatch hook

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_69
+### RPM lcg SCRAMV1 V3_00_70
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag f06afeba5ec011dd62e723a6490513bfddec7012
+%define tag 121148347412a0362c99139de0aa67e06171909d
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_68
+### RPM lcg SCRAMV1 V3_00_69
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 15a8797db3180ba786e6e131a9c4e3011b53bc68
+%define tag f06afeba5ec011dd62e723a6490513bfddec7012
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1233
+## REVISION 1234
 ## NOCOMPILER
 
-%define tag 17fc23fb375c04706a08f3f607a35ac6761067e1
+%define tag f1821e6c6953b601cb5501ced2125b15b65d6e26
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/cmssw-queue-override.file
+++ b/cmssw-queue-override.file
@@ -50,3 +50,10 @@ Source20: CXXModules.mk
 %define patchsrc20     cp %{_sourcedir}/CXXModules.mk config/SCRAM/GMake/CXXModules.mk
 %endif
 
+%if "%(case %realversion in (*MULTIARCH*) echo true ;; (*) echo false ;; esac)" == "true"
+%define scram_target_default auto
+%endif
+
+%if "%(case %realversion in (*SKYLAKE*) echo true ;; (*) echo false ;; esac)" == "true"
+%define scram_target_default auto
+%endif

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -6,11 +6,16 @@
 %define cmssw_libs biglib/%{cmsplatf} lib/%{cmsplatf}
 %define scram_home_suffix %(echo %{directpkgreqs} | grep -q /SCRAMV1/V2_ && echo /src || true)
 %define scram_script_prefix %(echo %{directpkgreqs} | grep -q /SCRAMV1/V2_ && echo .pl || echo .py)
+
 %if "%{?pkgname}" != "coral"
 %if "%{?package_vectorization}" != ""
 %define vectorized_build yes
+%if "%{?scram_target_default:set}" != "set"
+%define scram_target_default default
 %endif
 %endif
+%endif
+
 %if "%{?pgo_generate}"
 %undefine runGlimpse
 %undefine saveDeps
@@ -55,7 +60,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-02-13
+%define configtag       V09-02-14
 %endif
 
 %if "%{?buildarch:set}" != "set"
@@ -123,10 +128,12 @@ echo %{configtag} > %_builddir/config/config_tag
 %else
   --keys ENABLE_PGO=0
 %endif
+
 %if "%{?vectorized_build:set}" == "set"
 sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS="%{package_vectorization}"|' %_builddir/config/Self.xml
-sed -i -e 's|</tool>|<runtime name="SCRAM_TARGET" value="auto"/><runtime name="USER_TARGETS_ALL" value="1"/></tool>|' %_builddir/config/Self.xml
+sed -i -e 's|</tool>|<runtime name="SCRAM_TARGET" value="%{scram_target_default}"/><runtime name="USER_TARGETS_ALL" value="1"/></tool>|' %_builddir/config/Self.xml
 %endif
+
 %if "%{?release_usercxxflags:set}" == "set"
 echo '<flags CXXFLAGS="%{release_usercxxflags}"/>' >> %_builddir/config/BuildFile.xml
 %endif


### PR DESCRIPTION
backport of #9154

Also include changes from #9157 to deploy the new cms-common with os-mismatch hook. These changes do not change the way we build MULTIARCH or normal IBs. These changes will be needed when we enable multi-arch for default IBs(14.1.X) and 14.0.X
