### PR TITLE
Rivet 4.1.0 and Yoda 2.1.0

### DIFF
--- a/rivet-pyextfjcontrib.patch
+++ b/rivet-pyextfjcontrib.patch
@@ -1,0 +1,36 @@
+diff --git a/pyext/build.py.in b/pyext/build.py.in
+index 481798d48f8dc1917cd60da0a1e826dfbd6bdf4a..1f7eb7dd749d56026fe0baf2e8763947967dd096 100644
+--- a/pyext/build.py.in
++++ b/pyext/build.py.in
+@@ -25,7 +25,7 @@ if not os.path.isfile(srcpath): # distcheck has it in srcdir
+ ## Include args
+ incargs = " ".join("-I{}".format(d) for d in incdirs)
+ incargs += " -I@prefix@/include"
+-incargs += " @HEPMC3CPPFLAGS@ @FASTJETCPPFLAGS@ @YODACPPFLAGS@ @YAML_CPP_CPPFLAGS@"
++incargs += " @HEPMC3CPPFLAGS@ @FASTJETCPPFLAGS@ @FJCONTRIBCPPFLAGS@ @YODACPPFLAGS@ @YAML_CPP_CPPFLAGS@"
+ incargs += " @CPPFLAGS@"
+ incargs += " -I" + sysconfig.get_config_var("INCLUDEPY")
+ 
+diff --git a/pyext/build.py.in b/pyext/build.py.in
+index 1f7eb7dd749d56026fe0baf2e8763947967dd096..6c7dfb17b5332bf654dcae0ba022af5890af3dd2 100644
+--- a/pyext/build.py.in
++++ b/pyext/build.py.in
+@@ -13,7 +13,7 @@ incdirs = [os.path.abspath("@abs_top_srcdir@/include"),
+            os.path.abspath("@abs_builddir@/rivet")]
+ 
+ ## Library-search dirs
+-lookupdirs = ["@HEPMC3LIBPATH@", "@FASTJETLIBPATH@", "@YODALIBPATH@"]
++lookupdirs = ["@HEPMC3LIBPATH@", "@FASTJETLIBPATH@", "@FJCONTRIBLIBPATH@", "@YODALIBPATH@"]
+ 
+ 
+ ## The extension source file (built by separate Cython call)
+@@ -34,7 +34,7 @@ cmpargs = "@PYEXT_CXXFLAGS@"
+ cmpargs += " @CXXFLAGS@"
+ 
+ ## Link args -- base on install-prefix, or on local lib dirs for pre-install build
+-linkargs = " ".join("-L{}".format(d) for d in lookupdirs)
++linkargs = " ".join("-L{}".format(d) for d in lookupdirs if d)
+ linkargs += " -L@abs_top_builddir@/src/.libs" if "RIVET_LOCAL" in os.environ else "-L@prefix@/lib"
+ ## This needs to be passed separately on Mac, otherwise HepMC3 library won't be found
+ if platform.system() == "Darwin": linkargs += " -Wl,-rpath,@HEPMC3LIBPATH@"
+

--- a/rivet.spec
+++ b/rivet.spec
@@ -1,4 +1,4 @@
-### RPM external rivet 4.0.2
+### RPM external rivet 4.1.0
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
@@ -6,6 +6,7 @@
 Source: git+https://gitlab.com/hepcedar/rivet.git?obj=master/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Source99: scram-tools.file/tools/eigen/env
 Patch0: rivet-duplicate-libs
+Patch1: rivet-pyextfjcontrib
 
 Requires: hepmc3 fastjet fastjet-contrib yoda hdf5 highfive onnxruntime
 BuildRequires: python3 py3-cython autotools
@@ -14,6 +15,7 @@ BuildRequires: python3 py3-cython autotools
 ## OLD GENSER: %setup -n rivet/%{realversion}
 %setup -n %{n}-%{realversion}
 %patch0 -p1
+%patch1 -p1
 
 %build
 source %{_sourcedir}/env

--- a/yoda.spec
+++ b/yoda.spec
@@ -1,9 +1,9 @@
-### RPM external yoda 2.0.2
+### RPM external yoda 2.1.0
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 
 Source: git+https://gitlab.com/hepcedar/yoda.git?obj=main/%{n}-%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
-Requires: python3 root
+Requires: python3 root hdf5 highfive
 BuildRequires: py3-cython autotools python-python3
 
 %prep
@@ -13,9 +13,7 @@ autoreconf -fiv
 
 %build
 
-PYTHON=$(which python3) ./configure --prefix=%i --enable-root
-sed -i "s|env python|env python3|" bin/*
-sed -i "s|env python|env python3|" pyext/yoda/plotting/script_generator.py
+PYTHON=$(which python3) ./configure --prefix=%i --enable-root --with-highfive=${HIGHFIVE_ROOT} CXX="mpicxx"
 make %{makeprocesses} all
 make install
 


### PR DESCRIPTION
* Rivet version bump
* New temporary patch, can be removed for next upgrade

Unit tests:
```
Pass    4s ... GeneratorInterface/RivetInterface/test-particleLevel_fromPtGun
Pass   10s ... GeneratorInterface/RivetInterface/test-particleLevel_fromHepMC3
Pass   13s ... GeneratorInterface/RivetInterface/test-HTXS
Pass   13s ... GeneratorInterface/RivetInterface/test-particleLevel_fromGenParticles
Pass   15s ... GeneratorInterface/RivetInterface/test-rivet-run
Pass    2s ... GeneratorInterface/RivetInterface/test-yoda-merge
Pass    3s ... GeneratorInterface/RivetInterface/test-yoda-root
Pass   12s ... GeneratorInterface/RivetInterface/test-rivet-plot
Pass   27s ... GeneratorInterface/RivetInterface/test-particleLevel_fromMiniAod
Pass   27s ... GeneratorInterface/RivetInterface/test-rivet-list
>> Test sequence completed for CMSSW CMSSW_15_1_X_2025-03-27-1100
```