### PR TITLE
Backport alpaka#2295: Fix memcpy warning

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,9 +1,9 @@
 ### RPM external alpaka 1.1.0
 ## NOCOMPILER
 
-%define git_commit 1.1.0
+%define git_commit 1c19cf9e647bbd550148b4b219c0b62255970204
 
-Source: https://github.com/alpaka-group/%{n}/archive/%{git_commit}.tar.gz
+Source: https://github.com/cms-externals/%{n}/archive/%{git_commit}.tar.gz
 Requires: boost
 
 %prep


### PR DESCRIPTION
Backport https://github.com/alpaka-group/alpaka/pull/2295 to alpaka 1.1.0.