### PR TITLE
[cepgen] Disable BoostWrapper addon

### DIFF
--- a/cepgen.spec
+++ b/cepgen.spec
@@ -3,10 +3,11 @@
 Source: https://github.com/cepgen/cepgen/archive/refs/tags/%{realversion}.tar.gz
 
 BuildRequires: cmake ninja
-Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib zlib xz
+Requires: gsl OpenBLAS hepmc hepmc3 lhapdf pythia6 root bz2lib zlib xz python3
 
 %prep
 %setup -n %{n}-%{realversion}
+sed -i -e 's|add_subdirectory(BoostWrapper)||' CepGenAddOns/CMakeLists.txt
 
 %build
 rm -rf ../build
@@ -25,6 +26,7 @@ cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
   -DCMAKE_BUILD_TYPE=Release \
+  -DBoost_NO_SYSTEM_PATHS=ON \
   -DCMAKE_PREFIX_PATH="${BZ2LIB_ROOT};${ZLIB_ROOT};${XZ_ROOT}"
 
 ninja -v %{makeprocesses}


### PR DESCRIPTION
We were not building CepGen BoostWrapper as our containers (cmssw-elX) do not have boost installed on system (we always want to use boost from cms externals). But on systems with boost is installed (and where we can not use our containers e.g. riscv) cepgen picks up Boost from system and then packaging fail as it complains about wrong boost_system lib dependency. 

Somehow I was not able to convince cepgen build system to use our boost (may be we are missing something in our boost?) so for now we explicitly disable cepgen BoostWrapper