### PR TITLE
[rivet] fix to avoid invalid read

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -4,6 +4,7 @@
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source1: https://gitlab.com/hepcedar/rivet/-/commit/8869db87de9d6c8cfe57e16b2c1469c3cf3b38bd.diff
 Source99: scram-tools.file/tools/eigen/env
 Patch0: rivet-duplicate-libs
 
@@ -14,6 +15,7 @@ BuildRequires: python3 py3-cython autotools
 ## OLD GENSER: %setup -n rivet/%{realversion}
 %setup -n %{n}-%{realversion}
 %patch0 -p1
+patch -p1 <%{_sourcedir}/8869db87de9d6c8cfe57e16b2c1469c3cf3b38bd.diff
 
 %build
 source %{_sourcedir}/env


### PR DESCRIPTION
This applies the fix https://gitlab.com/hepcedar/rivet/-/merge_requests/913 and should fix the unit tests failures in 14.2.X IBs