### PR TITLE
[BuildRules] Added support to link default lib to the alpaka backends

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-11
+%define configtag       V09-04-12
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
See https://github.com/cms-sw/cmssw/pull/45285 .
Adding `<flags USE_ALPAKA="1"/>` OR `<flags USE_ALPAKA="Subsystem/Package"/>` will add dependency on `Subsystem/Package` for all the alpaka backends. This is same as using
```
<use name="1" for="alpaka"/>
OR
<use name="SubSystem/Package" for="alpaka"/>
```