### PR TITLE
onnxruntime: Use single thread to compile with nvcc

### DIFF
--- a/onnxruntime.spec
+++ b/onnxruntime.spec
@@ -34,7 +34,7 @@ cmake ../%{n}-%{realversion}/cmake -GNinja \
 %if 0%{!?without_cuda:1}
    -Donnxruntime_CUDA_HOME="${CUDA_ROOT}" \
    -Donnxruntime_CUDNN_HOME="${CUDNN_ROOT}" \
-   -Donnxruntime_NVCC_THREADS=0 \
+   -Donnxruntime_NVCC_THREADS=1 \
    -DCMAKE_CUDA_ARCHITECTURES=$(echo %{cuda_arch} | tr ' ' ';' | sed 's|;;*|;|') \
    -DCMAKE_CUDA_FLAGS="-DTHRUST_IGNORE_DEPRECATED_API -DCUB_IGNORE_DEPRECATED_API -Wno-deprecated-gpu-targets --static-global-template-stub=false -cudart shared" \
    -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared \


### PR DESCRIPTION
ONNXRuntime most of the time failed to build (out of memroy error) on aarch64 nodes ( 40 cores, 120GB) as `onnxruntime_NVCC_THREADS=0` starts `nvcc` with `--thread $(nproc)` causes `nproc x nproc` process running in parallel. As we already run `make -j $(nproc)` so it is better to run single `nvcc` process to avoid overloading build nodes. `onnxruntime_NVCC_THREADS=1` will slow down the build phase but it should not crash the node.

[a] https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver-threads
```
4.2.5.8. --threads number (-t)[](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#threads-number-t)
Specify the maximum number of threads to be used to execute the compilation steps in parallel.

This option can be used to improve the compilation speed when compiling for multiple architectures. The compiler creates number threads to execute the compilation steps in parallel. If number is 1, this option is ignored. If number is 0, the number of threads used is the number of CPUs on the machine.
```