### PR TITLE
Fix for multi-arch: copy vectorized_packages.txt in to tool-conf

### DIFF
--- a/scram/tool-conf.file
+++ b/scram/tool-conf.file
@@ -10,6 +10,7 @@ if [ -d %{cmsroot}/%{cmsplatf}/%{directpkgreqs}/lib ] ; then
 fi
 %{expand:%(cat %{cmsroot}/%{cmsplatf}/%{directpkgreqs}/tools/selected.tmpl)}
 %{expand:%(cat %{cmsroot}/%{cmsplatf}/%{directpkgreqs}/tools/available.tmpl)}
+[ ! -e %{cmsroot}/%{cmsplatf}/%{directpkgreqs}/vectorized_packages.txt ] || cp %{cmsroot}/%{cmsplatf}/%{directpkgreqs}/vectorized_packages.txt %{i}/
 
 %post
 echo "%{uctool}_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'"     > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh


### PR DESCRIPTION
https://github.com/cms-sw/cmsdist/pull/9218 broke the multi-arch builds. Though all the externals were built for default and extra micro-arch but multi-arch flags were disabled for cmssw due to missing vectorized_packages.txt file in `cmssw-tool-conf`. This PR properly copies `vectorized_packages.txt` from `cmssw-tools` in to `cmssw-tool-conf`