### PR TITLE
Update valgrind to 3.24

### DIFF
--- a/valgrind.spec
+++ b/valgrind.spec
@@ -1,4 +1,4 @@
-### RPM external valgrind 3.23.0
+### RPM external valgrind 3.24.0
 ## INITENV SET VALGRIND_LIB %{i}/lib/valgrind
 Source: https://sourceware.org/pub/valgrind/%{n}-%{realversion}.tar.bz2
 


### PR DESCRIPTION
It looks like this recent version adds support (via LibVEX) to more AVX instructions. https://valgrind.org/docs/manual/dist.news.html

I couldn't run our reco production job with x86-64-v3 under valgrind v3.23 from the default cvmfs distribution, while it runs with a locally build 3.24