### PR TITLE
TF2.15:  Apply abseil aarch64 patch

### DIFF
--- a/abseil-cpp.spec
+++ b/abseil-cpp.spec
@@ -2,11 +2,12 @@
 ## INCLUDE cpp-standard
 
 Source: https://github.com/abseil/abseil-cpp/archive/%{realversion}.tar.gz
-
+Source2: https://patch-diff.githubusercontent.com/raw/abseil/abseil-cpp/pull/1732.diff
 BuildRequires: cmake gmake
 
 %prep
 %setup -n %{n}-%{realversion}
+patch -p1 <%{_sourcedir}/1732.diff
 
 %build
 rm -rf ../build

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,5 +1,5 @@
 ### RPM external tensorflow-sources 2.15.0
-%define tag         76adab72b874c49eaaca0ea18e246d9309aa2b82
+%define tag         3f5b9e20a2e5f678f79baffc9c2a59ac554053b2
 %define branch      cms/v%{realversion}
 %define github_user cms-externals
 %define build_type opt


### PR DESCRIPTION
Building TF 2.15 with abseil aarch64 patch ( https://github.com/tensorflow/tensorflow/issues/62490#issuecomment-2267503013 )