### PR TITLE
Update ROCm to 6.2.4 and GPU targets

### DIFF
--- a/rocm-rocrand.spec
+++ b/rocm-rocrand.spec
@@ -1,4 +1,4 @@
-### RPM external rocm-rocrand 5.6.1
+### RPM external rocm-rocrand 6.2.4
 ## NOCOMPILER
 
 %if 0%{?rhel} == 7
@@ -10,12 +10,12 @@
 %define repository repo.radeon.com/rocm/rhel%{rhel}
 %endif
 
-# AMD repositories are numbered 5.5, 5.5.1, 5.5.2, ..., 5.6
+# AMD repositories are numbered 6.1, 6.1.1, 6.1.2, ..., 6.2
 # without any .0 in the directory name
 %define repoversion %(echo %{realversion} | sed -e's/\.0$//')
 
-Source0: https://%{repository}/%{repoversion}/main/rocrand-2.10.17.50601-93.el%{rhel}.%{_arch}.rpm
-Source1: https://%{repository}/%{repoversion}/main/rocrand-devel-2.10.17.50601-93.el%{rhel}.%{_arch}.rpm
+Source0: https://%{repository}/%{repoversion}/main/rocrand-3.1.1.60204-139.el%{rhel}.%{_arch}.rpm
+Source1: https://%{repository}/%{repoversion}/main/rocrand-devel-3.1.1.60204-139.el%{rhel}.%{_arch}.rpm
 Requires: rocm
 AutoReq: no
 

--- a/rocm.spec
+++ b/rocm.spec
@@ -1,4 +1,4 @@
-### RPM external rocm 5.6.1
+### RPM external rocm 6.2.4
 
 %if 0%{?rhel} == 7
 # allow rpm2cpio dependency on the bootstrap bundle
@@ -13,22 +13,29 @@
 # without any .0 in the directory name
 %define repoversion %(echo %{realversion} | sed -e's/\.0$//')
 
-Source0: https://%{repository}/%{repoversion}/main/comgr-2.5.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source1: https://%{repository}/%{repoversion}/main/hipcc-1.0.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source2: https://%{repository}/%{repoversion}/main/hip-devel-5.6.31062.50601-93.el%{rhel}.%{_arch}.rpm
-Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-5.6.31062.50601-93.el%{rhel}.%{_arch}.rpm
-Source4: https://%{repository}/%{repoversion}/main/hsa-rocr-1.9.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source5: https://%{repository}/%{repoversion}/main/rocm-core-5.6.1.50601-93.el%{rhel}.%{_arch}.rpm
-Source6: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.70.1.50601-93.el%{rhel}.%{_arch}.rpm
-Source7: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source8: https://%{repository}/%{repoversion}/main/rocm-llvm-16.0.0.23332.50601-93.el%{rhel}.%{_arch}.rpm
-Source9: https://%{repository}/%{repoversion}/main/rocm-smi-lib-5.0.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source10: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source11: https://%{repository}/%{repoversion}/main/openmp-extras-devel-16.56.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source12: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-16.56.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source13: https://%{repository}/%{repoversion}/main/rocm-openmp-sdk-5.6.1.50601-93.el%{rhel}.%{_arch}.rpm
-Source14: https://%{repository}/%{repoversion}/main/rocprim-devel-2.13.0.50601-93.el%{rhel}.%{_arch}.rpm
-Source15: https://%{repository}/%{repoversion}/main/rocthrust-devel-2.18.0.50601-93.el%{rhel}.%{_arch}.rpm
+Source0: https://%{repository}/%{repoversion}/main/comgr-2.8.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source1: https://%{repository}/%{repoversion}/main/hipcc-1.1.1.60204-139.el%{rhel}.%{_arch}.rpm
+Source2: https://%{repository}/%{repoversion}/main/hip-devel-6.2.41134.60204-139.el%{rhel}.%{_arch}.rpm
+Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-6.2.41134.60204-139.el%{rhel}.%{_arch}.rpm
+Source4: https://%{repository}/%{repoversion}/main/hsa-rocr-1.14.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source5: https://%{repository}/%{repoversion}/main/rocm-core-6.2.4.60204-139.el%{rhel}.%{_arch}.rpm
+Source6: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.76.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source7: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source8: https://%{repository}/%{repoversion}/main/rocm-llvm-18.0.0.24392.60204-139.el%{rhel}.%{_arch}.rpm
+Source9: https://%{repository}/%{repoversion}/main/rocm-smi-lib-7.3.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source10: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source11: https://%{repository}/%{repoversion}/main/openmp-extras-devel-18.62.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source12: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-18.62.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source13: https://%{repository}/%{repoversion}/main/rocm-openmp-sdk-6.2.4.60204-139.el%{rhel}.%{_arch}.rpm
+Source14: https://%{repository}/%{repoversion}/main/rocprim-devel-3.2.2.60204-139.el%{rhel}.%{_arch}.rpm
+Source15: https://%{repository}/%{repoversion}/main/rocthrust-devel-3.1.1.60204-139.el%{rhel}.%{_arch}.rpm
+Source16: https://%{repository}/%{repoversion}/main/rocprofiler-2.0.60204.60204-139.el%{rhel}.%{_arch}.rpm
+Source17: https://%{repository}/%{repoversion}/main/rocprofiler-devel-2.0.60204.60204-139.el%{rhel}.%{_arch}.rpm
+Source18: https://%{repository}/%{repoversion}/main/rocprofiler-docs-2.0.60204.60204-139.el%{rhel}.%{_arch}.rpm
+Source19: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.60204.60204-139.el%{rhel}.%{_arch}.rpm
+Source20: https://%{repository}/%{repoversion}/main/rocprofiler-register-0.4.0.60204-139.el%{rhel}.%{_arch}.rpm
+Source21: https://%{repository}/%{repoversion}/main/amd-smi-lib-24.6.3.60204-139.el%{rhel}.%{_arch}.rpm
+
 Requires: numactl zstd
 Requires: python3
 AutoReq: no
