### PR TITLE
GCC13: Disable arry-bound errors for GCC 13

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -43,6 +43,10 @@ GCC_CXXFLAGS="$GCC_CXXFLAGS -Xassembler --compress-debug-sections"
 #FIXME: GCC 12.2 workaround
 if [[ "$GCC_VERSION" =~ ^12\.[23]\. ]] ; then
   GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"
+elif [[ "$GCC_VERSION" =~ ^13\.[3]\. ]] ; then
+  GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"  
+elif [[ "$GCC_VERSION" =~ ^14\.[2]\. ]] ; then
+  GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"  
 fi
 
 # Explicitly use the GNU binutils ld.bfd linker


### PR DESCRIPTION
backport #9680 to GCC13 branch