### PR TITLE
[GCC14] build gcc with frame-pointers; sync changes from el10/gcc14

### DIFF
--- a/cmake.spec
+++ b/cmake.spec
@@ -1,4 +1,4 @@
-### RPM external cmake 3.31.5
+### RPM external cmake 3.31.7
 %define downloaddir %(echo %realversion | cut -d. -f1,2)
 Source: http://www.cmake.org/files/v%{downloaddir}/%n-%realversion.tar.gz
 Requires: bz2lib curl expat zlib

--- a/curl.spec
+++ b/curl.spec
@@ -1,5 +1,10 @@
-### RPM external curl 7.79.0
-Source: http://curl.haxx.se/download/%{n}-%{realversion}.tar.gz
+%if 0%{?rhel} > 9
+%define curl_version 8.13.0
+%else
+%define curl_version 7.79.0
+%endif
+### RPM external curl %{curl_version}
+Source: https://curl.se/download/%{n}-%{realversion}.tar.gz
 Requires: zlib
 
 %prep
@@ -23,6 +28,7 @@ Requires: zlib
   --without-nss \
   --without-libssh2 \
   --with-gssapi=${KERBEROS_ROOT} \
+  --without-libpsl \
   --with-openssl
 
 make %{makeprocesses}

--- a/gcc-prerequisites.spec
+++ b/gcc-prerequisites.spec
@@ -1,0 +1,190 @@
+### RPM external gcc-prerequisites 1.0
+## NOCOMPILER
+## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
+AutoReqProv: no
+
+%define keep_archives true
+%define gmpVersion 6.3.0
+%define mpfrVersion 4.2.1
+%define mpcVersion 1.3.1
+%define islVersion 0.27
+%define zlibVersion 1.2.13
+%define zstdVersion 1.5.4
+Source1: https://gmplib.org/download/gmp/gmp-%{gmpVersion}.tar.bz2
+Source2: http://www.mpfr.org/mpfr-%{mpfrVersion}/mpfr-%{mpfrVersion}.tar.bz2
+Source3: https://ftp.gnu.org/gnu/mpc/mpc-%{mpcVersion}.tar.gz
+Source4: https://libisl.sourceforge.io/isl-%{islVersion}.tar.bz2
+Source12: http://zlib.net/zlib-%{zlibVersion}.tar.gz
+Source13: https://github.com/facebook/zstd/releases/download/v%{zstdVersion}/zstd-%{zstdVersion}.tar.gz
+Source14: https://github.com/gcc-mirror/gcc/commit/0a1d2ea57722c248777e1130de076e28c443ff8b.diff
+Source15: https://github.com/gcc-mirror/gcc/commit/77d01927bd7c989d431035251a5c196fe39bcec9.diff
+
+%ifos linux
+%define bisonVersion 3.8.2
+%define binutilsVersion 2.43.1
+%define elfutilsVersion 0.192
+%define m4Version 1.4.19
+%define flexVersion 2.6.4
+Source7: http://ftp.gnu.org/gnu/bison/bison-%{bisonVersion}.tar.gz
+Source8: https://sourceware.org/pub/binutils/releases/binutils-%{binutilsVersion}.tar.bz2
+Source9: https://sourceware.org/pub/elfutils/%{elfutilsVersion}/elfutils-%{elfutilsVersion}.tar.bz2
+Source10: http://ftp.gnu.org/gnu/m4/m4-%{m4Version}.tar.gz
+Source11: https://github.com/westes/flex/releases/download/v%{flexVersion}/flex-%{flexVersion}.tar.gz
+%endif
+
+Patch0: gcc-flex-nonfull-path-m4
+Patch1: gcc-flex-disable-doc
+
+%prep
+# GCC prerequisites
+%setup -D -T -b 1 -n gmp-%{gmpVersion}
+%setup -D -T -b 2 -n mpfr-%{mpfrVersion}
+%setup -D -T -b 3 -n mpc-%{mpcVersion}
+%setup -D -T -b 4 -n isl-%{islVersion}
+%setup -D -T -b 12 -n zlib-%{zlibVersion}
+%setup -D -T -b 13 -n zstd-%{zstdVersion}
+
+%ifos linux
+%setup -D -T -b 7 -n bison-%{bisonVersion}
+%setup -D -T -b 8 -n binutils-%{binutilsVersion}
+%setup -D -T -b 9 -n elfutils-%{elfutilsVersion}
+%setup -D -T -b 10 -n m4-%{m4Version}
+%setup -D -T -b 11 -n flex-%{flexVersion}
+%patch0 -p1
+%patch1 -p1
+%endif
+
+%build
+%ifarch darwin
+  CC='clang'
+  CXX='clang++'
+  CPP='clang -E'
+  CXXCPP='clang++ -E'
+  ADDITIONAL_LANGUAGES=,objc,obj-c++
+  CONF_GCC_OS_SPEC=
+%else
+  CC=gcc
+  CXX=c++
+  CPP=cpp
+  CXXCPP='c++ -E'
+  CONF_GCC_OS_SPEC=
+%endif
+
+CC="$CC -fPIC"
+CXX="$CXX -fPIC"
+
+mkdir -p %{i}/tmp/sw
+export PATH=%{i}/tmp/sw/bin:$PATH
+
+# Build zlib (required for compressed debug information)
+cd ../zlib-%{zlibVersion}
+CONF_FLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1"
+%ifarch x86_64
+CONF_FLAGS="${CONF_FLAGS} -msse3"
+%endif
+CFLAGS="${CONF_FLAGS}" ./configure --static --prefix=%{i}/tmp/sw
+make %{makeprocesses}
+make install
+
+#Build and install zstd static library
+make -C ../zstd-%{zstdVersion}/lib %{makeprocesses} \
+  install-static install-includes prefix=%{i}/tmp/sw \
+  CPPFLAGS="-fPIC" CFLAGS="-fPIC"
+%ifos linux
+  CONF_BINUTILS_OPTS="--enable-ld=default --enable-lto --enable-plugins --enable-threads"
+  CONF_GCC_WITH_LTO="--enable-ld=default --enable-lto"
+
+  CONF_BINUTILS_OPTS="$CONF_BINUTILS_OPTS --enable-gold=yes"
+  CONF_GCC_WITH_LTO="$CONF_GCC_WITH_LTO --enable-gold=yes"
+
+  # Build M4 (for building)
+  cd ../m4-%{m4Version}
+  ./configure --prefix=%{i}/tmp/sw \
+              --build=%{_build} --host=%{_host} \
+              CC="$CC"
+  make %{makeprocesses}
+  make install
+  hash -r
+
+  # Build Bison (for building)
+  cd ../bison-%{bisonVersion}
+  ./configure --build=%{_build} --host=%{_host} \
+              --prefix=%{i}/tmp/sw CC="$CC"
+  make %{makeprocesses}
+  make install
+  hash -r
+
+  # Build Flex (for building)
+  cd ../flex-%{flexVersion}
+  ./configure --disable-nls --prefix=%{i}/tmp/sw \
+              --enable-static --disable-shared \
+              --build=%{_build} --host=%{_host} \
+              CC="$CC" CXX="$CXX"
+  make %{makeprocesses}
+  make install
+  hash -r
+
+  # Build elfutils
+  cd ../elfutils-%{elfutilsVersion}
+  ./configure --disable-static --with-zlib --without-bzlib --without-lzma \
+              --disable-libdebuginfod --enable-libdebuginfod=dummy --disable-debuginfod \
+              --build=%{_build} --host=%{_host} --program-prefix='eu-' --disable-silent-rules \
+              --prefix=%{i} CC="gcc" \
+              CPPFLAGS="-I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/tmp/sw/lib"
+  make %{makeprocesses}
+  make install
+
+%ifarch ppc64le
+    CONF_BINUTILS_OPTS="${CONF_BINUTILS_OPTS} --enable-targets=spu --enable-targets=powerpc-linux"
+%endif
+
+  # Build binutils
+  cd ../binutils-%{binutilsVersion}
+  ./configure --disable-static --prefix=%{i} ${CONF_BINUTILS_OPTS} --disable-werror --enable-deterministic-archives \
+              --build=%{_build} --host=%{_host} --disable-nls --with-system-zlib --enable-64-bit-bfd \
+              CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" CFLAGS="-I%{i}/include -I%{i}/tmp/sw/include" \
+              CXXFLAGS="-I%{i}/include -I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/lib -L%{i}/tmp/sw/lib"
+  make %{makeprocesses}
+  find . -name Makefile -exec perl -p -i -e 's|LN = ln|LN = cp -p|;s|ln ([^-])|cp -p $1|g' {} \; 
+  make install
+%endif
+
+# Build GMP
+cd ../gmp-%{gmpVersion}
+./configure --disable-static --prefix=%{i} --enable-shared --disable-static --enable-cxx \
+            --build=%{_build} --host=%{_host} \
+            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
+make %{makeprocesses}
+make install
+
+# Build MPFR
+cd ../mpfr-%{mpfrVersion}
+./configure --disable-static --prefix=%{i} --with-gmp=%{i} \
+            --build=%{_build} --host=%{_host} \
+            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
+make %{makeprocesses}
+make install
+
+# Build MPC
+cd ../mpc-%{mpcVersion}
+./configure --disable-static --prefix=%{i} --with-gmp=%{i} --with-mpfr=%{i} \
+            --build=%{_build} --host=%{_host} \
+            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
+make %{makeprocesses}
+make install
+
+# Build ISL
+cd ../isl-%{islVersion}
+./configure --disable-static --with-gmp-prefix=%i --prefix=%{i} \
+            --build=%{_build} --host=%{_host} \
+            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
+make %{makeprocesses}
+make install
+
+%install
+
+%post
+%{relocateConfig}bin/eu-make-debug-archive
+%{relocateConfig}etc/profile.d/debuginfod.*sh
+%{relocateConfig}share/fish/vendor_conf.d/debuginfod.fish
+for f in $(find $RPM_INSTALL_PREFIX/%{pkgrel}/*/lib/ldscripts -type f) ; do %{relocateCmsFiles} $f || true ; done

--- a/gcc.spec
+++ b/gcc.spec
@@ -4,44 +4,17 @@
 # Use the git repository for fetching the sources. This gives us more control while developing
 # a new platform so that we can compile yet to be released versions of the compiler.
 # See: https://gcc.gnu.org/viewcvs/gcc/branches/gcc-8-branch/?view=log
+
+BuildRequires: gcc-prerequisites
 %define gccTag a0550ff9f36a27a03c15d49383c6ec76fc6a8e99
 %define gccBranch releases/gcc-14
 
 %define moduleName %{n}-%{realversion}
 Source0: git+https://github.com/gcc-mirror/%{n}.git?obj=%{gccBranch}/%{gccTag}&export=%{moduleName}&output=/%{n}-%{realversion}-%{gccTag}.tgz
+Source1: https://github.com/gcc-mirror/gcc/commit/0a1d2ea57722c248777e1130de076e28c443ff8b.diff
+Source2: https://github.com/gcc-mirror/gcc/commit/77d01927bd7c989d431035251a5c196fe39bcec9.diff
 
 %define keep_archives true
-
-%define gmpVersion 6.3.0
-%define mpfrVersion 4.2.1
-%define mpcVersion 1.3.1
-%define islVersion 0.27
-%define zlibVersion 1.2.13
-%define zstdVersion 1.5.4
-Source1: https://gmplib.org/download/gmp/gmp-%{gmpVersion}.tar.bz2
-Source2: http://www.mpfr.org/mpfr-%{mpfrVersion}/mpfr-%{mpfrVersion}.tar.bz2
-Source3: https://ftp.gnu.org/gnu/mpc/mpc-%{mpcVersion}.tar.gz
-Source4: https://libisl.sourceforge.io/isl-%{islVersion}.tar.bz2
-Source12: http://zlib.net/zlib-%{zlibVersion}.tar.gz
-Source13: https://github.com/facebook/zstd/releases/download/v%{zstdVersion}/zstd-%{zstdVersion}.tar.gz
-Source14: https://github.com/gcc-mirror/gcc/commit/0a1d2ea57722c248777e1130de076e28c443ff8b.diff
-Source15: https://github.com/gcc-mirror/gcc/commit/77d01927bd7c989d431035251a5c196fe39bcec9.diff
-
-%ifos linux
-%define bisonVersion 3.8.2
-%define binutilsVersion 2.43.1
-%define elfutilsVersion 0.192
-%define m4Version 1.4.19
-%define flexVersion 2.6.4
-Source7: http://ftp.gnu.org/gnu/bison/bison-%{bisonVersion}.tar.gz
-Source8: https://sourceware.org/pub/binutils/releases/binutils-%{binutilsVersion}.tar.bz2
-Source9: https://sourceware.org/pub/elfutils/%{elfutilsVersion}/elfutils-%{elfutilsVersion}.tar.bz2
-Source10: http://ftp.gnu.org/gnu/m4/m4-%{m4Version}.tar.gz
-Source11: https://github.com/westes/flex/releases/download/v%{flexVersion}/flex-%{flexVersion}.tar.gz
-%endif
-
-Patch0: gcc-flex-nonfull-path-m4
-Patch1: gcc-flex-disable-doc
 
 %prep
 
@@ -94,24 +67,6 @@ cat << \EOF_CMS_H > gcc/config/general-cms.h
 #define CC1PLUS_SPEC "-fabi-version=0"
 EOF_CMS_H
 
-# GCC prerequisites
-%setup -D -T -b 1 -n gmp-%{gmpVersion}
-%setup -D -T -b 2 -n mpfr-%{mpfrVersion}
-%setup -D -T -b 3 -n mpc-%{mpcVersion}
-%setup -D -T -b 4 -n isl-%{islVersion}
-%setup -D -T -b 12 -n zlib-%{zlibVersion}
-%setup -D -T -b 13 -n zstd-%{zstdVersion}
-
-%ifos linux
-%setup -D -T -b 7 -n bison-%{bisonVersion}
-%setup -D -T -b 8 -n binutils-%{binutilsVersion}
-%setup -D -T -b 9 -n elfutils-%{elfutilsVersion}
-%setup -D -T -b 10 -n m4-%{m4Version}
-%setup -D -T -b 11 -n flex-%{flexVersion}
-%patch0 -p1
-%patch1 -p1
-%endif
-
 %build
 %ifarch darwin
   CC='clang'
@@ -131,115 +86,25 @@ EOF_CMS_H
 CC="$CC -fPIC"
 CXX="$CXX -fPIC"
 
-mkdir -p %{i}/tmp/sw
+mkdir -p %{i}
+rsync -a ${GCC_PREREQUISITES_ROOT}/ %{i}/
+rm -rf %{i}/etc/profile.d/dependencies-setup.*sh %{i}/etc/profile.d/init.*sh
+sed -i -e 's|%{builddirectpkgreqs}|%{pkgdir}|g' \
+  %{i}/etc/profile.d/debuginfod.*sh \
+  %{i}/bin/eu-make-debug-archive \
+  %{i}/share/fish/vendor_conf.d/debuginfod.fish
+for f in $(find %{i}/*/lib/ldscripts -type f) ; do
+  sed -i -e 's|%{builddirectpkgreqs}|%{pkgdir}|g' $f
+done
+
 export PATH=%{i}/tmp/sw/bin:$PATH
 
