### PR TITLE
[TF] Update Tensorflow to 2.17.0 build with c++20 standard

### DIFF
--- a/bazel-absl.patch
+++ b/bazel-absl.patch
@@ -1,26 +1,24 @@
 diff --git a/distdir_deps.bzl b/distdir_deps.bzl
-index b896f1b..0646f73 100755
+index a3cd93a..f756645 100755
 --- a/distdir_deps.bzl
 +++ b/distdir_deps.bzl
-@@ -229,17 +229,17 @@ DIST_DEPS = {
+@@ -229,16 +229,16 @@ DIST_DEPS = {
          ],
      },
      "com_google_absl": {
--        "archive": "20211102.0.tar.gz",
--        "sha256": "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
+-        "archive": "20230802.0.tar.gz",
+-        "sha256": "59d2976af9d6ecf001a81a35749a6e551a335b949d34918cfade07737b9d93c5",
 +        "archive": "20230802.2.tar.gz",
 +        "sha256": "7c11539617af1f332f0854a6fb21e296a1b29c27d03f23c7b49d4adefcd102cc",
          "urls": [
--            "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",
--            "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",
-+            "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/refs/tags/20230802.2.tar.gz",
+-            "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz",
 +            "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.2.tar.gz",
          ],
          "used_in": [
              "additional_distfiles",
              "test_WORKSPACE_files",
          ],
--        "strip_prefix": "abseil-cpp-20211102.0",
+-        "strip_prefix": "abseil-cpp-20230802.0",
 +        "strip_prefix": "abseil-cpp-20230802.2",
      },
      "zstd-jni": {

--- a/bazel.spec
+++ b/bazel.spec
@@ -1,4 +1,4 @@
-### RPM external bazel 6.1.0
+### RPM external bazel 6.5.0
 ## INCLUDE cpp-standard
 
 Source: https://github.com/bazelbuild/bazel/releases/download/%{realversion}/bazel-%{realversion}-dist.zip

--- a/eigen.spec
+++ b/eigen.spec
@@ -1,8 +1,8 @@
-### RPM external eigen aa6964bf3a34fd607837dd8123bc42465185c4f8
+### RPM external eigen c1d637433e3b3f9012b226c2c9125c494b470ae6
 ## INITENV +PATH PKG_CONFIG_PATH %{i}/share/pkgconfig
 ## NOCOMPILER
 ## INCLUDE cpp-standard
-%define tag c3c790ca28a2df90c602cda9cd591c0854777141
+%define tag 3cbe8e768c9c51af49d533eee3f3e96fd53e13d7
 %define branch cms/master/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/eigen-git-mirror.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/flatbuffers.spec
+++ b/flatbuffers.spec
@@ -1,6 +1,6 @@
-### RPM external flatbuffers 23.5.26
+### RPM external flatbuffers 24.3.25
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
-
+## INCLUDE cpp-standard
 %define tag v%{realversion}
 %define branch master
 %define github_user google
@@ -19,6 +19,7 @@ cd ../build
 cmake ../%{n}-%{realversion} \
    -DCMAKE_BUILD_TYPE=Release \
   -DFLATBUFFERS_BUILD_CPP17=ON \
+  -DFLATBUFFERS_CPP_STD=%{cms_cxx_standard}\
   -DFLATBUFFERS_BUILD_SHAREDLIB=ON \
   -DFLATBUFFERS_BUILD_TESTS=OFF \
   -DCMAKE_INSTALL_PREFIX="%{i}"

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -377,9 +377,9 @@ tables==3.9.0
 tblib==1.7.0
 tabulate==0.9.0
 tenacity==8.2.3
-#NO_AUTO_UPDATE:1: Force to use tensorflow 2.16.1; this should match the version in tensorflow-sources.spec
-tensorflow==2.16.1
-tensorboard==2.17.0
+#NO_AUTO_UPDATE:1: Force to use tensorflow 2.17.0; this should match the version in tensorflow-sources.spec
+tensorflow==2.17.0
+tensorboard==2.18.0
 tensorflow-io-gcs-filesystem==0.37.0
 tensorflow-estimator==2.15.0
 tensorboard-data-server==0.7.2

--- a/scram-tools.file/tools/tensorflow/tensorflow-c.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow-c.xml
@@ -1,7 +1,0 @@
-<tool name="tensorflow-c" version="@TOOL_VERSION@">
-  <lib name="tensorflow"/>
-  <use name="tensorflow-framework"/>
-  <use name="eigen"/>
-  <use name="libpng"/>
-  <use name="sqlite"/>
-</tool>

--- a/scram-tools.file/tools/tensorflow/tensorflow-executable_run_options.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow-executable_run_options.xml
@@ -1,4 +1,0 @@
-<tool name="tensorflow-executable_run_options" version="@TOOL_VERSION@">
-  <lib name="executable_run_options"/>
-  <use name="tensorflow"/>
-</tool>

--- a/scram-tools.file/tools/tensorflow/tensorflow-runtime.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow-runtime.xml
@@ -1,4 +1,0 @@
-<tool name="tensorflow-runtime" version="@TOOL_VERSION@">
-  <lib name="cpu_function_runtime"/>
-  <use name="tensorflow"/>
-</tool>

--- a/scram-tools.file/tools/tensorflow/tensorflow-tf2xla.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow-tf2xla.xml
@@ -1,4 +1,0 @@
-<tool name="tensorflow-tf2xla" version="@TOOL_VERSION@">
-  <lib name="tf2xla"/>
-  <use name="tensorflow"/>
-</tool>

--- a/scram-tools.file/tools/tensorflow/tensorflow-xla_compiled_cpu_function.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow-xla_compiled_cpu_function.xml
@@ -1,4 +1,0 @@
-<tool name="tensorflow-xla_compiled_cpu_function" version="@TOOL_VERSION@">
-  <lib name="xla_compiled_cpu_function"/>
-  <use name="tensorflow"/>
-</tool>

--- a/scram-tools.file/tools/tensorflow/tensorflow.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow.xml
@@ -4,7 +4,6 @@
     <environment name="LIBDIR" default="$TENSORFLOW_BASE/lib"/>
     <environment name="INCLUDE" default="$TENSORFLOW_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$TENSORFLOW_BASE/bin" type="path"/>
   <runtime name="KERAS_BACKEND" value="tensorflow"/>
   <runtime name="TF_CPP_MIN_LOG_LEVEL" value="3"/>
   <flags SYSTEM_INCLUDE="1"/>

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -146,7 +146,7 @@ bazel $BAZEL_OPTS //tensorflow/tools/pip_package:wheel
 %ifarch x86_64
 %define bazel_dir k8-%{build_type}
 %else
-%define bazel_dir ${_arch}-%{build_type}
+%define bazel_dir %{_arch}-%{build_type}
 %endif
 
 mkdir %{i}/lib-xla-runtime

--- a/tensorflow-sources.file
+++ b/tensorflow-sources.file
@@ -12,13 +12,6 @@ BuildRequires: bazel java-env git patchelf
 %define  enable_tf_mkldnn 1
 %endif
 
-
-#Set cms_cxx_standard to 17 as LLVM downloaded by TF does not build with c++20
-%if "%{cms_cxx_standard}" == "20"
-%undefine cms_cxx_standard
-%define cms_cxx_standard 17
-%endif
-
 Source: git+https://github.com/%{github_user}/tensorflow.git?obj=%{branch}/%{tag}&export=tensorflow-%{realversion}&output=/tensorflow-%{realversion}.tgz
 
 %if "%{?build_type:set}" != "set"
@@ -141,118 +134,26 @@ fi
 export PYTHONPATH=$PYTHON3PATH
 
 ./configure
+# build numpy first to fix the pypi_numpy repo
+bazel $BAZEL_OPTS //third_party/py/numpy
+build_dir=$(readlink bazel-out | sed 's|/execroot/org_tensorflow/bazel-out$||')
+ln -s ${PYTHON3_LIB_SITE_PACKAGES} ${build_dir}/external/pypi_numpy/site-packages
 # build tensorflow python targets
-bazel $BAZEL_OPTS @ducc//:fft
-bazel $BAZEL_OPTS @ducc//:fft_wrapper
-bazel $BAZEL_OPTS //tensorflow/tools/pip_package:build_pip_package
-bazel $BAZEL_OPTS //tensorflow:tensorflow
-bazel $BAZEL_OPTS //tensorflow:tensorflow_cc
-bazel $BAZEL_OPTS //tensorflow/tools/graph_transforms:transform_graph
-bazel $BAZEL_OPTS //tensorflow/compiler/tf2xla:tf2xla
-bazel $BAZEL_OPTS //tensorflow/compiler/tf2xla:xla_compiler
-bazel $BAZEL_OPTS //tensorflow/compiler/tf2xla:xla_compiled_cpu_function
-#bazel $BAZEL_OPTS //tensorflow/compiler/aot:tfcompile
-bazel $BAZEL_OPTS //tensorflow/core/profiler
-bazel $BAZEL_OPTS //tensorflow:install_headers
-bazel $BAZEL_OPTS //tensorflow/compiler/tf2xla:tf2xla_supported_ops
-
-# rebuild *.pb.{h|cc} files using the external protobuf compiler
-chmod -R a+rwX $PWD/bazel-bin/tensorflow/include
-# create symlinks for third-party packages
-
-for d in third_party/xla/third_party/tsl/tsl third_party/xla/xla ; do
-  ln -s $d .
-done
-for f in $(find tensorflow -name "*.proto")
-do
-  protoc --cpp_out=$PWD/bazel-bin/tensorflow/include $f
-done
+bazel $BAZEL_OPTS //tensorflow/tools/pip_package:wheel
 
 %install
 
-# define and create empty target directories
-outdir="$PWD/out"
-bindir="$outdir/bin"
-incdir="$outdir/include"
-libdir="$outdir/lib"
-rm -rf $bindir $incdir $libdir
-mkdir -p $bindir $incdir $libdir
-
-# copy targets
-srcdir="$PWD/bazel-bin/tensorflow"
-srcdir_ext="$PWD/bazel-bin/external"
-
-cp -p $srcdir/libtensorflow*.so* $libdir/
-cp -p $srcdir/compiler/tf2xla/lib*.so* $libdir/
-
-cp -p ${srcdir_ext}/ducc/*.so $libdir/
-
-for l in tensorflow_cc tensorflow_framework tensorflow ; do
-  # check if the actual lib exists
-  [ -f $libdir/lib${l}.so.%{tfversion} ] || exit 1
-
-  # link from majorversion to tfversion
-  rm -f $libdir/lib${l}.so.%{majorversion}
-  ln -s lib${l}.so.%{tfversion} $libdir/lib${l}.so.%{majorversion}
-
-  # link from default lib to majorversion
-  rm -f $libdir/lib${l}.so
-  ln -s lib${l}.so.%{majorversion} $libdir/lib${l}.so
-done
-
-#cp -p $srcdir/compiler/aot/tfcompile $bindir
-cp -p $srcdir/compiler/tf2xla/tf2xla_supported_ops $bindir
-for name in tensorflow absl re2 ; do
-    cp -r -p $srcdir/include/$name $incdir
-done
-
-# copy headers from downloaded dependencies
-copy_headers() {
-  for header_file in $(find $1/$2 -name *.h | grep -v '_virtual_includes' | sed "s|$1/||") ; do
-    header_dir="${incdir}/$(dirname ${header_file})"
-    mkdir -p "${header_dir}"
-    cp -p "$1/${header_file}" "${header_dir}/"
-  done
-}
-copy_headers "$PWD" tensorflow/compiler
-copy_headers "$PWD" tensorflow/core/profiler/internal
-copy_headers "$PWD" tensorflow/core/profiler/lib
-copy_headers "$PWD" tensorflow/core/util/tensor_bundle
-copy_headers "${PWD}/bazel-bin/tensorflow/tools/pip_package/build_pip_package.runfiles/local_tsl" tsl
-copy_headers "${PWD}/bazel-bin/tensorflow/tools/pip_package/build_pip_package.runfiles" ml_dtypes
-
-pushd $outdir
-  tar cfz %{i}/libtensorflow_cc.tar.gz .
-popd
-
-#FIXME: Create missing externals links
-pushd bazel-tensorflow-%{realversion}/external
-  srcdir=$(dirname $(readlink zlib))
-  for e in ducc farmhash_gpu_archive stablehlo cudnn_frontend_archive ; do
-    echo "Check external link: $e"
-    if [ -e ${srcdir}/$e ] ; then
-      if [ ! -e $e ] ; then
-        echo "Creating symlink ${srcdir}/$e->$e"
-        ln -s ${srcdir}/$e .
-      fi
-    fi
-  done
-popd
-
-# create the wheel file that is installed in py3-tensorflow
-export PYTHONPATH=$PYTHON3PATH
-bash -ex bazel-bin/tensorflow/tools/pip_package/build_pip_package %{i}
+%ifarch x86_64
+%define bazel_dir k8-%{build_type}
+%else
+%define bazel_dir ${_arch}-%{build_type}
+%endif
 
 mkdir %{i}/lib-xla-runtime
-cp $outdir/lib/libfft.so %{i}/lib-xla-runtime
-cp $outdir/lib/libfft_wrapper.so %{i}/lib-xla-runtime
-%ifarch x86_64
-find $srcdir/.. -name 'libmutex.pic.a' -path '*k8-opt/bin/external/local_tsl*' -exec cp {} %{i}/lib-xla-runtime \;
-find $srcdir/.. -name 'libnsync_cpp.pic.a' -path '*k8-opt*' -exec cp {} %{i}/lib-xla-runtime \;
-%endif
-%ifarch aarch64
-find $srcdir/.. -name 'libmutex.pic.a' -path '*aarch64-opt/bin/external/local_tsl*' -exec cp {} %{i}/lib-xla-runtime \;
-find $srcdir/.. -name 'libnsync_cpp.pic.a' -path '*aarch64-opt*' -exec cp {} %{i}/lib-xla-runtime \;
-%endif
-[ -e %{i}/lib-xla-runtime/libmutex.pic.a ]
-[ -e %{i}/lib-xla-runtime/libnsync_cpp.pic.a ]
+find bazel-out/%{bazel_dir}/bin -path '*/pip_package/wheel_house/tensorflow-%{realversion}*.whl' | xargs --no-run-if-empty -i cp '{}' %{i}/
+find bazel-out/%{bazel_dir}/bin -path '*/external/ducc/libfft*.pic.a'             | xargs --no-run-if-empty -i cp '{}' %{i}/lib-xla-runtime
+find bazel-out/%{bazel_dir}/bin -path '*/external/local_tsl/tsl/*/libmutex.pic.a' | xargs --no-run-if-empty -i cp '{}' %{i}/lib-xla-runtime
+find bazel-out/%{bazel_dir}/bin -path '*/external/nsync/libnsync_cpp.pic.a'       | xargs --no-run-if-empty -i cp '{}' %{i}/lib-xla-runtime
+for lib in libfft.pic.a libfft_wrapper.pic.a libmutex.pic.a libnsync_cpp.pic.a ; do
+  test -e %{i}/lib-xla-runtime/${lib}
+done

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,5 +1,5 @@
-### RPM external tensorflow-sources 2.16.1
-%define tag         765b0474b7290b30dcb07cd3c3a25c38ebbffe31
+### RPM external tensorflow-sources 2.17.0
+%define tag         95cfcd10d13e365e0c3f111c25cf9d61c15acce9
 %define branch      cms/v%{realversion}
 %define github_user cms-externals
 %define build_type opt

--- a/tensorflow-xla-runtime-absl.patch
+++ b/tensorflow-xla-runtime-absl.patch
@@ -1,5 +1,5 @@
---- tensorflow/xla_aot_runtime_src/CMakeLists.txt    2024-03-24 08:28:34.000000000 +0100
-+++ tensorflow/xla_aot_runtime_src/CMakeLists.txt      2024-03-25 11:17:58.108587945 +0100
+--- a/xla-aot-runtime/src/CMakeLists.txt    2024-03-24 08:28:34.000000000 +0100
++++ b/xla-aot-runtime/src/CMakeLists.txt    2024-03-25 11:17:58.108587945 +0100
 @@ -14,6 +14,8 @@
    -Wno-sign-compare
  )

