### PR TITLE
BuildRule: fix checkdeps for alpaka backends

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-07-07
+%define configtag       V09-08-05
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
As reported in https://github.com/cms-sw/cmssw/issues/48054 , new build rule now allows to checkout all the packages which depend on `alpaka` if any of the `alpaka` backend tools (e.g. `rocm, cuda`) are changed.