### PR TITLE
do not create symlinks if system gcc is used

### DIFF
--- a/scram-tools.file/tools/gcc/gcc-plugin.xml
+++ b/scram-tools.file/tools/gcc/gcc-plugin.xml
@@ -5,4 +5,7 @@
       <environment name="INCLUDE"   default="$GCC_PLUGIN_BASE/include"/>
       <environment name="LIBDIR"    default="$GCC_PLUGIN_BASE"/>
     </client>
+%if 0%{?use_system_gcc:1}
+    <flags SKIP_TOOL_SYMLINKS="1"/>
+%endif
   </tool>


### PR DESCRIPTION
Thsi should avoid creating symlinks for `/usr/lib/gcc/$(uname -m)-redhat-linux/<version>/plugin` if system gcc is used