### PR TITLE
Rivet 4.0.1 and YODA 2.0.1

### DIFF
--- a/rivet-duplicate-libs.patch
+++ b/rivet-duplicate-libs.patch
@@ -11,7 +11,7 @@ index d95c5d3a5..7ed7db87d 100644
      typedef map<string, const AnalysisBuilderBase*> AnalysisBuilderMap;
      /// Canonical analysis builder functors
 diff --git a/src/Core/AnalysisLoader.cc b/src/Core/AnalysisLoader.cc
-index 137383b12..e2a1cc91a 100644
+index e1bdd1226..dd836504f 100644
 --- a/src/Core/AnalysisLoader.cc
 +++ b/src/Core/AnalysisLoader.cc
 @@ -14,6 +14,7 @@ namespace Rivet {
@@ -22,7 +22,7 @@ index 137383b12..e2a1cc91a 100644
    AnalysisLoader::AnalysisBuilderMap AnalysisLoader::_ptrs;
    AnalysisLoader::AnalysisBuilderMap AnalysisLoader::_aliasptrs;
  
-@@ -159,6 +160,11 @@ namespace Rivet {
+@@ -160,6 +161,11 @@ namespace Rivet {
            if (filename.find("Rivet") != 0) continue;
            size_t posn = filename.find(libsuffix);
            if (posn == string::npos || posn != filename.length()-libsuffix.length()) continue;
@@ -33,5 +33,4 @@ index 137383b12..e2a1cc91a 100644
 +          _pluginnames += filename;
            /// @todo Make sure this is an abs path
            /// @todo Sys-dependent path separator instead of "/"
-           const string path = d + "/" + filename;
-
+           const string path = std::filesystem::canonical(f.path());

--- a/rivet.spec
+++ b/rivet.spec
@@ -1,10 +1,9 @@
-### RPM external rivet 4.0.0
+### RPM external rivet 4.0.1
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-Source1: https://gitlab.com/hepcedar/rivet/-/commit/9b9f49018fa2b3f2f3ee2f3f2bcba4e3a1d53f55.diff
 Source99: scram-tools.file/tools/eigen/env
 Patch0: rivet-duplicate-libs
 
@@ -15,7 +14,6 @@ BuildRequires: python3 py3-cython autotools
 ## OLD GENSER: %setup -n rivet/%{realversion}
 %setup -n %{n}-%{realversion}
 %patch0 -p1
-patch -p1 <%{_sourcedir}/9b9f49018fa2b3f2f3ee2f3f2bcba4e3a1d53f55.diff
 
 %build
 source %{_sourcedir}/env

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,4 +1,4 @@
-### RPM external yoda 2.0.0
+### RPM external yoda 2.0.1
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 
 Source: git+https://gitlab.com/hepcedar/yoda.git?obj=main/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
@@ -15,6 +15,7 @@ autoreconf -fiv
 
 PYTHON=$(which python3) ./configure --prefix=%i --enable-root
 sed -i "s|env python|env python3|" bin/*
+sed -i "s|env python|env python3|" pyext/yoda/plotting/script_generator.py
 make %{makeprocesses} all
 make install
 


### PR DESCRIPTION
- Updated Rivet and YODA, should fix some broken analyses, see https://gitlab.cern.ch/cms-gen/Rivet/-/issues/73
- Removed `Source1` patch as it is included in Rivet 4.0.1
- Change YODA plotting `script_generator.py` to `python3`, see https://gitlab.com/hepcedar/rivet/-/issues/494