### PR TITLE
buildrulles: fix for linking cuda libs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -52,7 +52,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-07-03
+%define configtag       V09-07-04
 %endif
 
 %if "%{?buildarch:set}" != "set"

--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -22,7 +22,7 @@ if [ $(uname -s) = "Darwin" ] ; then
   OS_LD_UNIT="-r"
 else
   OS_SHAREDFLAGS="-shared -Wl,-E"
-  OS_LDFLAGS="-Wl,-E -Wl,--hash-style=gnu -Wl,--as-needed"
+  OS_LDFLAGS="-Wl,-E -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-z,noexecstack"
   OS_CXXFLAGS="-Werror=overflow"
   OS_FFLAGS="-cpp"
   OS_LD_UNIT="-r -z muldefs"


### PR DESCRIPTION
This PR contains the following changes
- add  `-Wl,-z,noexecstack` link flag to avoid link type warings
```
gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: warning: DeviceAdditionKernel.cu_nv.o: missing .note.GNU-stack section implies executable stack
gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```
- Force link a CMSSW shared library if it has a `_nv.a` (see https://github.com/cms-sw/cmssw/issues/46864#issuecomment-2595894973 ). This should fix the GPU unit tests in 15.0.X IBs

fixes https://github.com/cms-sw/cmssw/issues/46864

failing gpu tests now run locally on lxplus-gpu
```
Singularity> scram b use-ibeos runtests -j 10
>> Local Products Rules ..... started
>> Local Products Rules ..... done
>> Creating project symlinks
Creating test log file logs/el8_amd64_gcc12/testing.log
>> Created tmp/el8_amd64_gcc12/das_client/dasgoclient
Pass    2s ... HeterogeneousTest/CUDAWrapper/testCudaDeviceAdditionWrapper
Pass    2s ... HeterogeneousTest/CUDAKernel/testCudaDeviceAdditionKernel
Pass    7s ... HeterogeneousTest/CUDAKernel/testCUDATestKernelAdditionModule
Pass    7s ... HeterogeneousTest/CUDAWrapper/testCUDATestWrapperAdditionModule
>> Test sequence completed for CMSSW CMSSW_15_0_X_2025-01-20-1100
```