### PR TITLE
build with frame pointer

### DIFF
--- a/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
@@ -9,7 +9,7 @@
     </client>
     <flags CPPDEFINES="GNU_GCC _GNU_SOURCE @GCC_CPPDEFINES@"/>
     <flags CXXSHAREDOBJECTFLAGS="-fPIC @GCC_CXXSHAREDOBJECTFLAGS@"/>
-    <flags CXXFLAGS="-O3 -pthread -pipe -Werror=main -Werror=pointer-arith"/>
+    <flags CXXFLAGS="-O3 -g -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -pthread -pipe -Werror=main -Werror=pointer-arith"/>
     <flags CXXFLAGS="-Werror=overlength-strings -Wno-vla @GCC_CXXFLAGS@"/>
     <flags CXXFLAGS="-felide-constructors -fmessage-length=0"/>
     <flags CXXFLAGS="-Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type"/>


### PR DESCRIPTION
This is to request a build with frame pointers enabled so that we can profile CMSSW with [Adaptyst](https://github.com/Adaptyst/Adaptyst).

FYI @maksgraczyk