### PR TITLE
Add explicit dependency on vecgeom to DD4Hep and G4HepEM

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -2,6 +2,7 @@
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
+## INCLUDE vecgeom-opt
 
 %define tag d119e3f8f5da75bd87632467df088197f84ed1b8
 %define branch master
@@ -11,6 +12,9 @@
 Source: git+https://github.com/%{github_user}/DD4hep.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake
 Requires: root boost clhep xerces-c expat geant4
+%if %{enable_vecgeom}
+Requires: vecgeom
+%endif
 
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}
 
@@ -40,7 +44,7 @@ export BOOST_ROOT
 
 #Build normal Shared D4Hep without Geant4
 rm -rf ../build; mkdir ../build; cd ../build
-cmake %{cmake_fixed_args} -DBUILD_SHARED_LIBS=ON ../%{n}-%{realversion}
+cmake %{cmake_fixed_args} -DBUILD_SHARED_LIBS=ON -DDD4HEP_USE_GEANT4=OFF ../%{n}-%{realversion}
 make %{makeprocesses} VERBOSE=1
 make install
 

--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -2,7 +2,7 @@
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
-## INCLUDE vecgeom-opt
+## INCLUDE g4deps
 
 %define tag d119e3f8f5da75bd87632467df088197f84ed1b8
 %define branch master
@@ -12,9 +12,6 @@
 Source: git+https://github.com/%{github_user}/DD4hep.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake
 Requires: root boost clhep xerces-c expat geant4
-%if %{enable_vecgeom}
-Requires: vecgeom
-%endif
 
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}
 

--- a/g4deps.file
+++ b/g4deps.file
@@ -1,0 +1,4 @@
+## INCLUDE vecgeom-opt
+%if %{enable_vecgeom}
+Requires: vecgeom
+%endif

--- a/g4hepem.spec
+++ b/g4hepem.spec
@@ -1,7 +1,7 @@
 ### RPM external g4hepem 20230309
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
-## INCLUDE vecgeom-opt
+## INCLUDE g4deps
 
 %define tag %{realversion}
 %define branch master
@@ -11,9 +11,6 @@ Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export
 BuildRequires: cmake gmake
 
 Requires: geant4 expat xerces-c
-%if %{enable_vecgeom}
-Requires: vecgeom
-%endif
 
 %define keep_archives true
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}

--- a/g4hepem.spec
+++ b/g4hepem.spec
@@ -1,6 +1,8 @@
 ### RPM external g4hepem 20230309
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
+## INCLUDE vecgeom-opt
+
 %define tag %{realversion}
 %define branch master
 %define github_user mnovak42
@@ -9,6 +11,9 @@ Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export
 BuildRequires: cmake gmake
 
 Requires: geant4 expat xerces-c
+%if %{enable_vecgeom}
+Requires: vecgeom
+%endif
 
 %define keep_archives true
 %define build_flags -fPIC %{?arch_build_flags} %{?lto_build_flags} %{?pgo_build_flags}


### PR DESCRIPTION
This should fix failing build in G4VECGEOM_X IB [link](https://cmssdt.cern.ch/SDT/jenkins-artifacts/build-any-ib/CMSSW_14_2_G4VECGEOM_X_2024-10-13-2300/el8_amd64_gcc12/191008/external/dd4hep/v01-29-00-9972cf4cee89bf7ee7bbbfdbb4e4cc96/log)

```
CMake Error at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cmake/3.28.3-7dddec75b0b5058f75bafde9edcd898d/share/cmake-3.28/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  By not providing "FindVecGeom.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "VecGeom", but
  CMake did not find one.

  Could not find a package configuration file provided by "VecGeom"
  (requested version 1.2.7) with any of the following names:

    VecGeomConfig.cmake
    vecgeom-config.cmake

  Add the installation prefix of "VecGeom" to CMAKE_PREFIX_PATH or set
  "VecGeom_DIR" to a directory containing one of the above files.  If
  "VecGeom" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/geant4/11.2.ref08-57dffc44c6562c291ca68332883617ef/lib64/cmake/Geant4/Geant4Config.cmake:316 (find_dependency)
  CMakeLists.txt:136 (find_package)
```