### PR TITLE
SCRAM: fix scram list when search project with part of version string

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_74
+### RPM lcg SCRAMV1 V3_00_73
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 6803a72cf9940043a009ca83cd1a64eb3c4c1b54
+%define tag d581e82dca1ac6e58f85424b6f69c56e8dc818f4
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
This update fixes SCRAM V3 `list`
```
Singularity> scram l -c ASNEED
SCRAM warning: >>>> There are no SCRAM project yet installed for architecture el8_amd64_gcc12. <<<<
```
vs
```
Singularity> ~/bin/scram3 l -c ASNEED
CMSSW           CMSSW_14_1_ASNEEDED_X_2024-08-12-2300 /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_ASNEEDED_X_2024-08-12-2300
CMSSW           CMSSW_14_1_ASNEEDED_X_2024-08-14-1100 /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_14_1_ASNEEDED_X_2024-08-14-1100
CMSSW           CMSSW_14_1_ASNEEDED_X_2024-08-16-1100 /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_ASNEEDED_X_2024-08-16-1100
CMSSW           CMSSW_14_1_ASNEEDED_X_2024-08-19-1100 /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_ASNEEDED_X_2024-08-19-1100
```