### PR TITLE
[riscv] changes needed for using system-gcc and disabling pkgs

### DIFF
--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tools 1.0
+### RPM cms cmssw-tools 2.0
 # With cmsBuild, change the above version only when a new tool is added
 
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cms-cat cmssw-osenv cms-git-tools SCRAMV2
@@ -72,7 +72,6 @@ Requires: pythia6
 Requires: pythia8
 Requires: python3
 Requires: root
-Requires: sherpa
 Requires: libpciaccess
 Requires: numactl
 Requires: hwloc
@@ -90,15 +89,14 @@ Requires: frontier_client
 Requires: xrootd
 Requires: xrdcl-record
 Requires: dd4hep
-Requires: valgrind
+%{!?without_valgrind:Requires: valgrind}
 Requires: cmsswdata
 Requires: zstd
 Requires: hls
 Requires: opencv
 Requires: grpc
 Requires: onnxruntime
-Requires: tensorflow-xla-runtime
-Requires: tensorflow
+%{!?without_tensorflow:Requires: tensorflow tensorflow-xla-runtime}
 Requires: TOoLLiP
 Requires: triton-inference-client
 Requires: hdf5
@@ -142,7 +140,7 @@ Requires: gosamcontrib
 Requires: gosam
 Requires: madgraph5amcatnlo
 Requires: python_tools
-Requires: dasgoclient
+%{!?without_dasgoclient:Requires: dasgoclient}
 Requires: dablooms
 Requires: zlib
 Requires: rivet
@@ -158,9 +156,11 @@ Requires: alpaka
 Requires: clue
 Requires: libunwind
 %ifnarch ppc64le
+%ifnarch riscv64
 Requires: igprof
 Requires: heaptrack
-Requires: openloops
+%endif
+%{!?without_openloops:Requires: openloops}
 %endif
 
 %ifarch x86_64

--- a/form.spec
+++ b/form.spec
@@ -18,6 +18,9 @@ CC="$(which gcc)"
 ./configure --prefix=%i \
             --bindir=%i/bin \
             --without-gmp \
+%ifarch riscv64
+            --build=%{_arch}-unknown-linux-gnu \
+%endif
             --with-zlib=${ZLIB_ROOT} \
             CXX="$CXX" CC="$CC" CXXFLAGS=-fpermissive
 

--- a/gosamcontrib.spec
+++ b/gosamcontrib.spec
@@ -18,6 +18,9 @@ PLATF_CONF_OPTS="--enable-shared --enable-static"
 ./configure $PLATF_CONF_OPTS \
             --prefix=%i \
             --bindir=%i/bin \
+%ifarch riscv64
+            --build=%{_arch}-unknown-linux-gnu \
+%endif
             --libdir=%i/lib \
             CXX="$CXX" CC="$CC" FC="$FC" F77="${FC}"
 

--- a/herwig7.spec
+++ b/herwig7.spec
@@ -11,9 +11,7 @@ Requires: fastjet
 Requires: gosamcontrib gosam
 Requires: madgraph5amcatnlo
 Requires: python3
-%ifnarch ppc64le
-Requires: openloops
-%endif
+%{!?without_openloops:Requires: openloops}
 BuildRequires: autotools
 Patch0: herwig_Matchbox_mg_py3
 Patch1: herwig7-fxfx-fix
@@ -49,12 +47,15 @@ PYTHON=python3 ./configure --prefix=%i \
             --with-gosam=$GOSAM_ROOT \
             --with-gosam-contrib=$GOSAMCONTRIB_ROOT \
             --with-hepmc=$HEPMC_ROOT \
-%ifnarch ppc64le
-            --with-openloops=$OPENLOOPS_ROOT \
-%endif
+            ${OPENLOOPS_ROOT+--with-openloops=$OPENLOOPS_ROOT} \
             $PLATF_CONF_OPTS \
             CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib" \
             FCFLAGS="$FCFLAGS"
