### PR TITLE
SCRAM to support extra config option and fix for multi-target release deployment

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_71
+### RPM lcg SCRAMV1 V3_00_72
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag d9563d4cdabd86a8fc3ef56dd59621747d3db670
+%define tag 51ef519755e3984ffe41deb7335f2b40998af6a1
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_72
+### RPM lcg SCRAMV1 V3_00_73
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 51ef519755e3984ffe41deb7335f2b40998af6a1
+%define tag bdea128a63a9fcfa70f0e148b660d91791dfd910
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV2.spec
+++ b/SCRAMV2.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV2 V2_2_9_pre20
+### RPM lcg SCRAMV2 V2_2_9_pre21
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -9,7 +9,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag d4db098ce51461d4c944e2618342b6fc06dda56a
+%define tag 044afff8b3de7e7eadac87a4e69007912a70829b
 %define branch SCRAMV2
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV2.spec
+++ b/SCRAMV2.spec
@@ -1,4 +1,4 @@
-### RPM lcg SCRAMV2 V2_2_9_pre21
+### RPM lcg SCRAMV2 V2_2_9_pre22
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -9,7 +9,7 @@ Provides: perl(BuildSystem::TemplateStash)
 Provides: perl(Cache::CacheUtilities)
 Provides: perl(BuildSystem::ToolManager)
 
-%define tag 044afff8b3de7e7eadac87a4e69007912a70829b
+%define tag 92aa727563d79e2bf6ce387c751e3bfa74201b38
 %define branch SCRAMV2
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -360,7 +360,9 @@ if [ -f compile_commands.json ] ; then
 fi
 %{relocateConfig}external/%cmsplatf/links.DB
 
+#Run site specific updates
 if [ -e $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg ] ; then
+  #Enable/Disable multi-targets if configured via site configuration
   if [ -e .SCRAM/%{cmsplatf}/multi-targets ] ; then
     site_scram_target=$(grep '^\s*scram-target\s*=' $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg | sed 's| ||g;s|.*=||')
     if [ "${site_scram_target}" != "" ] && [ "${site_scram_target}" != "none" ] && [ "${site_scram_target}" != "%{scram_target_default}" ] ; then
@@ -368,10 +370,15 @@ if [ -e $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg ] ; then
       $RPM_INSTALL_PREFIX/common/scram setup self
     fi
   fi
-  site_post_script=$(grep '^\s*%{lcprojtype}-post-install-script\s*=' $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg | sed 's| ||g;s|.*=||')
-  if [ "${site_post_script}" != "" ] && [ -e "${site_post_script}" ] && [ -x "${site_post_script}" ] ; then
-    ${site_post_script}
-  fi
+  #Run post install site specific scripts
+  #scram: For all scram based projects e.g. coral, cmssw, cmssw-patch, fwlite etc.
+  #cmssw: For both full or patch release e.g. cmssw and cmssw-patch
+  for type in scram %{lcprojtype} ; do
+    script=$(grep "^\s*${type}-post-install-script\s*=" $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg | sed 's| ||g;s|.*=||')
+    if [ "${script}" != "" ] && [ -e "${script}" ] && [ -x "${script}" ] ; then
+      ${script} %{cmsplatf}
+    fi
+  done
 fi
 
 %postun

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -360,11 +360,17 @@ if [ -f compile_commands.json ] ; then
 fi
 %{relocateConfig}external/%cmsplatf/links.DB
 
