### PR TITLE
[14.0.X] Update tag for RecoMuon-TrackerSeedGenerator to V00-07-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+RecoMuon-TrackerSeedGenerator=V00-07-00
 RecoBTag-Combined=V01-22-00
 RecoEgamma-PhotonIdentification=V01-08-00
 RecoTauTag-TrainingFiles=V00-09-00
@@ -25,7 +26,6 @@ DQM-Integration=V00-05-00
 DataFormats-DetId=V00-01-00
 RecoTracker-TkSeedGenerator=V00-03-00
 DataFormats-SiStripCluster=V00-01-00
-RecoMuon-TrackerSeedGenerator=V00-06-00
 L1Trigger-L1THGCal=V01-08-00
 L1Trigger-L1TCalorimeter=V01-02-00
 L1Trigger-TrackTrigger=V00-03-00


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/9210

Move RecoMuon-TrackerSeedGenerator data to new tag, see
https://github.com/cms-data/RecoMuon-TrackerSeedGenerator/pull/7

Cc: @wonpoint4