### PR TITLE
simplify micro arch selection; set default micro arch to x86-64-v2

### DIFF
--- a/OpenBLAS.spec
+++ b/OpenBLAS.spec
@@ -1,10 +1,9 @@
 ### RPM external OpenBLAS 0.3.15
 ## INCLUDE compilation_flags
+## INCLUDE microarch_flags
 Source: https://github.com/xianyi/OpenBLAS/archive/v%{realversion}.tar.gz
 Patch0: OpenBLAS-fix-dynamic-arch
 Patch1: OpenBLAS-disable-tests
-
-# Will be part of future release
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -13,10 +12,29 @@ Patch1: OpenBLAS-disable-tests
 
 %build
 
+%ifarch x86_64
+XTARGETS="sse3=CORE2"
+for t in nehalem sandybridge haswell ; do
+  XTARGETS="${XTARGETS} $t=$(echo $t | tr 'a-z' 'A-Z')"
+done
+XTARGETS="${XTARGETS} skylake-avx512=SKYLAKEX"
+XTARGETS="${XTARGETS} x86-64-v2=NEHALEM"
+XTARGETS="${XTARGETS} x86-64-v3=HASWELL"
+XTARGETS="${XTARGETS} x86-64-v4=SKYLAKEX"
+STARGET=$(echo %{selected_microarch} | sed 's|^-m||;s|^arch=||')
+TARGET_ARCH=$(echo ${XTARGETS} | tr ' ' '\n' | grep "^${STARGET}=" | sed "s|^${STARGET}=||")
+if [ "${TARGET_ARCH}" == "" ] ; then
+  echo "ERROR: Unable to match OpenBlas build target '${STARGET}'. Available build targets are"
+  echo "${XTARGETS}" | tr ' ' '\n' | sed 's|=.*||'
+  echo "Please use one of the supported targets or add support for $%{STARGET}'"
+  exit 1
+fi
+%endif
+
 # PRESCOTT is a generic x86-64 target https://github.com/xianyi/OpenBLAS/issues/685 
 %define build_opts FC=gfortran BINARY=64 NUM_THREADS=256 DYNAMIC_ARCH=0 MAKE_NB_JOBS=%{compiling_processes}
 %ifarch x86_64
-make %{build_opts} TARGET=CORE2
+make %{build_opts} TARGET=${TARGET_ARCH}
 %endif
 %ifarch aarch64
 make %{build_opts} TARGET=ARMV8 CFLAGS="%{arch_build_flags}"

--- a/cmssw-vectorization.file
+++ b/cmssw-vectorization.file
@@ -1,2 +1,4 @@
+%ifarch x86_64
 %define vectorized_packages zlib fastjet tensorflow-sources tensorflow OpenBLAS rivet gbl lwtnn opencv pytorch
 %{expand:%(for t in %{vectorized_packages} ; do echo Requires: $t; for v in %{package_vectorization}; do echo Requires: ${t}_${v}; done; done)}
+%endif

--- a/fastjet.spec
+++ b/fastjet.spec
@@ -1,6 +1,7 @@
 ### RPM external fastjet 3.4.1
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## INCLUDE compilation_flags
+## INCLUDE microarch_flags
 
 BuildRequires: autotools
 Requires: python3
@@ -23,11 +24,8 @@ chmod +x ./config.{sub,guess}
 cp ./config.sub   ./plugins/SISCone/siscone/config.sub
 cp ./config.guess ./plugins/SISCone/siscone/config.guess
 
-CXXFLAGS="-O3 -Wall -ffast-math -ftree-vectorize"
+CXXFLAGS="-O3 -Wall -ffast-math -ftree-vectorize %{selected_microarch}"
 
-%ifarch x86_64
-CXXFLAGS="${CXXFLAGS} -msse3"
-%endif
 %if "%{?arch_build_flags}"
 CXXFLAGS="${CXXFLAGS} %{arch_build_flags}"
 %endif

--- a/gbl.spec
+++ b/gbl.spec
@@ -1,5 +1,6 @@
 ### RPM external gbl V03-01-01
 ## INCLUDE cpp-standard
+## INCLUDE microarch_flags
 %define tag 59c2d99ea96bc739321fd251096504c91467be24
 Source: git+https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Source99: scram-tools.file/tools/eigen/env
@@ -24,11 +25,7 @@ cmake ../cpp \
   -DCMAKE_VERBOSE_MAKEFILE=ON \
   -DEIGEN3_INCLUDE_DIR=${EIGEN_ROOT}/include/eigen3 \
   -DSUPPORT_ROOT=False \
