### PR TITLE
[14.1.X] Update xrootd to latest version 5.7.2

### DIFF
--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.7.1
+### RPM external xrootd 5.7.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.7.0
+### RPM external xrootd 5.7.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/9318
and include changes from https://github.com/cms-sw/cmsdist/pull/9475

@cms-sw/orp-l2 , as discussed during O&C week and ORP, @cms-sw/core-l2 would like to get xrootd 5.7 in all CMSSW open release cycles (10.6 and above). xrootd 5.7.1 has been integrated in 14.2.X and it was also part of 14.2.0.pre3 release.