### PR TITLE
hotfix, CRABClient buggy when CMSSW < 12 version, bumped prod to v3.250318.

### DIFF
--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.250217
+%define crabclient_version v3.250318
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.250215
 

--- a/crab-prod.spec
+++ b/crab-prod.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.250217
+%define crabclient_version v3.250318
 ### RPM cms crab-prod %{crabclient_version}.%{version_suffix}
 %define crabserver_version v3.250215
 


### PR DESCRIPTION
Hi, CMSSW Team, Could you kindly help us releases this hotfix into `prod` as soon as your convenience please? Thanks you so much!

N.B. This bug, that was slip into prod, plague every users who use CRABClient with cmssw version older that 12. 
See also [cms-talk/new-buggy-crabclient-v3-250217-in-production](https://cms-talk.web.cern.ch/t/new-buggy-crabclient-v3-250217-in-production/118290)

FYI @belforte 