### PR TITLE
[ROOT6] ROOT Update Master

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag 41abeb88a72ed55b47cd2d3ba7937fbd30d0a2b3
-%define branch cms/master/2ae66788ce
+%define tag 96c2ea1bd461861f628f7e1dfc3f9b1a99a94217
+%define branch cms/master/b5d751c069
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
ROOT [version](https://github.com/root-project/root/blob/master/core/foundation/inc/ROOT/RVersion.hxx) is still `6.33.01`.