### PR TITLE
Update cmsml to enable XLA flags for AOT models

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -59,7 +59,7 @@ charset-normalizer==3.3.2
 cleo==2.1.0
 click==8.1.7
 clikit==0.6.2
-cmsml==0.2.5
+cmsml==0.2.6
 cms-tfaot==1.0.1
 contourpy==1.2.1
 correctionlib==2.5.0


### PR DESCRIPTION
This is a one-line PR that updates the cmsml python package to 0.2.6, which fixes the way that `TF_XLA_FLAGS` and `XLA_FLAGS` are passed to the AOT model compilation. These flags configure the TF->XLA export and the graph optimization process that we currently study.

@valsdav @Bogdan-Wiederspan