### PR TITLE
[DEVEL]Build more binary products for extra microarch

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-01
+%define configtag       V09-06-02
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Testing latest DEVEL IBs on `x86-64-v2` resources shows that `cmsRun` does not work even if environment is set to use `x86-64-v2`libsraries. Even building `cmsRun` executable for  `x86-64-v2` did not work [a]. I think it might be due to root dictionaries which are only built for default micro-arch (`x86-64-v3`) and root failed to load those on `x86-64-v2` node.

New build rule now explicitly build/compile all public binaries, root lcgdict and boost serialization for additional micro-arch too. Local compilation works but we need to get this in IBs so that we can test it on `x86-64-v2` resources via crab

FYI @makortel 

[a]
```
== CMSSW: + edmPluginDump -a
== CMSSW:
== CMSSW:  *** Break *** illegal instruction
== CMSSW:
== CMSSW:
== CMSSW:
== CMSSW: ===========================================================
== CMSSW: There was a crash.
== CMSSW: This is the entire stack trace of all threads:
== CMSSW: ===========================================================
== CMSSW: #0  0x00002b02f7eb1e0b in waitpid () from /lib64/libc.so.6
== CMSSW: #1  0x00002b02f7e05747 in do_system () from /lib64/libc.so.6
== CMSSW: #2  0x00002b02f84f5f2d in TUnixSystem::StackTrace() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_DEVEL_X_2024-12-05-0900/external/el8_amd64_gcc12/lib/libCore.so
== CMSSW: #3  0x00002b02f84f3a04 in TUnixSystem::DispatchSignals(ESignals) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_DEVEL_X_2024-12-05-0900/external/el8_amd64_gcc12/lib/libCore.so
== CMSSW: #4  <signal handler called>
== CMSSW: #5  0x000000000040235e in main ()
== CMSSW: ===========================================================
== CMSSW:
== CMSSW:
== CMSSW: The lines below might hint at the cause of the crash. If you see question
== CMSSW: marks as part of the stack trace, try to recompile with debugging information
== CMSSW: enabled and export CLING_DEBUG=1 environment variable before running.
== CMSSW: You may get help by asking at the ROOT forum https://root.cern/forum
== CMSSW: preferably using the command (.forum bug) in the ROOT prompt.
== CMSSW: Only if you are really convinced it is a bug in ROOT then please submit a
== CMSSW: report at https://root.cern/bugs or (preferably) using the command (.gh bug) in
== CMSSW: the ROOT prompt. Please post the ENTIRE stack trace
== CMSSW: from above as an attachment in addition to anything else
== CMSSW: that might help us fixing this issue.
== CMSSW: ===========================================================
== CMSSW: #5  0x000000000040235e in main ()
== CMSSW: ===========================================================
== CMSSW:
== CMSSW:
== CMSSW: + true
== CMSSW: + which cmsRun
== CMSSW: /srv/CMSSW_15_0_DEVEL_X_2024-12-05-0900/bin/el8_amd64_gcc12/scram_x86-64-v2/cmsRun
== CMSSW: + cmsRun --help
== CMSSW:
== CMSSW:  *** Break *** illegal instruction
== CMSSW:
== CMSSW:
== CMSSW:
== CMSSW: ===========================================================
== CMSSW: There was a crash.
== CMSSW: This is the entire stack trace of all threads:
== CMSSW: ===========================================================
== CMSSW: #0  0x00002b1fe1724e0b in waitpid () from /lib64/libc.so.6
== CMSSW: #1  0x00002b1fe1678747 in do_system () from /lib64/libc.so.6
== CMSSW: #2  0x00002b1fe0fdef2d in TUnixSystem::StackTrace() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_DEVEL_X_2024-12-05-0900/external/el8_amd64_gcc12/lib/libCore.so
== CMSSW: #3  0x00002b1fe0fdca04 in TUnixSystem::DispatchSignals(ESignals) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_DEVEL_X_2024-12-05-0900/external/el8_amd64_gcc12/lib/libCore.so
== CMSSW: #4  <signal handler called>
== CMSSW: #5  0x000000000040512b in main ()
== CMSSW: ===========================================================
== CMSSW:
== CMSSW:
== CMSSW: The lines below might hint at the cause of the crash. If you see question
== CMSSW: marks as part of the stack trace, try to recompile with debugging information
== CMSSW: enabled and export CLING_DEBUG=1 environment variable before running.
== CMSSW: You may get help by asking at the ROOT forum https://root.cern/forum
== CMSSW: preferably using the command (.forum bug) in the ROOT prompt.
== CMSSW: Only if you are really convinced it is a bug in ROOT then please submit a
== CMSSW: report at https://root.cern/bugs or (preferably) using the command (.gh bug) in
== CMSSW: the ROOT prompt. Please post the ENTIRE stack trace
== CMSSW: from above as an attachment in addition to anything else
== CMSSW: that might help us fixing this issue.
```