### PR TITLE
[15.0.X] Update AXOL1TL.spec to v5.0.1 for timing issue fix (backport)

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 5.0.0
+### RPM external AXOL1TL 5.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updating AXOL1TL model to v5.0.1

Includes some minor type changes in order to resolve timing issues. (See [JIRA ticket CMSLITDPG-1359)](https://its.cern.ch/jira/browse/CMSLITDPG-1359?focusedId=6768744&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6768744)

Backport of [PR#9809](https://github.com/cms-sw/cmsdist/pull/9809)

model release: https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v5.0.1