### PR TITLE
cleanup for py3 blosc/blosc2 and tables packages

### DIFF
--- a/c-blosc.spec
+++ b/c-blosc.spec
@@ -1,0 +1,33 @@
+### RPM external c-blosc 1.21.6
+Source: https://github.com/Blosc/c-blosc/archive/refs/tags/v%{realversion}.tar.gz
+Requires: zlib zstd lz4
+BuildRequires: ninja cmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build ; mkdir ../build; cd ../build
+cmake ../%{n}-%{realversion} \
+ -G Ninja \
+ -DCMAKE_BUILD_TYPE=Release \
+ -DCMAKE_INSTALL_PREFIX:STRING=%{i} \
+ -DDEACTIVATE_LZ4:BOOL=OFF \
+ -DDEACTIVATE_SNAPPY:BOOL=ON \
+ -DDEACTIVATE_ZLIB:BOOL=OFF \
+ -DDEACTIVATE_ZSTD:BOOL=OFF \
+ -DDEACTIVATE_AVX2:BOOL=ON \
+ -DDEACTIVATE_SSE2:BOOL=ON \
+ -DPREFER_EXTERNAL_ZSTD=ON \
+ -DPREFER_EXTERNAL_LZ4=ON \
+ -DPREFER_EXTERNAL_ZLIB=ON \
+ -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
+
+ninja -v %{makeprocesses}
+
+%install
+cd ../build
+ninja -v %{makeprocesses} install
+
+%post
+%{relocateConfig}lib64/pkgconfig/blosc.pc

--- a/c-blosc2.spec
+++ b/c-blosc2.spec
@@ -1,0 +1,30 @@
+### RPM external c-blosc2 2.20.0
+Source: https://github.com/Blosc/c-blosc2/archive/refs/tags/v%{realversion}.tar.gz
+Requires: zlib zstd lz4
+BuildRequires: ninja cmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build ; mkdir ../build; cd ../build
+cmake ../%{n}-%{realversion} \
+ -G Ninja \
+ -DCMAKE_BUILD_TYPE=Release \
+ -DCMAKE_INSTALL_PREFIX:STRING=%{i} \
+ -DDEACTIVATE_ZLIB:BOOL=OFF \
+ -DDEACTIVATE_ZSTD:BOOL=OFF \
+ -DDEACTIVATE_AVX2:BOOL=ON \
+ -DPREFER_EXTERNAL_ZSTD=ON \
+ -DPREFER_EXTERNAL_LZ4=ON \
+ -DPREFER_EXTERNAL_ZLIB=ON \
+ -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
+
+ninja -v %{makeprocesses}
+
+%install
+cd ../build
+ninja -v %{makeprocesses} install
+
+%post
+%{relocateConfig}lib64/pkgconfig/blosc2.pc

--- a/pip/blosc.file
+++ b/pip/blosc.file
@@ -1,0 +1,3 @@
+Requires: c-blosc
+BuildRequires: py3-scikit-build cmake ninja
+%define PipPreBuild export USE_SYSTEM_BLOSC=1; export Blosc_ROOT=${C_BLOSC_ROOT}; export CMAKE_ARGS="-DCMAKE_PREFIX_PATH=\"%{cmake_prefix_path}\""

--- a/pip/blosc2.file
+++ b/pip/blosc2.file
@@ -1,2 +1,3 @@
-Requires: py3-scikit-build py3-cython py3-numpy py3-msgpack py3-ndindex py3-py-cpuinfo py3-rich
-BuildRequires: cmake ninja
+Requires: c-blosc2  py3-cython py3-numpy py3-msgpack py3-ndindex py3-py-cpuinfo py3-rich
+BuildRequires: py3-scikit-build cmake ninja
+%define PipPreBuild export CMAKE_ARGS="-DUSE_SYSTEM_BLOSC2=1 -DCMAKE_PREFIX_PATH=\"%{cmake_prefix_path}\""

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -45,6 +45,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.13.4
 beniget==0.4.2.post1
 bleach==6.2.0
+blosc==1.11.3
 # NO_AUTO_UPDATE: version >= 2.6.0 needs Python 3.10
 blosc2==2.5.1
 bokeh==3.7.3

--- a/pip/tables.file
+++ b/pip/tables.file
@@ -1,6 +1,6 @@
 Requires: py3-numexpr py3-six hdf5 bz2lib py3-mock py3-numpy
 Requires: py3-numexpr py3-six py3-numpy hdf5 bz2lib py3-mock
-Requires: py3-blosc2
+Requires: py3-blosc2 py3-blosc
 Requires: openmpi
-%define PipPreBuild export CFLAGS="-pthread"; export HDF5_DIR=${HDF5_ROOT} CC="mpicc"; export DISABLE_AVX2=true
+%define PipPreBuild export CFLAGS="-pthread -I${C_BLOSC2_ROOT}/include -I${C_BLOSC_ROOT}/inlcude -I${BZ2LIB_ROOT}/include"; export LDFLAGS="-L${C_BLOSC2_ROOT}/lib64 -L${C_BLOSC_ROOT}/lib64 -L${BZ2LIB_ROOT}/lib"  export HDF5_DIR=${HDF5_ROOT} CC="mpicc"; export DISABLE_AVX2=true ; export BLOSC2_DIR="${C_BLOSC2_ROOT}"; export BLOSC_DIR="${C_BLOSC_ROOT}"; export CMAKE_ARGS="-DCMAKE_PREFIX_PATH='%{cmake_prefix_path}'"
 %define PipBuildOptions  --global-option="--hdf5=${HDF5_ROOT}" --global-option="--bzip2=${BZ2LIB_ROOT}"

--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -15,6 +15,8 @@ function copy_tools (){
 export TOOL_ROOT=$1
 export TOOL_VERSION=$2
 export TOOLFILES_INSTALL_DIR=$3
+export TOOL=$4
+export TOOL_BASE=$(echo $4 | tr 'a-z-' 'A-Z_')_BASE
 export SCRAM_TOOLS_BIN_DIR=$(dirname $(realpath ${0}))
 export SCRAM_TOOL_SOURCE_DIR=$(realpath ${SCRAM_TOOLS_BIN_DIR}/../tools)/$4
 

--- a/scram-tools.file/tools/c-blosc/c-blosc.xml
+++ b/scram-tools.file/tools/c-blosc/c-blosc.xml
@@ -1,0 +1,8 @@
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="1">
+  <lib name="blosc"/>
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"     default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib64"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/c-blosc2/c-blosc2.xml
+++ b/scram-tools.file/tools/c-blosc2/c-blosc2.xml
@@ -1,0 +1,8 @@
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="1">
+  <lib name="blosc2"/>
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
+  </client>
+</tool>


### PR DESCRIPTION
`py3-tables` was not able to find `libblosc2.so` and it was copying it from `py3-blosc2/lib64` in to `py3-tables/lib/pythonXX/site-packages` directory. This PR proposes the following changes

- explicitly build `c-blosc` using our `zlib, lz4 and zstd`
- build `py3-blosc` to make use of `c-blosc` instead of re-build it
- explicitly build `c-blosc2` using our `zlib, lz4 and zstd`
- build `py3-blosc2` to make use of `c-blosc2` instead of re-build it
- properly configure `py3-tables` so that it can find our `c-blosc and c-blosc2` packages