### PR TITLE
Cleanup cuda tools to avoid creation of cuda/lib64 links under cmssw/external

### DIFF
--- a/scram-tools.file/tools/cuda/cuda-interface.xml
+++ b/scram-tools.file/tools/cuda/cuda-interface.xml
@@ -1,0 +1,13 @@
+<tool name="cuda-interface" version="@TOOL_VERSION@" revision="1">
+  <info url="https://docs.nvidia.com/cuda/index.html"/>
+  <client>
+    <environment name="CUDA_INTERFACE_BASE" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR"              default="$CUDA_INTERFACE_BASE/bin"/>
+    <environment name="LIBDIR"              default="$CUDA_INTERFACE_BASE/lib64"/>
+    <environment name="INCLUDE"             default="$CUDA_INTERFACE_BASE/include"/>
+  </client>
+  <flags SKIP_TOOL_SYMLINKS="1"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LIBDIR"  type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH"        value="$INCLUDE" type="path"/>
+  <runtime name="PATH"                     value="$BINDIR"  type="path"/>
+</tool>

--- a/scram-tools.file/tools/cuda/cuda-stubs.xml
+++ b/scram-tools.file/tools/cuda/cuda-stubs.xml
@@ -1,10 +1,10 @@
-<tool name="cuda-stubs" version="@TOOL_VERSION@" revision="1">
+<tool name="cuda-stubs" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <lib name="cuda"/>
+  <use name="cuda-interface"/>
   <client>
     <environment name="CUDA_STUBS_BASE" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"          default="$CUDA_STUBS_BASE/lib64/stubs"/>
-    <environment name="INCLUDE"         default="$CUDA_STUBS_BASE/include"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
 </tool>

--- a/scram-tools.file/tools/cuda/cuda.xml
+++ b/scram-tools.file/tools/cuda/cuda.xml
@@ -1,15 +1,13 @@
-<tool name="cuda" version="@TOOL_VERSION@" revision="2">
+<tool name="cuda" version="@TOOL_VERSION@" revision="3">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <use name="cuda-stubs"/>
   <lib name="cudart"/>
   <lib name="cudadevrt"/>
   <lib name="nvToolsExt"/>
+  <use name="cuda-interface"/>
   <client>
     <environment name="CUDA_BASE" default="@TOOL_ROOT@"/>
     <environment name="NVCC"      default="$CUDA_BASE/bin/nvcc"/>
-    <environment name="BINDIR"    default="$CUDA_BASE/bin"/>
-    <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
-    <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
   <flags CUDA_FLAGS="@CUDA_FLAGS@"/>
   <flags REM_CUDA_HOST_CXXFLAGS="-std=%"/>
@@ -22,6 +20,4 @@
 %endif
 %endif
   <lib name="cudadevrt" type="cuda"/>
-  <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$CUDA_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/cuda/cupti.xml
+++ b/scram-tools.file/tools/cuda/cupti.xml
@@ -1,9 +1,5 @@
-<tool name="cupti" version="@TOOL_VERSION@" revision="1">
+<tool name="cupti" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.nvidia.com/cupti/Cupti/index.html"/>
   <lib name="cupti"/>
-  <client>
-    <environment name="CUPTI_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"     default="$CUPTI_BASE/lib64"/>
-    <environment name="INCLUDE"    default="$CUPTI_BASE/include"/>
-  </client>
+  <use name="cuda-interface"/>
 </tool>

--- a/scram-tools.file/tools/cuda/env.sh
+++ b/scram-tools.file/tools/cuda/env.sh
@@ -1,0 +1,1 @@
+source ${SCRAM_TOOLS_BIN_DIR}/os_libdir.sh

--- a/scram-tools.file/tools/cuda/nvperf.xml
+++ b/scram-tools.file/tools/cuda/nvperf.xml
@@ -1,10 +1,6 @@
-<tool name="nvperf" version="@TOOL_VERSION@" revision="1">
+<tool name="nvperf" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.nvidia.com/cupti/Cupti/index.html"/>
   <lib name="nvperf_host"/>
   <lib name="nvperf_target"/>
-  <client>
-    <environment name="NVPERF_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"      default="$NVPERF_BASE/lib64"/>
-    <environment name="INCLUDE"     default="$NVPERF_BASE/include"/>
-  </client>
+  <use name="cuda-interface"/>
 </tool>


### PR DESCRIPTION
This clean will help wioth CUDART libs where cmssw/external/lib links might be broken due to cern only access to /cvmfs/project.cern.ch area