### PR TITLE
Update gdrcopy to v2.4.2

### DIFF
--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.4.1
+### RPM external gdrcopy 2.4.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda


### PR DESCRIPTION
Minor bug fix release:
  - fix the size alignment bug in gdrdrv.
  - fix memory leak in gdr_pin_buffer.
  - add support for another flavor of BF3.