### PR TITLE
Add cms-cat.spec

### DIFF
--- a/cms-cat.spec
+++ b/cms-cat.spec
@@ -24,6 +24,14 @@ mv * %{i}/cat
 cd ${RPM_INSTALL_PREFIX}/%{pkgrel}
 mkdir -p ${RPM_INSTALL_PREFIX}/cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}
 
+# Check if a newer revision is already installed
+if [ -f ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version ] ; then
+  oldrev=$(cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version )
+  if [ ${oldrev} -ge %{fakerevision} ] ; then
+    exit 0
+  fi
+fi
+
 rsync -a --delete ${RPM_INSTALL_PREFIX}/%{pkgrel}/cat/ ${RPM_INSTALL_PREFIX}/cat/
 
 echo %{fakerevision} > ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version

--- a/cms-cat.spec
+++ b/cms-cat.spec
@@ -1,0 +1,42 @@
+### RPM cms cms-cat 240702.0
+## NOCOMPILER
+## NO_VERSION_SUFFIX
+
+# ***Do not change minor number of the above version. ***
+
+%define commit 0e3b60982ec088096fa67c46db5e9de2290ea5fb
+%define branch master
+# We do not use a revision explicitly, because revisioned packages do not get
+# updated automatically when there are dependencies.
+%define fakerevision %(echo %realversion | cut -d. -f1)
+Source0: git://gitlab.cern.ch/cms-analysis/services/cms.cern.ch-cat.git?obj=%{branch}/%{commit}&export=cms-cat&output=/cms-cat-%{commit}.tgz
+
+%prep
+%setup -n %{n}
+
+%build
+
+%install
+mkdir -p %{i}/cat
+mv * %{i}/cat
+
+%post
+cd ${RPM_INSTALL_PREFIX}/%{pkgrel}
+mkdir -p ${RPM_INSTALL_PREFIX}/cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}
+
+#Check if a newer revision is already installed
+if [ -f ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version ] ; then
+  oldrev=$(cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version )
+  if [ ${oldrev} -ge %{fakerevision} ] ; then
+    exit 0
+  fi
+fi
+
+for file in $(find . -name '*' -type f -path '*/cat/*') ; do
+  cp -f ${file} ${RPM_INSTALL_PREFIX}/${file}
+done
+for file in $(find . -name '*' -type l -path '*/cat/*') ; do
+  cp -pRf ${file} ${RPM_INSTALL_PREFIX}/${file}
+done
+
+echo %{fakerevision} > ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version

--- a/cms-cat.spec
+++ b/cms-cat.spec
@@ -24,19 +24,6 @@ mv * %{i}/cat
 cd ${RPM_INSTALL_PREFIX}/%{pkgrel}
 mkdir -p ${RPM_INSTALL_PREFIX}/cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}
 
-#Check if a newer revision is already installed
-if [ -f ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version ] ; then
-  oldrev=$(cat ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version )
-  if [ ${oldrev} -ge %{fakerevision} ] ; then
-    exit 0
-  fi
-fi
-
-for file in $(find . -name '*' -type f -path '*/cat/*') ; do
-  cp -f ${file} ${RPM_INSTALL_PREFIX}/${file}
-done
-for file in $(find . -name '*' -type l -path '*/cat/*') ; do
-  cp -pRf ${file} ${RPM_INSTALL_PREFIX}/${file}
-done
+rsync -a --delete ${RPM_INSTALL_PREFIX}/%{pkgrel}/cat/ ${RPM_INSTALL_PREFIX}/cat/
 
 echo %{fakerevision} > ${RPM_INSTALL_PREFIX}/etc/%{pkgname}/version

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -1,7 +1,7 @@
 ### RPM cms cmssw-tools 1.0
 # With cmsBuild, change the above version only when a new tool is added
 
-## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cmssw-osenv cms-git-tools SCRAMV2
+## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cms-cat cmssw-osenv cms-git-tools SCRAMV2
 ## UPLOAD_DEPENDENCIES dqmgui
 
 Requires: AXOL1TL


### PR DESCRIPTION
This is basically a copy of https://github.com/cms-sw/cmsdist/blob/HEAD/cmssw-osenv.spec, moving files into `cat` instead of `common` and cloning the contents of https://gitlab.cern.ch/cms-analysis/services/cms.cern.ch-cat (this is a public repository).

Let me know if I e.g. need to add this anywhere else (I saw that `cmssw-tools.spec` contains the following line related to `cmssw-osenv`:

```
## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cmssw-osenv cms-git-tools SCRAMV2
```
