### PR TITLE
[10.6.X] Add collier toolfile

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -155,6 +155,7 @@ Requires: scons-toolfile
 Requires: md5-toolfile
 Requires: gosamcontrib-toolfile
 Requires: gosam-toolfile
+Requires: collier-toolfile
 Requires: madgraph5amcatnlo-toolfile
 Requires: geneva-toolfile
 Requires: python_tools

--- a/collier-toolfile.spec
+++ b/collier-toolfile.spec
@@ -1,0 +1,19 @@
+### RPM external collier-toolfile 1.0
+Requires: collier
+%prep
+
+%build
+
+%install
+
+mkdir -p %i/etc/scram.d
+cat << \EOF_TOOLFILE >%i/etc/scram.d/collier.xml
+<tool name="collier" version="@TOOL_VERSION@">
+  <client>
+    <environment name="COLLIER_BASE" default="@TOOL_ROOT@"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+## IMPORT scram-tools-post
+


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/9206 to provide collier path for run 2 UL madgraph gridpack generation (not exactly the same since handling of toolfiles has changed)