### PR TITLE
[15.0.X] Update tag for DQM-Integration to V00-10-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -6,7 +6,7 @@
 RecoTracker-LSTCore=V00-01-00
 L1Trigger-L1TMuon=V01-12-00
 RecoMuon-TrackerSeedGenerator=V00-07-00
-DQM-Integration=V00-09-00
+DQM-Integration=V00-10-00
 Geometry-HGCalMapping=V00-01-00
 RecoTracker-MkFit=V00-17-00
 RecoBTag-Combined=V01-30-00


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/9958

Move DQM-Integration data to new tag, see https://github.com/cms-data/DQM-Integration/pull/11

Needed by https://github.com/cms-sw/cmssw/pull/48450