### PR TITLE
add CMS_X_SANITIZER macros

### DIFF
--- a/scram-tools.file/tools/gcc/sanitizer-flags-asan.xml
+++ b/scram-tools.file/tools/gcc/sanitizer-flags-asan.xml
@@ -1,5 +1,6 @@
   <tool name="sanitizer-flags-asan" version="1.0">
     <ifrelease name="ASAN">
+      <flags CPPDEFINES="CMS_ADDRESS_SANITIZER"/>
       <flags CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address"/>
       <!-- See https://github.com/cms-sw/cmssw/issues/36480 <flags CXXFLAGS="-fsanitize=pointer-compare"/> -->
       <flags CXXFLAGS="-fsanitize=pointer-subtract"/>

--- a/scram-tools.file/tools/gcc/sanitizer-flags-ubsan.xml
+++ b/scram-tools.file/tools/gcc/sanitizer-flags-ubsan.xml
@@ -1,5 +1,6 @@
   <tool name="sanitizer-flags-ubsan" version="1.0">
     <ifrelease name="UBSAN">
+      <flags CPPDEFINES="CMS_UNDEFINED_SANITIZER"/>
       <flags CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>
       <flags CXXFLAGS="-fsanitize=builtin -fsanitize=pointer-overflow"/>
       <flags REM_BOOST_SERIALIZATION_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>


### PR DESCRIPTION
These macros allows to check is code is compiled with `undefined` or `address` sanitizer