### PR TITLE
boost:1.80: patch to avoid gcc14 usage of conversion operator warning

### DIFF
--- a/boost.spec
+++ b/boost.spec
@@ -1,6 +1,6 @@
 ### RPM external boost 1.80.0
 ## INCLUDE compilation_flags
-%define tag 004432a23db29c0abc336dbdbc52cbdf0a04f3ce
+%define tag 66e4a726b4ac46155ef33553b65172900660dde5
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%n.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz

--- a/boost.spec
+++ b/boost.spec
@@ -1,6 +1,6 @@
 ### RPM external boost 1.80.0
 ## INCLUDE compilation_flags
-%define tag 0ec9fc110aae47fb4746730b3fbaf1e894d60b80
+%define tag 004432a23db29c0abc336dbdbc52cbdf0a04f3ce
 %define branch cms/v%realversion
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%n.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz

--- a/scram-tools.file/tools/boost/boost_header.xml
+++ b/scram-tools.file/tools/boost/boost_header.xml
@@ -1,4 +1,4 @@
-<tool name="boost_header" version="@TOOL_VERSION@" revision="1">
+<tool name="boost_header" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.boost.org"/>
   <client>
     <environment name="BOOSTHEADER_BASE" default="@TOOL_ROOT@"/>
@@ -11,6 +11,7 @@
   <flags CPPDEFINES="BOOST_SPIRIT_THREADSAFE PHOENIX_THREADSAFE"/>
   <flags CPPDEFINES="BOOST_MATH_DISABLE_STD_FPCLASSIFY"/>
   <flags CPPDEFINES="BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX"/>
+  <flags CPPDEFINES="BOOST_MPL_IGNORE_PARENTHESES_WARNING"/>
   <flags CXXFLAGS="-Wno-error=unused-variable"/>
   <flags SYSTEM_INCLUDE="1"/>
   @CXXMODULE_DATA@


### PR DESCRIPTION
This PR contains the following changes on top of existing boost 1.80.0
- Suppress warning `boost/type_traits/has_nothrow_assign.hpp:65:7: warning: builtin __has_nothrow_assign is deprecated; use __is_nothrow_assignable instead [-Wdeprecated-builtins]` by back porting https://github.com/boostorg/type_traits/commit/a1d0b207c523c13b4fa46fd9b77bdb15ce554051 
- make base_type public so that it can be used by client code and avoid GCC 14 warnings `warning: casting 'boost::archive::class_id_type' to 'boost::uint_t<16>::least&' {aka 'short unsigned int&'} does not use 'boost::archive::class_id_type::operator base_type&()'` . The GCC 14 warning will go away once https://github.com/cms-sw/cmssw/pull/47411 is merged
- Suppress warning `boost/mpl/assert.hpp:193:42: warning: unnecessary parentheses in declaration of 'assert_arg' [-Wparentheses]` by [patching boost](https://github.com/cms-externals/boost/commit/68ce4e3689e7f04c8ce5b646c8acea00743f1b03) and setting `BOOST_MPL_IGNORE_PARENTHESES_WARNING` macro