### PR TITLE
[CMSSW_14_0] Update UTM to 13.0

### DIFF
--- a/utm.spec
+++ b/utm.spec
@@ -1,4 +1,4 @@
-### RPM external utm utm_0.12.0
+### RPM external utm utm_0.13.0
 Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake
 Requires: xerces-c boost


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/9214

> Updates UTM to 13.0 to support MHTHF objects and combinations of up to 12 calo objects.

This backport has been requested by the L1T DPG to support it's use in the CMSSW_14_0 emulator.