### PR TITLE
BuildRules: Fix for class version checks

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_79
+### RPM lcg SCRAMV1 V3_00_80
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag af033651aa22ea8b005413c971b5a28aa64a28d1
+%define tag 99e5d148c90173c06d6a7cab53911c4db5243a9a
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-05
+%define configtag       V09-05-06
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-06
+%define configtag       V09-05-07
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-07
+%define configtag       V09-05-08
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-04
+%define configtag       V09-05-05
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
See https://github.com/cms-sw/cmssw/pull/46678#issuecomment-2514223602
`edmCheckClassVersion` was move from `FWCore/Utilities` to `FWCore/Reflection`

New build rules 
- uses the correct path for `edmCheckClassVersion`
- fails if `edmCheckClassVersion` or `edmCheckClassTransients` are not found