### PR TITLE
[protobuf]Patched to avoid non-virtual-dtor warning

### DIFF
--- a/protobuf-non-virtual-dtor.patch
+++ b/protobuf-non-virtual-dtor.patch
@@ -1,0 +1,13 @@
+diff --git a/src/google/protobuf/map_field.h b/src/google/protobuf/map_field.h
+index 287d58f..c243e4a 100644
+--- a/src/google/protobuf/map_field.h
++++ b/src/google/protobuf/map_field.h
+@@ -348,7 +348,7 @@ class PROTOBUF_EXPORT MapFieldBase {
+       : arena_(arena), repeated_field_(nullptr), state_(STATE_MODIFIED_MAP) {}
+ 
+  protected:
+-  ~MapFieldBase() {  // "protected" stops users from deleting a `MapFieldBase *`
++  virtual ~MapFieldBase() {  // "protected" stops users from deleting a `MapFieldBase *`
+     GOOGLE_DCHECK(repeated_field_ == nullptr);
+   }
+   void Destruct();

--- a/protobuf.spec
+++ b/protobuf.spec
@@ -16,10 +16,13 @@ Requires: zlib
 BuildRequires: cmake ninja
 # improves text_format printing
 Patch0: protobuf_text_format
+Patch1: protobuf-non-virtual-dtor
 
 %prep
 %setup -n %{n}-%{realversion}
 %patch0 -p1
+%patch1 -p1
+
 # Make sure the default c++sdt stand is c++11
 grep -q 'CMAKE_CXX_STANDARD  *11' CMakeLists.txt
 sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt


### PR DESCRIPTION
Patched protobuf to avoid following warnings in CMSSW

[a]
```
     34  protobuf/3.21.9-3b4dc3892e5c8da1829fdf0bfe570820/include/google/protobuf/map_field.h:332:23: warning: 'class google::protobuf::internal::MapFieldBase' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
    434  protobuf/3.21.9-3b4dc3892e5c8da1829fdf0bfe570820/include/google/protobuf/map_field.h:494:7: warning: base class 'class google::protobuf::internal::MapFieldBase' has accessible non-virtual destructor [-Wnon-virtual-dtor]
```