### PR TITLE
BuildRules: add libresolv in LD_PRELOAD for unit tests

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-08-08
+%define configtag       V09-08-09
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
New build rules add `libresolv.so` in `LD_PRELOAD` env for xSAN IBs  if
- resolv tool is available and
- gcc version is >12