### PR TITLE
Added mozearch clang-plugin to generate mozsearch indexing

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -169,6 +169,7 @@ Requires: openloops
 %endif
 
 %ifarch x86_64
+Requires: mozsearch
 Requires: tkonlinesw
 Requires: oracle
 Requires: icc

--- a/mozsearch-gcc-toolchain.patch
+++ b/mozsearch-gcc-toolchain.patch
@@ -1,0 +1,30 @@
+diff --git a/clang-plugin/Makefile b/clang-plugin/Makefile
+index 014e311..07ed438 100644
+--- a/clang-plugin/Makefile
++++ b/clang-plugin/Makefile
+@@ -2,9 +2,9 @@ CC = clang
+ CXX = clang++
+ LLVM_CONFIG ?= llvm-config
+ LLVM_LDFLAGS := $(shell ${LLVM_CONFIG} --ldflags)
+-CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -Wall -Wno-strict-aliasing \
++CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -Wall -Wno-strict-aliasing --gcc-toolchain=$(GCC_ROOT) \
+ 	$(if $(DEBUG),-O0 -g)
+-LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared
++LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS)  --gcc-toolchain=$(GCC_ROOT) -shared
+ 
+ build: libclang-index-plugin.so
+ 
+diff --git a/clang-plugin/MozsearchIndexer.cpp b/clang-plugin/MozsearchIndexer.cpp
+index e9b7af3..818496e 100644
+--- a/clang-plugin/MozsearchIndexer.cpp
++++ b/clang-plugin/MozsearchIndexer.cpp
+@@ -2445,9 +2445,6 @@ protected:
+     }
+     Objdir += PATHSEP_STRING;
+ 
+-    printf("MOZSEARCH: %s %s %s\n", Srcdir.c_str(), Outdir.c_str(),
+-           Objdir.c_str());
+-
+     return true;
+   }
+ 

--- a/mozsearch.spec
+++ b/mozsearch.spec
@@ -1,0 +1,22 @@
+### RPM external mozsearch 20240514
+
+%define tag d697005b97f28d493a24887ed25fd2e68839c716
+%define branch master
+
+%define github_user mozsearch
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Patch0: mozsearch-gcc-toolchain
+BuildRequires: gmake
+Requires: llvm
+
+%prep
+%setup -n %{n}-%{realversion}
+%patch0 -p1
+
+%build
+cd clang-plugin
+GCC_ROOT=${GCC_ROOT} make %{makeprocesses} build 
+
+%install
+mkdir -p %{i}/lib64
+cp clang-plugin/libclang-index-plugin.so %{i}/lib64

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-10
+%define configtag       V09-04-11
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-tools.file/tools/mozsearch/mozsearch.xml
+++ b/scram-tools.file/tools/mozsearch/mozsearch.xml
@@ -1,0 +1,14 @@
+<tool name="mozsearch" version="1.0">
+  <client>
+    <environment name="MOZSEARCH_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$MOZSEARCH_BASE/lib64"/>
+  </client>
+  <flags INDEX_FLAGS="
+    -Xclang -load
+    -Xclang libclang-index-plugin.so
+    -Xclang -add-plugin                 -Xclang mozsearch-index
+    -Xclang -plugin-arg-mozsearch-index -Xclang src/
+    -Xclang -plugin-arg-mozsearch-index -Xclang mozsearch/
+    -Xclang -plugin-arg-mozsearch-index -Xclang tmp/$SCRAM_ARCH/src/
+  "/>
+</tool>


### PR DESCRIPTION
Mozsearch is DXR replacement. This PR adds the mozsearch clang-plugin in cmssw distro which we can use later for generating the cmssw indexing

FYI @aandvalenzuela 