### PR TITLE
[14.0.X]Backport xrootd 5.7.2

### DIFF
--- a/isal.spec
+++ b/isal.spec
@@ -1,0 +1,24 @@
+### RPM external isal 2.30.0
+
+%define strip_files %i/lib
+%define tag %{realversion}
+%define branch master
+%define github_user xrootd
+Source: https://github.com/intel/isa-l/archive/refs/tags/v%{realversion}.tar.gz
+
+%ifarch x86_64
+BuildRequires: nasm
+%endif
+BuildRequires: autotools
+
+%prep
+%setup -n isa-l-%{realversion}
+
+%build
+./autogen.sh
+./configure --prefix=%{i} --with-pic
+
+make %{makeprocesses}
+
+%install
+make install

--- a/scram-tools.file/tools/isal/isal.xml
+++ b/scram-tools.file/tools/isal/isal.xml
@@ -1,0 +1,10 @@
+<tool name="isal" version="@TOOL_VERSION@">
+  <info url="https://github.com/intel/isa-l/wiki"/>
+  <lib name="isal"/>
+  <client>
+    <environment name="ISAL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$ISAL_BASE/lib"/>
+    <environment name="INCLUDE" default="$ISAL_BASE/include"/>
+  </client>
+  <use name="eigen"/>
+</tool>

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.7.1
+### RPM external xrootd 5.7.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.7.0
+### RPM external xrootd 5.7.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.6.4
+### RPM external xrootd 5.7.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 
@@ -6,12 +6,14 @@
 %define tag %{realversion}
 %define branch master
 %define github_user xrootd
-Source: https://xrootd.slac.stanford.edu/download/v%{realversion}/%{n}-%{realversion}.tar.gz
+Source: https://github.com/xrootd/xrootd/releases/download/v%{realversion}/%{n}-%{realversion}.tar.gz
 
 BuildRequires: cmake gmake autotools py3-pip
 Requires: zlib libuuid curl davix
 Requires: python3 py3-setuptools
 Requires: libxml2
+
+Requires: isal
 
 %define soext so
 %ifarch darwin
@@ -39,11 +41,12 @@ cmake ../%n-%{realversion} \
   -DCMAKE_SKIP_RPATH=TRUE \
   -DENABLE_PYTHON=TRUE \
   -DENABLE_HTTP=TRUE \
+  -DENABLE_XRDEC=TRUE \
   -DXRD_PYTHON_REQ_VERSION=3 \
   -DPIP_OPTIONS="--verbose" \
   -DCMAKE_CXX_FLAGS="-I${LIBUUID_ROOT}/include" \
   -DCMAKE_SHARED_LINKER_FLAGS="-L${LIBUUID_ROOT}/lib64" \
-  -DCMAKE_PREFIX_PATH="${ZLIB_ROOT};${PYTHON3_ROOT};${LIBXML2_ROOT};${LIBUUID_ROOT};${CURL_ROOT};${DAVIX_ROOT}"
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
 
 make %makeprocesses VERBOSE=1
 
@@ -54,4 +57,4 @@ make install
 
 %post
 %{relocateConfig}bin/xrootd-config
-%{relocateConfig}share/xrootd/cmake/XRootDConfig.cmake
+%{relocateConfig}lib64/cmake/XRootD/XRootDConfig.cmake


### PR DESCRIPTION
backport of #9318
and include changes from https://github.com/cms-sw/cmsdist/pull/9475

@cms-sw/orp-l2 , as discussed during O&C week and ORP, @cms-sw/core-l2 would like to get xrootd 5.7 in all CMSSW open release cycles (10.6 and above). xrootd 5.7.1 has been integrated in 14.2.X and it was also part of 14.2.0.pre3 release.