### PR TITLE
BuildRule: export explicitly added alpaka backend deps

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-13
+%define configtag       V09-04-14
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Explicit dependencies for alpaka backends were not exported e.g. following in `Subsystem/Package/BuildFile.xml`
```
<use name="foo" for="alpaka/serial"/>
```
was used as a private dependency (only used for building `SubsystemPackageSerialAsync` ) and it was not exported for the dependent packages `alpaka/serial` backends. This PR fixes this and now a dependent serial backend should also get this depenency.