### PR TITLE
[ROOT6] Instead of creating cuda.pcm delete cuda.modulemap

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -177,11 +177,7 @@ export ROOTSYS="%{i}"
 
 ninja -v %{makeprocesses} install
 
-# Generate cuda.pcm if CUDA is available
-%if 0%{!?without_cuda:1}
-echo '#include <cuda_runtime.h>' | %{i}/bin/root -b -n -l
-%endif
-
+rm -f %{i}/etc/cling/cuda.modulemap
 find %{i} -type f -name '*.py' | xargs chmod -x
 grep -rlI '#!.*python' %{i} | xargs chmod +x
 for p in $(grep -rlI -m1 '^#\!.*python' %i/bin %i/etc) ; do

--- a/root.spec
+++ b/root.spec
@@ -28,6 +28,7 @@ Requires: dcap
 %prep
 %setup -n %{n}-%{realversion}
 rm -f interpreter/cling/include/cling/cuda.modulemap
+sed -i -e 's| cuda.modulemap | |' core/clingutils/CMakeLists.txt
 %get_config_sub graf2d/asimage/src/libAfterImage/config.sub
 %get_config_guess graf2d/asimage/src/libAfterImage/config.guess
 chmod +x graf2d/asimage/src/libAfterImage/config.{sub,guess}

--- a/root.spec
+++ b/root.spec
@@ -27,6 +27,7 @@ Requires: dcap
 
 %prep
 %setup -n %{n}-%{realversion}
+rm -f interpreter/cling/include/cling/cuda.modulemap
 %get_config_sub graf2d/asimage/src/libAfterImage/config.sub
 %get_config_guess graf2d/asimage/src/libAfterImage/config.guess
 chmod +x graf2d/asimage/src/libAfterImage/config.{sub,guess}
@@ -177,7 +178,6 @@ export ROOTSYS="%{i}"
 
 ninja -v %{makeprocesses} install
 
-rm -f %{i}/etc/cling/cuda.modulemap
 find %{i} -type f -name '*.py' | xargs chmod -x
 grep -rlI '#!.*python' %{i} | xargs chmod +x
 for p in $(grep -rlI -m1 '^#\!.*python' %i/bin %i/etc) ; do


### PR DESCRIPTION
`cuda.pcm` contains ref to the build directory path for `math.h` file
```
[cmsbld@cmsbuild957 lib]$ strings /cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02885/el8_aarch64_gcc12/lcg/root/6.35.1-7c4ea1a1bc92e150e3e1f567333c632d/lib/cuda.pcm  | grep math.h
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/aarch64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/math.h
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/aarch64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/math.h
```

may be that is causing various relvals failing for aarch64 [a]. Though x86_64 build of root also contains refs to build directory `math.h` but for some reason relvals does not fail for x86_64.

This PR drops the creation of `cuda.pcm` and also deletes `root/etc/cuda.modulemap` to avoid the creation of `cuda.pcm` as runtime. Let see if this fixes the issue with aarch64 relvals

[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc12/CMSSW_15_1_ROOT6_X_2025-04-13-2300/pyRelValMatrixLogs/run/7.25_Cosmics_UP25/step2_Cosmics_UP25.log#/
```
fatal error: cannot open file '/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/aarch64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/math.h': No such file or directory
14-Apr-2025 07:55:40 CEST  Closed file file:step1.root
----- Begin Fatal Exception 14-Apr-2025 07:55:40 CEST-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=L2MuonProducer label='hltL2Muons'
   [2] While initializing meta data for branch: L2MuonTrajectorySeedsToManyL2MuonTrajectorySeedsAssociation_hltL2Muons__HLT.
   [3] Calling edm::TypeWithDict::byName()
   Additional Info:
      [a] Getting TClass for edm::AssociationMap<edm::OneToMany<std::vector<L2MuonTrajectorySeed>,std::vector<L2MuonTrajectorySeed>,unsigned int> >
      [b] Fatal Root Error: @SUB=TInterpreter::AutoParse
Error parsing payload code for class L2MuonTrajectorySeed with content:
```