### PR TITLE
Set c++20 as a default standard

### DIFF
--- a/cpp-standard.file
+++ b/cpp-standard.file
@@ -1,4 +1,4 @@
 # C++ standard to use for CMS externals
 %if "%{?cms_cxx_standard:set}" != "set"
-%define cms_cxx_standard 17
+%define cms_cxx_standard 20
 %endif


### PR DESCRIPTION
We do not have a special branch for CPP20, so this is the only change required.