-# Build zlib (required for compressed debug information)
-cd ../zlib-%{zlibVersion}
-CONF_FLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1"
+CONF_GCC_ARCH_SPEC="--enable-frame-pointer"
 %ifarch x86_64
-CONF_FLAGS="${CONF_FLAGS} -msse3"
+%if 0%{?rhel} > 9
+CONF_GCC_ARCH_SPEC="$CONF_GCC_ARCH_SPEC --with-arch=x86-64-v3"
 %endif
-CFLAGS="${CONF_FLAGS}" ./configure --static --prefix=%{i}/tmp/sw
-make %{makeprocesses}
-make install
-
-#Build and install zstd static library
-make -C ../zstd-%{zstdVersion}/lib %{makeprocesses} \
-  install-static install-includes prefix=%{i}/tmp/sw \
-  CPPFLAGS="-fPIC" CFLAGS="-fPIC"
-%ifos linux
-  CONF_BINUTILS_OPTS="--enable-ld=default --enable-lto --enable-plugins --enable-threads"
-  CONF_GCC_WITH_LTO="--enable-ld=default --enable-lto"
-
-  CONF_BINUTILS_OPTS="$CONF_BINUTILS_OPTS --enable-gold=yes"
-  CONF_GCC_WITH_LTO="$CONF_GCC_WITH_LTO --enable-gold=yes"
-
-  # Build M4 (for building)
-  cd ../m4-%{m4Version}
-  ./configure --prefix=%{i}/tmp/sw \
-              --build=%{_build} --host=%{_host} \
-              CC="$CC"
-  make %{makeprocesses}
-  make install
-  hash -r
-
-  # Build Bison (for building)
-  cd ../bison-%{bisonVersion}
-  ./configure --build=%{_build} --host=%{_host} \
-              --prefix=%{i}/tmp/sw CC="$CC"
-  make %{makeprocesses}
-  make install
-  hash -r
-
-  # Build Flex (for building)
-  cd ../flex-%{flexVersion}
-  ./configure --disable-nls --prefix=%{i}/tmp/sw \
-              --enable-static --disable-shared \
-              --build=%{_build} --host=%{_host} \
-              CC="$CC" CXX="$CXX"
-  make %{makeprocesses}
-  make install
-  hash -r
-
-  # Build elfutils
-  cd ../elfutils-%{elfutilsVersion}
-  ./configure --disable-static --with-zlib --without-bzlib --without-lzma \
-              --disable-libdebuginfod --enable-libdebuginfod=dummy --disable-debuginfod \
-              --build=%{_build} --host=%{_host} --program-prefix='eu-' --disable-silent-rules \
-              --prefix=%{i} CC="gcc" \
-              CPPFLAGS="-I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/tmp/sw/lib"
-  make %{makeprocesses}
-  make install
-
-%ifarch ppc64le
-    CONF_BINUTILS_OPTS="${CONF_BINUTILS_OPTS} --enable-targets=spu --enable-targets=powerpc-linux"
 %endif
