### PR TITLE
updated pip pkg: requests, Jinja2, tqdm, Werkzeug

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -164,7 +164,7 @@ jaraco-context==5.3.0
 jax==0.4.26
 jedi==0.19.1
 jeepney==0.8.0
-Jinja2==3.1.3
+Jinja2==3.1.4
 jinja2-time==0.2.0
 joblib==1.4.0
 json5==0.9.25
@@ -331,7 +331,7 @@ referencing==0.35.1
 regex==2024.4.28
 repoze-lru==0.7
 rep==0.6.6
-requests==2.31.0
+requests==2.32.1
 requests-toolbelt==1.0.0
 requests-oauthlib==2.0.0
 requests-unixsocket==0.3.0
@@ -392,7 +392,7 @@ tomli-w==1.0.0
 tomlkit==0.12.4
 toolz==0.12.1
 tornado==6.4
-tqdm==4.66.2
+tqdm==4.66.4
 traitlets==5.14.3
 trove-classifiers==2024.4.10
 typed-ast==1.5.5
@@ -413,7 +413,7 @@ virtualenvwrapper==6.1.0
 wcwidth==0.2.13
 webencodings==0.5.1
 websocket-client==1.8.0
-Werkzeug==3.0.2
+Werkzeug==3.0.3
 #NO_AUTO_UPDATE:1: you need wheel to build wheel
 wheel==0.40.0
 widgetsnbextension==4.0.10


### PR DESCRIPTION
As nonted by dependabot, this update fixes following isses
- Werkzeug debugger vulnerable to remote execution when interacting with attacker controlled domain
- Requests `Session` object does not verify requests after making first request with verify=False
- Jinja vulnerable to HTML attribute injection when passing user input as keys to xmlattr filter
- tqdm CLI arguments injection attack