### PR TITLE
Updated root to tip of branch v6-32-00-patches for 15.1.X default IBs

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag 4e50d5412e654c757fe78cb5475b30363541951a
-%define branch cms/v6-32-00-patches/4467b6916f
+%define tag 101b78bfce1a48ef030d70816bb459e71973732d
+%define branch cms/v6-32-00-patches/9880139790
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Update ROOT for 15.1.X default IBs to latest v6-32-00-patches branch. This includes https://github.com/root-project/root/compare/4467b6916f08474c4a56ee7c77c9b282f1ba3e00...9880139790b33fea40d7657af669ba7d7aa877af changes on top of existing root in 15.1.X

FYI @makortel 