-
-  # Build binutils
-  cd ../binutils-%{binutilsVersion}
-  ./configure --disable-static --prefix=%{i} ${CONF_BINUTILS_OPTS} --disable-werror --enable-deterministic-archives \
-              --build=%{_build} --host=%{_host} --disable-nls --with-system-zlib --enable-64-bit-bfd \
-              CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP" CFLAGS="-I%{i}/include -I%{i}/tmp/sw/include" \
-              CXXFLAGS="-I%{i}/include -I%{i}/tmp/sw/include" LDFLAGS="-L%{i}/lib -L%{i}/tmp/sw/lib"
-  make %{makeprocesses}
-  find . -name Makefile -exec perl -p -i -e 's|LN = ln|LN = cp -p|;s|ln ([^-])|cp -p $1|g' {} \; 
-  make install
-%endif
-
-# Build GMP
-cd ../gmp-%{gmpVersion}
-./configure --disable-static --prefix=%{i} --enable-shared --disable-static --enable-cxx \
-            --build=%{_build} --host=%{_host} \
-            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
-make %{makeprocesses}
-make install
-
-# Build MPFR
-cd ../mpfr-%{mpfrVersion}
-./configure --disable-static --prefix=%{i} --with-gmp=%{i} \
-            --build=%{_build} --host=%{_host} \
-            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
-make %{makeprocesses}
-make install
-
-# Build MPC
-cd ../mpc-%{mpcVersion}
-./configure --disable-static --prefix=%{i} --with-gmp=%{i} --with-mpfr=%{i} \
-            --build=%{_build} --host=%{_host} \
-            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
-make %{makeprocesses}
-make install
-
-# Build ISL
-cd ../isl-%{islVersion}
-./configure --disable-static --with-gmp-prefix=%i --prefix=%{i} \
-            --build=%{_build} --host=%{_host} \
-            CC="$CC" CXX="$CXX" CPP="$CPP" CXXCPP="$CXXCPP"
-make %{makeprocesses}
-make install
-
-CONF_GCC_ARCH_SPEC=
 %ifarch aarch64
     CONF_GCC_ARCH_SPEC="$CONF_GCC_ARCH_SPEC \
                         --enable-threads=posix --enable-initfini-array --disable-libmpx"