-%ifarch x86_64
-  -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS -msse3"
-%else
-  -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS"
-%endif
+  -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS %{selected_microarch}"
 
 make %{makeprocesses}
 

--- a/lwtnn.spec
+++ b/lwtnn.spec
@@ -1,5 +1,6 @@
 ### RPM external lwtnn 2.14.1
 ## INCLUDE cpp-standard
+## INCLUDE microarch_flags
 
 Source: https://github.com/lwtnn/lwtnn/archive/v%{realversion}.tar.gz
 Source99: scram-tools.file/tools/eigen/env
@@ -20,11 +21,7 @@ source %{_sourcedir}/env
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_CXX_COMPILER="g++" \
-%ifarch x86_64
-  -DCMAKE_CXX_FLAGS="-fPIC $CMS_EIGEN_CXX_FLAGS -msse3" \
-%else
-  -DCMAKE_CXX_FLAGS="-fPIC $CMS_EIGEN_CXX_FLAGS" \
- %endif
+  -DCMAKE_CXX_FLAGS="-fPIC $CMS_EIGEN_CXX_FLAGS %{selected_microarch}" \
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILTIN_BOOST=OFF \

--- a/microarch_flags.file
+++ b/microarch_flags.file
@@ -1,0 +1,11 @@
+%ifarch x86_64
+%define default_microarch -mx86-64-v2
+%if "%{?override_microarch:set}" == "set"
+%define selected_microarch %{override_microarch}
+%else
+%define selected_microarch %{default_microarch}
+%endif
+%else
+%define selected_microarch %{nil}
+%define default_microarch %{nil}
+%endif

--- a/microarch_flags.file
+++ b/microarch_flags.file
@@ -1,5 +1,5 @@
 %ifarch x86_64
-%define default_microarch -mx86-64-v2
+%define default_microarch -march=x86-64-v2
 %if "%{?override_microarch:set}" == "set"
 %define selected_microarch %{override_microarch}
 %else

--- a/opencv.spec
+++ b/opencv.spec
@@ -1,6 +1,8 @@
 ### RPM external opencv 4.9.0
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## INCLUDE cpp-standard
+## INCLUDE microarch_flags
+
 %define tag %{realversion}
 %define branch master
 %define github_user opencv
@@ -33,11 +35,7 @@ cmake ../%{n}-%{realversion} \
     -DPYTHON3_INCLUDE_DIR:PATH="${PYTHON3_ROOT}/include/python%{cms_python3_major_minor_version}" \
     -DPYTHON3_LIBRARY:FILEPATH="${PYTHON3_ROOT}/lib/libpython%{cms_python3_major_minor_version}.so" \
     -DCMAKE_BUILD_TYPE=Release \
-%ifarch x86_64
-    -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS -msse3" \
-%else
-    -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS" \
-%endif
+    -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS %{selected_microarch}" \
     -DCMAKE_PREFIX_PATH="${LIBPNG_ROOT};${LIBTIFF_ROOT};${LIBJPEG_TURBO_ROOT};${ZLIB_ROOT};${PYTHON3_ROOT};${PY2_NUMPY_ROOT};${PY3_NUMPY_ROOT};${EIGEN_ROOT};${OPENBLAS_ROOT}"
 
 ninja -v %{makeprocesses}

--- a/pgo/cmsdist_packages.py
+++ b/pgo/cmsdist_packages.py
@@ -1,5 +1,5 @@
 from os.path import dirname, join
-pgo_packages = ["geant4", "vecgeom", "g4hepem", "dd4hep", "cmssw", "cmssw-patch", "cmssw-tool-conf"]
+pgo_packages = ["geant4", "vecgeom", "OpenBLAS", "g4hepem", "dd4hep", "cmssw", "cmssw-patch", "cmssw-tool-conf"]
 
 def packages(virtual_packages, *args):
   opts = args[0].options
@@ -7,11 +7,33 @@ def packages(virtual_packages, *args):
     if (not opts.PGOGenerate) and (not opts.PGOUse): return
   except:
     return
