### PR TITLE
[14.2.X] Backport multi-arch chanegs from 15.0.X

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-03-01
+%define configtag       V09-05-03-02
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This includes
- Fix for python import issues during patch release build phase (https://github.com/cms-sw/cmssw/pull/46919) #9574
- Copying of rootmap files before running `edmCheckClassVersion` (https://github.com/cms-sw/cmsdist/pull/9568)
- Use correct object for alpaka serial backend for additional micro-arch (https://github.com/cms-sw/cmsdist/pull/9571)