### PR TITLE
update crab-dev to v3.250806

### DIFF
--- a/crab-dev.spec
+++ b/crab-dev.spec
@@ -3,8 +3,8 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define crabclient_version v3.250522
+%define crabclient_version v3.250806
 ### RPM cms crab-dev %{crabclient_version}.%{version_suffix}
-%define crabserver_version v3.250424
+%define crabserver_version v3.250728
 
 ## IMPORT crab-build


### PR DESCRIPTION
Bump crab-dev to [v3.250806](https://github.com/dmwm/CRABClient/releases/tag/v3.250806). Also bump crabserver to keep shared modules up-to-date.

cc: @belforte 