### PR TITLE
Enable new CUDA visibility flags

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -26,6 +26,10 @@
 # allow __host__, __device__ attributes in lambda declaration
 %define nvcc_flags_lambda --extended-lambda
 
+# - in whole-program compilation mode (-rdc=false), force 'static' linkage for host side stub functions generated for __global__ function templates
+# - mark __global__ functions and function templates, and __constant__, __device__ and __managed__ variables and variable templates, with __attribute__((visibility("hidden")))
+%define nvcc_visibility_flags --static-global-template-stub=true --device-entity-has-hidden-visibility=true
+
 # build support for the various compute architectures
 %define nvcc_flags_cuda_archs %(echo $(for ARCH in %cuda_arch; do echo "-gencode arch=compute_$ARCH,code=[sm_$ARCH,compute_$ARCH]"; done)) -Wno-deprecated-gpu-targets
 
@@ -46,5 +50,5 @@
 
 # collect all CUDA flags
 %define nvcc_cuda_flags \
-  %{nvcc_flags_stdcxx} %{nvcc_flags_opt} %{nvcc_flags_debug} %{nvcc_flags_constexpr} %{nvcc_flags_lambda} \
+  %{nvcc_flags_stdcxx} %{nvcc_flags_opt} %{nvcc_flags_debug} %{nvcc_flags_constexpr} %{nvcc_flags_lambda} %{nvcc_visibility_flags} \
   %{nvcc_flags_cuda_archs} %{nvcc_flags_cuda_diag_suppress} %{nvcc_flags_cudafe_diag} %{nvcc_flags_gnu_version} %{nvcc_flags_cudart}


### PR DESCRIPTION
CUDA 12.8.0 introduce two flags that restrict the linkage and visibility of `__global__` functions (kernels) and global device variables.

Enabling them should make the CUDA device code and kernel launch interface more self-contained, potentially reducing conflicts across shared libraries.

The new behaviour will be the default in CUDA 13.0.