### PR TITLE
Updated cryptography  to 44.0.1

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -79,9 +79,7 @@ contextlib2==21.6.0
 contextvars==2.4
 coverage==7.5.0
 cppy==1.2.1
-# Newer versions of py3-cryptography require OpenSSL 1.1.0+, see https://github.com/pyca/cryptography/issues/5906
-cryptography==3.2.1 ; cmsos_name=='slc7'
-cryptography==43.0.1
+cryptography==44.0.1
 cx-Oracle==8.3.0
 cycler==0.12.1
 # NO_AUTO_UPDATE: numpy 1.24.3 doesn't support cython 3.x


### PR DESCRIPTION
Dropped slc7 support of old cryptography version
This should fix the `Vulnerable OpenSSL included in cryptography wheels` but as we build from sources, so our distribution should be fine