### PR TITLE
Bump cepgen to 1.2.4

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.2.3
+### RPM external cepgen 1.2.4
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 


### PR DESCRIPTION
This PR bumps the CepGen version from 1.2.3 to 1.2.4.
Release notes can be found [here](https://github.com/cepgen/cepgen/releases/tag/1.2.4).