### PR TITLE
Add L1TSC4NGJetModel

### DIFF
--- a/L1TSC4NGJetModel.spec
+++ b/L1TSC4NGJetModel.spec
@@ -1,0 +1,13 @@
+### RPM external L1TSC4NGJetModel 0.0.0
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
+Requires: hls4mlEmulatorExtras hls
+BuildRequires: gmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+make %{makeprocesses} EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT} HLS_ROOT=${HLS_ROOT}
+
+%install
+make PREFIX=%{i} install

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tools 2.0
+### RPM cms cmssw-tools 3.0
 # With cmsBuild, change the above version only when a new tool is added
 
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cms-cat cmssw-osenv cms-git-tools SCRAMV2
@@ -57,6 +57,7 @@ Requires: jemalloc-prof
 Requires: json
 Requires: ktjet
 Requires: L1METML
+Requires: L1TSC4NGJetModel
 Requires: lhapdf
 Requires: libjpeg-turbo
 Requires: libpng

--- a/scram-tools.file/tools/L1TSC4NGJetModel/l1tsc4ngjetmodel.xml
+++ b/scram-tools.file/tools/L1TSC4NGJetModel/l1tsc4ngjetmodel.xml
@@ -1,6 +1,6 @@
-<tool name="l1tsc4ngjetmodel" version="@TOOL_VERSION@">
+<tool name="l1tsc4ngjetmodel" version="@TOOL_VERSION@" revision="1">
   <client>
-    <environment name="L1TSC4NGJetModel_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$L1TSC4NGJetModel_BASE/lib64"/>
+    <environment name="L1TSC4NGJETMODEL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$L1TSC4NGJETMODEL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/L1TSC4NGJetModel/l1tsc4ngjetmodel.xml
+++ b/scram-tools.file/tools/L1TSC4NGJetModel/l1tsc4ngjetmodel.xml
@@ -1,0 +1,6 @@
+<tool name="l1tsc4ngjetmodel" version="@TOOL_VERSION@">
+  <client>
+    <environment name="L1TSC4NGJetModel_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$L1TSC4NGJetModel_BASE/lib64"/>
+  </client>
+</tool>


### PR DESCRIPTION
This PR adds one new package for an upcoming CMSSW PR for the Phase 2 Level 1 Trigger Jet Tagging Model.

Firmware, model and performance plots can be found [here](https://cms-l1t-jet-tagger.web.cern.ch/TrainTagger/tags/v0.0.0/) with training code [here](https://github.com/CMS-L1T-Jet-Tagging/TrainTagger)

@thesps @quinnanm @BenjaminRS
 

