### PR TITLE
[ROOT632] Root update v6 32 00 patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag 63824298aba1ee2f42bd08243ae35184a4c02df2
-%define branch cms/v6-32-00-patches/4fcfdac2f3
+%define tag 54f8f41b73e2ae2f7d228c3fdefb866879cfb105
+%define branch cms/v6-32-00-patches/e5b2c7fb2d
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
ROOT [version](https://github.com/root-project/root/blob/v6-32-00-patches/core/foundation/inc/ROOT/RVersion.hxx) is still `6.31.99`.