### PR TITLE
vecgeom:  Do not read destructed memory

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -6,7 +6,7 @@
 
 %define tag bf8de1e0c18fb7b33c0871fab244de00d2bb2a44
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-Source1: https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/f7dff633131329d5f97709d413b6046656edd498.patch
+Source1: https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/1262.patch
 Patch0: vecgeom-fix-vector
 BuildRequires: cmake gmake
 %define keep_archives true
@@ -17,7 +17,7 @@ BuildRequires: cmake gmake
 %prep
 %setup -n %{n}-%{realversion}
 %patch0 -p1
-patch -p1 <%{_sourcedir}/f7dff633131329d5f97709d413b6046656edd498.patch
+patch -p1 <%{_sourcedir}/1262.patch
 
 %build
 %ifarch x86_64

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -6,6 +6,7 @@
 
 %define tag bf8de1e0c18fb7b33c0871fab244de00d2bb2a44
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source1: https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/f7dff633131329d5f97709d413b6046656edd498.patch
 Patch0: vecgeom-fix-vector
 BuildRequires: cmake gmake
 %define keep_archives true
@@ -15,8 +16,8 @@ BuildRequires: cmake gmake
 
 %prep
 %setup -n %{n}-%{realversion}
-
 %patch0 -p1
+patch -p1 <%{_sourcedir}/f7dff633131329d5f97709d413b6046656edd498.patch
 
 %build
 %ifarch x86_64


### PR DESCRIPTION
Apply changes from https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/1262

FYI @civanch 
We do get these warnings for GCC 14 builds https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-02-24-1900/BigProducts/Simulation
```
  vecgeom/v1.2.10-73ad1151de5c4a9ee0003bb695ac82c0/include/VecGeom/base/VariableSizeObj.h:182:32: warning: 'MEM[(struct VariableData_t &)_6 + 4].fSelfAlloc' may be used uninitialized [-Wmaybe-uninitialized]
   182 |     if (obj->GetVariableData().fSelfAlloc) delete[](char *) obj;
      |                                ^
In function 'ReleaseInstance',
    inlined from '__dt_base ' at vecgeom/v1.2.10-73ad1151de5c4a9ee0003bb695ac82c0/include/VecGeom/volumes/TessellatedStruct.h:229:43,
    inlined from '__dt_base ' at vecgeom/v1.2.10-73ad1151de5c4a9ee0003bb695ac82c0/include/VecGeom/volumes/UnplacedTessellated.h:38:7,
    inlined from '__dt_base ' at geant4/11.2.2-cb96bd8c2ff4d6e5ba67de349ddad4cb/geant4.11.2.2/source/geometry/management/include/G4UAdapter.hh:264:1,
    inlined from '__dt_base ' at geant4/11.2.2-cb96bd8c2ff4d6e5ba67de349ddad4cb/geant4.11.2.2/source/geometry/solids/specific/src/G4UTessellatedSolid.cc:76:1:
  vecgeom/v1.2.10-73ad1151de5c4a9ee0003bb695ac82c0/include/VecGeom/base/VariableSizeObj.h:182:32: warning: 'MEM[(struct VariableData_t &)_57 + 4].fSelfAlloc' may be used uninitialized [-Wmaybe-uninitialized]
   182 |     if (obj->GetVariableData().fSelfAlloc) delete[](char *) obj;
```
