### PR TITLE
Update RDMA Core, OFI, UCX, and Open MPI

### DIFF
--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -78,6 +78,7 @@ Requires: numactl
 Requires: hwloc
 Requires: rdma-core
 Requires: ucx
+Requires: libfabric
 Requires: openmpi
 Requires: sigcpp
 Requires: sqlite

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -1,0 +1,79 @@
+### RPM external libfabric 2.1.0
+Source: https://github.com/ofiwg/%{n}/releases/download/v%{realversion}/%{n}-%{realversion}.tar.bz2
+%{!?without_cuda:Requires: cuda gdrcopy}
+%{!?without_rocm:Requires: rocm}
+Requires: curl
+Requires: numactl
+Requires: rdma-core
+Requires: xpmem
+
+%prep
+%setup -q -n %{n}-%{realversion}
+
+# regenerate the configure files and Makefiles
+./autogen.sh
+
+./configure \
+  --prefix=%i \
+  --disable-dependency-tracking \
+  --disable-debug \
+  --disable-profile \
+  --disable-asan \
+  --disable-lsan \
+  --disable-tsan \
+  --disable-ubsan \
+  --enable-shared \
+  --disable-static \
+  --enable-shm \
+  --enable-sm2 \
+  --enable-xpmem=$XPMEM_ROOT \
+  --disable-sockets \
+  --enable-tcp \
+  --enable-udp \
+  --enable-verbs=$RDMA_CORE_ROOT \
+  --disable-opx \
+  --disable-psm2 \
+  --disable-psm3 \
+  --disable-usnic \
+  --disable-efa \
+  --disable-cxi \
+  --disable-mrail \
+  --disable-lpp \
+  --disable-ucx \
+  --enable-rxm \
+  --enable-lnx \
+%if 0%{!?without_cuda:1}
+  --enable-cuda-dlopen \
+  --enable-gdrcopy-dlopen \
+  --with-cuda=$CUDA_ROOT \
+  --with-gdrcopy=$GDRCOPY_ROOT \
+%else
+  --disable-cuda-dlopen \
+  --disable-gdrcopy-dlopen \
+  --without-cuda \
+  --without-gdrcopy \
+%endif
+%if 0%{!?without_rocm:1}
+  --enable-rocr-dlopen \
+  --with-rocr=$ROCM_ROOT \
+%else
+  --disable-rocr-dlopen \
+  --without-rocr \
+%endif
+  --disable-ze-dlopen \
+  --without-ze \
+  --with-pic \
+  --with-dlopen \
+  --with-gnu-ld \
+  --with-curl=DIR \
+  --with-numa=$NUMACTL_ROOT
+
+  # CFLAGS="-Wno-error=array-bounds"
+
+%build
+make %{makeprocesses} 
+
+%install
+make install
+
+%post

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,7 +1,9 @@
-### RPM external openmpi 4.1.8
+### RPM external openmpi 4.1.x-20250505
 ## INITENV SET OPAL_PREFIX %{i}
-Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
-BuildRequires: autotools
+%define branch v4.1.x
+%define tag e6d2cb856f3fc649aa01bd5b688a003b3b33db7d
+Source: git+https://github.com/open-mpi/ompi.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+BuildRequires: autotools flex
 %{!?without_cuda:Requires: cuda}
 Requires: libfabric
 Requires: hwloc
@@ -19,6 +21,8 @@ Requires: zlib
 
 %prep
 %setup -q -n %{n}-%{realversion}
+
+AUTOMAKE_JOBS=%{compiling_processes} ./autogen.pl
 
 ./configure \
   --prefix=%i \

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 4.1.6
+### RPM external openmpi 4.1.8
 ## INITENV SET OPAL_PREFIX %{i}
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -3,6 +3,7 @@
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/%{n}-%{realversion}.tar.bz2
 BuildRequires: autotools
 %{!?without_cuda:Requires: cuda}
+Requires: libfabric
 Requires: hwloc
 Requires: rdma-core
 Requires: xpmem
@@ -10,7 +11,6 @@ Requires: ucx
 Requires: zlib
 
 # external libraries are needed for additional protocols:
-#   --with-ofi:         Open Fabric Interface's libfabric
 #   --with-mxm:         Mellanox Messaging (depracated, use UCX instead)
 #   --with-fca:         Mellanox Fabric Collective Accelerator
 #   --with-hcoll:       Mellanox Hierarchical Collectives
