### PR TITLE
Update professor2 to 2.4.2 and fixing Python3 env

### DIFF
--- a/pip/iminuit.file
+++ b/pip/iminuit.file
@@ -1,0 +1,1 @@
+Requires: py3-numpy py3-matplotlib py3-scipy py3-ipywidgets

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -423,3 +423,4 @@ wrapt==1.14.1
 xgboost==1.7.5
 yarl==1.9.4
 zipp==3.18.1
+iminuit==1.2

--- a/professor2-ppc64-flag-change.patch
+++ b/professor2-ppc64-flag-change.patch
@@ -15,7 +15,7 @@ diff --git a/pyext/setup.py b/pyext/setup.py
 index adf3b19..fabdbf0 100644
 --- a/pyext/setup.py
 +++ b/pyext/setup.py
-@@ -14,7 +14,7 @@ ext = Extension("professor2.core",
+@@ -19,7 +19,7 @@ ext = Extension("professor2.core",
                  language="C++",
                  depends=glob("../include/*.h"),
                  include_dirs=[incdir, os.path.join(srcdir, "pyext", "professor2")],

--- a/professor2.spec
+++ b/professor2.spec
@@ -3,14 +3,14 @@
 ## INITENV +PATH PROF_VERSION %{realversion}
 ## INCLUDE cpp-standard
 
-Source: http://www.hepforge.org/archive/professor/professor-professor-%{realversion}.tar.gz
+Source: git+https://gitlab.com/hepcedar/professor.git?obj=main/professor-%{realversion}&export=professor-%{realversion}&output=/professor-%{realversion}.tgz
 Requires: py3-matplotlib root yoda eigen py3-iminuit
 BuildRequires: py3-cython py3-pip
 
 Patch0: professor2-ppc64-flag-change
 
 %prep
-%setup -n professor-professor-%{realversion}
+%setup -n professor-%{realversion}
 
 %ifarch ppc64le
 %patch0 -p1

--- a/professor2.spec
+++ b/professor2.spec
@@ -4,7 +4,7 @@
 ## INCLUDE cpp-standard
 
 Source: http://www.hepforge.org/archive/professor/professor-professor-%{realversion}.tar.gz
-Requires: py3-matplotlib root yoda eigen
+Requires: py3-matplotlib root yoda eigen py3-iminuit
 BuildRequires: py3-cython py3-pip
 
 Patch0: professor2-ppc64-flag-change

--- a/professor2.spec
+++ b/professor2.spec
@@ -1,6 +1,5 @@
 ### RPM external professor2 2.4.2
 ## INITENV +PATH PYTHON3PATH %i/lib/python%{cms_python3_major_minor_version}/site-packages
-## INITENV +PATH PROF_VERSION %{realversion}
 ## INCLUDE cpp-standard
 
 Source: git+https://gitlab.com/hepcedar/professor.git?obj=main/professor-%{realversion}&export=professor-%{realversion}&output=/professor-%{realversion}.tgz

--- a/professor2.spec
+++ b/professor2.spec
@@ -1,15 +1,16 @@
-### RPM external professor2 2.3.3
+### RPM external professor2 2.4.2
 ## INITENV +PATH PYTHON3PATH %i/lib/python%{cms_python3_major_minor_version}/site-packages
+## INITENV +PATH PROF_VERSION %{realversion}
 ## INCLUDE cpp-standard
 
-Source: http://www.hepforge.org/archive/professor/Professor-%{realversion}.tar.gz
+Source: http://www.hepforge.org/archive/professor/professor-professor-%{realversion}.tar.gz
 Requires: py3-matplotlib root yoda eigen
 BuildRequires: py3-cython py3-pip
 
 Patch0: professor2-ppc64-flag-change
 
 %prep
-%setup -n Professor-%{realversion}
+%setup -n professor-professor-%{realversion}
 
 %ifarch ppc64le
 %patch0 -p1
@@ -22,13 +23,22 @@ sed -i -e 's|-std=c[+][+]11|-std=c++%{cms_cxx_standard}|' pyext/setup.py
 # Same for Makefile
 grep -q 'CXXSTD := c[+][+]11' Makefile
 sed -i -e 's|CXXSTD := c[+][+]11|CXXSTD := c++%{cms_cxx_standard}|' Makefile
+sed -i -e "s|pip install -vv|pip install --target ../${PYTHON3_LIB_SITE_PACKAGES} -vv|" Makefile
+
+# Update Python2 to Python3
+for i in `ls bin`
+do
+   echo "bin/${i}"
+   sed -i -e 's|/usr/bin/env python|/usr/bin/env python3|' "bin/${i}"
+done
 
 %define build_flags CPPFLAGS=-I${EIGEN_ROOT}/include/eigen3 PYTHON=$(which python3) PROF_VERSION=%{realversion} PYTHONPATH=./${PYTHON3_LIB_SITE_PACKAGES}
-
 %build
-make %{build_flags}
+make PREFIX=%{i} %{build_flags}
 
 %install
 make install PREFIX=%{i} %{build_flags}
-mv %{i}/${PYTHON3_LIB_SITE_PACKAGES}/%{n}-%{realversion}*.egg %{i}/${PYTHON3_LIB_SITE_PACKAGES}/%{n}
+mv %{i}/${PYTHON3_LIB_SITE_PACKAGES}/%{n}-%{realversion}*.dist* %{i}/${PYTHON3_LIB_SITE_PACKAGES}/%{n}
 rm -f %{i}/${PYTHON3_LIB_SITE_PACKAGES}/*.pth
+
+

--- a/scram-tools.file/tools/professor2/professor2.xml
+++ b/scram-tools.file/tools/professor2/professor2.xml
@@ -8,6 +8,4 @@
 <use name="yoda"/>
 <use name="eigen"/>
 <runtime name="PATH" value="$PROFESSOR2_BASE/bin" type="path"/>
-<runtime name="PYTHONPATH" value="$PROFESSOR2_BASE/lib/python3.9/site-packages" type="path"/>
-<runtime name="LD_LIBRARY_PATH" value="$LIBDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/professor2/professor2.xml
+++ b/scram-tools.file/tools/professor2/professor2.xml
@@ -8,4 +8,6 @@
 <use name="yoda"/>
 <use name="eigen"/>
 <runtime name="PATH" value="$PROFESSOR2_BASE/bin" type="path"/>
+<runtime name="PYTHONPATH" value="$PROFESSOR2_BASE/lib/python3.9/site-packages" type="path"/>
+<runtime name="LD_LIBRARY_PATH" value="$LIBDIR" type="path"/>
 </tool>


### PR DESCRIPTION
This is the draft PR to update `professor2` to the most recent version 2.4.2.

Some changes of the code are due to the change of the installation commands (`python setup.py` to `python -m pip install`), while the `python` in shebang has been updated to `python3`

@shimashimarin

