### PR TITLE
Fix symlinks for PATH and PYTHONPATH

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-23
+%define configtag       V09-05-01
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-tools.file/tools/OpenBLAS/vectorized.tmpl
+++ b/scram-tools.file/tools/OpenBLAS/vectorized.tmpl
@@ -1,5 +1,6 @@
 <tool name="openblas_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@">
   <client>
     <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_BINDIR" default="@TOOL_ROOT@/bin"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/lwtnn/vectorized.tmpl
+++ b/scram-tools.file/tools/lwtnn/vectorized.tmpl
@@ -2,4 +2,5 @@
   <client>
     <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
   </client>
+  <runtime name="@TOOL_VECTORIZATION_KEY@_PATH" value="@TOOL_ROOT@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/opencv/vectorized.tmpl
+++ b/scram-tools.file/tools/opencv/vectorized.tmpl
@@ -1,5 +1,6 @@
 <tool name="opencv_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@">
   <client>
     <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_BINDIR" default="@TOOL_ROOT@/bin"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/rivet/rivet.xml
+++ b/scram-tools.file/tools/rivet/rivet.xml
@@ -1,20 +1,20 @@
 <tool name="rivet" version="@TOOL_VERSION@">
-<lib name="Rivet"/>
-<client>
-<environment name="RIVET_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$RIVET_BASE/lib"/>
-<environment name="INCLUDE" default="$RIVET_BASE/include"/>
-</client>
-<runtime name="PATH" value="$RIVET_BASE/bin" type="path"/>
-<runtime name="RIVET_DATA_PATH" value="$RIVET_BASE/share/Rivet" type="path"/>
-<runtime name="PDFPATH" default="$RIVET_BASE/share" type="path"/>
-<runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-<use name="hepmc"/>
-<use name="fastjet"/>
-<use name="fastjet-contrib"/>
-<use name="gsl"/>
-<use name="yoda"/>
-<use name="hdf5"/>
-<use name="highfive"/>
-<use name="onnxruntime"/>
+  <lib name="Rivet"/>
+  <client>
+    <environment name="RIVET_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$RIVET_BASE/lib"/>
+    <environment name="INCLUDE" default="$RIVET_BASE/include"/>
+  </client>
+  <runtime name="PATH" value="$RIVET_BASE/bin" type="path"/>
+  <runtime name="RIVET_DATA_PATH" value="$RIVET_BASE/share/Rivet" type="path"/>
+  <runtime name="PDFPATH" default="$RIVET_BASE/share" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <use name="hepmc"/>
+  <use name="fastjet"/>
+  <use name="fastjet-contrib"/>
+  <use name="gsl"/>
+  <use name="yoda"/>
+  <use name="hdf5"/>
+  <use name="highfive"/>
+  <use name="onnxruntime"/>
 </tool>

--- a/scram-tools.file/tools/rivet/vectorized.tmpl
+++ b/scram-tools.file/tools/rivet/vectorized.tmpl
@@ -2,4 +2,5 @@
   <client>
     <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
   </client>
+  <runtime name="@TOOL_VECTORIZATION_KEY@_PATH" value="@TOOL_ROOT@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/tensorflow/vectorized.tmpl
+++ b/scram-tools.file/tools/tensorflow/vectorized.tmpl
@@ -2,4 +2,5 @@
   <client>
     <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
   </client>
+  <runtime name="@TOOL_VECTORIZATION_KEY@_PATH" value="@TOOL_ROOT@/bin" type="path"/>
 </tool>

--- a/scram/tool-conf-src.file
+++ b/scram/tool-conf-src.file
@@ -78,16 +78,6 @@ if [ -e $SCRAMV1_ROOT/bin/chktool ] ; then
 fi
 
 echo '<tool name="python-paths" version="1.0">' > %{i}/tools/selected/python-paths.xml
-if [ "${PYTHON27PATH}" != "" ] ; then
-  py27List=`echo ${PYTHON27PATH} | tr ':' '\n'`
-  mkdir -p %{i}/${PYTHON_LIB_SITE_PACKAGES}
-  touch %{i}/${PYTHON_LIB_SITE_PACKAGES}/tool-deps.pth
-  for pkg in ${py27List} ; do
-     echo "adding $pkg"
-     echo "$pkg" >> %{i}/${PYTHON_LIB_SITE_PACKAGES}/tool-deps.pth
-  done
-  echo '  <runtime name="PYTHON27PATH"  value="%{i}/'${PYTHON_LIB_SITE_PACKAGES}'" type="path"/>' >> %{i}/tools/selected/python-paths.xml
-fi
 
 if [ "${PYTHON3PATH}" != "" ] ; then
   py3List=`echo ${PYTHON3PATH} | tr ':' '\n'`
@@ -99,6 +89,38 @@ if [ "${PYTHON3PATH}" != "" ] ; then
   done
   echo '  <runtime name="PYTHON3PATH"  value="%{i}/'${PYTHON3_LIB_SITE_PACKAGES}'" type="path"/>' >> %{i}/tools/selected/python-paths.xml
 fi
+
+%if "%{package_vectorization}"
+%if "%{vectorized_packages}"
+for pth in %{i}/${PYTHON3_LIB_SITE_PACKAGES}/tool-deps.pth ; do
+  [ -f ${pth} ] ||  continue
+  dir=$(dirname $pth)
+  for tool in %{vectorized_packages} ; do
+    for vec in %{package_vectorization} ; do
+      uctool=`echo ${tool}_${vec}_ROOT | tr '[a-z-]' '[A-Z_]'`
+      toolbase=`eval echo \\$${uctool}`
+      if [ $(grep "${toolbase}/" ${pth} |wc -l) -gt 0 ] ; then
+        mkdir -p ${dir}/scram_${vec}
+        grep "${toolbase}/" ${pth} >> ${dir}/scram_${vec}/tool-deps.pth
+        sed -i -e "\#^${toolbase}#d" ${pth}
+      fi
+    done
+  done
+done
+for vec in default %{package_vectorization} ; do
+  xvar=`echo ${vec}_${vec}_ROOT | tr '[a-z-]' '[A-Z_]'`
+  for item in PYTHON3PATH:${PYTHON3_LIB_SITE_PACKAGES} ; do
+    pydir=$(echo $item | sed 's|.*:||')
+    dir=%{i}/${pydir}/${vec}
+    [ "${vec}" != "default" ] && dir=%{i}/${pydir}/scram_${vec}
+    [ -f ${dir}/tool-deps.pth ] ||  continue
+    var=$(echo $item | sed 's|:.*||')
+    xvar=`echo ${vec}_${var} | tr '[a-z-]' '[A-Z_]'`
+    echo '  <runtime name="'${xvar}'"  value="'${dir}'" type="path"/>' >> %{i}/tools/selected/python-paths.xml
+  done
+done
+%endif
+%endif
 
 echo '</tool>' >> %{i}/tools/selected/python-paths.xml
 


### PR DESCRIPTION
backport of #9487 
plus the extra commits https://github.com/cms-sw/cmsdist/commit/720bf837a6cc11adc9afef270b823aacb8a07ee7

This allows SCRAM to select dedicated bin and pythonpath for externals which are build for multiple archs.
This also drop py2 support for scram tools files