### PR TITLE
update ppypi packages to gets security updates

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -285,7 +285,7 @@ prometheus-client==0.22.1
 prompt_toolkit==3.0.51
 propcache==0.3.2
 #NO_AUTO_UPDATE:1: Update together with Tensorflow
-protobuf==4.25.8
+protobuf==4.21.9
 prwlock==0.4.1
 psutil==7.0.0
 ptyprocess==0.7.0

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -13,7 +13,7 @@
 #############################################################################
 absl-py==2.3.0
 aiohappyeyeballs==2.6.1
-aiohttp==3.12.12
+aiohttp==3.12.14
 aiosqlite==0.21.0
 aiosignal==1.3.2
 annotated-types==0.7.0
@@ -270,7 +270,7 @@ pbs-installer==2025.6.12
 pdm-backend==2.4.4
 pexpect==4.9.0
 pickleshare==0.7.5
-pillow==11.2.1
+pillow==11.3.0
 pkgconfig==1.5.5
 plac==1.4.5
 platformdirs==4.3.8
@@ -285,7 +285,7 @@ prometheus-client==0.22.1
 prompt_toolkit==3.0.51
 propcache==0.3.2
 #NO_AUTO_UPDATE:1: Update together with Tensorflow
-protobuf==4.21.9
+protobuf==4.25.8
 prwlock==0.4.1
 psutil==7.0.0
 ptyprocess==0.7.0


### PR DESCRIPTION
Updated
- aiohttp 3.12.14: AIOHTTP is vulnerable to HTTP Request/Response Smuggling through incorrect parsing of chunked trailer sections
- pillow 11.3.0: Pillow vulnerability can cause write buffer overflow on BCn encoding