### PR TITLE
fix jupyter-server deps: added overrides

### DIFF
--- a/pip/jupyter-server.file
+++ b/pip/jupyter-server.file
@@ -1,4 +1,4 @@
 Requires: py3-anyio py3-argon2-cffi py3-Jinja2 py3-jupyter-client py3-jupyter-core py3-jupyter-server-terminals py3-nbconvert py3-nbformat
 Requires: py3-packaging py3-prometheus-client py3-pyzmq py3-Send2Trash py3-terminado py3-tornado py3-traitlets py3-websocket-client
-Requires: py3-jupyter-events
+Requires: py3-jupyter-events py3-overrides
 BuildRequires: py3-hatch-jupyter-builder py3-jupyter-packaging

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -248,6 +248,7 @@ onnxmltools==1.12.0
 onnxconverter-common==1.14.0
 oauthlib==3.2.2
 opt-einsum==3.3.0
+overrides==7.7.0
 pkginfo==1.10.0
 packaging==24.0
 # NO_AUTO_UPDATE: requires Cython3


### PR DESCRIPTION
Fixes https://mattermost.web.cern.ch/cms-o-and-c/pl/kxd1xzbhrjrcmjnogk39arn8ue issue

`jupyter-server` was updated to version `2.14.0` which had a hidden dependency on `overrides` package. This PR adds the missing package and fixes the `jupyter notebook` [issue](https://mattermost.web.cern.ch/cms-o-and-c/pl/kxd1xzbhrjrcmjnogk39arn8ue)