### PR TITLE
Update libunwind version disable per thread cache

### DIFF
--- a/libunwind.spec
+++ b/libunwind.spec
@@ -1,5 +1,5 @@
-### RPM external libunwind 1.7.2-master
-%define tag 24947191d61dda869e039e0414fe97e9f594acd5
+### RPM external libunwind 1.8.1
+%define tag 9cc4d98b22ae57bc1d8c253988feb85d4298a634
 %define branch master
 Source0: git://github.com/%{n}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
@@ -14,7 +14,7 @@ autoreconf -fiv
 ./configure CFLAGS="-g -O3 -fcommon" \
   CPPFLAGS="-I${ZLIB_ROOT}/include -I${XZ_ROOT}/include" \
   LDFLAGS="-L${ZLIB_ROOT}/lib -L${XZ_ROOT}/lib" \
-  --prefix=%{i} --disable-block-signals --enable-zlibdebuginfo
+  --prefix=%{i} --disable-block-signals --enable-zlibdebuginfo --disable-per-thread-cache
 make %{makeprocesses}
 
 %install


### PR DESCRIPTION
Disable the creation of thread_local cache for every pthread in libunwind. Enabling asserts in libjemalloc showed that libunwind created a thread_local cache during a new operation.