### PR TITLE
[el10] various fixes/cleanup to avoid el10 errors/warnings

### DIFF
--- a/git.spec
+++ b/git.spec
@@ -1,4 +1,4 @@
-### RPM external git 2.47.1
+### RPM external git 2.49.0
 ## INITENV +PATH PATH %{i}/bin
 ## INITENV +PATH PATH %{i}/libexec/git-core
 ## INITENV SET GIT_TEMPLATE_DIR %{i}/share/git-core/templates
@@ -6,7 +6,7 @@
 ## INITENV SET GIT_EXEC_PATH %{i}/libexec/git-core
 
 Source0: https://github.com/git/git/archive/v%{realversion}.tar.gz
-Source1: https://raw.github.com/curl/curl/curl-8_11_1/scripts/mk-ca-bundle.pl
+Source1: https://raw.githubusercontent.com/curl/curl/eeed87f0563d3ca73ff53813418d1f9f03c81fe5/scripts/mk-ca-bundle.pl
 Patch1: git-2.19.0-runtime
 
 Requires: curl expat zlib pcre2 python3
@@ -45,7 +45,7 @@ mkdir ./ca-bundle
 pushd ./ca-bundle
 cp %{SOURCE1} ./mk-ca-bundle.pl
 chmod +x ./mk-ca-bundle.pl
-./mk-ca-bundle.pl
+./mk-ca-bundle.pl -k
 popd
 
 %install

--- a/java-env.spec
+++ b/java-env.spec
@@ -1,18 +1,18 @@
-### RPM external java-env 11_17
+### RPM external java-env 17_21
 ## INITENV SET JAVA_HOME %{java_home}
 ## INITENV +PATH PATH %{java_home}/bin
 ## INITENV +PATH LD_LIBRARY_PATH %{java_home}/lib
 ## NOCOMPILER
 
-#For RHEL: Use java 11 for el7 and java 17 for el8 and above
+#For RHEL: Use java 17 for el8/el9 and 21 for above
 #Nor non RHEL e.g FC: use default system java
 %define java_home /usr/lib/jvm/java
 %if 0%{?rhel:1}
-%if %{?rhel} < 8
-%define java_home /usr/lib/jvm/java-11
-%endif
-%if %{?rhel} > 7
+%if 0%{rhel} <= 10
 %define java_home /usr/lib/jvm/java-17
+%endif
+%if 0%{?rhel} > 10
+%define java_home /usr/lib/jvm/java-21
 %endif
 %endif
 Source: none

--- a/meschach.spec
+++ b/meschach.spec
@@ -1,6 +1,6 @@
 ### RPM external meschach 1.2.pCMS1
 Source: http://www.math.uiowa.edu/~dstewart/meschach/mesch12b.tar.gz
-Patch: meschach-1.2-slc4
+Patch0: meschach-1.2-slc4
 Patch1: meschach-1.2b-fPIC
 Patch2: meschach-1.2b-parallel-build
 
@@ -8,7 +8,7 @@ Patch2: meschach-1.2b-parallel-build
 
 %prep
 %setup -c -n meschach-1.2 -a 0
-%patch -p0
+%patch0 -p0
 %patch1 -p0
 %patch2 -p1
 

--- a/pip/cms-tfaot.file
+++ b/pip/cms-tfaot.file
@@ -9,4 +9,4 @@ Requires: py3-PyYAML py3-cmsml
 # copy test models
 %define PipPostInstall \
   mkdir -p %{i}/share; \
-  cp -r cmsdist-tmp/pip-req-build-*/test_models %{i}/share/
+  cp -r %{pkgbuilddir}/pip-req-build-*/test_models %{i}/share/

--- a/pip/cms-tfaot.file
+++ b/pip/cms-tfaot.file
@@ -9,4 +9,4 @@ Requires: py3-PyYAML py3-cmsml
 # copy test models
 %define PipPostInstall \
   mkdir -p %{i}/share; \
-  cp -r %{pkgbuilddir}/pip-req-build-*/test_models %{i}/share/
+  cp -r %{pkgbuilddir}/cmsdist-tmp/pip-req-build-*/test_models %{i}/share/

