### PR TITLE
Buildrule: fixes when extra micro-arch is subset of default microarch

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-06-11
+%define configtag       V09-07-01
 %endif
 
 %if "%{?buildarch:set}" != "set"
@@ -242,6 +242,16 @@ for cmd in edmPluginRefresh ; do
       if [ -d %i/$lib ] ; then
         rm -f %i/$lib/.edmplugincache
         $cmd %i/$lib
+%if "%{package_vectorization}"
+        for arch in %{package_vectorization} ; do
+          arch_dir=%i/$lib/scram_${arch}
+          [ -d ${arch_dir} ] || continue
+          rm -f ${arch_dir}/.edmplugincache
+          if [ -e %i/$lib/.edmplugincache ] ; then
+            cp %i/$lib/.edmplugincache ${arch_dir}/.edmplugincache
+          fi
+        done
+%endif
       fi
     done
   fi
@@ -343,7 +353,15 @@ if [ -d python ]; then %{relocateCmsFiles} $(find python -maxdepth 1 -type f); f
 ./config/SCRAM/projectAreaRename%{scram_script_prefix} %{cmsroot}  $CMS_INSTALL_PREFIX  %cmsplatf
 %{?buildarch:%buildarch}
 
-for lib in %{cmssw_libs} ; do
+xlibs="%{cmssw_libs}"
+%if "%{package_vectorization}"
+for dir in %{cmssw_libs} ; do
+  for arch in %{package_vectorization} ; do
+    xlibs="{xlibs} ${dir}/scram_${arch}"
+  done
+done
+%endif
+for lib in ${xlibs} ; do
   if [ -f $lib/.edmplugincache ] ; then
     find  $lib -name "*.edmplugin" -type f -exec touch {} \;
     touch $lib/.edmplugincache

--- a/scram-tools.file/tools/cuda/cuda.xml
+++ b/scram-tools.file/tools/cuda/cuda.xml
@@ -1,4 +1,4 @@
-<tool name="cuda" version="@TOOL_VERSION@" revision="1">
+<tool name="cuda" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <use name="cuda-stubs"/>
   <lib name="cudart"/>
@@ -15,6 +15,12 @@
   <flags REM_CUDA_HOST_CXXFLAGS="-std=%"/>
   <flags REM_CUDA_HOST_CXXFLAGS="%potentially-evaluated-expression"/>
   <flags CUDA_HOST_CXXFLAGS="@CUDA_HOST_CXXFLAGS@"/>
+%if "%{default_microarch_name}"
+%if "%{default_microarch_name}" != "%{min_microarch_name}"
+  <flags REM_CUDA_HOST_CXXFLAGS="-march=%%"/>
+  <flags CUDA_HOST_CXXFLAGS="-march=%{min_microarch_name}"/>
+%endif
+%endif
   <lib name="cudadevrt" type="cuda"/>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -1,4 +1,4 @@
-<tool name="rocm" version="@TOOL_VERSION@" revision="1">
+<tool name="rocm" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.amd.com/"/>
   <lib name="amdhip64"/>
   <lib name="hsa-runtime64"/>
@@ -16,6 +16,12 @@
   <flags ROCM_FLAGS="--offload-arch=gfx1100"/>  <!-- Radeon Pro W7800/W7900 -->
   <flags ROCM_FLAGS="--offload-arch=gfx1102"/>  <!-- Radeon Pro W7600 -->
   <flags ROCM_FLAGS="-fgpu-rdc --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
+%if "%{default_microarch_name}"
+%if "%{default_microarch_name}" != "%{min_microarch_name}"
+  <flags REM_ROCM_HOST_CXXFLAGS="-march=%%"/>
+  <flags ROCM_HOST_CXXFLAGS="-march=%{min_microarch_name}"/>
+%endif
+%endif
   <!-- use -isystem instead of -I to silence warnings in the HIP/ROCm headers -->
   <flags SYSTEM_INCLUDE="1"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>

--- a/toolflags.file
+++ b/toolflags.file
@@ -4,3 +4,10 @@
 ## INCLUDE cpp-standard
 ## INCLUDE warning-flags
 ## INCLUDE vecgeom-opt
+## INCLUDE microarch_flags
+
+%if "%{default_microarch_name}"
+%define min_microarch_name %(echo '%{default_microarch_name} %{package_vectorization}' | tr ' ' '\\n' | grep -v '^$' | sort -r | tail -1)
+%else
+%define min_microarch_name %{nil}
+%endif


### PR DESCRIPTION
This contains build rules improvement. By default, during the build phase, we use the default micro-arch edm tools to

    register edm plugins
    generate edm plugin configuration
    Run edm class version checks

This break the build if the build node does not support default micro-arch e.g. building on node with x86-64-v2 only support for CMSSW releases where x86-64-v3 is default micro-arch.

Also we only build cuda/rocm code for default micro-arch and then link it for additional micro-archs. This works as long as default micro-arch is subset of all addtional micro-archs but fails otherwise.

New build rules has the following changes

    Use min supported micro-arch edm tools to register edm plugins, generate edn plugin configs and edm class version checks
    Build cuda/rocm (+ alpaka cuda/rocm backend) once using the min supported micro-arch flags

These changes have been tested in DEVEL IBs

backport of #9610