### PR TITLE
Updating cms-common: Use SCRAM V3 as default if system python3 is available

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1237
+## REVISION 1238
 ## NOCOMPILER
 
-%define tag 7889b174d7bbbd119a004f8088ceb148b82d3eb9
+%define tag e5a4fde0df8e60f2ed0668c2e7468976b1bba576
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1238
+## REVISION 1239
 ## NOCOMPILER
 
-%define tag e5a4fde0df8e60f2ed0668c2e7468976b1bba576
+%define tag 11a2dabda326ca78f7bb0c032a46ad7675d05187
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 240814.0
+### RPM cms cmssw-osenv 240815.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit cc61d5356f60a5a3a56a32a738fb1958f7836db7
+%define commit 1cf01acd2220bfbed8eb6222871fd12fe40bdf8f
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.

--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 240628.0
+### RPM cms cmssw-osenv 240814.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit bf08ae2197605d001dca4454b9e9df7b52304f76
+%define commit cc61d5356f60a5a3a56a32a738fb1958f7836db7
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.

--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -4,7 +4,7 @@
 
 # ***Do not change minor number of the above version. ***
 
-%define commit 1cf01acd2220bfbed8eb6222871fd12fe40bdf8f
+%define commit 1ebcf0788e8801cb6f1c4f975e308a4cb0dc1ce8
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.


### PR DESCRIPTION
By default `scram` wrapper uses SCRAM V2 (PERL based). This was done to avoid failures on `slc6` where we do not have system `python3` ( needed by SCRAM V3). This change proposes to use [SCRAM V3](https://github.com/cms-sw/cmssw-osenv/commit/cc61d5356f60a5a3a56a32a738fb1958f7836db7) for containers where python3 is installed in the container (e.g. el7 and above). 

This change should allow CMS Connect jobs to use `cmssw-el7/el8` for CMSSW projects which use SCRAM V3. Note that currently CMS Connect sources some el9 based script ( /cvmfs/oasis.opensciencegrid.org/mis/osg-wn-client/23-main/23.240627-1/el9-x86_64/setup.sh ) before starting `cmssw-el7/el8`. This adds some extra binary Perl modules in PERL5LIB which breaks PERL [a] within the container. As SCRAM V2 is perl based, so scram commands fail in such an environment. 

Correct fix for CMS Connect jobs should be to unset the `PERL5LIB` env before starting  `cmssw-elX` (where X is not 9)

[a]
```
> source /cvmfs/oasis.opensciencegrid.org/mis/osg-wn-client/23-main/23.240805-1/el9-x86_64/setup.sh
> cmssw-el8 -- perl -e 'use Cwd'
Can't load '/cvmfs/oasis.opensciencegrid.org/mis/osg-wn-client/23-main/23.240805-1/el9-x86_64/usr/lib64/perl5/vendor_perl/auto/Cwd/Cwd.so' for module Cwd: libperl.so.5.32: cannot open shared object file: No such file or directory at /cvmfs/oasis.opensciencegrid.org/mis/osg-wn-client/23-main/23.240805-1/el9-x86_64/usr/share/perl5/XSLoader.pm line 93.
 at /cvmfs/oasis.opensciencegrid.org/mis/osg-wn-client/23-main/23.240805-1/el9-x86_64/usr/lib64/perl5/vendor_perl/Cwd.pm line 82.
```