### PR TITLE
update dwz, fix g4hepem and celeritas deps

### DIFF
--- a/celeritas.spec
+++ b/celeritas.spec
@@ -2,6 +2,7 @@
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
+## INCLUDE vecgeom-opt
 %define keep_archives true
 %define celeritas_gitversion %(echo %{realversion} | sed -e 's|^v||;s|-.*||')
 %define tag f9b51d72fc268bf22c5560b82d3dd3d7613a8106
@@ -12,7 +13,10 @@ BuildRequires: cmake
 Requires: python3
 Requires: json
 Requires: geant4
+Requires: expat xerces-c
+%if %{enable_vecgeom}
 Requires: vecgeom
+%endif
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -45,7 +49,11 @@ cmake ../%{n}-%{realversion} \
   -DCELERITAS_USE_MPI=OFF \
   -DCELERITAS_USE_ROOT=OFF \
   -DCELERITAS_USE_SWIG=OFF \
+%if %{enable_vecgeom}
   -DCELERITAS_USE_VecGeom=ON
+%else
+  -DCELERITAS_USE_VecGeom=OFF
+%endif
 
 make %{makeprocesses} VERBOSE=1
 

--- a/dwz.spec
+++ b/dwz.spec
@@ -1,7 +1,7 @@
-### RPM external dwz 0.14
-
-%define dwz_branch %{n}-%{realversion}-branch
-%define dwz_commit b612e38de2a1a376362cc2ac0da3c0938b8e0bca
+### RPM external dwz 0.15
+Requires: xxhash
+%define dwz_branch master
+%define dwz_commit 0171f3e7ac09fa44cb1eb299f2703faa113a207e
 
 Source: git://sourceware.org/git/dwz.git?obj=%{dwz_branch}/%{dwz_commit}&export=dwz-%{dwz_commit}&output=/dwz-%{dwz_commit}.tgz
 
@@ -9,7 +9,9 @@ Source: git://sourceware.org/git/dwz.git?obj=%{dwz_branch}/%{dwz_commit}&export=
 %setup -T -b 0 -n dwz-%{dwz_commit}
 
 %build
-make %{makeprocesses}
+make %{makeprocesses} \
+  CFLAGS="-I${XXHASH_ROOT}/include -O2" \
+  LDFLAGS="-L${XXHASH_ROOT}/lib"
 
 %install
 mkdir -p %{i}/bin

--- a/g4hepem.spec
+++ b/g4hepem.spec
@@ -8,7 +8,7 @@ Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export
 
 BuildRequires: cmake gmake
 
-Requires: geant4
+Requires: geant4 expat
 
 %define keep_archives true
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}
@@ -29,7 +29,7 @@ cmake ../%{n}.%{realversion} \
   -DCMAKE_RANLIB=$(which gcc-ranlib) \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_PREFIX_PATH="${GEANT4_ROOT}"
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
 
 make %makeprocesses VERBOSE=1
 

--- a/geant4.spec
+++ b/geant4.spec
@@ -2,6 +2,7 @@
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
+## INCLUDE vecgeom-opt
 %define tag 95f4cebf4a63598d695070bf92e47355eef94a5f
 %define branch cms/v%{realversion}
 %define github_user cms-externals
@@ -12,9 +13,6 @@ BuildRequires: cmake gmake
 Requires: clhep
 Requires: expat
 Requires: xerces-c
-%if "%{?enable_vecgeom:set}" != "set"
-%define enable_vecgeom 1
-%endif
 %if %{enable_vecgeom}
 Requires: vecgeom
 %endif

--- a/scram-tools.file/tools/celeritas/celeritas.xml
+++ b/scram-tools.file/tools/celeritas/celeritas.xml
@@ -9,7 +9,11 @@
     <environment name="LIBDIR" default="$CELERITAS_BASE/lib64"/>
   </client>
   <flags REM_CXXFLAGS="-Werror=missing-braces"/>
-  <use name="vecgeom_interface"/>
   <use name="geant4core"/>
+  <use name="expat"/>
+  <use name="xerces-c"/>
+%if %{enable_vecgeom}
+  <use name="vecgeom_interface"/>
   <use name="vecgeom"/>
+%endif
 </tool>

--- a/scram-tools.file/tools/geant4/env.sh
+++ b/scram-tools.file/tools/geant4/env.sh
@@ -1,6 +1,0 @@
-GEANT4_VECGEOM=""
-if grep VECGEOM_ ${TOOL_ROOT}/etc/profile.d/dependencies-setup.sh >/dev/null 2>&1  ; then
-  GEANT4_VECGEOM='<use name="vecgeom"/>'
-fi
-export GEANT4_VECGEOM
-

--- a/scram-tools.file/tools/geant4/geant4_interface.xml
+++ b/scram-tools.file/tools/geant4/geant4_interface.xml
@@ -9,7 +9,9 @@
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags cppdefines="GNU_GCC G4V9"/>
   <use name="clhep"/>
-  @GEANT4_VECGEOM@
+%if %{enable_vecgeom}
+  <use name="vecgeom"/>
+%endif
   <use name="zlib"/>
   <use name="expat"/>
   <use name="xerces-c"/>

--- a/scram/tool-conf.file
+++ b/scram/tool-conf.file
@@ -1,4 +1,5 @@
 ## NOCOMPILER
+## INCLUDE toolflags
 %define auto_dependencies no
 %define uctool %(echo %{n} | tr '[a-z-]' '[A-Z_]')
 %prep

--- a/scram/toolfile.file
+++ b/scram/toolfile.file
@@ -1,4 +1,5 @@
 ## NOCOMPILER
+## INCLUDE toolflags
 %define auto_dependencies no
 %define uctool %(echo %{n} | tr '[a-z-]' '[A-Z_]')
 %prep

--- a/toolflags.file
+++ b/toolflags.file
@@ -3,3 +3,4 @@
 ## INCLUDE cuda-flags
 ## INCLUDE cpp-standard
 ## INCLUDE warning-flags
+## INCLUDE vecgeom-opt

--- a/vecgeom-opt.file
+++ b/vecgeom-opt.file
@@ -1,0 +1,3 @@
+%if "%{?enable_vecgeom:set}" != "set"
+%define enable_vecgeom 1
+%endif

--- a/xxhash.spec
+++ b/xxhash.spec
@@ -1,0 +1,12 @@
+### RPM external xxhash 0.8.2
+
+Source: https://github.com/Cyan4973/xxHash/archive/refs/tags/v%{realversion}.tar.gz
+
+%prep
+%setup -n xxHash-%{realversion}
+
+%build
+make %{makeprocesses} prefix=%{i}
+
+%install
+make install prefix=%{i}


### PR DESCRIPTION
Various updates/fixes
- Update dwz to 0.15
  - Added xxHash deps
- Fixed g4hepem : Missing expat deps
- Fixed celeritas: Missing expat and xerces-c dep. Build with-out vecgeom if geant4 is build without vecgeom
- Fixed geant4/celeritas toolsfiles to enable vecgeom based on vecgeom build option