### PR TITLE
Fixes release sources usage information

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-22
+%define configtag       V09-04-23
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This includes https://github.com/cms-sw/cmssw-config/commit/7b34c62d4bdff00e7bc6e8f7e295598a31bdcba1 which allows to keep track of all sources build by scram (even if they are not using any cmssw headers)