### PR TITLE
Disable arry-bound errors for GCC 14

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -43,6 +43,8 @@ GCC_CXXFLAGS="$GCC_CXXFLAGS -Xassembler --compress-debug-sections"
 #FIXME: GCC 12.2 workaround
 if [[ "$GCC_VERSION" =~ ^12\.[23]\. ]] ; then
   GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"
+elif [[ "$GCC_VERSION" =~ ^14\.[2]\. ]] ; then
+  GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"
 fi
 
 # Explicitly use the GNU binutils ld.bfd linker


### PR DESCRIPTION
Lets convert the array-bound errors to warnings for GCC 14.

I have opened https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118817  issue , once that is fixed then we can revert this change