+
+  def process_pkg(vpkg, pkg):
+    xindex = 0
+    pkgspec = "%s.spec" % pkg
+    spec = []
+    if vpkg in virtual_packages:
+      for line in virtual_packages[vpkg]:
+        if not pkgspec in line:
+          xindex += 1
+          spec.append(line)
+        else: break
+    spec.append('%define pgo_path_prefix {0}'.format('@LOCALTOP@' if pkg in ["cmssw-tool-conf"] else '%{_builddir}'))
+    spec.append('%define pgo_package_name {0}'.format('cmssw' if pkg in ["cmssw-tool-conf"] else vpkg))
+    spec.append('%define {0} 1'.format('pgo_generate' if opts.PGOGenerate else 'pgo_use'))
+    spec.append('## INCLUDE pgo/compilation_flags_pgo')
+    if not vpkg in virtual_packages:
+      spec.append("cmd: cat {0}/{1}".format(opts.cmsdist, pkgspec))
+    else:
+      spec +=  virtual_packages[vpkg][xindex:]
+    virtual_packages[vpkg] = spec[:]
+    return
+
   for pkg in pgo_packages:
-    spec  = "  echo '%%define pgo_path_prefix  %s'" % ('@LOCALTOP@' if pkg in ["cmssw-tool-conf"] else '%{_builddir}')
-    spec += "; echo '%%define pgo_package_name %s'" % ('cmssw' if pkg in ["cmssw-tool-conf"] else pkg)
-    spec += "; echo '%%define %s 1'" % ('pgo_generate' if opts.PGOGenerate else 'pgo_use')
-    spec += "; echo '## INCLUDE pgo/compilation_flags_pgo'"
-    spec += "; cat %s/%s.spec" % (opts.cmsdist, pkg)
-    virtual_packages[pkg] = spec
+    process_pkg(pkg, pkg)
+    for v in opts.vectorization:
+      vpkg = "%s_%s" % (pkg,v)
+      if vpkg in virtual_packages:
+          pgo_packages.append(vpkg)
+          process_pkg(vpkg, pkg)
   return

--- a/pytorch.spec
+++ b/pytorch.spec
@@ -1,5 +1,6 @@
 ### RPM external pytorch 2.1.1
 ## INCLUDE cuda-flags
+## INCLUDE microarch_flags
 
 %define cuda_arch_float $(echo %{cuda_arch} | tr ' ' '\\n' | sed -E 's|([0-9])$|.\\1|' | tr '\\n' ' ')
 %define tag bb938bbe9f53414dda1e1159795b7536dbffd041
@@ -76,11 +77,7 @@ cmake ../%{n}-%{realversion} \
     -DUSE_SYSTEM_FXDIV=ON \
     -DUSE_SYSTEM_PYBIND11=ON \
     -DUSE_SYSTEM_BENCHMARK=ON \
-%ifarch x86_64
-    -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS -msse3" \
-%else
-    -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS" \
-%endif
+    -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS %{selected_microarch}" \
     -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
     -DPYTHON_EXECUTABLE=${PYTHON3_ROOT}/bin/python3
 

--- a/rivet.spec
+++ b/rivet.spec
@@ -1,5 +1,6 @@
 ### RPM external rivet 3.1.10
 ## INCLUDE cpp-standard
+## INCLUDE microarch_flags
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
@@ -39,10 +40,7 @@ autoreconf -fiv
 %ifarch aarch64
 sed -i -e 's|^ax_openmp_flags=".*"|ax_openmp_flags="none"|' ./configure
 %endif
-CXXFLAGS="-std=c++%{cms_cxx_standard} $CMS_EIGEN_CXX_FLAGS"
-%ifarch x86_64
-    CXXFLAGS="${CXXFLAGS} -msse3"
-%endif
+CXXFLAGS="-std=c++%{cms_cxx_standard} $CMS_EIGEN_CXX_FLAGS %{selected_microarch}"
 sed -i "/_pow10 only defined for positive powers/d" include/Rivet/Tools/ParticleIdUtils.hh
 
 PYTHON=$(which python3) \

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -7,15 +7,6 @@
 %define scram_home_suffix %(echo %{directpkgreqs} | grep -q /SCRAMV1/V2_ && echo /src || true)
 %define scram_script_prefix %(echo %{directpkgreqs} | grep -q /SCRAMV1/V2_ && echo .pl || echo .py)
 
-%if "%{?pkgname}" != "coral"
-%if "%{?package_vectorization}" != ""
-%define vectorized_build yes
-%if "%{?scram_target_default:set}" != "set"
-%define scram_target_default default
-%endif
-%endif
-%endif
-
 %if "%{?pgo_generate}"
 %undefine runGlimpse
 %undefine saveDeps
