### PR TITLE
py3-dxr: Fix for python 3.12

### DIFF
--- a/py3-dxr.spec
+++ b/py3-dxr.spec
@@ -2,7 +2,7 @@
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 Requires: zlib llvm sqlite
 Requires: py3-Jinja2 py3-parsimonious py3-pysqlite3 py3-Pygments
-%define dxrCommit d3c6e5b745c93b6e7788c734f7cb0dc14d957d37
+%define dxrCommit 737d3b0570e5e4a7845e8cba7c0b000d2911f24e
 %define branch cms/6ea764102a/clang18
 
 Source0: git+https://github.com/cms-externals/dxr.git?obj=%{branch}/%{dxrCommit}&export=dxr-%{dxrCommit}&module=dxr-%dxrCommit&output=/dxr-%{dxrCommit}.tgz


### PR DESCRIPTION
see https://github.com/cms-externals/dxr/pull/2  ( removed `imp` usage)