### PR TITLE
Revert build rules: python import fix, prefer generated cfipython files

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-08
+%define configtag       V09-06-07
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This reverts the change https://github.com/cms-sw/cmssw-config/commit/91e7bf620361fad2a8427d018e8839c50c183263