### PR TITLE
Adding missing deps for libunwind, libtiff and llvm

### DIFF
--- a/libtiff.spec
+++ b/libtiff.spec
@@ -1,7 +1,7 @@
 ### RPM external libtiff 4.0.10
 Source: http://download.osgeo.org/libtiff/tiff-%{realversion}.zip
 
-Requires: libjpeg-turbo zlib
+Requires: libjpeg-turbo zlib xz zstd
 
 %prep
 %setup -n tiff-%{realversion}
@@ -14,13 +14,17 @@ chmod +x ./config/config.{sub,guess}
 
 %build
 ./configure --prefix=%{i} --disable-static \
+            --with-zstd-lib-dir=${ZSTD_ROOT}/lib \
+            --with-zstd-include-dir=${ZSTD_ROOT}/include \
+            --with-lzma-lib-dir=${XZ_ROOT}/lib \
+            --with-lzma-include-dir=${XZ_ROOT}/include \
             --with-zlib-lib-dir=${ZLIB_ROOT}/lib \
             --with-zlib-include-dir=${ZLIB_ROOT}/include \
             --with-jpeg-lib-dir=${LIBJPEG_TURBO_ROOT}/lib64 \
             --with-jpeg-include-dir=${LIBJPEG_TURBO_ROOT}/include \
             --disable-dependency-tracking \
             --without-x
-                          
+
 make %{makeprocesses}
 
 %install

--- a/libunwind.spec
+++ b/libunwind.spec
@@ -4,14 +4,17 @@
 Source0: git://github.com/%{n}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 BuildRequires: autotools gmake
-Requires: zlib
+Requires: zlib xz
 
 %prep
 %setup -n %{n}-%{realversion}
 
 %build
 autoreconf -fiv
-./configure CFLAGS="-g -O3 -fcommon" --prefix=%{i} --disable-block-signals --enable-zlibdebuginfo
+./configure CFLAGS="-g -O3 -fcommon" \
+  CPPFLAGS="-I${ZLIB_ROOT}/include -I${XZ_ROOT}/include" \
+  LDFLAGS="-L${ZLIB_ROOT}/lib -L${XZ_ROOT}/lib" \
+  --prefix=%{i} --disable-block-signals --enable-zlibdebuginfo
 make %{makeprocesses}
 
 %install

--- a/llvm.spec
+++ b/llvm.spec
@@ -3,7 +3,7 @@
 ## INITENV +PATH PYTHON3PATH %{i}/lib64/python%{cms_python3_major_minor_version}/site-packages
 
 BuildRequires: cmake ninja
-Requires: gcc zlib python3
+Requires: gcc zlib python3 libxml2
 %{!?without_cuda:Requires: cuda}
 
 %define llvmCommit 83204dfcd4277154e46a5c6094aee389a7f260e8
@@ -55,7 +55,7 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES="%omptarget_cuda_archs" \
 %endif
   -DCMAKE_REQUIRED_INCLUDES="${ZLIB_ROOT}/include" \
-  -DCMAKE_PREFIX_PATH="${ZLIB_ROOT}"
+  -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${LIBXML2_ROOT}"
 
 ninja -v %{makeprocesses}
 ninja -v %{makeprocesses} check-clang-tools


### PR DESCRIPTION
Explicitly add the missing deps
- libxml2 for llvm
- zstd and xz(lzma) for libtiff
- xz(lzma) for libunwind

for el8, these packages are built without lzma/zstd support and for el9  these dependencies were found from system 
```
Missing  libunwind ['liblzma.so.5()(64bit)', 'liblzma.so.5(XZ_5.0)(64bit)']
Missing  llvm ['libxml2.so.2()(64bit)', 'libxml2.so.2(LIBXML2_2.4.30)(64bit)', 'libxml2.so.2(LIBXML2_2.5.2)(64bit)', 'libxml2.so.2(LIBXML2_2.6.0)(64bit)']
Missing  libtiff ['liblzma.so.5()(64bit)', 'liblzma.so.5(XZ_5.0)(64bit)']

```