### PR TITLE
[13.1.X] Update correctionlib to 2.7

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -15,6 +15,7 @@ absl-py==1.4.0
 aiohttp==3.8.4
 aiosqlite==0.18.0
 aiosignal==1.3.1
+annotated-types==0.7.0
 anyio==3.6.2
 appdirs==1.4.4
 argon2-cffi==21.3.0
@@ -58,7 +59,7 @@ click==8.1.3
 clikit==0.6.2
 cmsml==0.1.2
 contourpy==1.0.7
-correctionlib==2.2.2
+correctionlib==2.7.0
 crashtest==0.4.1
 certifi==2022.12.7
 cffi==1.15.1
@@ -276,7 +277,8 @@ pyproject-hooks==1.0.0
 pyproject-metadata==0.7.1
 pyrsistent==0.19.3
 py==1.11.0
-pydantic==1.10.7
+pydantic==2.11.5
+pydantic-core==2.33.2
 pygithub==1.58.1
 pylev==1.4.0
 PyNaCl==1.5.0
@@ -362,7 +364,8 @@ tqdm==4.65.0
 traitlets==5.9.0
 trove-classifiers==2023.3.9
 typed-ast==1.5.4
-typing-extensions==4.5.0
+typing-extensions==4.14.0
+typing-inspection==0.4.1
 tzdata==2023.3
 uhi==0.3.3
 uncertainties==3.1.7


### PR DESCRIPTION
Backporting to older CMSSW versions before we auto-update packages regularly.
If this works well and is correct I'll propagate it to other versions.