### PR TITLE
[TF] Do not use mcpu/mtune native if CMS arch_build_flags are not set

### DIFF
--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -59,8 +59,6 @@ BAZEL_OPTS="$BAZEL_OPTS --distinct_host_configuration=true"
 %endif
 %if "%{?arch_build_flags}"
 BAZEL_OPTS="$BAZEL_OPTS $(echo %{arch_build_flags} | tr ' ' '\n' | grep -v '^$' | sed -e 's|^|--copt=|' | tr '\n' ' ')"
-%else
-BAZEL_OPTS="$BAZEL_OPTS --copt=-mcpu=native --copt=-mtune=native"
 %endif
 BAZEL_OPTS="$BAZEL_OPTS --config=%{build_type} --cxxopt=-std=c++%{cms_cxx_standard} --host_cxxopt=-std=c++%{cms_cxx_standard} %{makeprocesses}"
 BAZEL_OPTS="$BAZEL_OPTS --config=noaws --config=nogcp --config=nohdfs --config=nonccl"


### PR DESCRIPTION
do not pass `--copt=-mcpu=native --copt=-mtune=native` to TF build if CMS `arch_build_flags` is not set. For `x86_64` though we set `--copt=-march=x86-64-v2` but as  `arch_build_flags` is not set for `x86_64` so we also end up passing  `--copt=-mcpu=native --copt=-mtune=native` . This can cause compiler to optimize tf build for the machine where it was build .

https://github.com/cms-sw/cmsdist/pull/9166/ PR has accidentally included `--copt=-mcpu=native --copt=-mtune=native` for `x86_64`. Before that `--copt=-mcpu=native --copt=-mtune=native` were added for non-x86_64 arch if  `arch_build_flags` was not set for those archs.