### PR TITLE
Set CLING_PREBUILT_MODULE_PATH so that rootcling can find cuda.pcm from full cmssw

### DIFF
--- a/scram-tools.file/tools/cmssw/cmssw.xml
+++ b/scram-tools.file/tools/cmssw/cmssw.xml
@@ -15,6 +15,7 @@
   <runtime name="ROOT_INCLUDE_PATH" value="$CMSSW_BASE/src" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$CMSSW_BASE/include/$SCRAM_ARCH/include" type="path" handler="warn"/>
   <runtime name="CMSSW_FULL_RELEASE_BASE" value="$CMSSW_BASE"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
   @CXXMODULE_DATA@
   <use name="root_cxxdefaults"/>
 </tool>


### PR DESCRIPTION
This add CLING_PREBUILT_MODULE_PATH to cmssw toolfile so that `cuda.pcm` can be found from full cmssw lib's directory for a patch release. This should hopefully fix the failing unit test in ROOT6 IBs ( https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc12/CMSSW_15_1_ROOT6_X_2025-05-09-2300/unitTestLogs/HeterogeneousCore/CUDATest#/ )