### PR TITLE
enable --as-needed flag for scram projects

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -22,7 +22,7 @@ if [ $(uname -s) = "Darwin" ] ; then
   OS_LD_UNIT="-r"
 else
   OS_SHAREDFLAGS="-shared -Wl,-E"
-  OS_LDFLAGS="-Wl,-E -Wl,--hash-style=gnu"
+  OS_LDFLAGS="-Wl,-E -Wl,--hash-style=gnu -Wl,--as-needed"
   OS_CXXFLAGS="-Werror=overflow"
   OS_FFLAGS="-cpp"
   OS_LD_UNIT="-r -z muldefs"

--- a/scram-tools.file/tools/lhapdf/lhapdf.xml
+++ b/scram-tools.file/tools/lhapdf/lhapdf.xml
@@ -1,11 +1,10 @@
-<tool name="lhapdf" version="@TOOL_VERSION@">
+<tool name="lhapdf" version="@TOOL_VERSION@" revision="1">
   <lib name="LHAPDF"/>
   <client>
     <environment name="LHAPDF_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$LHAPDF_BASE/lib"/>
     <environment name="INCLUDE" default="$LHAPDF_BASE/include"/>
   </client>
-  <use name="pythia6"/>
   <runtime name="LHAPDF_DATA_PATH" value="$LHAPDF_BASE/share/LHAPDF"/>
   <runtime name="PATH" value="$LHAPDF_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/pythia6/pythia6.xml
+++ b/scram-tools.file/tools/pythia6/pythia6.xml
@@ -1,10 +1,11 @@
-<tool name="pythia6" version="@TOOL_VERSION@" revision="1">
+<tool name="pythia6" version="@TOOL_VERSION@" revision="2">
   <lib name="pythia6"/>
   <lib name="pythia6_dummy"/>
   <client>
     <environment name="PYTHIA6_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$PYTHIA6_BASE/lib"/>
   </client>
+  <use name="lhapdf"/>
   <use name="pythia6_headers"/>
   <use name="f77compiler"/>
 </tool>


### PR DESCRIPTION
This allows to build scram base projects using `-Wl,--as-needed` flags (which instruct linker to only link libraries which are needed) and drop every thing else.