### PR TITLE
[ROOT632] Updated root to tip of branch v6-32-00-patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag c78c8a2b9810caeeef675b8c515fea8d3e2889fc
-%define branch cms/v6-32-00-patches/2a7f09a95e
+%define tag 44cdd0c2db8d3f45c2cbbfc270532d5e399836c7
+%define branch cms/v6-32-00-patches/a445a82af3
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
ROOT [version](https://github.com/root-project/root/blob/v6-32-00-patches/core/foundation/inc/ROOT/RVersion.hxx) is still `6.32.04`.