### PR TITLE
cmssw-osenv: Fix for calling cmsset_default and user login scripts

### DIFF
--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 240627.0
+### RPM cms cmssw-osenv 240628.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit 066f3cdc976f9e5cdf6aae82e434d4e2f6764385
+%define commit bf08ae2197605d001dca4454b9e9df7b52304f76
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.

--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 240514.0
+### RPM cms cmssw-osenv 240627.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit ca8901b3b404f7fa8ec80112b85840c9647335ac
+%define commit 066f3cdc976f9e5cdf6aae82e434d4e2f6764385
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.


### PR DESCRIPTION
This update should fix the source of `cmsset_default.sh` and user login scripts e.g. previously we get
- Interactive shell: user alias were not available inside the container but cms alias e.g. `cmsenv` is available
```
> my_alias 
My Alias OK
> cmssw-el7
Singularity> my_alias
bash: my_alias: command not found
Singularity> cmsenv
SCRAM fatal: Unable to locate the top of local release. Please run this command from a SCRAM-based area.
Singularity> echo $SCRAM_ARCH
slc7_amd64_gcc10
Singularity> exit
>
```
- also batch mode both user and cms alias are not available
```
> cmssw-el7 -- 'echo $SCRAM_ARCH; my_alias;cmsenv; echo DONE'

/bin/bash: my_alias: command not found
/bin/bash: cmsenv: command not found
DONE
```

After these changes, both in interactive shell and batch mode user and cms alias are available
- interactive shell
```
> PATH=/build/muz/env/common:$PATH cmssw-el7 --interactive
Singularity> my_alias 
My Alias OK
Singularity> cmsenv
SCRAM fatal: Unable to locate the top of local release. Please run this command from a SCRAM-based area.
Singularity> echo $SCRAM_ARCH
slc7_amd64_gcc10
Singularity> exit
```
- batch mode
```
>  PATH=/build/muz/env/common:$PATH cmssw-el7 --interactive -- 'echo $SCRAM_ARCH; my_alias;cmsenv; echo DONE'
slc7_amd64_gcc10
My Alias OK
SCRAM fatal: Unable to locate the top of local release. Please run this command from a SCRAM-based area.
DONE
```

