### PR TITLE
[py312][xrootd] disable python binding for slc7 due to openssl version 1.0.2

### DIFF
--- a/xrootd.spec
+++ b/xrootd.spec
@@ -28,6 +28,14 @@ sed -i -e 's|^ *check_library_exists("uuid" "uuid_generate_random".*$|set(_have_
 # By default xrootd has fuse, krb5, readline, and crypto enabled.
 # libfuse is not produced by CMSDIST.
 
+%if 0%{?fedora:1}
+%define build_python 1
+%elif 0%{rhel} > 7
+%define build_python 1
+%else
+%define build_python 0
+%endif
+
 rm -rf ../build; mkdir ../build; cd ../build
 cmake ../%n-%{realversion} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
@@ -39,11 +47,15 @@ cmake ../%n-%{realversion} \
   -DENABLE_KRB5=TRUE \
   -DENABLE_READLINE=TRUE \
   -DCMAKE_SKIP_RPATH=TRUE \
+%if %{build_python}
   -DENABLE_PYTHON=TRUE \
-  -DENABLE_HTTP=TRUE \
-  -DENABLE_XRDEC=TRUE \
   -DXRD_PYTHON_REQ_VERSION=3 \
   -DPIP_OPTIONS="--verbose" \
+%else
+  -DENABLE_PYTHON=FALSE \
+%endif
+  -DENABLE_HTTP=TRUE \
+  -DENABLE_XRDEC=TRUE \
   -DCMAKE_CXX_FLAGS="-I${LIBUUID_ROOT}/include" \
   -DCMAKE_SHARED_LINKER_FLAGS="-L${LIBUUID_ROOT}/lib64" \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"


### PR DESCRIPTION
CentOS7  has OpenSSL 1.0.2 and python 3.12 SSL module requires OpenSSL 1.1.1. This causes xrootd python binding to fail with error [a]. This PR proposes to disable Xrootd python bindings for `slc7`

```
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
Processing ./bindings/python
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  error: subprocess-exited-with-error
  
  pip subprocess to install build dependencies did not run successfully.
   exit code: 1
   [11 lines of output]
      WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
      WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/setuptools/
      WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/setuptools/
      WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/setuptools/
      WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/setuptools/
      WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/setuptools/
      Could not fetch URL https://pypi.org/simple/setuptools/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/setuptools/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping
      ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: none)
      ERROR: No matching distribution found for setuptools>=40.8.0
      WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
      Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping

```