### PR TITLE
Add scram project hook for setting up local cuda

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1247
+## REVISION 1248
 ## NOCOMPILER
 
-%define tag 81b35f466ec55e2899f6393dc8ddca6125650b4f
+%define tag 82405344f084df3db0d698f23aa8b862076ccb82
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-08-05
+%define configtag       V09-08-06
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Added new cuda-setup scram project hook to check if full cuda distribution ( including nvcc compiler) is accessible at `scram project <version>` time. In case it is not accessible then inform developer about it [a]. If developer already has cuda insrtalled under `$USER_CUDA_BASE ` using the `cuda-runtime/<version>/bin/install-cuda.sh` script then new hook will automatically update cuda tools to use it

[a]
```
> scram p CMSSW_15_1_CUDART_X_2025-05-14-2300
WARNING: <install-path>/el8_amd64_gcc12/external/cuda/12.8.1-34746837041956539e2528219c10f2df/bin/nvcc not accessible.
WARNING: Setting up cuda-runtime environment only.
         You should be able to run but build/compile cuda code locally will not work.
         In order to build/compile cuda code locally please set USER_CUDA_BASE env and
         run "<install-path>/el8_amd64_gcc12/external/cuda-runtime/12.8.1-fc0f437c711c5caf2b7b50d2aea4a9a2/bin/install-cuda.sh" to install cuda under $USER_CUDA_BASE/x86_64/rhel8/external/cuda/12.8.1
        and run the following from the SCRAM developer area
        scram build setup-cuda
```