### PR TITLE
Update CICADA.spec to 1.4.0

### DIFF
--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,5 +1,5 @@
 ### RPM external CICADA 1.4.0
-Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake
 

--- a/CICADA.spec
+++ b/CICADA.spec
@@ -1,4 +1,4 @@
-### RPM external CICADA 1.3.1
+### RPM external CICADA 1.4.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updates externals to have CICADA 2.2.0 model (CICADA repository version 1.4.0)