### PR TITLE
BuildRules: add default test path for cuda/rocm unit tests

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-19
+%define configtag       V09-04-20
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This should fix the issue https://github.com/cms-sw/cmssw/issues/45851