### PR TITLE
[SCRAM] scram setup to create external symlinks

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_76
+### RPM lcg SCRAMV1 V3_00_77
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 7e196fb3e46c2988515345a705bfa905461f6321
+%define tag 3e481c9f139604424fc8fa1872fdacd99af9fe98
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Currently when one sets up a tool (`scram setup <tool>`) then scram only updates the tool information but does not create `external/$SCRAM_ARCH` symlinks. These symlinks are only created when one checks out/adds any sources to build and run `scram build`. Changes in https://github.com/cms-sw/SCRAM/commit/3e481c9f139604424fc8fa1872fdacd99af9fe98#diff-dcc66ec8ccccf1efdc345c110d38965e3064c8c1053b395f6b3d1b433e6a69c9R96 should allow `scram setup` to also generate these symlinks if needed