### PR TITLE
Add collier toolfile

### DIFF
--- a/scram-tools.file/tools/collier/collier.xml
+++ b/scram-tools.file/tools/collier/collier.xml
@@ -1,0 +1,5 @@
+<tool name="collier" version="@TOOL_VERSION@">
+  <client>
+    <environment name="COLLIER_BASE" default="@TOOL_ROOT@"/>
+  </client>
+</tool>


### PR DESCRIPTION
The standard CMS event generation workflow involves building madgraph outside of CMSSW for use in gridpacks. However due to frequent HepForge downtime we would like to be able to install the madgraph prerequisites from CMSSW (https://github.com/cms-sw/genproductions/pull/3712). Collier is built in CMSSW, however it did not have a toolfile, so its directory could not be found by the `scram tool info` command. This PR adds a basic toolfile for collier to rectify this.

I don't have much experience with toolfiles, so please let me know if something is missing or there is a better solution.