### PR TITLE
Update SCRAM, build rules and cms-common with rivet hook

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_75
+### RPM lcg SCRAMV1 V3_00_76
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag d581e82dca1ac6e58f85424b6f69c56e8dc818f4
+%define tag 7e196fb3e46c2988515345a705bfa905461f6321
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1240
+## REVISION 1241
 ## NOCOMPILER
 
-%define tag 11546571f0f2b00a5165525db80a67356eb025c9
+%define tag 0471f579747f77a5a723337eed1c55cdf95afa45
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-21
+%define configtag       V09-04-22
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Various updates
- `SCRAM`: Python 3.12 fixes https://github.com/cms-sw/SCRAM/commit/7e196fb3e46c2988515345a705bfa905461f6321
- `Build Rules`:
  -  Update build message to use `ROCm` https://github.com/cms-sw/cmssw-config/pull/111
  - Python 3.12 fixes https://github.com/cms-sw/cmssw-config/commit/e0e3dd1e8b0f1640135835298acc27c93b733941
- `cms-common`: Added rivet data path env setup runtime hook https://github.com/cms-sw/cmssw/pull/46065