### PR TITLE
[14.0.x] Added explicit tensorflow dependency

### DIFF
--- a/cmssw-tool-conf.spec
+++ b/cmssw-tool-conf.spec
@@ -141,6 +141,7 @@ Requires: madgraph5amcatnlo
 Requires: python_tools
 Requires: dasgoclient
 Requires: dablooms
+Requires: tensorflow
 
 # Only for Linux platform.
 %ifos linux


### PR DESCRIPTION
https://github.com/cms-sw/cmsdist/pull/9363 accidently droped the tensorflow deps for non-x86-64 archs. This PR add tensorflow dependency back for cmssw-tool-conf