### PR TITLE
Update pybind11 and apply array out of bound patch

### DIFF
--- a/pip/pybind11.file
+++ b/pip/pybind11.file
@@ -1,3 +1,4 @@
+Patch0: pybind11-array-bound
 %define PipPostInstall \
   ln -s ${PYTHON3_LIB_SITE_PACKAGES}/pybind11/share %{i}/share; \
   ln -s ${PYTHON3_LIB_SITE_PACKAGES}/pybind11/include %{i}/include

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -287,7 +287,7 @@ pure-eval==0.2.2
 py-cpuinfo==9.0.0
 pyasn1-modules==0.4.0
 pyasn1==0.6.0
-pybind11==2.12.0
+pybind11==2.13.6
 pybrain==0.3.3
 pycodestyle==2.11.1
 pycparser==2.22

--- a/pybind11-array-bound.patch
+++ b/pybind11-array-bound.patch
@@ -1,0 +1,22 @@
+diff --git a/pybind11/include/pybind11/pybind11.h b/pybind11/include/pybind11/pybind11.h
+index 1806583e6b..e56e2a0589 100644
+--- a/pybind11/include/pybind11/pybind11.h
++++ b/pybind11/include/pybind11/pybind11.h
+@@ -1380,7 +1380,17 @@ class generic_type : public object {
+             } else {
+                 internals.registered_types_cpp[tindex] = tinfo;
+             }
++
++            PYBIND11_WARNING_PUSH
++#if defined(__GNUC__) && __GNUC__ == 12
++            // When using GCC 12 these warnings are disabled as they trigger
++            // false positive warnings.  Discussed here:
++            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824.
++            PYBIND11_WARNING_DISABLE_GCC("-Warray-bounds")
++            PYBIND11_WARNING_DISABLE_GCC("-Wstringop-overread")
++#endif
+             internals.registered_types_py[(PyTypeObject *) m_ptr] = {tinfo};
++            PYBIND11_WARNING_POP
+         });
+ 
+         if (rec.bases.size() > 1 || rec.multiple_inheritance) {

--- a/pybind11-array-bound.patch
+++ b/pybind11-array-bound.patch
@@ -8,7 +8,7 @@ index 1806583e6b..e56e2a0589 100644
              }
 +
 +            PYBIND11_WARNING_PUSH
-+#if defined(__GNUC__) && __GNUC__ == 12
++#if defined(__GNUC__) && __GNUC__ >= 12
 +            // When using GCC 12 these warnings are disabled as they trigger
 +            // false positive warnings.  Discussed here:
 +            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824.


### PR DESCRIPTION
This should fix the gcc13 ASAN IB build issue.
See https://github.com/pybind/pybind11/pull/5355 and https://github.com/pybind/pybind11/issues/5224 for details