### PR TITLE
Drop crab nosort option; fizes for zsh

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1234
+## REVISION 1235
 ## NOCOMPILER
 
-%define tag f1821e6c6953b601cb5501ced2125b15b65d6e26
+%define tag 2f8b40d4907649b7cca9a7750bf6e57b7b1f195d
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/crab-build.file
+++ b/crab-build.file
@@ -44,7 +44,7 @@ for pkg in %{crabserver_packages} ; do
 done
 
 #complete command in crab-bash-completion.sh should match '^\s*complete\s+-F\s+.*\s<Crab-function-Name>\s.*\scrab\s*$'
-COMPLETE_CMD=$(grep '^\s*complete\s\s*-F\s' %{i}/etc/crab-bash-completion.sh | grep '\scrab\s*$')
+COMPLETE_CMD=$(grep '^\s*complete\s\s*-F\s' %{i}/etc/crab-bash-completion.sh | grep '\scrab\s*$' | sed 's|-o\s\s*nosort||')
 if [ "${COMPLETE_CMD}" != "" ] ; then
   CRAB_FUNC=$(echo "${COMPLETE_CMD}" | sed 's|^.*\s-F\s\s*||;s|\s.*||')
   sed -i -e 's|^\s*complete\s\s*-F\s.*$|@COMPLETE_CMD@|' %{i}/etc/crab-bash-completion.sh

--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.240621
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.240527

--- a/crab-pre.spec
+++ b/crab-pre.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 01
+%define version_suffix 02
 %define crabclient_version v3.240416
 ### RPM cms crab-pre %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.240325

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -2,7 +2,7 @@
 #For new crabclient_version, set the version_suffix to 00
 #For any other change, increment version_suffix
 ##########################################
-%define version_suffix 00
+%define version_suffix 01
 %define crabclient_version v3.240621
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.240527

--- a/crab/crab-env.sh.file
+++ b/crab/crab-env.sh.file
@@ -1,13 +1,13 @@
 #!/bin/bash
-#CMSDIST_FILE_REVISION=3
+#CMSDIST_FILE_REVISION=4
 cms_basedir="@CMS_PATH@/share/cms"
 crab_shared_dir="${cms_basedir}/crab/@CRAB_COMMON_VERSION@"
 for crab_latest in $(ls ${crab_shared_dir}/etc/crab-*.latest 2>/dev/null) ; do
   crab_type=$(basename ${crab_latest} | sed 's|.latest$||;s|^crab-||')
   crab_version=$(cat ${crab_latest})
   if [ -e ${cms_basedir}/crab-${crab_type}/${crab_version}/etc/crab-bash-completion.sh ]; then
-    if [ "$(ps -p$$ -ocmd=)" = "zsh" ] ; then
-      autoload -U +X compinit && compinit
+    if [[ $(ps -p$$ --no-headers -o cmd | cut -d' ' -f1) =~ ^.*zsh$ ]] ; then
+      autoload -U +X compinit && compinit -u
       autoload -U +X bashcompinit && bashcompinit
     fi
     source ${cms_basedir}/crab-${crab_type}/${crab_version}/etc/crab-bash-completion.sh >/dev/null 2>&1


### PR DESCRIPTION
This PR fixes the following issues
- Update cms-common so that cmsset_default.sh do not fail under zsh ( `export -f` fails for `zsh`)
- Drop `nosort` option from crab auto complete script. This allow it to run it under `el7`. `nosort` option was added for `bash>=4.4` which in `el7` we have `bash 4.2` 
  -  See https://cms-talk.web.cern.ch/t/crab-is-not-working/41539 for details
- Fix the logic for zsh 