### PR TITLE
cms-common: Update scram project hook to look for system cuda too

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1250
+## REVISION 1251
 ## NOCOMPILER
 
-%define tag dd126d15667f91fd42a22d0ee42dcaf4a8e56e3f
+%define tag aead6251e27548e048e86d829737664ad13e58ea
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1249
+## REVISION 1250
 ## NOCOMPILER
 
-%define tag 82405344f084df3db0d698f23aa8b862076ccb82
+%define tag dd126d15667f91fd42a22d0ee42dcaf4a8e56e3f
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep


### PR DESCRIPTION
Update [scram project hook](https://github.com/cms-sw/cms-common/commit/dd126d15667f91fd42a22d0ee42dcaf4a8e56e3f) for cuda setup now does the following
- Prefer to use cuda installation from `$USER_CUDA_BASE` if set and available
- Use CUDA versions ( e.g. for `12.9.0` used by cmssw it looks for `cuda-12.9.0 or cuda-12.9`) from system install path `/usr/local/cuda-<version>`. System cuda install should have followed https://docs.nvidia.com/cuda/cuda-installation-guide-linux/ to install local cuda e.g. 
```
> dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo 
> dnf install cuda-12-9
```