### PR TITLE
[pypi] Update packages with security fixes

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -241,12 +241,12 @@ notebook-shim==0.2.4
 nvidia-ml-py==12.550.52
 # numba==0.56.4
 # NO_AUTO_UPDATE: update together with numpy
-numexpr==2.8.4
+numexpr==2.8.5
 # setuptools version <64 is needed by numpy: https://github.com/pypa/setuptools/issues/3549
 # NO_AUTO_UPDATE: update together with tensorflow
 numpy==1.24.3
 # NO_AUTO_UPDATE:1
-onnx==1.16.0
+onnx==1.17.0
 onnxmltools==1.12.0
 onnxconverter-common==1.14.0
 oauthlib==3.2.2
@@ -414,7 +414,7 @@ virtualenvwrapper==6.1.0
 wcwidth==0.2.13
 webencodings==0.5.1
 websocket-client==1.8.0
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 #NO_AUTO_UPDATE:1: you need wheel to build wheel
 wheel==0.40.0
 widgetsnbextension==4.0.10

--- a/py3-onnx.patch
+++ b/py3-onnx.patch
@@ -1,6 +1,8 @@
---- a/setup.py	2024-04-24 14:45:57.575099922 +0200
-+++ b/setup.py	2024-04-24 14:46:34.916770226 +0200
-@@ -30,7 +30,7 @@
+diff --git a/setup.py b/setup.py
+index 029584c..32d3558 100644
+--- a/setup.py
++++ b/setup.py
+@@ -31,7 +31,7 @@ CMAKE_BUILD_DIR = os.path.join(TOP_DIR, ".setuptools-cmake-build")
  
  WINDOWS = os.name == "nt"
  


### PR DESCRIPTION
This should fixes some of the issue reported by dependabot

- Werkzeug
  - safe_join not safe on Windows
  - possible resource exhaustion when parsing file data in forms
- onnx: allows Arbitrary File Overwrite in download_model_with_test_data
- numexpr: vulnerable to arbitrary code execution via the evaluate function in the numexpr library