### PR TITLE
[rivet] Apply missing header VetoedFinalState.hh change

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -4,6 +4,7 @@
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source1: https://gitlab.com/hepcedar/rivet/-/commit/9b9f49018fa2b3f2f3ee2f3f2bcba4e3a1d53f55.diff
 Source99: scram-tools.file/tools/eigen/env
 Patch0: rivet-duplicate-libs
 
@@ -14,6 +15,7 @@ BuildRequires: python3 py3-cython autotools
 ## OLD GENSER: %setup -n rivet/%{realversion}
 %setup -n %{n}-%{realversion}
 %patch0 -p1
+patch -p1 <%{_sourcedir}/9b9f49018fa2b3f2f3ee2f3f2bcba4e3a1d53f55.diff
 
 %build
 source %{_sourcedir}/env


### PR DESCRIPTION
This should fix the build errors[a] we randomly get while building rivet

[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-009ffd/41616/externals/rivet/4.0.0-57d8f601c3c8a9de147843a10172837f/log
```
pluginATLAS/ATLAS_2017_I1517194.cc: In member function 'virtual void Rivet::ATLAS_2017_I1517194::init()':
pluginATLAS/ATLAS_2017_I1517194.cc:42:7: error: 'VetoedFinalState' was not declared in this scope
   42 |       VetoedFinalState vfs;
      |       ^~~~~~~~~~~~~~~~
pluginATLAS/ATLAS_2017_I1517194.cc:43:7: error: 'vfs' was not declared in this scope; did you mean 'ffs'?
   43 |       vfs.vetoFinalState(lf);
      |       ^~~
      |       ffs
```