### PR TITLE
Add MPICH v4.3 and a generic MPI tool

### DIFF
--- a/cmssw-drop-tools.file
+++ b/cmssw-drop-tools.file
@@ -1,1 +1,1 @@
-%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp intel-vtune icx-cxxcompiler icx-ccompiler icx-f77compiler
+%define skipreqtools jcompiler icc-cxxcompiler icc-ccompiler icc-f77compiler rivet2 opencl opencl-cpp intel-vtune icx-cxxcompiler icx-ccompiler icx-f77compiler mpich

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -80,6 +80,7 @@ Requires: rdma-core
 Requires: ucx
 Requires: libfabric
 Requires: openmpi
+Requires: mpi
 Requires: sigcpp
 Requires: sqlite
 Requires: tauolapp

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -80,6 +80,7 @@ Requires: rdma-core
 Requires: ucx
 Requires: libfabric
 Requires: openmpi
+Requires: mpich
 Requires: mpi
 Requires: sigcpp
 Requires: sqlite

--- a/mpi.spec
+++ b/mpi.spec
@@ -1,0 +1,10 @@
+### RPM external mpi 1.0
+Requires: openmpi
+
+%prep
+
+%build
+
+%install
+
+%post

--- a/mpich.spec
+++ b/mpich.spec
@@ -1,0 +1,103 @@
+### RPM external mpich v4.3.0
+## INCLUDE cuda-flags
+## INCLUDE rocm-flags
+%define branch 4.3.x
+%define tag %{realversion}
+Source: git+https://github.com/pmodels/mpich.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
+BuildRequires: autotools
+%{!?without_cuda:Requires: cuda}
+%{!?without_rocm:Requires: rocm}
+Requires: libfabric
+Requires: ucx
+Requires: hwloc
+Requires: xpmem
+
+# external libraries are needed for additional protocols:
+#   --with-hcoll:       Mellanox Hierarchical Collectives
+#   --with-pmix:        PMIx Reference Library (OpenPMIx)
+# etc.
+
+%prep
+%setup -q -n %{n}-%{realversion}
+
+# remove the submodules we do not want to use
+rm -rf modules/hwloc
+sed -e's/do_hwloc=.*/do_hwloc=no/' -i autogen.sh
+
+rm -rf modules/libfabric
+sed -e's/do_ofi=.*/do_ofi=no/' -i autogen.sh
+
+rm -rf modules/ucx
+sed -e's/do_ucx=.*/do_ucx=no/' -i autogen.sh
+
+./autogen.sh
+
+# MPICH communication device:
+#   --with-device=ch4:ofi
+#       should work for TCP networks and any high-bandwidth interconnect supported by libfabric.
+#   --with-device=ch4:ucx
+#       should work for TCP networks and any high-bandwidth interconnect supported by the UCX library.
+#   --with-device=ch3
+#       the legacy device ch3
+
+# MPICH multi-threading support:
+#   --enable-thread-cs={default, global, per-vci, lock-free}
+#       Default is global for ch3 and per-vci for ch4
+#   --enable-ch4-vci-method={default, zero, communicator, tag, implicit, explicit}
+#   --enable-ch4-mt={direct, lockless, runtime}
+#       direct    - Each thread directly accesses lower-level fabric (default)
+#       lockless  - Use the thread safe serialization model supported by the provider
+#       runtime   - Determine the model at runtime through a CVAR
+
+# Note: using --enable-fast=O2,ndebug,alwaysinline,sse2 the compilation hangs (or takes a very long time to complete).
+
+./configure \
+  --prefix=%i \
+  --enable-error-checking=all \
+  --enable-tag-error-bits=yes \
+  --enable-fast=O2,ndebug,sse2 \
+  --enable-cxx \
+  --enable-romio \
+  --disable-mpi-abi \
+  --enable-versioning \
+  --enable-threads=multiple \
+  --enable-thread-cs=default \
+  --disable-dependency-tracking \
+  --disable-silent-rules \
+  --disable-maintainer-mode \
+  --enable-shared \
+  --disable-static \
+  --enable-nemesis-shm-collectives \
+%if 0%{!?without_cuda:1}
+  --with-cuda=$CUDA_ROOT \
+  --with-cuda-sm=%(echo %{cuda_arch} | sed -e's/ \+/,/g') \
+%else
+  --without-cuda \
+%endif
+%if 0%{!?without_rocm:1}
+  --with-hip=$ROCM_ROOT \
+  --with-hip-sm=%(echo %{rocm_archs} | sed -e's/ \+/,/g') \
+%else
+  --without-hip \
+%endif
+  --without-ze \
+  --with-pic \
+  --with-gnu-ld \
+  --with-libfabric=$LIBFABRIC_ROOT \
+  --with-ucx=$UCX_ROOT \
+  --with-hwloc=$HWLOC_ROOT \
+  --without-netloc \
+  --with-xpmem=$XPMEM_ROOT \
+  --with-yaksa=embedded \
+  --with-device=ch4:ofi
+
+%build
+make %{makeprocesses} V=1
+
+%install
+make install
+
+%post
+%{relocateConfig}bin/mpicc
+%{relocateConfig}bin/mpicxx
+%{relocateConfig}bin/mpifort

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 4.1.x-20250505
+### RPM external openmpi 4.1.9a1-20250505
 ## INITENV SET OPAL_PREFIX %{i}
 %define branch v4.1.x
 %define tag e6d2cb856f3fc649aa01bd5b688a003b3b33db7d

--- a/scram-tools.file/tools/mpi/mpi.xml
+++ b/scram-tools.file/tools/mpi/mpi.xml
@@ -1,0 +1,3 @@
+<tool name="mpi" version="@TOOL_VERSION@" revision="1">
+  <use name="openmpi"/>
+</tool>

--- a/scram-tools.file/tools/mpich/mpich.xml
+++ b/scram-tools.file/tools/mpich/mpich.xml
@@ -1,0 +1,10 @@
+<tool name="mpich" version="@TOOL_VERSION@" revision="1">
+  <lib name="mpi"/>
+  <lib name="mpicxx"/>
+  <client>
+    <environment name="MPICH_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"     default="$MPICH_BASE/lib"/>
+    <environment name="INCLUDE"    default="$MPICH_BASE/include"/>
+  </client>
+  <runtime name="PATH" value="$MPICH_BASE/bin" type="path"/>
+</tool>


### PR DESCRIPTION
MPICH is not selected by default, as it would conflict with Open MPI.

Fix the Open MPI version to 4.1.9a1.

Add a generic MPI tool, using by default Open MPI. The CMSSW packages can declare `use name="mpi"` to use the generic tool. Updating the tool to use MPICH instead of Open MPI automatically updates all packages.