### PR TITLE
ROCM: set HIP_PATH and created clang++.cfg to provide gcc-toolchain and target

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -1,5 +1,6 @@
 ### RPM external rocm 6.3.2
 ## INCLUDE cpp-standard
+## INITENV SET HIP_PATH %{i}
 
 %if 0%{?rhel} == 7
 # allow rpm2cpio dependency on the bootstrap bundle
@@ -148,4 +149,14 @@ find %{i}/bin/ %{i}/libexec/ %{i}/llvm/bin/ %{i}/llvm/lib/ -type f | xargs -r \
 cd build/rocprofiler-register
 make install
 
+#Create clang cfg file for gcc-toolchain
+%if 0%{!?use_system_gcc:1}
+host_triple=$(gcc -dumpmachine)
+echo "--gcc-toolchain=$GCC_ROOT" > %{i}/llvm/bin/clang++.cfg
+echo "--target=$host_triple" >> %{i}/llvm/bin/clang++.cfg
+%endif
+
 %post
+%if 0%{!?use_system_gcc:1}
+%{relocateConfig}/llvm/bin/clang++.cfg
+%endif


### PR DESCRIPTION
Set `HIP_PATH` to point to ROCM installation.
Save  `--gcc-toolchain and --target` in `rocm/llvm/bin/clang++.cfg` so that `hipcc` use the correct gcc header. This should fix the errors like [a] which we get for CLANG_X IBs

[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/build-any-ib/CMSSW_15_1_CLANG_X_2025-05-26-2300/el8_amd64_gcc12/210560/external/mpich/v4.3.0-c040835408ff8a8ea619ea18241c5d7d/log
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/rocm/6.3.2-7a3def4b63757b1f9ab69ba8ae027e92/lib/llvm/lib/clang/18/include/cuda_wrappers/cmath:27:15: fatal error: 'cmath' file not found
   27 | #include_next <cmath>
```