+
+%ifarch riscv64
+sed -i -e 's|^install-data-hook:|install-data-hook:\n\techo Skip data\n\ninstall-data-hookX:|' src/Makefile
+%endif
+
 make %makeprocesses all
 
 %install

--- a/libzmq.spec
+++ b/libzmq.spec
@@ -11,6 +11,7 @@ BuildRequires: autotools
 
 ./configure --prefix=%{i} \
             --without-docs \
+            --enable-libunwind=no \
             --disable-dependency-tracking
 
 %build

--- a/llvm.spec
+++ b/llvm.spec
@@ -37,19 +37,21 @@ cd %{_builddir}/build
 
 cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -G Ninja \
+%if 0%{!?use_system_gcc:1}
   -DGCC_INSTALL_PREFIX="${GCC_ROOT}" \
+  -DLLVM_BINUTILS_INCDIR:STRING="${GCC_ROOT}/include" \
+%endif
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lld;openmp" \
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DLLVM_LIBDIR_SUFFIX:STRING=64 \
-  -DLLVM_BINUTILS_INCDIR:STRING="${GCC_ROOT}/include" \
   -DLLVM_BUILD_LLVM_DYLIB:BOOL=ON \
   -DLLVM_LINK_LLVM_DYLIB:BOOL=ON \
   -DLLVM_ENABLE_EH:BOOL=ON \
   -DLLVM_ENABLE_PIC:BOOL=ON \
   -DLLVM_ENABLE_RTTI:BOOL=ON \
   -DLLVM_HOST_TRIPLE=$(gcc -dumpmachine) \
-  -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64;NVPTX" \
+  -DLLVM_TARGETS_TO_BUILD:STRING="X86;PowerPC;AArch64;RISCV;NVPTX" \
 %if 0%{!?without_cuda:1}
   -DLIBOMPTARGET_NVPTX_ALTERNATE_HOST_COMPILER=/usr/bin/gcc \
   -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES="%omptarget_cuda_archs" \

--- a/professor2.spec
+++ b/professor2.spec
@@ -14,6 +14,9 @@ Patch0: professor2-ppc64-flag-change
 %ifarch ppc64le
 %patch0 -p1
 %endif
+%ifarch riscv64
+sed -i -e 's|-march=native||' Makefile
+%endif
 
 # Make sure the default c++sdt stand is c++11 in pyext/setup.py
 grep -q 'std=c[+][+]11' pyext/setup.py

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -11,7 +11,7 @@ Requires: py3-scipy
 Requires: py3-keras
 Requires: py3-scikit-learn
 #save for the end
-Requires: py3-tensorflow
+%{!?without_tensorflow:Requires: py3-tensorflow}
 Requires: py3-cms-tfaot
 Requires: py3-cmsml
 Requires: py3-law

--- a/scram-tools.file/tools/gcc/gcc-ccompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-ccompiler.xml
@@ -1,7 +1,11 @@
   <tool name="gcc-ccompiler" version="@TOOL_VERSION@" type="compiler">
     <client>
       <environment name="GCC_CCOMPILER_BASE" default="@TOOL_ROOT@"/>
+%if 0%{!?use_system_gcc:1}
       <environment name="CC" value="$GCC_CCOMPILER_BASE/bin/gcc@COMPILER_NAME_SUFFIX@"/>
+%else
+      <environment name="CC" value="gcc@COMPILER_NAME_SUFFIX@"/>
+%endif
     </client>
     <flags CSHAREDOBJECTFLAGS="-fPIC @GCC_CSHAREDOBJECTFLAGS@"/>
     <flags CFLAGS="-O3 -pthread @GCC_CFLAGS@"/>

--- a/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
@@ -1,7 +1,11 @@
   <tool name="gcc-cxxcompiler" version="@TOOL_VERSION@" type="compiler">
     <client>
