### PR TITLE
GDB:Update to latest version 16.2

### DIFF
--- a/gdb.spec
+++ b/gdb.spec
@@ -1,4 +1,4 @@
-### RPM external gdb 10.2
+### RPM external gdb 16.2
 Source: https://ftp.gnu.org/gnu/%{n}/%{n}-%{realversion}.tar.gz
 
 Patch0: gdb-disable-makeinfo


### PR DESCRIPTION
Thsi should fix the gdb issue in GCC 14 builds
```
GNU gdb (GDB) 10.2
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-03-21-1100/test/el8_amd64_gcc14/deviceVertexFinderByDensity_tSerialSync...
I'm sorry, Dave, I can't do that.  Symbol format `elf64-x86-64' unknown.
```