### PR TITLE
Generate cuda.pcm if CUDA is available

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -12,6 +12,7 @@ Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&expo
 BuildRequires: cmake ninja
 
 Requires: gsl libjpeg-turbo libpng libtiff giflib pcre2 python3 fftw3 xz xrootd libxml2 zlib davix tbb OpenBLAS py3-numpy lz4 freetype zstd
+%{!?without_cuda:Requires: cuda}
 
 %ifos linux
 Requires: dcap
@@ -177,6 +178,11 @@ export ROOT_INCLUDE_PATH
 export ROOTSYS="%{i}"
 
 ninja -v %{makeprocesses} install
+
+# Generate cuda.pcm if CUDA is available
+%if 0%{!?without_cuda:1}
+echo '#include <cuda_runtime.h>' | %{i}/bin/root -b -n -l
+%endif
 
 find %{i} -type f -name '*.py' | xargs chmod -x
 grep -rlI '#!.*python' %{i} | xargs chmod +x


### PR DESCRIPTION
If CUDA is available, let ROOT generate the `cuda.pcm` file after the build, and include it in the distribution.
This fixes the current problem where a missing dictionary for a type that includes a CUDA header leads to a fatal exception.