### PR TITLE
[14_0_X] Update L1Trigger-L1TMuon tag

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+L1Trigger-L1TMuon=V01-12-00
 RecoMuon-TrackerSeedGenerator=V00-07-00
 RecoBTag-Combined=V01-22-00
 RecoEgamma-PhotonIdentification=V01-08-00
@@ -30,7 +31,6 @@ L1Trigger-L1THGCal=V01-08-00
 L1Trigger-L1TCalorimeter=V01-02-00
 L1Trigger-TrackTrigger=V00-03-00
 Geometry-TestReference=V00-12-00
-L1Trigger-L1TMuon=V01-10-00
 DQM-HcalTasks=V00-01-00
 DataFormats-Scouting=V00-02-00
 L1Trigger-Phase2L1ParticleFlow=V00-06-00


### PR DESCRIPTION
Updates muon tag as done in https://github.com/cms-sw/cmsdist/pull/9226/files [as requested](https://github.com/cms-sw/cmssw/pull/45107#issuecomment-2159480470). This should update the L1Muon data repository for L1Muon backport PR https://github.com/cms-sw/cmssw/pull/45107