### PR TITLE
[AARCH64] jemalloc: explicitly set pagesize

### DIFF
--- a/jemalloc-common.file
+++ b/jemalloc-common.file
@@ -27,6 +27,7 @@ BuildRequires: patchelf
   --prefix %{i} \
   --disable-doc \
 %ifarch aarch64
+  --with-lg-page=16 \
   --with-lg-hugepage=24 \
 %endif
   --enable-shared \


### PR DESCRIPTION
On GRID nodes, pagesize is set to 4096, while on lxplus-arm and vocms-arm it is 65536. If jemalloc was built on GRID node, using it on lxplus or vocms will cause failures ([e.g.](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc12/CMSSW_14_1_X_2024-06-06-2300/pyRelValMatrixLogs/run/4.17_RunMinBias2011A/step2_RunMinBias2011A.log#/)):

```
<jemalloc>: Unsupported system page size
```

From install.MD for jemalloc:
> `--with-lg-page`: Specify the base 2 log of the allocator page size, which must in turn be at least as large as the system page size. 

Notice that this change *may* cause performance issues, see e.g. discussion here: https://github.com/jemalloc/jemalloc/issues/2639#issuecomment-2073576515