### PR TITLE
Test the  g++ `-fimplicit-constexpr` option

### DIFF
--- a/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
@@ -12,6 +12,7 @@
     <flags CXXFLAGS="-O3 -pthread -pipe -Werror=main -Werror=pointer-arith"/>
     <flags CXXFLAGS="-Werror=overlength-strings -Wno-vla @GCC_CXXFLAGS@"/>
     <flags CXXFLAGS="-felide-constructors -fmessage-length=0"/>
+    <flags CXXFLAGS="-fimplicit-constexpr"/>
     <flags CXXFLAGS="-Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type"/>
     <flags CXXFLAGS="-Wextra -Wpessimizing-move -Wclass-memaccess"/>
     <flags CXXFLAGS="-Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter"/>

--- a/scram-tools.file/tools/icx/icx-cxxcompiler.xml
+++ b/scram-tools.file/tools/icx/icx-cxxcompiler.xml
@@ -6,6 +6,7 @@
       <environment name="LIBDIR" default="$ICX_CXXCOMPILER_BASE/lib"/>
     </client>
     <flags REM_CXXFLAGS="-felide-constructors"/>
+    <flags REM_CXXFLAGS="-fimplicit-constexpr"/>
     <flags REM_CXXFLAGS="-ftree-vectorize"/>
     <flags REM_CXXFLAGS="-fno-crossjumping"/>
     <flags REM_CXXFLAGS="-Wno-non-template-friend"/>

--- a/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
@@ -11,6 +11,7 @@
     <flags REM_CXXFLAGS="-Werror=maybe-uninitialized"/>
     <flags REM_CXXFLAGS="-Werror=unused-but-set-variable"/>
     <flags REM_CXXFLAGS="-Werror=return-local-addr"/>
+    <flags REM_CXXFLAGS="-fimplicit-constexpr"/>
     <flags REM_CXXFLAGS="-fipa-pta"/>
     <flags REM_CXXFLAGS="-frounding-math"/>
     <flags REM_CXXFLAGS="-mrecip"/>


### PR DESCRIPTION
From the [GCC 12 manual](https://gcc.gnu.org/onlinedocs/gcc-12.4.0/gcc/C_002b_002b-Dialect-Options.html#index-fimplicit-constexpr):
> #### `-fimplicit-constexpr`
> Make inline functions implicitly constexpr, if they satisfy the requirements for a constexpr function. This option can be used in C++14 mode or later. This can result in initialization changing from dynamic to static and other optimizations.

@makortel [noted](https://github.com/cms-sw/cmssw/issues/47239#issuecomment-2629356875) that this flag makes the compilation very slow and memory consuming with GCC 12.x and 13.2, but is should be usable with GCC 13.3.