### PR TITLE
Do not look for libnvToolsExt.{so,a}

### DIFF
--- a/cuda-runtime.spec
+++ b/cuda-runtime.spec
@@ -14,7 +14,6 @@
 %define nv_runtime           nvrtc nvrtc-builtins
 %define nv_jit               nvJitLink
 %define cuda_profile         cupti
-%define cuda_tools_ext       nvToolsExt
 %define cuda_fileio          cufile cufile_rdma
 
 #Cuda Driver libs


### PR DESCRIPTION
In `CMSSW_15_1_CUDART_X_2025-05-20-1100`, build of `cuda-runtime` failed:

```
+ '[' -e /cvmfs/projects.cern.ch/cms-restricted/x86_64/rhel8/external/cuda/12.9.0/lib64/libnvToolsExt.so ']'
+ '[' -e /cvmfs/projects.cern.ch/cms-restricted/x86_64/rhel8/external/cuda/12.9.0/lib64/libnvToolsExt.a ']'
+ echo 'ERROR: Unable to find lib64/libnvToolsExt'
ERROR: Unable to find lib64/libnvToolsExt
+ exit 1
``` 

[full log](https://cmssdt.cern.ch/SDT/jenkins-artifacts/build-any-ib/CMSSW_15_1_CUDART_X_2025-05-20-1100/el8_amd64_gcc12/209941/external/cuda-runtime/12.9.0-5acf516cd9e8d298db6e015cbe06b1ac/log).

`libnvToolsExt` is now a header-only library. @fwyzard FYI