### PR TITLE
[ROOT6.32] Updated root to tip of branch v6-32-00-patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,4 +1,4 @@
-### RPM lcg root 6.32.07
+### RPM lcg root 6.32.09
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags

--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag e9d73ee6cda14c229f9966bd53f7fcecb1526884
-%define branch cms/v6-32-00-patches/0d2bd0755c
+%define tag 85c3123562e0c0a641c8ac604bf46dbd3d12cc36
+%define branch cms/v6-32-00-patches/dd086f7a9a
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Update to ROOT 6.32.08 tag . This integrates https://github.com/root-project/root/compare/0d2bd0755c6484f9aedf08edfb75b117d60f14da...dd086f7a9a00e7bafda387ec11b12817a71c558e changes