### PR TITLE
[BuildRule] Properly build test dependencies before running test command

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-16
+%define configtag       V09-04-17
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-15
+%define configtag       V09-04-16
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
- Bug fix for `<use name="1" for="alpaka"/>` (https://github.com/cms-sw/cmssw/pull/45117#issuecomment-2266156875) 

- Crrently having something like the following
```
<test name="MyTest" command="run.sh">
  <use name="Subsystem/Package"/>
  <lib name="SomeLocalLib"/>
</test>
```

does not re-build `libSubsystemPackage.so` or `libSomeLocalLib.so` when `scram build runtests_MyTest` is run. This change should allow scram to properly (re)build (if needed) the test dependencies before running the unit tests.