### PR TITLE
Update NVIDIA gdrcopy to v2.4.3

### DIFF
--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.4.2
+### RPM external gdrcopy 2.4.3
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda


### PR DESCRIPTION
Bug fixes:
  - fix `NVIDIA_IS_OPENSOURCE` detection when compile with NVIDIA driver version 545 or newer;
  - fix compile error in `gdrdrv` when compiling on RHEL9.5.