--- a/tensorflow-xla-runtime.spec
+++ b/tensorflow-xla-runtime.spec
@@ -1,21 +1,24 @@
-### RPM external tensorflow-xla-runtime 2.12.0
+### RPM external tensorflow-xla-runtime 2.17.0
 ## INCLUDE cpp-standard
 ## INCLUDE compilation_flags
 ## INCLUDE microarch_flags
 
 Source99: scram-tools.file/tools/eigen/env
-
 Patch0: tensorflow-xla-runtime-absl
-
-Requires: eigen py3-tensorflow abseil-cpp
-BuildRequires: cmake tensorflow-sources
+Requires: eigen abseil-cpp tensorflow
+BuildRequires: cmake
 
 %prep
+case ${TENSORFLOW_VERSION} in
+  %{realversion}|%{realversion}-*) ;;
+  * ) echo "ERROR: Mismatch %{n} (%{realversion}) and tensorflow (${TENSORFLOW_VERSION}) versions."
+      echo "Please update %{n}.spec to use ${TENSORFLOW_VERSION} verison."
+      exit 1
+      ;;
+esac
 
-cp -r ${PY3_TENSORFLOW_ROOT}/lib/python%{cms_python3_major_minor_version}/site-packages/tensorflow .
-mkdir -p tensorflow/lib
-cp ${TENSORFLOW_SOURCES_ROOT}/lib-xla-runtime/* tensorflow/lib/
-%patch -p0
+cp -r ${TENSORFLOW_ROOT}/xla-aot-runtime .
+%patch -p1
 
 %build
 
@@ -24,15 +27,15 @@ export CPATH="${CPATH}:${EIGEN_ROOT}/include/eigen3"
 
 CXXFLAGS="-fPIC -Wl,-z,defs %{arch_build_flags} ${CMS_EIGEN_CXX_FLAGS} %{selected_microarch}"
 
-pushd tensorflow/xla_aot_runtime_src
+pushd xla-aot-runtime/src
   # remove unnecessary implementations that use symbols that are not even existing
   find . -type f -path '*/service/cpu/runtime_fork_join.cc' | xargs rm -f
 
   cmake . \
