### PR TITLE
BuildRules: Fixes for PGO and biglib

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -60,7 +60,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-06
+%define configtag       V09-04-07
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -60,7 +60,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-05
+%define configtag       V09-04-06
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
- Use relative `-I` for local sources i.e. `-Isrc` instead of `I$CMSSW_BASE/src`. This allows CMSSW PGO generate/use in different dev area.
- In multiarch builds, use correct bigobjs for generating big library
- Fix findDependency to avoid duplicates due to multiple build products