@@ -274,7 +139,6 @@ make %{makeprocesses} profiledbootstrap
 
 %install
 cd %_builddir/%{moduleName}/obj && make install
-
 ln -s gcc %{i}/bin/cc
 find %{i}/lib %{i}/lib64 -name '*.la' -exec rm -f {} \; || true
 
@@ -295,4 +159,5 @@ rm -rf %{i}/lib/pkg-config
 %{relocateConfig}lib64/libstdc++*-gdb.py
 %{relocateConfig}libexec/gcc/*/%{realversion}/install-tools/mkheaders
 %{relocateConfig}libexec/gcc/*/%{realversion}/liblto_plugin.la
+%{relocateConfig}share/fish/vendor_conf.d/debuginfod.fish
 for f in $(find $RPM_INSTALL_PREFIX/%{pkgrel}/*/lib/ldscripts -type f) ; do %{relocateCmsFiles} $f || true ; done


### PR DESCRIPTION
Backport chaqnges from el10 branch
- Improved gcc spec ( splitted in to gcc-prerequisites)
- Bukld GCC with `--enable-frame-pointer` which by default enables frame-pointers for all packages built with this GCC on X86_64.  Note that this does not enable frame-pointers for aarch64
- updated cmake to version 3.31. which has a fix for newer curl
- sync curl changes from el10 branch to reduce the differences between el10 and g14 branch
