### PR TITLE
[BuildRules] Check for private header included from release area

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -60,7 +60,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-08
+%define configtag       V09-04-09
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
After moving to build with relative path then private header include check was failing for PR tests. This change should fix this issue