### PR TITLE
Buildrules: Use sort instead of python3 to calculcate the dependency order

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-12
+%define configtag       V09-04-13
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Using `sort` to calculcate the order is much faster then using `python3`.  Using `sort` to calculate the dependency order of all product takes around 40s which python takes over 4mins