@@ -129,9 +120,16 @@ echo %{configtag} > %_builddir/config/config_tag
   --keys ENABLE_PGO=0
 %endif
 
-%if "%{?vectorized_build:set}" == "set"
-sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS="%{package_vectorization}"|' %_builddir/config/Self.xml
-sed -i -e 's|</tool>| <runtime name="SCRAM_TARGET" value="%{scram_target_default}"/>\n <runtime name="USER_TARGETS_ALL" value="1"/>\n</tool>|' %_builddir/config/Self.xml
+MULTIVEC_ENABLED=false
+%if "%{package_vectorization}"
+%if "%{?scram_target_default:set}" != "set"
+%define scram_target_default default
+%endif
+if [ -e ${%{toolconf}}/vectorized_packages.txt ] ; then
+  MULTIVEC_ENABLED=true
+  sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS="%{package_vectorization}"|' %_builddir/config/Self.xml
+  sed -i -e 's|</tool>| <runtime name="SCRAM_TARGET" value="%{scram_target_default}"/>\n <runtime name="USER_TARGETS_ALL" value="1"/>\n</tool>|' %_builddir/config/Self.xml
+fi
 %endif
 
 %if "%{?release_usercxxflags:set}" == "set"
@@ -194,9 +192,9 @@ export SCRAM_NOSYMCHECK=true
 %if "%{?pgo_generate:set}" != "set"
 case %{n} in (cmssw|cmssw-patch) %scramcmd b -f -k %{makeprocesses} llvm-ccdb </dev/null || true ;; esac
 %endif
-%if "%{?vectorized_build:set}" == "set"
-touch %{i}/.SCRAM/%{cmsplatf}/multi-targets
-%endif
+if $MULTIVEC_ENABLED ; then
+  touch %{i}/.SCRAM/%{cmsplatf}/multi-targets
+fi
 %scramcmd b --verbose -f %{compileOptions} %{extraOptions} %{makeprocesses} %{buildtarget} </dev/null || { touch ../build-errors && %scramcmd b -f outputlog && [ "%{?ignore_compile_errors:set}" == "set" ]; }
 
 %if "%{?additionalBuildTarget0:set}" == "set"

--- a/scram-tool-conf.file
+++ b/scram-tool-conf.file
@@ -3,14 +3,18 @@
 ## NO_AUTO_RUNPATH
 ## NO_AUTO_DEPENDENCY
 ## INCLUDE toolflags
+## INCLUDE microarch_flags
 
 BuildRequires: SCRAMV1
 Source99: scram-tools
 Source: none
-%{expand:%(i=90; for v in %{package_vectorization}; do let i=$i+1 ; echo Source${i}: vectorization/$v; done)}
 
+%if "%{package_vectorization}"
 %if "%{?vectorized_packages:set}" != "set"
 %define vectorized_packages %{nil}
+%else
+%{expand:%(i=90; for v in %{package_vectorization}; do let i=$i+1 ; echo Source${i}: vectorization/$v; done)}
+%endif
 %endif
 
 %prep
@@ -39,6 +43,9 @@ for tool in %requiredtools; do
 done
 %{_sourcedir}/scram-tools/bin/get_tools "" "system" %i "systemtools"
 
+%if "%{package_vectorization}"
+%if "%{vectorized_packages}"
+echo %{vectorized_packages} > %i/vectorized_packages.txt
 for vec in %{package_vectorization}; do \
   ucvec=`echo $vec | tr '[a-z-]' '[A-Z_]'`
   for tool in %{vectorized_packages}; do \
@@ -52,6 +59,8 @@ for vec in %{package_vectorization}; do \
     sed -i -e "s#</tool>#    <flags CXXFLAGS_TARGETS_${ucvec}=\"${f}\"/>\n</tool>#" %i/tools/selected/gcc-cxxcompiler.xml
   fi
 done
+%endif
+%endif
 
 for stool in $(echo %skipreqtools | tr '[A-Z]' '[a-z]') ; do
   [ -f %i/tools/selected/${stool}.xml ] || continue

--- a/scram-tools.file/tool-env.file
+++ b/scram-tools.file/tool-env.file
@@ -1,11 +1,10 @@
+## INCLUDE microarch_flags
 export ROOT_CXXMODULES="0"
 export PKG_VECTORIZATION="%{?package_vectorization}"
 export CMSDIST_DIR="%{cmsdist_directory}"
 export CMS_CXX_STANDARD=%{cms_cxx_standard}
 
