### PR TITLE
[14.1]Backport build rule changes

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_75
+### RPM lcg SCRAMV1 V3_00_80
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag d581e82dca1ac6e58f85424b6f69c56e8dc818f4
+%define tag 99e5d148c90173c06d6a7cab53911c4db5243a9a
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-04-20
+%define configtag       V09-04-24
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of #9543 

Fixes class version check rule.

This also contains bacport  of following
- #9400 : new build targets to enable/disable alpaka backends
- #9429: Update SCRAM, build rules and cms-common with rivet hook
- #9447: Fixes release sources usage information
