### PR TITLE
[131x]Fix xrootd toolfile touse isal instead of scitokens-cpp

### DIFF
--- a/scram-tools.file/tools/xrootd/xrootd.xml
+++ b/scram-tools.file/tools/xrootd/xrootd.xml
@@ -10,5 +10,5 @@
   <runtime name="PATH" value="$XROOTD_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
-  <use name="scitokens-cpp"/>
+  <use name="isal"/>
 </tool>


### PR DESCRIPTION
https://github.com/cms-sw/cmsdist/pull/9655/files removed scitokens-cpp and add isal as xroot dependency. This PR updates the xrootd toolfile to use the `isal` too