### PR TITLE
Fix unittest link flags for extra micro-arch

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -60,7 +60,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-07
+%define configtag       V09-04-08
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-tool-conf.file
+++ b/scram-tool-conf.file
@@ -50,7 +50,7 @@ for vec in %{package_vectorization}; do \
   done
   if [ -f %i/tools/selected/gcc-cxxcompiler.xml ] ; then
     f=$(%{cmsdist_directory}/vectorization/cmsdist_packages.py $vec)
-    sed -i -e "s#</tool>#  <flags CXXFLAGS_TARGETS_${ucvec}=\"${f}\"/>\n <flags REM_CXXFLAGS_TARGETS_${ucvec}=\"${default_microarch_flag}\"/>\n</tool>#" %i/tools/selected/gcc-cxxcompiler.xml
+    sed -i -e "s# *</tool>#    <flags CXXFLAGS_TARGETS_${ucvec}=\"${f}\"/>\n    <flags REM_CXXFLAGS_TARGETS_${ucvec}=\"${default_microarch_flag}\"/>\n  </tool>#" %i/tools/selected/gcc-cxxcompiler.xml
   fi
 done
 

--- a/scram-tool-conf.file
+++ b/scram-tool-conf.file
@@ -39,6 +39,7 @@ for tool in %requiredtools; do
 done
 %{_sourcedir}/scram-tools/bin/get_tools "" "system" %i "systemtools"
 
+default_microarch_flag=$(%{cmsdist_directory}/vectorization/cmsdist_packages.py)
 for vec in %{package_vectorization}; do \
   ucvec=`echo $vec | tr '[a-z-]' '[A-Z_]'`
   for tool in %{vectorized_packages}; do \
@@ -49,7 +50,7 @@ for vec in %{package_vectorization}; do \
   done
   if [ -f %i/tools/selected/gcc-cxxcompiler.xml ] ; then
     f=$(%{cmsdist_directory}/vectorization/cmsdist_packages.py $vec)
-    sed -i -e "s#</tool>#    <flags CXXFLAGS_TARGETS_${ucvec}=\"${f}\"/>\n</tool>#" %i/tools/selected/gcc-cxxcompiler.xml
+    sed -i -e "s#</tool>#  <flags CXXFLAGS_TARGETS_${ucvec}=\"${f}\"/>\n <flags REM_CXXFLAGS_TARGETS_${ucvec}=\"${default_microarch_flag}\"/>\n</tool>#" %i/tools/selected/gcc-cxxcompiler.xml
   fi
 done
 


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/44873

This PR include the following fixes
- Pass the extra micro-arch flag to unit tests linking (cms-sw/cmssw#44873)
- Remove the default microarch flag when building for extra arch
- Remove dupilcate microarch string message when compiling for bigobj
`>> Compiling` **scram_x86-64-v3 scram_x86-64-v3** `bigobj src/<filename>`
