### PR TITLE
ThePeg/Herwig7 build with cms default standard i.e. c++20

### DIFF
--- a/herwig7.spec
+++ b/herwig7.spec
@@ -1,4 +1,5 @@
 ### RPM external herwig7 7.2.2
+## INCLUDE cpp-standard
 Source: https://www.hepforge.org/archive/herwig/Herwig-%{realversion}.tar.bz2
 
 Requires: lhapdf
@@ -29,8 +30,8 @@ Patch3: herwig_MB
 autoreconf -fiv
 
 %build
-CXX="$(which g++) -fPIC"
-CC="$(which gcc) -fPIC"
+CXX="$(which g++) -fPIC -std=c++%{cms_cxx_standard}"
+CC="$(which gcc)  -fPIC -std=c++%{cms_cxx_standard}"
 PLATF_CONF_OPTS="--enable-shared --disable-static"
 FCFLAGS=""
 if [[ `gcc --version | head -1 | cut -d' ' -f3 | cut -d. -f1,2,3 | tr -d .` -gt 1000 ]] ; then FCFLAGS="-fallow-argument-mismatch" ; fi
@@ -56,7 +57,7 @@ PYTHON=python3 ./configure --prefix=%i \
 sed -i -e 's|^install-data-hook:|install-data-hook:\n\techo Skip data\n\ninstall-data-hookX:|' src/Makefile
 %endif
 
-make %makeprocesses all
+make %makeprocesses all V=1
 
 %install
 make %makeprocesses install LHAPDF_DATA_PATH=$LHAPDF_ROOT/share/LHAPDF

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -1,7 +1,7 @@
 ### RPM external thepeg 2.2.2
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib/ThePEG
 ## INITENV +PATH DYLD_LIBRARY_PATH %{i}/lib/ThePEG
-
+## INCLUDE cpp-standard
 # Download from official webpage
 Source: http://www.hepforge.org/archive/thepeg/ThePEG-%{realversion}.tar.bz2
 Patch0: LHEEventNum
@@ -43,6 +43,7 @@ rm -f ./Config/config.{sub,guess}
 chmod +x ./Config/config.{sub,guess}
 
 sed -i -e "s|-lgslcblas|-lopenblas|" ./configure
+COMPILE_FLAGS="-g0 -O2 -DNDEBUG -std=c++%{cms_cxx_standard}"
 ./configure $PLATF_CONF_OPTS \
             --with-lhapdf=$LHAPDF_ROOT \
             --with-boost=$BOOST_ROOT \
@@ -52,7 +53,7 @@ sed -i -e "s|-lgslcblas|-lopenblas|" ./configure
             --with-fastjet=$FASTJET_ROOT \
             --without-javagui \
             --prefix=%{i} \
-            --disable-readline CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib" CXXFLAGS="-g0 -O2 -DNDEBUG" CFLAGS="-g0 -O2 -DNDEBUG"
+            --disable-readline CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib" CXXFLAGS="${COMPILE_FLAGS}" CFLAGS="${COMPILE_FLAGS}"
 
 make %{makeprocesses}
 

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -55,7 +55,7 @@ COMPILE_FLAGS="-g0 -O2 -DNDEBUG -std=c++%{cms_cxx_standard}"
             --prefix=%{i} \
             --disable-readline CXX="$CXX" CC="$CC" LDFLAGS="-L${OPENBLAS_ROOT}/lib" CXXFLAGS="${COMPILE_FLAGS}" CFLAGS="${COMPILE_FLAGS}"
 
-make %{makeprocesses}
+make %{makeprocesses} V=1
 
 %install
 make install


### PR DESCRIPTION
Enablign c++20 ( i.e. the default cms cpp standard) for ThePEG and Herwig7. See https://github.com/cms-sw/cmssw/issues/45872