### PR TITLE
Added tool to link resolv system lib

### DIFF
--- a/scram-tools.file/tools/systemtools/resolv.xml
+++ b/scram-tools.file/tools/systemtools/resolv.xml
@@ -1,0 +1,4 @@
+  <tool name="resolv" version="system" revision="1">
+    <lib name="resolv"/>
+    <flags FORCE_LINK="1"/>
+  </tool>


### PR DESCRIPTION
Starting with GLIBC version 2.34, the `dn_expand` function, previously found in `libresolv.so`, was moved to `libc.so`. This function is used internally by the `getaddrinfo()` system call. This is causing unit tests and relvals for GCC 13/14 ASAB IBs to fail. This PR properly to add a new toolfile to explicitly link against system `resolv` library.  inking this for cmssw FWCore/Utilities should be enough to fix the cmssw issues.

see https://github.com/awslabs/aws-c-io/pull/700 and https://github.com/llvm/llvm-project/issues/59007 for more details