### PR TITLE
[15.0] Update root to tip of root v6-32-00-patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -1,10 +1,10 @@
-### RPM lcg root 6.32.11
+### RPM lcg root 6.32.13
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag fbd52cd62ba7950ce0f1a8d98225f87d3796068b
-%define branch cms/v6-32-00-patches/57a3e46a6d
+%define tag 4e50d5412e654c757fe78cb5475b30363541951a
+%define branch cms/v6-32-00-patches/4467b6916f
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
As requested in https://github.com/cms-sw/cmssw/issues/47697#issuecomment-2866457556 , this PR updates ROOT for 15.0.X to latest ROOT changes from v6-32-00-patches branch