### PR TITLE
Update CUDA to 12.8.1

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 12.8.0
+### RPM external cuda 12.8.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 570.86.10
+%define driversversion 570.124.06
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run


### PR DESCRIPTION
Update CUDA to version 12.8.1

---

Note: we keep support for Pascal (sm 6.x) GPUs for the time being.

Launching a kernel on Pascal and older GPUs is limited to a total of 4 kB for the kernel arguments.

Volta (sm_70) and newer GPUs increased the limit to 32 kB since CUDA 12.1. 