-%ifarch x86_64
-export COMPILER_CXXFLAGS="$(%{cmsdist_directory}/vectorization/cmsdist_packages.py)"
-%endif
+export COMPILER_CXXFLAGS="%{selected_microarch}"
 %if "%{?arch_build_flags}"
 export COMPILER_CXXFLAGS="%{arch_build_flags}"
 %endif

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -4,6 +4,7 @@ BuildRequires: bazel java-env git
 ## INCLUDE cpp-standard
 ## INCLUDE tensorflow-requires
 ## INCLUDE compilation_flags
+## INCLUDE microarch_flags
 
 #Set tensorflow_mkldnn_contraction_kernel option
 #https://github.com/tensorflow/tensorflow/blob/v2.12.1/tensorflow/core/kernels/BUILD#L79-L89
@@ -42,14 +43,16 @@ export GCC_HOST_COMPILER_PATH="$(which gcc)"
 export CC_OPT_FLAGS="-Wno-sign-compare"
 
 BAZEL_OPTS="--batch --output_user_root ../build build -s --verbose_failures --distinct_host_configuration=false"
-%ifarch x86_64
-BAZEL_OPTS="$BAZEL_OPTS --copt=%{vectorize_flag}"
-%else
+%if "%{selected_microarch}"
+BAZEL_OPTS="$BAZEL_OPTS --copt=%{selected_microarch}"
+%if "%{selected_microarch}" != "%{default_microarch}"
+BAZEL_OPTS="$BAZEL_OPTS --distinct_host_configuration=true"
+%endif
+%endif
 %if "%{?arch_build_flags}"
 BAZEL_OPTS="$BAZEL_OPTS $(echo %{arch_build_flags} | tr ' ' '\n' | grep -v '^$' | sed -e 's|^|--copt=|' | tr '\n' ' ')"
 %else
 BAZEL_OPTS="$BAZEL_OPTS --copt=-mcpu=native --copt=-mtune=native"
-%endif
 %endif
 BAZEL_OPTS="$BAZEL_OPTS --config=%{build_type} --cxxopt=-std=c++%{cms_cxx_standard} --host_cxxopt=-std=c++%{cms_cxx_standard} %{makeprocesses}"
 BAZEL_OPTS="$BAZEL_OPTS --config=noaws --config=nogcp --config=nohdfs --config=nonccl"

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -6,5 +6,4 @@
 %define python_env PYTHON3PATH
 %define build_type opt
 %define pythonOnly no
-%define vectorize_flag -msse3
 ## INCLUDE tensorflow-sources

--- a/tensorflow-xla-runtime.spec
+++ b/tensorflow-xla-runtime.spec
@@ -1,6 +1,7 @@
 ### RPM external tensorflow-xla-runtime 2.12.0
 ## INCLUDE cpp-standard
 ## INCLUDE compilation_flags
+## INCLUDE microarch_flags
 
 Source99: scram-tools.file/tools/eigen/env
 
@@ -19,10 +20,7 @@ cp -r ${PY3_TENSORFLOW_ROOT}/lib/python%{cms_python3_major_minor_version}/site-p
 source %{_sourcedir}/env
 export CPATH="${CPATH}:${EIGEN_ROOT}/include/eigen3"
 
-CXXFLAGS="-fPIC -Wl,-z,defs %{arch_build_flags} ${CMS_EIGEN_CXX_FLAGS}"
-%ifarch x86_64
-  CXXFLAGS="${CXXFLAGS} -msse3"
-%endif
+CXXFLAGS="-fPIC -Wl,-z,defs %{arch_build_flags} ${CMS_EIGEN_CXX_FLAGS} %{selected_microarch}"
 
 pushd tensorflow/xla_aot_runtime_src
   # remove unnecessary implementations that use symbols that are not even existing

--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -2,15 +2,14 @@
 from platform import machine
 from sys import exit, argv
 
-DEFAULT_TARGET_FLAG="-msse3"
 MULTI_TARGET_PACKAGES = []
 VALID_TARGETS = {}
 if machine() == "x86_64":
