### PR TITLE
[15.0.X] Update AXOL1TL.spec with axol1tl v5

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 4.0.0
+### RPM external AXOL1TL 5.0.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Update to most recent model version 5 for new menu

Backport of https://github.com/cms-sw/cmsdist/pull/9741 

tag: https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v5.0.0