### PR TITLE
cleanup intel-vtune; remove duplicate toolfile

### DIFF
--- a/intel-vtune.spec
+++ b/intel-vtune.spec
@@ -1,31 +1,14 @@
 ### RPM external intel-vtune 2025.0
 ## NOCOMPILER
+## NO_AUTO_DEPENDENCY
+## NO_VERSION_SUFFIX
 
 %define year %(echo %realversion | cut -d. -f1)
+
+## INITENV SET INTEL_VTUNE_INSTALLDIR /cvmfs/projects.cern.ch/intelsw/oneAPI/linux/x86_64/%{year}/vtune/%{realversion}
 
 Source: none
 
 %prep
-
 %build
-
 %install
-mkdir -p %i/etc/scram.d
-cat << \EOF_TOOLFILE >%i/etc/scram.d/intel-vtune.xml
-<tool name="intel-vtune" version="%{realversion}">
-  <info url="https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html"/>
-  <client>
-    <environment name="INTEL_VTUNE_BASE" default="/cvmfs/projects.cern.ch/intelsw/oneAPI/linux/x86_64/%{year}/vtune/%{realversion}"/>
-    <environment name="BINDIR" default="$INTEL_VTUNE_BASE/bin64"/>
-  </client>
-  <runtime name="PATH" value="$INTEL_VTUNE_BASE/bin64" type="path"/>
-  <runtime name="VTUNE_PROFILER_DIR" value="$INTEL_VTUNE_BASE"/>
-  <runtime name="VTUNE_PROFILER_%{year}_DIR" value="$INTEL_VTUNE_BASE"/>
-</tool>
-EOF_TOOLFILE
-
-%post
-if [ "$CMS_INSTALL_PREFIX" = "" ] ; then CMS_INSTALL_PREFIX=$RPM_INSTALL_PREFIX; export CMS_INSTALL_PREFIX; fi
-%{relocateConfig}etc/scram.d/*.xml
-echo "INTEL_VTUNE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.sh
-echo "set INTEL_VTUNE_ROOT='$CMS_INSTALL_PREFIX/%{pkgrel}'" > $RPM_INSTALL_PREFIX/%{pkgrel}/etc/profile.d/init.csh

--- a/scram-tools.file/tools/intel-vtune/intel-vtune.xml
+++ b/scram-tools.file/tools/intel-vtune/intel-vtune.xml
@@ -1,7 +1,7 @@
 <tool name="intel-vtune" version="@TOOL_VERSION@">
   <info url="https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html"/>
   <client>
-    <environment name="INTEL_VTUNE_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INTEL_VTUNE_BASE" default="@INTEL_VTUNE_INSTALLDIR@"/>
     <environment name="BINDIR" default="$INTEL_VTUNE_BASE/bin64"/>
   </client>
   <runtime name="PATH" value="$INTEL_VTUNE_BASE/bin64" type="path"/>


### PR DESCRIPTION
This PR contains the following changes (follow up on https://github.com/cms-sw/cmsdist/pull/9503#discussion_r1832188693)
- Remove duplicate `intel-vtune.xml` generation from the `intel-vtue.spec`
- Added `NO_VERSION_SUFFIX` to avoid adding any `-suffix` in version sothat xml file contains the realversion
- Added `NO_AUTO_DEPENDENCY` to avoid generation extra dep env file for `intel-vtune` stub package
- Set `INTEL_VTUNE_INSTALLDIR` as env pointing to actual pathof `intel-vtune` . This is then used by `intel-vtune.xml` 

FYI @fwyzard 