### PR TITLE
update `hls4mlEmulatorExtras` to v1.1.4

### DIFF
--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.1.3
+### RPM external hls4mlEmulatorExtras 1.1.4
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 


### PR DESCRIPTION
Update of the `hls4mlEmulatorExtras` to [v1.1.4](https://github.com/cms-hls4ml/hls4mlEmulatorExtras/releases/tag/v1.1.4) to include https://github.com/cms-hls4ml/hls4mlEmulatorExtras/pull/6, which is required by https://github.com/cms-sw/cmssw/pull/47070 to address https://github.com/cms-sw/cmssw/issues/46740.
