### PR TITLE
force use SCRAM V2 for cmssw-el6 containers

### DIFF
--- a/cmssw-osenv.spec
+++ b/cmssw-osenv.spec
@@ -1,10 +1,10 @@
-### RPM cms cmssw-osenv 240815.0
+### RPM cms cmssw-osenv 240816.0
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
 # ***Do not change minor number of the above version. ***
 
-%define commit 1ebcf0788e8801cb6f1c4f975e308a4cb0dc1ce8
+%define commit 35500d47783eb0aa2b9ed7bd4a71e4ee0fe90612
 %define branch master
 # We do not use a revision explicitly, because revisioned packages do not get
 # updated automatically when there are dependencies.


### PR DESCRIPTION
Last update of cmssw-osenv broke the grid-pack relvals which start cmssw-el6 container from the cmssw dev area based on SCRAM V3. This reverts the last changes and forces to use SCRAM V2 for cmssw-el6

- Currently running scram in cmssw-el6 started from CMSSW_14_1_X dev area fails
```
> pwd
/build/muz/del/CMSSW_14_1_X_2024-08-15-2300
> /cvmfs/cms.cern.ch/common/cmssw-el6 -- scram v
which: no python3 in (/afs/cern.ch/cms/caf/scripts:/cvmfs/cms.cern.ch/common:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
env: command: No such file or directory
/usr/bin/env: python3: No such file or directory
> /build/muz/cvmfs/cms.cern.ch/common/cmssw-el6 -- scram v
muz/
```

- With this change
```
> pwd
/build/muz/del/CMSSW_14_1_X_2024-08-15-2300
> /build/muz/del/common/cmssw-el6 -- scram v
V2_2_9_pre20
```