### PR TITLE
[G4AdePT] add AdePT host library

### DIFF
--- a/scram-tools.file/tools/adept/adept.xml
+++ b/scram-tools.file/tools/adept/adept.xml
@@ -1,4 +1,5 @@
-<tool name="adept" version="@TOOL_VERSION@" revision="1">
+<tool name="adept" version="@TOOL_VERSION@" revision="2">
+  <lib name="AdePT_G4_integration"/>
   <lib name="AdePT_G4_integration_final"/>
   <use name="adept_interface"/>
 </tool>


### PR DESCRIPTION
The AdePT host library also needs to be exposed as otherwise it wasn't linking as symbols from the host library were missing:

```
undefined reference to `AdePTTrackingManager::AdePTTrackingManager(AdePTConfiguration*, int)'
collect2: error: ld returned 1 exit status
```

This is fixed by exposing both   `<lib name="AdePT_G4_integration"/>` for the host symbols and `<lib name="AdePT_G4_integration_final"/>` for the device symbols.

No new IB needs to be created, as I can fix this locally for now, until a new IB is needed.