### PR TITLE
[15.0.X] Update tag for DQM-Integration to V00-09-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -6,7 +6,7 @@
 RecoTracker-LSTCore=V00-01-00
 L1Trigger-L1TMuon=V01-12-00
 RecoMuon-TrackerSeedGenerator=V00-07-00
-DQM-Integration=V00-07-00
+DQM-Integration=V00-09-00
 Geometry-HGCalMapping=V00-01-00
 RecoTracker-MkFit=V00-15-00
 RecoBTag-Combined=V01-26-00


### PR DESCRIPTION
Move DQM-Integration data to new tag, see cms-data/DQM-Integration#10
Needed by https://github.com/cms-sw/cmssw/pull/47449

backport of #9718