-############ IMPORTANT NOTE #############
-# For any newly added vecrtorized packages here,
-# please also add scram-tools.file/tools/package/vectorized.tmpl file
-# and vectorized_packages list in cmssw-vectorization.file file
-#########################################
+  ############ IMPORTANT NOTE #############
+  # For any newly added vecrtorized packages here,
+  # please also add scram-tools.file/tools/package/vectorized.tmpl file
+  # and vectorized_packages list in cmssw-vectorization.file file
+  #########################################
   MULTI_TARGET_PACKAGES = [
     "zlib",
     "fastjet",
@@ -34,47 +33,23 @@ if machine() == "x86_64":
     psABI = "x86-64-v%s" % v
     VALID_TARGETS[psABI] = "-march=" + psABI
 
-def fix_tensorflow_sources(vec, value):
-  return [(DEFAULT_TARGET_FLAG,"%s %s" % (value, "--distinct_host_configuration=true"))]
-
-def fix_vecgeom(vec, value):
-  return [(DEFAULT_TARGET_FLAG.replace("-m", ""), value.replace("-m", ""))]
-
-def fix_OpenBLAS(vec, value):
-  if   vec=="skylake-avx512": vec="SKYLAKEX"
-  elif vec=="x86-64-v2": vec="NEHALEM"
-  elif vec=="x86-64-v3": vec="HASWELL"
-  elif vec=="x86-64-v4": vec="SKYLAKEX"
-  return [("TARGET=CORE2", "TARGET=%s" % vec.upper())]
-
 def packages(virtual_packages, *args):
   opts = args[0].options
   if not opts.vectorization: return
   for pkg in MULTI_TARGET_PACKAGES:
     err = False
     for v in opts.vectorization:
-      if v not in  VALID_TARGETS:
+      if v not in VALID_TARGETS:
         print("Vectorization instructions %s not supported. Please update %s to generate specs for this vectorized instructions set." % (v, __file__))
         err = True
       vpkg = "%s_%s" % (pkg, v)
-      rdata = [(DEFAULT_TARGET_FLAG, VALID_TARGETS[v])]
-      try:
-        ndata = eval('fix_%s' % pkg.replace("-","_").replace(".","_"))(v, rdata[0][1])
-        if ndata is not None: rdata = ndata
-      except:
-        pass
-      xregexp = ""
-      for item in rdata:
-        xregexp = "s|%s|%s|g;" % (item[0], item[1])
-      spec = "echo -e '%%define vectorized_package %s\n%%define vectorized_flags  %s'; sed -e '%ss|\(^###  *RPM  *[^\s]*\)  *%s |\\1 %s |;s|%%{n}|%s|g;' %s/%s.spec"
-      virtual_packages[vpkg] = spec % (v, rdata[0][1], xregexp, pkg, vpkg, pkg, opts.cmsdist, pkg)
+      spec =     ["%define vectorized_package {0}".format(v)]
+      spec.append("%define override_microarch {0}".format(VALID_TARGETS[v]))
+      spec.append("cmd:sed -e 's|\(^###  *RPM  *[^\s]*\)  *{0} |\\1 {1} |;s|%{{n}}|{0}|g;' {2}/{0}.spec".format(pkg, vpkg, opts.cmsdist))
+      virtual_packages[vpkg] = spec[:]
     if err:
       exit(1)
   return
 
 if __name__ == '__main__':
-  if len(argv)==2:
-    if argv[1] in VALID_TARGETS:
-      print (VALID_TARGETS[argv[1]])
-  else:
-    print (DEFAULT_TARGET_FLAG)
+  print (VALID_TARGETS[argv[1]])

--- a/zlib.spec
+++ b/zlib.spec
@@ -1,4 +1,5 @@
 ### RPM external zlib 1.2.11
+## INCLUDE microarch_flags
 %ifarch x86_64
 %define git_repo cms-externals
 %define git_branch cms/v%{realversion}
@@ -15,10 +16,7 @@ Source0: git://github.com/%{git_repo}/zlib.git?obj=%{git_branch}/%{git_commit}&e
 
 %build
 
-CONF_FLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1"
-%ifarch x86_64
-CONF_FLAGS="${CONF_FLAGS} -msse3"
-%endif
+CONF_FLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1 %{selected_microarch}"
 CFLAGS="${CONF_FLAGS}" ./configure --prefix=%{i}
 
 make %{makeprocesses}


### PR DESCRIPTION
This PR simplify the selection of default micro archtitecture which is now defined in `cmsdist/microarch_flags.file` file. Every package which needs to be enable micro-instraction should include it and pass `%{selected_microarch}` to the its build system.

This also updates the default micro arch to `x86-64-v2` ( previously it was `sse3`)