### PR TITLE
changed dependency of hdf5 and sherpa to more general mpi.xml

### DIFF
--- a/scram-tools.file/tools/hdf5/hdf5.xml
+++ b/scram-tools.file/tools/hdf5/hdf5.xml
@@ -7,5 +7,5 @@
     <environment name="LIBDIR" default="$HDF5_BASE/lib"/>
     <environment name="INCLUDE" default="$HDF5_BASE/include"/>
   </client>
-  <use name="openmpi"/>
+  <use name="mpi"/>
 </tool>

--- a/scram-tools.file/tools/sherpa/sherpa.xml
+++ b/scram-tools.file/tools/sherpa/sherpa.xml
@@ -20,7 +20,7 @@
   <use name="blackhat"/>
   <use name="fastjet"/>
   <use name="sqlite"/>
-  <use name="openmpi"/>
+  <use name="mpi"/>
   <ifarchitecture name="!ppc64le">
     <use name="openloops"/>
   </ifarchitecture>


### PR DESCRIPTION
In the process of making it possible to use any mpi library, we also should try changing dependencies for other tools which currently depend on openmpi