### PR TITLE
Updated Celeritas->v0.6.0, VecGeom->v1.2.11 & updated the patches fro…

### DIFF
--- a/celeritas.spec
+++ b/celeritas.spec
@@ -1,6 +1,6 @@
-### RPM external celeritas v0.4.1
+### RPM external celeritas v0.6.0
 %define celeritas_gitversion %(echo %{realversion} | sed -e 's|^v||;s|-.*||')
-%define tag f9b51d72fc268bf22c5560b82d3dd3d7613a8106
+%define tag dfa4cde7d7d65bf656b17a24c59fcc030aa6b0d9 
 Source: git+https://github.com/celeritas-project/celeritas?obj=develop/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 
 %define package_build_flags -Wall -Wextra -pedantic
@@ -38,6 +38,7 @@ cmake ../%{n}-%{realversion} \
   -DCELERITAS_USE_MPI=OFF \
   -DCELERITAS_USE_ROOT=OFF \
   -DCELERITAS_USE_SWIG=OFF \
+  -DCELERITAS_USE_PNG=OFF \
 %if %{enable_vecgeom}
   -DCELERITAS_USE_VecGeom=ON
 %else

--- a/vecgeom-fix-vector.patch
+++ b/vecgeom-fix-vector.patch
@@ -1,13 +1,31 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e6a4329..7e77333 100644
+index e46a355..6d74ea5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -92,7 +92,7 @@ endif()
+@@ -6,7 +6,7 @@ include(ExternalProject)
+
+ # Set VecGeom_VERSION using git tags or release metadata
+ include("${CMAKE_CURRENT_LIST_DIR}/cmake/CgvFindVersion.cmake")
+-cgv_find_version(VecGeom)
++#cgv_find_version(VecGeom)
+
+ project(VecGeom
+   VERSION ${VecGeom_VERSION}
+@@ -96,7 +96,7 @@ endif()
  # - ISA
  set(VECGEOM_ISAS empty)
  if(CMAKE_SYSTEM_PROCESSOR MATCHES "(i686|x86_64)")
 -  set(VECGEOM_ISAS sse2 sse3 ssse3 sse4.1 sse4.2 avx avx2 native empty)
 +  set(VECGEOM_ISAS sse2 sse3 ssse3 sse4.1 sse4.2 avx avx2 native empty arch=nehalem arch=sandybridge  arch=haswell arch=skylake-avx512 arch=x86-64-v2 arch=x86-64-v3 arch=x86-64-v4)
  endif()
- 
+
  enum_option(VECGEOM_VECTOR DOC "Vector instruction set to be used"
+@@ -804,7 +804,7 @@ install(EXPORT VecGeomTargets
+
+ ################################################################################
+ # Doxygen documentation
+-find_package(Doxygen)
++#find_package(Doxygen)
+ if(DOXYGEN_FOUND)
+   set(DOXYFILE_OUTPUT_DIR  ${PROJECT_BINARY_DIR}/doxygen)
+   foreach(d doc/doxygen VecGeom persistency scripts source)

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,14 +1,14 @@
-### RPM external vecgeom v1.2.10
+### RPM external vecgeom v1.2.11
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
 
-%define tag bf8de1e0c18fb7b33c0871fab244de00d2bb2a44
+%define tag 47dd602df7074fcc78036e93cd639ae6270207fd
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
-Source1: https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/1262.patch
 Patch0: vecgeom-fix-vector
 BuildRequires: cmake gmake
+Requires: xerces-c
 %define keep_archives true
 %define vecgeom_backend Scalar
 %define vecgeom_version %(echo %{realversion} | sed -e 's|^v||;s|-.*||')
@@ -17,7 +17,6 @@ BuildRequires: cmake gmake
 %prep
 %setup -n %{n}-%{realversion}
 %patch0 -p1
-patch -p1 <%{_sourcedir}/1262.patch
 
 %build
 %ifarch x86_64
@@ -33,6 +32,8 @@ cd ../build
 cmake ../%{n}-%{realversion} \
   -DVecGeom_GIT_DESCRIBE="%{vecgeom_version};;" \
   -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DBUILD_TESTING=OFF \
+  -DVecGeom_VERSION=%{vecgeom_version} \
   -DCMAKE_CXX_STANDARD:STRING="%{cms_cxx_standard}" \
   -DCMAKE_AR=$(which gcc-ar) \
   -DCMAKE_RANLIB=$(which gcc-ranlib) \
@@ -52,7 +53,8 @@ cmake ../%{n}-%{realversion} \
   -DVECGEOM_BUILTIN_VECCORE=ON \
   -DVECGEOM_BACKEND=%{vecgeom_backend} \
   -DVECGEOM_GEANT4=OFF \
-  -DVECGEOM_ROOT=OFF
+  -DVECGEOM_ROOT=OFF \
+  -DCMAKE_PREFIX_PATH="${XERCES_C_ROOT}"
 
 make %{makeprocesses} VERBOSE=1
 


### PR DESCRIPTION
## Updates to Celeritas and VecGeom

- Updated celeritas.spec from v0.4.1 to **v0.6.0**
- Updated vecgeom.spec from v1.2.10 to **v1.2.11**
- Integrates patches for vecgeom from [v2.0.0-rc4](https://github.com/akritkbehera/cmsdist/commit/67a2c12e521b5b4ae9238033080e39545d01a0c9)

Relates to Issue: _#9945_ 