-    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS} -I${TENSORFLOW_ROOT}/include" \
     -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
     -DCMAKE_PREFIX_PATH=${ABSEIL_CPP_ROOT} \
-    -DCMAKE_SHARED_LINKER_FLAGS="-L../lib -lfft -lfft_wrapper -l:libmutex.pic.a -l:libnsync_cpp.pic.a" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-L../lib -Wl,--whole-archive -l:libfft_wrapper.pic.a -Wl,--no-whole-archive -l:libfft.pic.a -l:libmutex.pic.a -l:libnsync_cpp.pic.a" \
     -DBUILD_SHARED_LIBS=ON
   make %{makeprocesses}
 popd
@@ -40,5 +43,4 @@ popd
 %install
 
 mkdir -p %{i}/lib
-mv tensorflow/lib/libfft*.so %{i}/lib/
-mv tensorflow/xla_aot_runtime_src/libtf_xla_runtime.so %{i}/lib/
+mv xla-aot-runtime/src/libtf_xla_runtime.so %{i}/lib/

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -21,6 +21,7 @@ wheel unpack ${%{tf_root}}/tensorflow-%{realversion}*-cp%{cms_python3_major_mino
 mv tensorflow-%{realversion}/tensorflow/include %{i}/include
 for l in libtensorflow_cc.so  libtensorflow_framework.so ; do
   mv tensorflow-%{realversion}/tensorflow/${l}.%{tf_major} %{i}/lib
+  chmod 0755 %{i}/lib/${l}.%{tf_major}
   ln -s ${l}.%{tf_major} %{i}/lib/${l}
 done
 mv tensorflow-%{realversion}/tensorflow/xla_aot_runtime_src %{i}/xla-aot-runtime/src

--- a/tensorflow.spec
+++ b/tensorflow.spec
@@ -1,30 +1,31 @@
-### RPM external tensorflow 2.16.1
+### RPM external tensorflow 2.17.0
 %if "%{?vectorized_package:set}" != "set"
 %define source_package tensorflow-sources
 %else
 %define source_package tensorflow-sources_%{vectorized_package}
 %endif
 ## INCLUDE tensorflow-requires
-BuildRequires: %{source_package}
+BuildRequires: %{source_package} py3-wheel
+%define tf_major %(echo %realversion | cut -d. -f1)
 %define tf_root %(echo %{source_package}_ROOT | tr '[a-z-]' '[A-Z_]')
-%define tf_version %(echo %{source_package}_VERSION | tr '[a-z-]' '[A-Z_]')
-Provides: libtensorflow_cc.so(tensorflow)(64bit)
 Source: none
 
 %prep
-case ${%{tf_version}} in
-  %{realversion}|%{realversion}-*) ;;
-  * ) echo "ERROR: Mismatch %{n} (%{realversion}) and %{source_package} (${%{tf_version}}) versions."
-      echo "Please update %{n}.spec to use ${%{tf_version}} verison."
-      exit 1
-      ;;
-esac
 
 %build
 
 %install
