### PR TITLE
[10.6.X] Backport the electron & photon energy correction file updates for 10_6_X/gcc700

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -22,7 +22,7 @@ L1Trigger-L1THGCal=V01-00-12
 CondTools-SiPhase2Tracker=V00-01-00
 PhysicsTools-NanoAOD=V01-01-00-01-00
 CalibCalorimetry-EcalTrivialCondModules=V00-02-00
-EgammaAnalysis-ElectronTools=V00-03-01
+EgammaAnalysis-ElectronTools=V00-04-00
 RecoTauTag-TrainingFiles=V00-01-01
 
 ########################################################################################


### PR DESCRIPTION
Backport of the #9448. Detailed discussions on the cms-data/EgammaAnalysis-ElectronTools#12 and cms-sw/cmssw#46046.

Edit: FYI https://github.com/cms-sw/cmssw/pull/46138 (10_6_X backport PR in the main cmssw)