### PR TITLE
Move to x86-64-v3 microarch

### DIFF
--- a/cmssw-vectorization.file
+++ b/cmssw-vectorization.file
@@ -1,4 +1,4 @@
 %ifarch x86_64
-%define vectorized_packages zlib fastjet tensorflow-sources tensorflow OpenBLAS rivet gbl lwtnn opencv pytorch
+%define vectorized_packages fastjet tensorflow-sources tensorflow OpenBLAS rivet gbl lwtnn opencv pytorch
 %{expand:%(for t in %{vectorized_packages} ; do echo Requires: $t; for v in %{package_vectorization}; do echo Requires: ${t}_${v}; done; done)}
 %endif

--- a/coral-tools.spec
+++ b/coral-tools.spec
@@ -17,5 +17,5 @@ Requires: oracle
 %endif
 
 %define skipreqtools jcompiler
-
+%define override_microarch -march=x86-64-v2
 ## INCLUDE scram/tool-conf-src

--- a/microarch_flags.file
+++ b/microarch_flags.file
@@ -1,11 +1,13 @@
 %ifarch x86_64
-%define default_microarch -march=x86-64-v2
+%define default_microarch_name x86-64-v3
+%define default_microarch -march=%{default_microarch_name}
 %if "%{?override_microarch:set}" == "set"
 %define selected_microarch %{override_microarch}
 %else
 %define selected_microarch %{default_microarch}
 %endif
 %else
+%define default_microarch_name %{nil}
 %define selected_microarch %{nil}
 %define default_microarch %{nil}
 %endif

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -1,6 +1,7 @@
 ### FILE scram-project-build
 ## NO_AUTO_DEPENDENCY
 ## INCLUDE compilation_flags_lto
+## INCLUDE microarch_flags
 # FIXME: support building all platforms together like scram does?
 # FIXME: automatic sub-packages for "doc" etc?
 %define cmssw_libs biglib/%{cmsplatf} lib/%{cmsplatf}
@@ -51,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-08
+%define configtag       V09-06-03
 %endif
 
 %if "%{?buildarch:set}" != "set"
@@ -123,10 +124,12 @@ echo %{configtag} > %_builddir/config/config_tag
 sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS=""|' %_builddir/config/Self.xml
 %if "%{package_vectorization}"
 %if "%{?scram_target_default:set}" != "set"
-%define scram_target_default default
+%define scram_target_default auto
 %endif
 if [ -e ${%{toolconf}}/vectorized_packages.txt ] ; then
   sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS="%{package_vectorization}"|' %_builddir/config/Self.xml
+  sed -i -e 's|</tool>| <runtime name="SCRAM_DEFAULT_MICROARCH" value="%{default_microarch_name}"/>\n</tool>|' %_builddir/config/Self.xml
+  sed -i -e 's|</tool>| <runtime name="SCRAM_MIN_SUPPORTED_MICROARCH" value="%{default_microarch_name}"/>\n</tool>|' %_builddir/config/Self.xml
   sed -i -e 's|</tool>| <runtime name="SCRAM_TARGET" value="%{scram_target_default}"/>\n <runtime name="USER_TARGETS_ALL" value="1"/>\n</tool>|' %_builddir/config/Self.xml
 fi
 %endif

--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -11,7 +11,6 @@ if machine() == "x86_64":
   # and vectorized_packages list in cmssw-vectorization.file file
   #########################################
   MULTI_TARGET_PACKAGES = [
-    "zlib",
     "fastjet",
     "tensorflow-sources",
     "tensorflow",

--- a/zlib.spec
+++ b/zlib.spec
@@ -1,14 +1,7 @@
-### RPM external zlib 1.2.11
-## INCLUDE microarch_flags
-%ifarch x86_64
-%define git_repo cms-externals
-%define git_branch cms/v%{realversion}
-%define git_commit 822f7f5a8c57802faf8bbfe16266be02eff8c2e2
-%else
+### RPM external zlib 1.2.13
 %define git_repo madler
 %define git_branch master
 %define git_commit v%{realversion}
-%endif
 Source0: git://github.com/%{git_repo}/zlib.git?obj=%{git_branch}/%{git_commit}&export=zlib-%{realversion}&output=/zlib-%{realversion}.tgz
 
 %prep
@@ -16,7 +9,7 @@ Source0: git://github.com/%{git_repo}/zlib.git?obj=%{git_branch}/%{git_commit}&e
 
 %build
 
-CONF_FLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1 %{selected_microarch}"
+CONF_FLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1"
 CFLAGS="${CONF_FLAGS}" ./configure --prefix=%{i}
 
 make %{makeprocesses}


### PR DESCRIPTION
Backport changes from DEVEL branch
- Move to x86-64-v3 as default microarch
- Updates build rules to build publich binaries ( e.g cmsRun, edm<tools>) for additional micro-archs
- Update zlib 1.2.13 to use consistent version for all archs