### PR TITLE
pass the G4HepEm_EARLY_TRACKING_EXIT flag

### DIFF
--- a/scram-tools.file/tools/g4hepem/g4hepem_interface.xml
+++ b/scram-tools.file/tools/g4hepem/g4hepem_interface.xml
@@ -6,4 +6,5 @@
     <environment name="INCLUDE" default="$G4HEPEM_INTERFACE_BASE/include/G4HepEm"/>
   </client>
   <use name="geant4core"/>
+  <flags CXXFLAGS="-DG4HepEm_EARLY_TRACKING_EXIT=ON"/>
 </tool>

--- a/scram-tools.file/tools/g4hepem/g4hepem_interface.xml
+++ b/scram-tools.file/tools/g4hepem/g4hepem_interface.xml
@@ -1,4 +1,4 @@
-<tool name="g4hepem_interface" version="@TOOL_VERSION@" revision="3">
+<tool name="g4hepem_interface" version="@TOOL_VERSION@" revision="4">
   <info url="https://github.com/mnovak42/g4hepem"/>
   <client>
     <environment name="G4HEPEM_INTERFACE_BASE" default="@TOOL_ROOT@"/>


### PR DESCRIPTION
G4HepEm is build with the flag `-DG4HepEm_EARLY_TRACKING_EXIT=ON` but it seems that it must be also passed via the scram-tools such that the flag is available in the AdePT header files that we require for the integration into cmssw.

Please check and confirm @civanch @smuzaffar 

Note that we do have a local workaround (by passing it via the `BuildFile.xml`), so we do not need a new IB build *yet* (we will need it after a few more fixes are pushed to AdePT and AdePT is tagged again).