### PR TITLE
faksesystem: added perl strict which is needed by roc-obj-x tools

### DIFF
--- a/fakesystem.spec
+++ b/fakesystem.spec
@@ -1,5 +1,5 @@
 ### RPM cms fakesystem 1.0
-## REVISION 1015
+## REVISION 1016
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
@@ -128,6 +128,8 @@ Provides: perl(Sys::Hostname)
 #################################
 Provides: perl(Mpslib)
 Provides: perl(Tk)
+
+Provides: perl(strict)
 
 Provides: /bin/csh
 Provides: /bin/tcsh

--- a/fakesystem.spec
+++ b/fakesystem.spec
@@ -115,6 +115,7 @@ Provides: libdrm.so.2()(64bit)
 Provides: libdrm_amdgpu.so.1()(64bit)
 Provides: perl(File::Which)
 Provides: perl(URI::Encode)
+Provides: perl(strict)
 
 #################################
 # Needed by ROCm on EL9
@@ -128,8 +129,6 @@ Provides: perl(Sys::Hostname)
 #################################
 Provides: perl(Mpslib)
 Provides: perl(Tk)
-
-Provides: perl(strict)
 
 Provides: /bin/csh
 Provides: /bin/tcsh


### PR DESCRIPTION
This should fix building DEVEL_X for slc7:

```
* The action "install-lcg+SCRAMV2+V2_2_9_pre22" was not completed successfully because Traceback (most recent call last):
File "/data/cmsbld/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 265, in doSerial
result = commandSpec[0](*commandSpec[1:])
File "PKGTOOLS/cmsBuild", line 3616, in installApt
RpmInstallFailed: Failed to install package SCRAMV2. Reason:
error: Failed dependencies:
	perl(strict) is needed by lcg+SCRAMV2+V2_2_9_pre22-1-1.x86_64
```