### PR TITLE
[12.4.X] Update gosamcontrib version

### DIFF
--- a/gosamcontrib-module-patch.patch
+++ b/gosamcontrib-module-patch.patch
@@ -1,0 +1,15 @@
+diff --git a/ninja-1.1.0/Makefile.in b/ninja-1.1.0/Makefile.in
+index 7ecdbf8..31dc69c 100644
+--- a/ninja-1.1.0/Makefile.in
++++ b/ninja-1.1.0/Makefile.in
+@@ -642,6 +642,10 @@ quadsources/rambo.lo: quadsources/$(am__dirstamp)
+ quadsources/ninja_wraps.lo: quadsources/$(am__dirstamp)
+ quadsources/avholo_wrapper.lo: quadsources/$(am__dirstamp)
+ 
++mninja.mod: mninja.lo
++ninjago_module.mod: ninjago.lo
++ninjavholo.mod: ninjavholo.lo
++
+ libninja.la: $(libninja_la_OBJECTS) $(libninja_la_DEPENDENCIES) $(EXTRA_libninja_la_DEPENDENCIES) 
+ 	$(AM_V_CXXLD)$(CXXLINK) -rpath $(libdir) $(libninja_la_OBJECTS) $(libninja_la_LIBADD) $(LIBS)
+ install-binPROGRAMS: $(bin_PROGRAMS)

--- a/gosamcontrib.spec
+++ b/gosamcontrib.spec
@@ -1,4 +1,4 @@
-### RPM external gosamcontrib 2.0-20150803
+### RPM external gosamcontrib 2.0-20180708
 Source: http://www.hepforge.org/archive/gosam/gosam-contrib-%{realversion}.tar.gz
 
 Requires: qgraf

--- a/gosamcontrib.spec
+++ b/gosamcontrib.spec
@@ -1,13 +1,14 @@
 ### RPM external gosamcontrib 2.0-20180708
 Source: http://www.hepforge.org/archive/gosam/gosam-contrib-%{realversion}.tar.gz
-
-Requires: qgraf
-Requires: form
+Patch0: gosamcontrib-module-patch
+Requires: qgraf form
+BuildRequires: gmake
 
 %define keep_archives true
 
 %prep
 %setup -q -n gosam-contrib-2.0
+%patch0 -p1
 
 %build
 CXX="$(which c++) -fPIC"


### PR DESCRIPTION
Backport of #9406 for use in el8 and slc7 gridpack production. Updates gosam-contrib to version 2018.07.08 and hence ninja to v1.1. Tested that build works OK and external gridpacks can link against the new libraries