@@ -52,6 +59,12 @@ rpm2cpio %{SOURCE12} | cpio -idmv
 rpm2cpio %{SOURCE13} | cpio -idmv
 rpm2cpio %{SOURCE14} | cpio -idmv
 rpm2cpio %{SOURCE15} | cpio -idmv
+rpm2cpio %{SOURCE16} | cpio -idmv
+rpm2cpio %{SOURCE17} | cpio -idmv
+rpm2cpio %{SOURCE18} | cpio -idmv
+rpm2cpio %{SOURCE19} | cpio -idmv
+rpm2cpio %{SOURCE20} | cpio -idmv
+rpm2cpio %{SOURCE21} | cpio -idmv
 
 %install
 rmdir %{i}

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -11,10 +11,12 @@
     <environment name="INCLUDE"   default="$ROCM_BASE/include"/>
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
-  <flags ROCM_FLAGS="--offload-arch=gfx900"/>   <!-- Radeon Pro WX 8200/9100 -->
-  <flags ROCM_FLAGS="--offload-arch=gfx90a"/>   <!-- Instinct MI210/MI250 -->
-  <flags ROCM_FLAGS="--offload-arch=gfx1100"/>  <!-- Radeon Pro W7800/W7900 -->
-  <flags ROCM_FLAGS="--offload-arch=gfx1102"/>  <!-- Radeon Pro W7600 -->
+  <flags ROCM_FLAGS="--offload-arch=gfx908:sramecc+:xnack-"/>   <!-- Instinct MI100 -->
+  <flags ROCM_FLAGS="--offload-arch=gfx90a:sramecc+:xnack-"/>   <!-- Instinct MI210/MI250 -->
+  <flags ROCM_FLAGS="--offload-arch=gfx942:sramecc+:xnack-"/>   <!-- Instinct MI300X -->
+  <flags ROCM_FLAGS="--offload-arch=gfx1030"/>                  <!-- Radeon Pro W6800 -->
+  <flags ROCM_FLAGS="--offload-arch=gfx1100"/>                  <!-- Radeon Pro W7800/W7900 -->
+  <flags ROCM_FLAGS="--offload-arch=gfx1102"/>                  <!-- Radeon Pro W7600 -->
   <flags ROCM_FLAGS="-fgpu-rdc --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
 %if "%{default_microarch_name}"
 %if "%{default_microarch_name}" != "%{min_microarch_name}"


### PR DESCRIPTION
Update ROCm to version 6.2.4:
  - add `amd-smi` and ROCProfiler binaries and libraries
  - for the changes since ROCm 5.6.1, see the release notes for [ROCm 5.7.1](https://rocm.docs.amd.com/en/docs-5.7.1/release.html), [ROCm 6.0](https://rocm.docs.amd.com/en/docs-6.0.0/about/release-notes.html), [ROCm 6.1.2](https://rocm.docs.amd.com/en/docs-6.1.2/about/release-notes.html) and [ROCm 6.2.4](https://rocm.docs.amd.com/en/docs-6.2.4/about/release-notes.html).

Update the AMD GPU targets to those officially supported by ROCm 6.2.4, available to the public, and not deprecated:
  - Radeon Pro W6800, W7600†, W7800/W7900
  - Instinct MI100, MI210/MI250, MI300A/MI300X

See [this list](https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.2.4/reference/system-requirements.html) for more details.

---
† not officially supported but actively tested.