### PR TITLE
ROCM: do not set --gcc-toolchain/--target via toolfile

### DIFF
--- a/scram-tools.file/tools/rocm/env.sh
+++ b/scram-tools.file/tools/rocm/env.sh
@@ -1,2 +1,0 @@
-#!/bin/bash -e
-export COMPILER_HOST=$(gcc -dumpmachine)

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -1,4 +1,4 @@
-<tool name="rocm" version="@TOOL_VERSION@" revision="4">
+<tool name="rocm" version="@TOOL_VERSION@" revision="5">
   <info url="https://rocm.docs.amd.com/en/docs-@TOOL_VERSION@/"/>
   <lib name="amdhip64"/>
   <lib name="hsa-runtime64"/>
@@ -12,7 +12,7 @@
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
   <flags ROCM_FLAGS="@ROCM_FLAGS@"/>
-  <flags ROCM_FLAGS="-fgpu-rdc --target=@COMPILER_HOST@ --gcc-toolchain=$(COMPILER_PATH)"/>
+  <flags ROCM_FLAGS="-fgpu-rdc"/>
 %if "%{default_microarch_name}"
 %if "%{default_microarch_name}" != "%{min_microarch_name}"
   <flags REM_ROCM_HOST_CXXFLAGS="-march=%%"/>


### PR DESCRIPTION
`--gcc-toolchain and --target` are now set via `rocm/llvm/bin/clang++.cfg` (see https://github.com/cms-sw/cmsdist/pull/9893 ), so no need to set these via scram rocm.xml toolfile
