### PR TITLE
[vdt]Apply patch to avoid UBSan signed integer overflow error

### DIFF
--- a/vdt-integer-overflow.patch
+++ b/vdt-integer-overflow.patch
@@ -1,8 +1,18 @@
 diff --git a/include/sincos.h b/include/sincos.h
-index 563ae93..2ca2855 100644
+index 563ae93..e5708c5 100644
 --- a/include/sincos.h
 +++ b/include/sincos.h
-@@ -204,6 +204,9 @@ inline void fast_sincosf_m45_45( const float x, float & s, float &c ) {
+@@ -129,6 +129,9 @@ inline void fast_sincos_m45_45( const double z, double & s, double &c ) {
+ } // End namespace details
+ 
+ /// Double precision sincos
++#ifdef CMS_UNDEFINED_SANITIZER
++__attribute__((no_sanitize("signed-integer-overflow")))
++#endif
+ inline void fast_sincos( const double xx, double & s, double &c ) {
+     // I have to use doubles to make it vectorise...
+ 
+@@ -204,6 +207,9 @@ inline void fast_sincosf_m45_45( const float x, float & s, float &c ) {
  } // end details namespace
  
  /// Single precision sincos

--- a/vdt-integer-overflow.patch
+++ b/vdt-integer-overflow.patch
@@ -1,0 +1,14 @@
+diff --git a/include/sincos.h b/include/sincos.h
+index 563ae93..2ca2855 100644
+--- a/include/sincos.h
++++ b/include/sincos.h
+@@ -204,6 +204,9 @@ inline void fast_sincosf_m45_45( const float x, float & s, float &c ) {
+ } // end details namespace
+ 
+ /// Single precision sincos
++#ifdef CMS_UNDEFINED_SANITIZER
++__attribute__((no_sanitize("signed-integer-overflow")))
++#endif
+ inline void fast_sincosf( const float xx, float & s, float &c ) {
+ 	
+ 

--- a/vdt.spec
+++ b/vdt.spec
@@ -1,7 +1,8 @@
 ### RPM cms vdt 0.4.3
 
-Source: https://github.com/dpiparo/%{n}/archive/v%{realversion}.tar.gz 
-
+Source: https://github.com/dpiparo/%{n}/archive/v%{realversion}.tar.gz
+# To avoid UBSan runtime errors about signed integer overflow: cms-sw/cmssw#46417
+Patch0: vdt-integer-overflow
 BuildRequires: cmake python3
 
 
@@ -9,6 +10,7 @@ BuildRequires: cmake python3
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 cmake . \


### PR DESCRIPTION
This should avoid the UBSan runtime errors we see in UBSAN workflows
```
vdt/0.4.3-820b4286c899d81142fb8526a68cf80f/include/vdt/sincos.h:214:6: runtime error: signed integer overflow: -2147483648 - 2 cannot be represented in type 'int'
```