### PR TITLE
[BuildRule]Fix for code checks

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -168,7 +168,7 @@ for t in %{extra_tools}; do %scramcmd setup $t; done
 %if "%{?remove_tools:set}" == "set"
 for t in %{remove_tools}; do  %scramcmd tool remove $t; done
 %endif
-echo -e '<tool name="cmssw-config" version="%{configtag}" revision="1"></tool>' > %{i}/config/toolbox/%{cmsplatf}/tools/selected/cmssw-config.xml
+echo -e '<tool name="cmssw-config" version="%{configtag}" revision="1">\n</tool>' > %{i}/config/toolbox/%{cmsplatf}/tools/selected/cmssw-config.xml
 %scramcmd setup cmssw-config
 %{?buildarch:%buildarch}
 

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -121,7 +121,6 @@ echo %{configtag} > %_builddir/config/config_tag
   --keys ENABLE_PGO=0
 %endif
 
-echo -e '<tool name="cmssw-config" version="%{configtag}" revision="1"></tool>' > %i/config/toolbox/%{cmsplatf}/tools/selected/cmssw-config.xml
 sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS=""|' %_builddir/config/Self.xml
 %if "%{package_vectorization}"
 %if "%{?scram_target_default:set}" != "set"
@@ -169,6 +168,8 @@ for t in %{extra_tools}; do %scramcmd setup $t; done
 %if "%{?remove_tools:set}" == "set"
 for t in %{remove_tools}; do  %scramcmd tool remove $t; done
 %endif
+echo -e '<tool name="cmssw-config" version="%{configtag}" revision="1"></tool>' > %{i}/config/toolbox/%{cmsplatf}/tools/selected/cmssw-config.xml
+%scramcmd setup cmssw-config
 %{?buildarch:%buildarch}
 
 export BUILD_LOG=yes

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-08
+%define configtag       V09-06-09
 %endif
 
 %if "%{?buildarch:set}" != "set"
@@ -121,6 +121,7 @@ echo %{configtag} > %_builddir/config/config_tag
   --keys ENABLE_PGO=0
 %endif
 
+echo -e '<tool name="cmssw-config" version="%{configtag}" revision="1"></tool>' > %i/config/toolbox/%{cmsplatf}/tools/selected/cmssw-config.xml
 sed -i -e 's| SCRAM_TARGETS=.*"| SCRAM_TARGETS=""|' %_builddir/config/Self.xml
 %if "%{package_vectorization}"
 %if "%{?scram_target_default:set}" != "set"


### PR DESCRIPTION
New cmssw-config tag which fixes code-checks. Once this is merged  and available in the IBs then
- we will open cmssw PR to apply to code-checks ( clang-tidy) on the files which were merged without clang-tidy fixes. 
- Already open PRs (when updated) might fail code checks