### PR TITLE
Downgrade grpcio-tools to 1.60.1 to match grpcio

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -128,7 +128,7 @@ google-pasta==0.2.0
 # NO_AUTO_UPDATE: update together with TF
 grpcio==1.60.1
 # NO_AUTO_UPDATE: update together with grpcio
-grpcio-tools==1.63.0
+grpcio-tools==1.60.1
 hatch-fancy-pypi-readme==24.1.0
 hatch-jupyter-builder==0.9.1
 hatch-nodejs-version==0.3.2


### PR DESCRIPTION
Removes the following warning:
```
(...)/tritonclient/grpc/service_pb2_grpc.py:21: RuntimeWarning: The grpc package installed is at version 1.60.1, but the generated code in grpc_service_pb2_grpc.py depends on grpcio>=1.63.0. Please upgrade your grpc module to grpcio>=1.63.0 or downgrade your generated code using grpcio-tools<=1.60.1. This warning will become an error in 1.65.0, scheduled for release on June 25, 2024.
  warnings.warn(
```