### PR TITLE
Bump cepgen version to 1.2.5

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -1,4 +1,4 @@
-### RPM external cepgen 1.2.4
+### RPM external cepgen 1.2.5
 
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 


### PR DESCRIPTION
This release, among other things, fixes the missing particles status code propagation to the HepMC2 event content noticed by @bbilin, and documented in https://github.com/cepgen/cepgen/issues/88.

As usual, full release notes are available at: https://cepgen.hepforge.org/changelog.html