### PR TITLE
[BuildRules] patch release build fix: use realpath for import python module

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-09
+%define configtag       V09-06-10
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
As https://github.com/cms-sw/cmssw/pull/46955 has been merged , so we can enable the usage of realpth for cmssw python package imports