### PR TITLE
[BuildRules] Various fixes

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-15
+%define configtag       V09-04-18
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Include changes from #9340 plus fix for multi-target test failure we have seen after merging #9340
```
/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: cannot find tmp/el8_amd64_gcc12/src/Alignment/CommonAlignment/test/test_CreateFileLists/1.o: No such file or directory
collect2: error: ld returned 1 exit status
>> Deleted: tmp/el8_amd64_gcc12/src/Alignment/CommonAlignment/test/test_CreateFileLists/scram_x86-64-v3/test_CreateFileLists
  gmake: *** [tmp/el8_amd64_gcc12/src/Alignment/CommonAlignment/test/test_CreateFileLists/scram_x86-64-v3/test_CreateFileLists] Error 1

```