### PR TITLE
BuildRules: Explicitly add gcc-toolchain in compile_commands.json

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-08-09
+%define configtag       V09-08-10
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
Updated to new [build rules](https://github.com/cms-sw/cmssw-config/commit/1f0bfea04927c0f48dc2c7c4e9261ee2388cb7c5) where scram explicitly include `--gcc-toolchain` so that clang-tidy can use it. Ideally clang-tidy should read the `llvm/bin/clang++.cfg` to get extra arguments. I will open a issue with llvm to check why clang-tidy is not respecting `llvm/bin/clang++.cfg`