### PR TITLE
Bug fix: Only create poison edm cache if the multi-arch dir exists

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-07-02
+%define configtag       V09-07-03
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/47127