### PR TITLE
g4hepem/dd4hep: Added xerces-c/expat dep

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -10,7 +10,7 @@
 
 Source: git+https://github.com/%{github_user}/DD4hep.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake
-Requires: root boost clhep xerces-c  expat geant4
+Requires: root boost clhep xerces-c expat geant4
 
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}
 

--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -10,7 +10,7 @@
 
 Source: git+https://github.com/%{github_user}/DD4hep.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake
-Requires: root boost clhep xerces-c geant4
+Requires: root boost clhep xerces-c  expat geant4
 
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}
 
@@ -28,7 +28,7 @@ Requires: root boost clhep xerces-c geant4
   -DCMAKE_BUILD_TYPE=%{cmake_build_type} \\\
   -DDD4HEP_USE_GEANT4_UNITS=ON \\\
   -DXERCESC_ROOT_DIR=${XERCES_C_ROOT} \\\
-  -DCMAKE_PREFIX_PATH="${CLHEP_ROOT};${XERCES_C_ROOT}"
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
 
 %prep
 

--- a/g4hepem.spec
+++ b/g4hepem.spec
@@ -8,7 +8,7 @@ Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export
 
 BuildRequires: cmake gmake
 
-Requires: geant4 expat
+Requires: geant4 expat xerces-c
 
 %define keep_archives true
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}


### PR DESCRIPTION
explicitly add xerces-c dep instead of getting it via geant4 configuration
explicit dependency on excat for dd4hep