--- a/rivet.spec
+++ b/rivet.spec
@@ -12,7 +12,6 @@ Requires: hepmc3 fastjet fastjet-contrib yoda hdf5 highfive onnxruntime
 BuildRequires: python3 py3-cython autotools
 
 %prep
-## OLD GENSER: %setup -n rivet/%{realversion}
 %setup -n %{n}-%{realversion}
 %patch0 -p1
 %patch1 -p1

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -12,6 +12,26 @@
 %define _source_payload w9.gzdio
 %define _binary_payload w9.gzdio
 
+%if "%{?rpmversion:set}" == "set"
+%define rpm_major_version %(echo %{rpmversion} | cut -d. -f1)
+%define rpm_minor_version %(echo %{rpmversion} | cut -d. -f1)
+%if %{rpm_major_version} >= 4
+%if %{rpm_minor_version} > 19
+#Disable use of unshare plugin
+%_build_use_unshare 0
+#Avoid: warning: private mounts in chroot not implemented
+%_build_use_chroot_private_mounts 0
+%endif
+%endif
+%endif
+
+#Disable setting of Compilation flags
+%if 0%{?_build_flags:1}
+%undefine _build_flags
+%endif
+%if 0%{?set_build_flags:1}
+%global set_build_flags :
+%endif
 
 #disable running find-debuginfo.sh
 %define  debug_package %{nil}
@@ -87,6 +107,7 @@
 %endif
 
 %define pkginstroot	%{instroot}/%{pkgrel}
+%define pkgbuilddir %{cmsroot}/BUILD/%{cmsplatf}/%{pkgdir}
 
 %define _sourcedir	%{cmsroot}/SOURCES/%{pkgdir}
 %define _builddir	%{cmsroot}/BUILD/%{cmsplatf}/%{pkgdir}
@@ -320,7 +341,7 @@ fi
 %if "%{?cms_debug_packages:set}" == "set"
 %define is_debug_build() %(if echo %{cms_debug_packages} | tr , '\\n' | grep -q '^%{1}$' ; then echo 1 ; else echo 0; fi)
 %else
-%define is_debug_build 0
+%define is_debug_build() 0
 %endif
 
 %if %{is_debug_build %{pkgname}}

--- a/tensorflow-xla-runtime.spec
+++ b/tensorflow-xla-runtime.spec
@@ -13,7 +13,7 @@ BuildRequires: cmake
 %prep
 
 cp -r ${PY3_TENSORFLOW_ROOT}/lib/python%{cms_python3_major_minor_version}/site-packages/tensorflow .
-%patch -p0
+%patch0 -p0
 
 %build
 

--- a/tinyxml2.spec
+++ b/tinyxml2.spec
@@ -4,7 +4,7 @@ Source: https://github.com/leethomason/%{n}/archive/%{realversion}.tar.gz
 BuildRequires: gmake cmake
 
 %prep
-%setup -n %setup -q -n %{n}-%{realversion}
+%setup -q -n %{n}-%{realversion}
 
 %build
 rm -rf ../build; mkdir ../build ; cd ../build

--- a/xrdcl-record.spec
+++ b/xrdcl-record.spec
@@ -5,7 +5,7 @@ BuildRequires: gmake cmake
 Requires: xrootd
 
 %prep
-%setup -n %setup -q -n %{n}-%{realversion}
+%setup -n -q -n %{n}-%{realversion}
 
 %build
 rm -rf ../build; mkdir ../build ; cd ../build


### PR DESCRIPTION
These changes are needed to avoid errors/warnings generated by newer RPM package version 4.20
- fix: clean up `%patchN` instead of simple `%patch`
- fix: Avoid duplicate %setup
- fix: Update git mk-ca-bundle url
- As we do not build packages for slc7 so update java env rto use either java 17 or java 21
- fix: use `%{pkgbuilddir}` instead of assuming the tmp directory is in `%_builddir`
- fix: update various macros for `rpm>=4.20`