### PR TITLE
ThePeg: fix warning for arithmetic between enumeration and float type

### DIFF
--- a/thepeg-deprecated-warn.patch
+++ b/thepeg-deprecated-warn.patch
@@ -20,3 +20,25 @@ index 485d51e..b5f80f5 100644
    bool operator()(const type_info * x, const type_info * y) const {
      return x->before(*y); }
  };
+diff --git a/Vectors/LorentzVector.h b/Vectors/LorentzVector.h
+index 7399255..7468e0c 100644
+--- a/Vectors/LorentzVector.h
++++ b/Vectors/LorentzVector.h
+@@ -726,7 +726,7 @@ template <typename Value>
+ inline LorentzVector<Value>
+ lightConeDir(Value plus, Value minus,
+ 	     Value x = Value(), Value y = Value()) {
+-  LorentzVector<Value> r(x, y, Direction<0>::dir()*0.5*(plus - minus),
++  LorentzVector<Value> r(x, y, static_cast<int>(Direction<0>::dir())*0.5*(plus - minus),
+ 		  0.5*(plus + minus));
+   return r;
+ }
+@@ -737,7 +737,7 @@ lightConeDir(Value plus, Value minus,
+ template <typename Value>
+ inline LorentzVector<Value>
+ lightConeDir(Value plus, Value minus, Transverse<Value> pt) {
+-  LorentzVector<Value> r(pt.x(), pt.y(), Direction<0>::dir()*0.5*(plus - minus),
++  LorentzVector<Value> r(pt.x(), pt.y(), static_cast<int>(Direction<0>::dir())*0.5*(plus - minus),
+ 		  0.5*(plus + minus));
+   return r;
+ 


### PR DESCRIPTION
This fixes the warnings we get in cmssw
```
  8  thepeg/2.2.2-ded973583b26dabf833075154083899b/include/ThePEG/Vectors/LorentzVector.h:729:51: warning: arithmetic between enumeration type 'ThePEG::Direction&lt;0&gt;::Dir' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
  8  thepeg/2.2.2-ded973583b26dabf833075154083899b/include/ThePEG/Vectors/LorentzVector.h:740:61: warning: arithmetic between enumeration type 'ThePEG::Direction&lt;0&gt;::Dir' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]

```