### PR TITLE
Rivet 4.0.2 and YODA 2.0.2

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -1,10 +1,9 @@
-### RPM external rivet 4.0.1
+### RPM external rivet 4.0.2
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 ## OLD GENSER Source: http://cern.ch/service-spi/external/MCGenerators/distribution/rivet/rivet-%{realversion}-src.tgz
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-Source1: https://gitlab.com/hepcedar/rivet/-/commit/8869db87de9d6c8cfe57e16b2c1469c3cf3b38bd.diff
 Source99: scram-tools.file/tools/eigen/env
 Patch0: rivet-duplicate-libs
 
@@ -15,7 +14,6 @@ BuildRequires: python3 py3-cython autotools
 ## OLD GENSER: %setup -n rivet/%{realversion}
 %setup -n %{n}-%{realversion}
 %patch0 -p1
-patch -p1 <%{_sourcedir}/8869db87de9d6c8cfe57e16b2c1469c3cf3b38bd.diff
 
 %build
 source %{_sourcedir}/env

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,4 +1,4 @@
-### RPM external yoda 2.0.1
+### RPM external yoda 2.0.2
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 
 Source: git+https://gitlab.com/hepcedar/yoda.git?obj=main/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz


### PR DESCRIPTION
Small version bump, mostly new B factory analyses.

No CMSSW updates required. Tested single-thread analysis compilation in docker image -> no warnings/errors, so hopefully the includes are all good this time.

```
Pass    3s ... GeneratorInterface/RivetInterface/test-particleLevel_fromPtGun       
Pass   10s ... GeneratorInterface/RivetInterface/test-particleLevel_fromHepMC3      
Pass   10s ... GeneratorInterface/RivetInterface/test-HTXS                          
Pass   13s ... GeneratorInterface/RivetInterface/test-particleLevel_fromGenParticles
Pass   14s ... GeneratorInterface/RivetInterface/test-rivet-run                     
Pass    2s ... GeneratorInterface/RivetInterface/test-yoda-merge                    
Pass    2s ... GeneratorInterface/RivetInterface/test-yoda-root                     
Pass   17s ... GeneratorInterface/RivetInterface/test-particleLevel_fromMiniAod     
Pass   11s ... GeneratorInterface/RivetInterface/test-rivet-plot                    
Pass   26s ... GeneratorInterface/RivetInterface/test-rivet-list                    
>> Test sequence completed for CMSSW CMSSW_15_0_X_2025-01-14-1100                   
```