### PR TITLE
[14.2.X] Revert build rule : pyint import fix

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-03-02
+%define configtag       V09-05-03-03
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/9577