@@ -33,7 +33,7 @@ Requires: zlib
   --with-zlib=$ZLIB_ROOT \
   %{!?without_cuda:--with-cuda=$CUDA_ROOT} \
   --with-hwloc=$HWLOC_ROOT \
-  --without-ofi \
+  --with-ofi=$LIBFABRIC_ROOT \
   --without-portals4 \
   --without-psm \
   --without-psm2 \

--- a/rdma-core-VERBS_CONFIG_DIR.patch
+++ b/rdma-core-VERBS_CONFIG_DIR.patch
@@ -1,0 +1,42 @@
+diff --git a/libibverbs/dynamic_driver.c b/libibverbs/dynamic_driver.c
+index 7fa4233..c2ff2bb 100644
+--- a/libibverbs/dynamic_driver.c
++++ b/libibverbs/dynamic_driver.c
+@@ -115,27 +115,33 @@ static void read_config_file(const char *path)
+ 
+ static void read_config(void)
+ {
++	char *verbs_config_dir;
+ 	DIR *conf_dir;
+ 	struct dirent *dent;
+ 	char *path;
+ 
+-	conf_dir = opendir(IBV_CONFIG_DIR);
++	verbs_config_dir = getenv("VERBS_CONFIG_DIR");
++	if (!verbs_config_dir) {
++		verbs_config_dir = IBV_CONFIG_DIR;
++	}
++
++	conf_dir = opendir(verbs_config_dir);
+ 	if (!conf_dir) {
+ 		fprintf(stderr,
+ 			PFX "Warning: couldn't open config directory '%s'.\n",
+-			IBV_CONFIG_DIR);
++			verbs_config_dir);
+ 		return;
+ 	}
+ 
+ 	while ((dent = readdir(conf_dir))) {
+ 		struct stat buf;
+ 
+-		if (asprintf(&path, "%s/%s", IBV_CONFIG_DIR, dent->d_name) <
++		if (asprintf(&path, "%s/%s", verbs_config_dir, dent->d_name) <
+ 		    0) {
+ 			fprintf(stderr,
+ 				PFX
+ 				"Warning: couldn't read config file %s/%s.\n",
+-				IBV_CONFIG_DIR, dent->d_name);
++				verbs_config_dir, dent->d_name);
+ 			goto out;
+ 		}
+ 

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -1,4 +1,4 @@
-### RPM external rdma-core 50.0
+### RPM external rdma-core 57.0
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 
 Source: https://github.com/linux-rdma/%{n}/releases/download/v%{realversion}/rdma-core-%{realversion}.tar.gz

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -2,10 +2,12 @@
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 
 Source: https://github.com/linux-rdma/%{n}/releases/download/v%{realversion}/rdma-core-%{realversion}.tar.gz
+Patch: rdma-core-VERBS_CONFIG_DIR
 BuildRequires: cmake ninja
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch -p1
 
 %build
 rm -rf build
@@ -33,10 +35,19 @@ ninja -v %{makeprocesses} install
 # remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
 rm -rf %{i}/lib64/pkgconfig
 
-# keep only the libraries and include files
-rm -rf %{i}/bin
-rm -rf %{i}/etc
+# keep only the user binaries, libibverbs configuration, libraries and include files
+rm -rf %{i}/etc/infiniband-diags
+rm -rf %{i}/etc/init.d
+rm -rf %{i}/etc/modprobe.d
+rm -rf %{i}/etc/rdma
 rm -rf %{i}/lib
 rm -rf %{i}/libexec
 rm -rf %{i}/sbin
-rm -rf %{i}/share
+rm -rf %{i}/share/perl5
+
+# update the libibverbs plugins with the full path
+sed -e's#driver \(\w\+\)#driver %{i}/lib64/libibverbs/lib\1#' -i %{i}/etc/libibverbs.d/*
+
+%post
+# relocate the libibverbs plugins path
+%{relocateConfig}etc/libibverbs.d/*

--- a/rocm.spec
+++ b/rocm.spec
@@ -23,43 +23,33 @@
 %define rocprofiler_register_pkg    rocprofiler-register-%{rocprofiler_register_tag}
 
 Source0: https://%{repository}/%{repoversion}/main/amd-smi-lib-24.7.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source1: https://%{repository}/%{repoversion}/main/amd-smi-lib-debuginfo-24.7.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source2: https://%{repository}/%{repoversion}/main/comgr-2.8.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source3: https://%{repository}/%{repoversion}/main/comgr-debuginfo-2.8.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source4: https://%{repository}/%{repoversion}/main/hip-devel-6.3.42134.60302-66.el%{rhel}.%{_arch}.rpm
-Source5: https://%{repository}/%{repoversion}/main/hip-runtime-amd-6.3.42134.60302-66.el%{rhel}.%{_arch}.rpm
-Source6: https://%{repository}/%{repoversion}/main/hip-runtime-amd-debuginfo-6.3.42134.60302-66.el%{rhel}.%{_arch}.rpm
-Source7: https://%{repository}/%{repoversion}/main/hipcc-1.1.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source8: https://%{repository}/%{repoversion}/main/hipcc-debuginfo-1.1.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source9: https://%{repository}/%{repoversion}/main/hsa-rocr-1.14.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source10: https://%{repository}/%{repoversion}/main/hsa-rocr-debuginfo-1.14.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source11: https://%{repository}/%{repoversion}/main/openmp-extras-devel-18.63.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source12: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-18.63.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source13: https://%{repository}/%{repoversion}/main/rocm-core-6.3.2.60302-66.el%{rhel}.%{_arch}.rpm
-Source14: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.77.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source15: https://%{repository}/%{repoversion}/main/rocm-dbgapi-debuginfo-0.77.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source16: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source17: https://%{repository}/%{repoversion}/main/rocm-llvm-18.0.0.25012.60302-66.el%{rhel}.%{_arch}.rpm
-Source18: https://%{repository}/%{repoversion}/main/rocm-smi-lib-7.4.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source19: https://%{repository}/%{repoversion}/main/rocm-smi-lib-debuginfo-7.4.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source20: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source21: https://%{repository}/%{repoversion}/main/rocminfo-debuginfo-1.0.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source22: https://%{repository}/%{repoversion}/main/rocprim-devel-3.3.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source23: https://%{repository}/%{repoversion}/main/rocprofiler-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source24: https://%{repository}/%{repoversion}/main/rocprofiler-compute-3.0.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source25: https://%{repository}/%{repoversion}/main/rocprofiler-debuginfo-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source26: https://%{repository}/%{repoversion}/main/rocprofiler-devel-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source27: https://%{repository}/%{repoversion}/main/rocprofiler-docs-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source28: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source29: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-debuginfo-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source30: https://%{repository}/%{repoversion}/main/rocprofiler-register-0.4.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source31: https://%{repository}/%{repoversion}/main/rocprofiler-systems-0.1.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source32: https://%{repository}/%{repoversion}/main/rocprofiler-systems-debuginfo-0.1.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source33: https://%{repository}/%{repoversion}/main/rocthrust-devel-3.3.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source1: https://%{repository}/%{repoversion}/main/comgr-2.8.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source2: https://%{repository}/%{repoversion}/main/hip-devel-6.3.42134.60302-66.el%{rhel}.%{_arch}.rpm
+Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-6.3.42134.60302-66.el%{rhel}.%{_arch}.rpm
+Source4: https://%{repository}/%{repoversion}/main/hipcc-1.1.1.60302-66.el%{rhel}.%{_arch}.rpm
+Source5: https://%{repository}/%{repoversion}/main/hsa-rocr-1.14.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source6: https://%{repository}/%{repoversion}/main/hsa-rocr-devel-1.14.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source7: https://%{repository}/%{repoversion}/main/openmp-extras-devel-18.63.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source8: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-18.63.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source9: https://%{repository}/%{repoversion}/main/rocm-core-6.3.2.60302-66.el%{rhel}.%{_arch}.rpm
+Source10: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.77.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source11: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source12: https://%{repository}/%{repoversion}/main/rocm-llvm-18.0.0.25012.60302-66.el%{rhel}.%{_arch}.rpm
+Source13: https://%{repository}/%{repoversion}/main/rocm-smi-lib-7.4.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source14: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source15: https://%{repository}/%{repoversion}/main/rocprim-devel-3.3.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source16: https://%{repository}/%{repoversion}/main/rocprofiler-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
+Source17: https://%{repository}/%{repoversion}/main/rocprofiler-compute-3.0.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source18: https://%{repository}/%{repoversion}/main/rocprofiler-devel-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
+Source19: https://%{repository}/%{repoversion}/main/rocprofiler-docs-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
+Source20: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
+Source21: https://%{repository}/%{repoversion}/main/rocprofiler-register-0.4.0.60302-66.el%{rhel}.%{_arch}.rpm
+Source22: https://%{repository}/%{repoversion}/main/rocprofiler-systems-0.1.1.60302-66.el%{rhel}.%{_arch}.rpm
+Source23: https://%{repository}/%{repoversion}/main/rocthrust-devel-3.3.0.60302-66.el%{rhel}.%{_arch}.rpm
 
 
 # sources for rocprofiler-register
-Source34: git+https://github.com/ROCm/rocprofiler-register.git?obj=%{rocprofiler_register_branch}/%{rocprofiler_register_tag}&export=%{rocprofiler_register_pkg}&submodules=1&output=/%{rocprofiler_register_pkg}.tgz
+Source24: git+https://github.com/ROCm/rocprofiler-register.git?obj=%{rocprofiler_register_branch}/%{rocprofiler_register_tag}&export=%{rocprofiler_register_pkg}&submodules=1&output=/%{rocprofiler_register_pkg}.tgz
 
 BuildRequires: gmake cmake
 Requires: numactl zstd fmt
@@ -70,7 +60,7 @@ AutoReq: no
 
 # unpack rocprofiler-register
 mkdir src
-tar xavf %{SOURCE34} -C src
+tar xavf %{SOURCE24} -C src
 
 %build
 rpm2cpio %{SOURCE0} | cpio -idmv
@@ -97,16 +87,6 @@ rpm2cpio %{SOURCE20} | cpio -idmv
 rpm2cpio %{SOURCE21} | cpio -idmv
 rpm2cpio %{SOURCE22} | cpio -idmv
 rpm2cpio %{SOURCE23} | cpio -idmv
-rpm2cpio %{SOURCE24} | cpio -idmv
-rpm2cpio %{SOURCE25} | cpio -idmv
-rpm2cpio %{SOURCE26} | cpio -idmv
-rpm2cpio %{SOURCE27} | cpio -idmv
-rpm2cpio %{SOURCE28} | cpio -idmv
-rpm2cpio %{SOURCE29} | cpio -idmv
-rpm2cpio %{SOURCE30} | cpio -idmv
-rpm2cpio %{SOURCE31} | cpio -idmv
-rpm2cpio %{SOURCE32} | cpio -idmv
-rpm2cpio %{SOURCE33} | cpio -idmv
 
 # build rocprofiler-register
 sed -i -e 's|add_subdirectory(external)|find_package(fmt REQUIRED)\nadd_subdirectory(external)|' src/%{rocprofiler_register_pkg}/CMakeLists.txt

--- a/scram-tools.file/tools/libfabric/libfabric.xml
+++ b/scram-tools.file/tools/libfabric/libfabric.xml
@@ -1,0 +1,8 @@
+<tool name="libfabric" version="@TOOL_VERSION@" revision="1">
+  <lib name="fabric"/>
+  <client>
+    <environment name="LIBFABRIC_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$LIBFABRIC_BASE/lib"/>
+    <environment name="INCLUDE"        default="$LIBFABRIC_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/rdma-core/rdma-core.xml
+++ b/scram-tools.file/tools/rdma-core/rdma-core.xml
@@ -5,5 +5,7 @@
     <environment name="LIBDIR"         default="$RDMA_CORE_BASE/lib64"/>
     <environment name="INCLUDE"        default="$RDMA_CORE_BASE/include"/>
   </client>
+  <runtime name="PATH" value="$RDMA_CORE_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <runtime name="VERBS_CONFIG_DIR" value="$RDMA_CORE_BASE/etc/libibverbs.d" type="path"/>
 </tool>

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,4 +1,4 @@
-### RPM external ucx 1.17.0
+### RPM external ucx 1.18.1
 Source: https://github.com/openucx/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: autotools
 %{!?without_cuda:Requires: cuda gdrcopy}


### PR DESCRIPTION
#### ROCm
  * add ROCr headers (used by OFI), remove debuginfo files.

#### RDMA Core
  * update RDMA Core Userspace Libraries to version 57.0
  * make libibverbs plugins relocatable

#### OFI
  * add Libfabric OpenFabrics version 2.1.0

#### UCX
  * update UCX to version 1.18.1

#### Open MPI
  * update Open MPI to version 4.1.8