### PR TITLE
[el10] Update gcc, cmake and curl

### DIFF
--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.31.5
+### RPM external cmake 3.31.7
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib

--- a/curl.spec
+++ b/curl.spec
@@ -1,5 +1,5 @@
-### RPM external curl 7.79.0
-Source: http://curl.haxx.se/download/%{n}-%{realversion}.tar.gz
+### RPM external curl 8.13.0
+Source: https://curl.se/download/%{n}-%{realversion}.tar.gz
 Requires: zlib
 
 %prep
@@ -23,6 +23,7 @@ Requires: zlib
   --without-nss \
   --without-libssh2 \
   --with-gssapi=${KERBEROS_ROOT} \
+  --without-libpsl \
   --with-openssl
 
 make %{makeprocesses}

--- a/gcc-prerequisites.spec
+++ b/gcc-prerequisites.spec
@@ -1,6 +1,7 @@
 ### RPM external gcc-prerequisites 1.0
 ## NOCOMPILER
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
+AutoReqProv: no
 
 %define keep_archives true
 %define gmpVersion 6.3.0

--- a/gcc.spec
+++ b/gcc.spec
@@ -101,7 +101,9 @@ export PATH=%{i}/tmp/sw/bin:$PATH
 
 CONF_GCC_ARCH_SPEC="--enable-frame-pointer"
 %ifarch x86_64
+%if 0%{?rhel} > 9
 CONF_GCC_ARCH_SPEC="$CONF_GCC_ARCH_SPEC --with-arch=x86-64-v3"
+%endif
 %endif
 %ifarch aarch64
     CONF_GCC_ARCH_SPEC="$CONF_GCC_ARCH_SPEC \


### PR DESCRIPTION
GCC: Enable x86-64-v3 psABI as default for x86-64 archs and rhel10 and above
CURL: 8.13.0 
CMake: 3.31.7 which contains fix for curl 8