-      <environment name="GCC_CXXCOMPILER_BASE" default="@TOOL_ROOT@"/>
-      <environment name="CXX" value="$GCC_CXXCOMPILER_BASE/bin/c++@COMPILER_NAME_SUFFIX@"/>
+	    <environment name="GCC_CXXCOMPILER_BASE" default="@TOOL_ROOT@"/>
+%if 0%{!?use_system_gcc:1}
+	    <environment name="CXX" value="$GCC_CXXCOMPILER_BASE/bin/c++@COMPILER_NAME_SUFFIX@"/>
+%else
+	    <environment name="CXX" value="c++@COMPILER_NAME_SUFFIX@"/>
+%endif
     </client>
     <flags CPPDEFINES="GNU_GCC _GNU_SOURCE @GCC_CPPDEFINES@"/>
     <flags CXXSHAREDOBJECTFLAGS="-fPIC @GCC_CXXSHAREDOBJECTFLAGS@"/>
@@ -31,9 +35,11 @@
     <flags LDFLAGS="@GCC_LDFLAGS@"/>
     <flags CXXSHAREDFLAGS="@GCC_SHAREDFLAGS@"/>
     <flags LD_UNIT="@GCC_LD_UNIT@"/>
+    <runtime name="SCRAM_CXX11_ABI" value="@SCRAM_CXX11_ABI@"/>
+%if 0%{!?use_system_gcc:1}
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$GCC_CXXCOMPILER_BASE/@OS_LIB64DIR@" type="path"/>
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$GCC_CXXCOMPILER_BASE/lib" type="path"/>
-    <runtime name="SCRAM_CXX11_ABI" value="@SCRAM_CXX11_ABI@"/>
+    <runtime name="COMPILER_PATH" value="@TOOL_ROOT@"/>
     <runtime name="PATH" value="$GCC_CXXCOMPILER_BASE/bin" type="path"/>
     <ifrelease name="ASAN">
       <runtime name="GCC_RUNTIME_ASAN" value="$GCC_CXXCOMPILER_BASE/@OS_LIB64DIR@/libasan.so" type="path"/>
@@ -44,5 +50,5 @@
     <elif name="TSAN"/>
       <runtime name="GCC_RUNTIME_TSAN" value="$GCC_CXXCOMPILER_BASE/@OS_LIB64DIR@/libtsan.so" type="path"/>
     </ifrelease>
-    <runtime name="COMPILER_PATH" value="@TOOL_ROOT@"/>
+%endif
   </tool>

--- a/scram-tools.file/tools/gcc/gcc-f77compiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-f77compiler.xml
@@ -2,8 +2,12 @@
     <lib name="gfortran"/>
     <lib name="m"/>
     <client>
-      <environment name="GCC_F77COMPILER_BASE" default="@TOOL_ROOT@"/>
-      <environment name="FC" default="$GCC_F77COMPILER_BASE/bin/gfortran"/>
+	    <environment name="GCC_F77COMPILER_BASE" default="@TOOL_ROOT@"/>
+%if 0%{!?use_system_gcc:1}
+	    <environment name="FC" default="$GCC_F77COMPILER_BASE/bin/gfortran"/>
+%else
+            <environment name="FC" default="gfortran"/>
+%endif
     </client>
     <flags FFLAGS="-fno-second-underscore -Wunused -Wuninitialized -O3 @GCC_FFLAGS@"/>
     <flags FFLAGS="-std=legacy"/>

--- a/scram-tools.file/tools/icx/icx-f77compiler.xml
+++ b/scram-tools.file/tools/icx/icx-f77compiler.xml
@@ -1,7 +1,11 @@
   <tool name="icx-f77compiler" version="@TOOL_VERSION@" type="compiler">
     <use name="gcc-f77compiler"/>
     <client>
+%if 0%{!?use_system_gcc:1}
       <environment name="FC" default="@GCC_ROOT@/bin/gfortran"/>
