### PR TITLE
[G4AdePT] update AdePT to v0.1.2-alpha

### DIFF
--- a/adept.spec
+++ b/adept.spec
@@ -1,4 +1,4 @@
-### RPM external adept v0.1.1-alpha
+### RPM external adept v0.1.2-alpha
 %define tag %{realversion}
 %define branch master
 %define github_user apt-sim


### PR DESCRIPTION
Updating the version needed to compile AdePT headers in cmssw