### PR TITLE
[BuildRules] For PR test: drop additional microarch release/externals lib/bindirs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-10
+%define configtag       V09-06-11
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
During PR tests for externals , we were removing externals/arch/bin, externals/arch/lib directories of release area. This was done to make sure we only use locally build externals tools. Now with multi-arch builds, we should also drop externals/arch/bin/microarch, externals/arch/lib/microarch  path from the release. This makes sure and additional libs/binaries from these dirs are not in PATH/LD_LIBRARY_PATH during PR tests.