### PR TITLE
Do not set PYTHONHOME via gdb; set python ignore-env for gdb

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_83
+### RPM lcg SCRAMV1 V3_00_84
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 096dfcbb22c7ac627e8a5fcd4f7e4c606bcb2931
+%define tag 7b4455f33cbf875bc8a618844a6e4fca84245104
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/gdb.spec
+++ b/gdb.spec
@@ -30,18 +30,13 @@ cd ../build
 make install
 
 cd %i/bin/
-mv gdb gdb-%{realversion}
 cat << \EOF_GDBINIT > %{i}/share/gdbinit
-set substitute-path %{installroot} %{cmsroot}
+set substitute-path %{instroot} %{cmsroot}
+set python ignore-environment on
 EOF_GDBINIT
-
-echo "#!/bin/bash" > gdb
-echo "PYTHONHOME=${PYTHON3_ROOT} gdb-%{realversion} \"\$@\"" >> gdb
-chmod +x gdb
 
 # To save space, clean up some things that we don't really need 
 %define drop_files %i/lib %i/bin/{gdbserver,gdbtui} %i/share/{man,info,locale}
 
 %post
 %{relocateConfig}/share/gdbinit
-%{relocateConfig}/bin/gdb


### PR DESCRIPTION
Instead of SCRAM unsetting PYTHONHOME, lets update GDB to not set PYTHONHOME