### PR TITLE
added frame_pointer build option

### DIFF
--- a/etc/build_options.py
+++ b/etc/build_options.py
@@ -1,6 +1,6 @@
 def get_build_options(options, *args):
   opts = {}
-  boolean_opts = ["vecgeom", "lto", "warnings", "tf_mkldnn"]
+  boolean_opts = ["vecgeom", "lto", "warnings", "tf_mkldnn", "frame_pointer"]
   for opt in boolean_opts:
     opts[opt] = ["enable_%s=1" % opt]
     opts["no-"+opt] = ["enable_%s=0" % opt]

--- a/frame_pointer-opt.file
+++ b/frame_pointer-opt.file
@@ -1,0 +1,3 @@
+%if "%{?enable_frame_pointer:set}" != "set"
+%define enable_frame_pointer 0
+%endif

--- a/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
@@ -10,6 +10,9 @@
     <flags CPPDEFINES="GNU_GCC _GNU_SOURCE @GCC_CPPDEFINES@"/>
     <flags CXXSHAREDOBJECTFLAGS="-fPIC @GCC_CXXSHAREDOBJECTFLAGS@"/>
     <flags CXXFLAGS="-O3 -pthread -pipe -Werror=main -Werror=pointer-arith"/>
+%if 0%{?enable_frame_pointer}
+    <flags CXXFLAGS="-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"/>
+%endif
     <flags CXXFLAGS="-Werror=overlength-strings -Wno-vla @GCC_CXXFLAGS@"/>
     <flags CXXFLAGS="-felide-constructors -fmessage-length=0"/>
     <flags CXXFLAGS="-Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type"/>

--- a/toolflags.file
+++ b/toolflags.file
@@ -5,6 +5,7 @@
 ## INCLUDE warning-flags
 ## INCLUDE vecgeom-opt
 ## INCLUDE microarch_flags
+## INCLUDE frame_pointer-opt
 
 %if "%{default_microarch_name}" == ""
   %if "%{arch_build_flags}"


### PR DESCRIPTION
Changes needed to build SCRAM based projects with frame-pointer. By default frame pointers are omitted. For special IBs ( e.g. `FP_X` we can build with `--build-option frame_pomiter`