### PR TITLE
Fix xrootd for non-default arch

### DIFF
--- a/isal.spec
+++ b/isal.spec
@@ -6,7 +6,10 @@
 %define github_user xrootd
 Source: https://github.com/intel/isa-l/archive/refs/tags/v%{realversion}.tar.gz
 
+%ifarch x86_64
 BuildRequires: nasm
+%endif
+BuildRequires: autotools
 
 %prep
 %setup -n isa-l-%{realversion}

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -13,9 +13,7 @@ Requires: zlib libuuid curl davix
 Requires: python3 py3-setuptools
 Requires: libxml2
 
-%ifarch x86_64
 Requires: isal
-%endif
 
 %define soext so
 %ifarch darwin


### PR DESCRIPTION
* ISA-L is always required
* ISA-L needs autotools at buildtime, nasm only on x86_64