### PR TITLE
[gcc14] Build meschach archive libs with -fPIC

### DIFF
--- a/meschach-1.2b-fPIC.patch
+++ b/meschach-1.2b-fPIC.patch
@@ -5,7 +5,7 @@
  # CFLAGS = -O -g
  # CFLAGS = -pg -g
 -CFLAGS = -O
-+CFLAGS = -O -fPIC
++CFLAGS = -O -fPIC -Wno-error=implicit-function-declaration
  
  
  .c.o:

--- a/meschach.spec
+++ b/meschach.spec
@@ -17,7 +17,7 @@ Patch2: meschach-1.2b-parallel-build
 %ifarch darwin
 perl -p -i -e "s|define HAVE_MALLOC_H 1|undef MALLOCDECL|g" machine.h
 %endif
-make %{makeprocesses} CFLAGS="-Wno-error=implicit-function-declaration"
+make %{makeprocesses}
 %install
 mkdir -p %i/include
 mkdir -p %i/lib


### PR DESCRIPTION
This should fix the GCC14 build/link errors
```
ld.bfd: libmeschach.a(copy.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
ld.bfd: failed to set dynamic section sizes: bad value
```