### PR TITLE
[BuildRule] Copy rootmap to lib product store

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-05
+%define configtag       V09-06-06
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-04
+%define configtag       V09-06-05
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Looks like edm class checks silently ignore missing `rootmap` files and suggest a different checksum when rootmap files are not there. New tag makes sure that `rootmap` files are also moved to lib production store when `pcm` files are moved.

Looks like if `rootmap` files (which are generated (along with `pcm`) when we generate root dict source file) are missing then root suggests different checksum. For normal PR tests it works as `rootmap` files are read from the release area but for PR tests with full rebuild ( where we remove ref to release area)  the rootmap files are missing and root suggests different checksum. A simple script ( copied from edm class check) [a] shows that if we have `rootmap` files then class checksum is same as we have in classes_def file but if we remove the `rootmap` files then it shows different checksum [b]


[a]
```
> cat get_class_checksum.py
#!/usr/bin/env python3
import sys, ROOT
name=sys.argv[1]
lib=sys.argv[2]
ROOT.PyConfig.DisableRootLogon = True
ROOT.gROOT.SetBatch(True)
ROOT.gROOT.ProcessLine(".autodict")
ROOT.gSystem.Load("lib%s.so" % lib)
ROOT.gROOT.ProcessLine("class checkclass {public: int f(char const* name) {TClass* cl = TClass::GetClass(name); bool b = false; cl->GetCheckSum(b); return (int)b;} };")
ROOT.gROOT.ProcessLine("checkclass checkTheClass;")
c = ROOT.TClass.GetClass(name)
temp = "checkTheClass.f(" + '"' + name + '"' + ");"
ROOT.gROOT.ProcessLine(temp)
print(c.GetCheckSum(),c.GetClassVersion())
```

[b]
- DataFormats/CTPPSDetId/src/classes_def.xml
``` 
<class name="CTPPSDetId" ClassVersion="3">
    <version ClassVersion="3" checksum="2579437464"/>
</class>
```
- content of lib/arch
```
DataFormatsCTPPSDetId_xr.rootmap    DataFormatsCommon_xr.rootmap
DataFormatsDetId_xr.rootmap    DataFormatsProvenance_xr.rootmap
libDataFormatsCTPPSDetId.so  libDataFormatsDetId.so
libFWCoreMessageLogger.so  libFWCoreReflection.so
DataFormatsCTPPSDetId_xr_rdict.pcm  DataFormatsCommon_xr_rdict.pcm
DataFormatsDetId_xr_rdict.pcm  DataFormatsProvenance_xr_rdict.pcm
libDataFormatsCommon.so      libDataFormatsProvenance.so
libFWCorePluginManager.so  libFWCoreUtilities.so
```
- running  script with `rootmap` files available
```
> get_class_checksum.py CTPPSDetId DataFormatsCTPPSDetId
2579437464 3
```
- running script without `rootmap` files
```
> mv lib/el8_amd64_gcc12/*.rootmap backup/
> get_class_checksum.py CTPPSDetId DataFormatsCTPPSDetId
1554945820 3
```