+mkdir %{i}/lib %{i}/xla-aot-runtime
+rm -rf tensorflow-%{realversion}
+wheel unpack ${%{tf_root}}/tensorflow-%{realversion}*-cp%{cms_python3_major_minor}-cp%{cms_python3_major_minor}-linux_%{_arch}.whl
+mv tensorflow-%{realversion}/tensorflow/include %{i}/include
+for l in libtensorflow_cc.so  libtensorflow_framework.so ; do
+  mv tensorflow-%{realversion}/tensorflow/${l}.%{tf_major} %{i}/lib
+  ln -s ${l}.%{tf_major} %{i}/lib/${l}
+done
+mv tensorflow-%{realversion}/tensorflow/xla_aot_runtime_src %{i}/xla-aot-runtime/src
+cp -r ${%{tf_root}}/lib-xla-runtime %{i}/xla-aot-runtime/lib
 
-tar xfz ${%{tf_root}}/libtensorflow_cc.tar.gz -C %{i}
 %if %{enable_gpu}
 mkdir -p %{i}/etc/scram.d
 cat << \EOF_TOOLFILE >%{i}/etc/scram.d/tf_cuda_support.xml
@@ -32,6 +33,3 @@ cat << \EOF_TOOLFILE >%{i}/etc/scram.d/tf_cuda_support.xml
   </tool>
 EOF_TOOLFILE
 %endif
