### PR TITLE
[CUDART_X] Make cuda-runtime provide libnvrtc-builtins

### DIFF
--- a/cuda-runtime.spec
+++ b/cuda-runtime.spec
@@ -6,6 +6,8 @@ Source99: install-cuda.sh
 ## INCLUDE cuda-version
 ### RPM external cuda-runtime %{cuda_version}
 
+Provides: libnvrtc-builtins.so.12.8()(64bit)
+
 %install
 #Copy runtime libs
 mkdir -p %i/lib64/stubs


### PR DESCRIPTION
This fixes build failure of onnxruntime [link](https://cmssdt.cern.ch/jenkins/job/build-any-ib/200843/):

```
Checking local path dependency for rpm package external+onnxruntime+1.20.1-5b770e6b075607a7a6ec9767ece84472 just build.
RPM installation stderr onnxruntime:
error: Failed dependencies:
	libnvrtc-builtins.so.12.8()(64bit) is needed by external+onnxruntime+1.20.1-5b770e6b075607a7a6ec9767ece84472-1-1.x86_64

Failed to install RPM for onnxruntime
```