+%else
+      <environment name="FC" default="gfortran"/>
+%endif
     </client>
     <flags SKIP_TOOL_SYMLINKS="1"/>
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-ccompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-ccompiler.xml
@@ -4,5 +4,7 @@
       <environment name="LLVM_CCOMPILER_BASE" default="@TOOL_ROOT@"/>
       <environment name="CC" value="$LLVM_CCOMPILER_BASE/bin/clang"/>
     </client>
+%if 0%{!?use_system_gcc:1}
     <flags CFLAGS="--gcc-toolchain=@GCC_ROOT@"/>
+%endif
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
@@ -32,7 +32,9 @@
     <flags CXXFLAGS="-Wno-error=potentially-evaluated-expression"/>
     <flags CXXFLAGS="-Wno-tautological-type-limit-compare"/>
     <flags CXXFLAGS="-fsized-deallocation"/>
+%if 0%{!?use_system_gcc:1}
     <flags CXXFLAGS="--gcc-toolchain=@GCC_ROOT@"/>
+%endif
     <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LLVM_CXXCOMPILER_BASE/lib64" type="path"/>
     <runtime name="PATH" value="$LLVM_CXXCOMPILER_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-f77compiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-f77compiler.xml
@@ -1,6 +1,10 @@
   <tool name="llvm-f77compiler" version="@TOOL_VERSION@" type="compiler">
     <use name="gcc-f77compiler"/>
     <client>
+%if 0%{!?use_system_gcc:1}
       <environment name="FC" default="@GCC_ROOT@/bin/gfortran"/>
+%else
+      <environment name="FC" default="gfortran"/>
+%endif
     </client>
   </tool>

--- a/scram-tools.file/tools/systemtools/root_cxxdefaults.xml
+++ b/scram-tools.file/tools/systemtools/root_cxxdefaults.xml
@@ -1,5 +1,7 @@
 <tool name="root_cxxdefaults" version="@TOOL_VERSION@">
+%if 0%{!?use_system_gcc:1}
   <runtime name="ROOT_GCC_TOOLCHAIN" value="@GCC_ROOT@" type="path"/>
+%endif
   <runtime name="ROOT_INCLUDE_PATH" value="/usr/local/include" type="path" handler="warn"/>
   <runtime name="ROOT_INCLUDE_PATH" value="/usr/include"       type="path" handler="warn"/>
 </tool>

--- a/scram/tool-conf-src.file
+++ b/scram/tool-conf-src.file
@@ -34,8 +34,7 @@ mkdir -p %{i}/tools/selected %{i}/tools/available
 %endif
 
 ## INCLUDE scram-tools.file/tool-env
-
-for tool in %requiredtools; do
+for tool in %requiredtools %{?use_system_gcc:gcc}; do
   echo ">> Copying tool files from: $tool"
   uctool=`echo $tool | tr '[a-z-]' '[A-Z_]'`
   toolbase=`eval echo \\$${uctool}_ROOT`

--- a/scram/tools
+++ b/scram/tools
@@ -1,0 +1,1 @@
+../scram-tools.file/tools

--- a/scram/tools
+++ b/scram/tools
@@ -1,1 +1,0 @@
-../scram-tools.file/tools

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -5,11 +5,7 @@ BuildRequires: mcfm swig autotools
 Patch0: sherpa-2.2.10-hepmcshort
 Patch1: sherpa-cpp20
 
-%ifos linux
-%ifnarch ppc64le
-Requires: openloops
-%endif
-%endif
+%{!?without_openloops:Requires: openloops}
 
 %prep
 %setup -q -n SHERPA-MC-%{realversion}

--- a/tfaot-models.file
+++ b/tfaot-models.file
@@ -1,3 +1,5 @@
 # test models needed by unit tests in PhysicsTools/TensorFlowAOT
+%if 0%{!?without_tensorflow:1}
 Requires: tfaot-model-test-simple
 Requires: tfaot-model-test-multi
+%endif


### PR DESCRIPTION
- Allow to disable packages which do not build on riscv64 e.g
  - valgrind, tensorflow, dasgoclient,  openloops
- Make sure that scram tools use the correct gcc/g++/gfortran in system gcc is used