### PR TITLE
[TF][xz] version 5.6.2 and build with -fnofast-math

### DIFF
--- a/xz.spec
+++ b/xz.spec
@@ -1,10 +1,5 @@
-### RPM external xz 5.2.5
-
-%define tag 50f585dc3b7b9b94b6b7f7a4c29903602d1e2a2d
-%define branch cms/v%{realversion}
-%define github_user cms-externals
-Source0: git+https://github.com/%github_user/xz.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-
+### RPM external xz 5.6.2
+Source: https://github.com/tukaani-project/xz/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: autotools
 
 %prep
@@ -12,7 +7,7 @@ BuildRequires: autotools
 
 %build
 ./autogen.sh --no-po4a
-./configure CFLAGS='-fPIC -Ofast' --prefix=%{i} --disable-static --disable-nls --disable-rpath --disable-dependency-tracking --disable-doc
+./configure CFLAGS='-fPIC -Ofast -fno-fast-math' --prefix=%{i} --disable-static --disable-nls --disable-rpath --disable-dependency-tracking --disable-doc
 make %{makeprocesses}
 
 %install


### PR DESCRIPTION
Used `-fno-fast-math` to build  `xz`  (see https://github.com/cms-sw/cmssw/issues/41773). 
Looks like new `xz` version `5.6.2` is relatively faster than `5.2.5`. ROOT bench mark test https://github.com/cms-sw/cmssw/issues/41773#issuecomment-2328555041 timings are below (avg of 5 runs)
- `xz 5.2.5 with -Ofast`:  8.251s
- `xz 5.6.2 with -Ofast -fno-fast-math`: 8.1s

Generated root file size is exactly same for both.