### PR TITLE
[Buildrules] Avoid duplicate compilation messages for BUILD_LOG=yes

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-02
+%define configtag       V09-05-03
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
As reported [here](https://github.com/cms-sw/cmssw/pull/46663#issuecomment-2491477766)