-
-%post
-%{relocateConfig}lib/lib*.params

--- a/tfaot-compile.file
+++ b/tfaot-compile.file
@@ -5,7 +5,7 @@
 ##    (in this case a "Source" should be defined and %{aot_source} is likely %{n}-%{realversion})
 
 BuildRequires: py3-cms-tfaot
-Requires: tensorflow-xla-runtime
+Requires: tensorflow-xla-runtime py3-tensorflow
 
 %ifarch ppc64le
 %define build_arch powerpc64le-unknown-linux-gnu


### PR DESCRIPTION
This PR updates tensorflow to version `2.17.0` for special TF_X IBs. It also contains following changes
- Bazel: Update to `6.5.0`
- Eigen: https://gitlab.com/libeigen/eigen/-/commit/c1d637433e3b3f9012b226c2c9125c494b470ae6 used by new TF 2.17.0 
  -  Thsi also container CMS changes : https://github.com/cms-externals/eigen-git-mirror/commit/3cbe8e768c9c51af49d533eee3f3e96fd53e13d7
- flatbuffers: `24.3.25` (TF 2.17.0 requires version >=24)
- tensorboard: `2.18.0`
- cleanup TF spec to not hand pick headers and libs. Just use what is distributed by TF wheel
  - cleanup TF scram tools (removed tools which are not in use)
  - Apply fixes to build TF with `c++20`
- Updated tensorflow-xla-runtime, tensorflow and tfaot build recipes