-if [ -e .SCRAM/%{cmsplatf}/multi-targets ] && [ -e $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg ]; then
-  site_scram_target=$(grep '^\s*scram-target\s*=' $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg | sed 's| ||g;s|.*=||')
-  if [ "${site_scram_target}" != "" ] && [ "${site_scram_target}" != "none" ] && [ "${site_scram_target}" != "%{scram_target_default}" ] ; then
-    sed -i -e "/=\"SCRAM_TARGET\"/s/\"%{scram_target_default}\"/\"${site_scram_target}\"/" config/Self.xml
-    $RPM_INSTALL_PREFIX/common/scram setup self
+if [ -e $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg ] ; then
+  if [ -e .SCRAM/%{cmsplatf}/multi-targets ] ; then
+    site_scram_target=$(grep '^\s*scram-target\s*=' $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg | sed 's| ||g;s|.*=||')
+    if [ "${site_scram_target}" != "" ] && [ "${site_scram_target}" != "none" ] && [ "${site_scram_target}" != "%{scram_target_default}" ] ; then
+      sed -i -e "/=\"SCRAM_TARGET\"/s/\"%{scram_target_default}\"/\"${site_scram_target}\"/" config/Self.xml
+      $RPM_INSTALL_PREFIX/common/scram setup self
+    fi
+  fi
+  site_post_script=$(grep '^\s*%{lcprojtype}-post-install-script\s*=' $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg | sed 's| ||g;s|.*=||')
+  if [ "${site_post_script}" != "" ] && [ -e "${site_post_script}" ] && [ -x "${site_post_script}" ] ; then
+    ${site_post_script}
   fi
 fi
 

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-18
+%define configtag       V09-04-19
 %endif
 
 %if "%{?buildarch:set}" != "set"
@@ -120,13 +120,11 @@ echo %{configtag} > %_builddir/config/config_tag
   --keys ENABLE_PGO=0
 %endif
 
-MULTIVEC_ENABLED=false
 %if "%{package_vectorization}"
 %if "%{?scram_target_default:set}" != "set"
 %define scram_target_default default
 %endif
 if [ -e ${%{toolconf}}/vectorized_packages.txt ] ; then
-  MULTIVEC_ENABLED=true
   sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS="%{package_vectorization}"|' %_builddir/config/Self.xml
   sed -i -e 's|</tool>| <runtime name="SCRAM_TARGET" value="%{scram_target_default}"/>\n <runtime name="USER_TARGETS_ALL" value="1"/>\n</tool>|' %_builddir/config/Self.xml
 else
@@ -201,7 +199,7 @@ export SCRAM_NOSYMCHECK=true
 %if "%{?pgo_generate:set}" != "set"
 case %{n} in (cmssw|cmssw-patch) %scramcmd b -f -k %{makeprocesses} llvm-ccdb </dev/null || true ;; esac
 %endif
-if $MULTIVEC_ENABLED ; then
+if grep 'name="SCRAM_TARGET"' %{i}/config/Self.xml ; then
   touch %{i}/.SCRAM/%{cmsplatf}/multi-targets
 fi
 %scramcmd b --verbose -f %{compileOptions} %{extraOptions} %{makeprocesses} %{buildtarget} </dev/null || { touch ../build-errors && %scramcmd b -f outputlog && [ "%{?ignore_compile_errors:set}" == "set" ]; }
@@ -361,5 +359,14 @@ if [ -f compile_commands.json ] ; then
   %{relocateConfig}compile_commands.json
 fi
 %{relocateConfig}external/%cmsplatf/links.DB
+
+if [ -e .SCRAM/%{cmsplatf}/multi-targets ] && [ -e $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg ]; then
+  site_scram_target=$(grep '^\s*scram-target\s*=' $RPM_INSTALL_PREFIX/etc/scramrc/site.cfg | sed 's| ||g;s|.*=||')
+  if [ "${site_scram_target}" != "" ] && [ "${site_scram_target}" != "none" ] && [ "${site_scram_target}" != "%{scram_target_default}" ] ; then
+    sed -i -e "/=\"SCRAM_TARGET\"/s/\"%{scram_target_default}\"/\"${site_scram_target}\"/" config/Self.xml
+    $RPM_INSTALL_PREFIX/common/scram setup self
+  fi
+fi
+
 %postun
 rm -fR $RPM_INSTALL_PREFIX/%pkgrel


### PR DESCRIPTION
This PR includes the following updates

- SCRAM V2 (Perl based) and SCRAM V3 (Python based) to support extra site config options e.g. `scram-target`
- For a release built with multiple targets, allow to selected the release default SCRAM_TARGET based on site-config. Currently we do not make use of it but can be helpful for future. 