### PR TITLE
auto generate/repalce tool name and base variables

### DIFF
--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -16,7 +16,7 @@ export TOOL_ROOT=$1
 export TOOL_VERSION=$2
 export TOOLFILES_INSTALL_DIR=$3
 export TOOL=$4
-export UC_TOOL=$(echo $4 | tr 'a-z-' 'A-Z_')
+export TOOL_BASE=$(echo $4 | tr 'a-z-' 'A-Z_')_BASE
 export SCRAM_TOOLS_BIN_DIR=$(dirname $(realpath ${0}))
 export SCRAM_TOOL_SOURCE_DIR=$(realpath ${SCRAM_TOOLS_BIN_DIR}/../tools)/$4
 

--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -15,6 +15,8 @@ function copy_tools (){
 export TOOL_ROOT=$1
 export TOOL_VERSION=$2
 export TOOLFILES_INSTALL_DIR=$3
+export TOOL=$4
+export UC_TOOL=$(echo $4 | tr 'a-z-' 'A-Z_')
 export SCRAM_TOOLS_BIN_DIR=$(dirname $(realpath ${0}))
 export SCRAM_TOOL_SOURCE_DIR=$(realpath ${SCRAM_TOOLS_BIN_DIR}/../tools)/$4
 

--- a/scram-tools.file/tools/abseil-cpp/abseil-cpp.xml
+++ b/scram-tools.file/tools/abseil-cpp/abseil-cpp.xml
@@ -1,4 +1,4 @@
-<tool name="abseil-cpp" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/abseil/abseil-cpp"/>
   <lib name="absl_bad_any_cast_impl"/>
   <lib name="absl_bad_optional_access"/>
@@ -60,8 +60,8 @@
   <lib name="absl_time"/>
   <lib name="absl_time_zone"/>
   <client>
-    <environment name="ABSEIL_CPP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$ABSEIL_CPP_BASE/lib"/>
-    <environment name="INCLUDE" default="$ABSEIL_CPP_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"  default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/abseil-cpp/abseil-cpp.xml
+++ b/scram-tools.file/tools/abseil-cpp/abseil-cpp.xml
@@ -60,8 +60,8 @@
   <lib name="absl_time"/>
   <lib name="absl_time_zone"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"  default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"  default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/alpaka/alpaka.xml
+++ b/scram-tools.file/tools/alpaka/alpaka.xml
@@ -1,8 +1,8 @@
-<tool name="alpaka" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <use name="boost"/>
   <client>
-    <environment name="ALPAKA_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"     default="$ALPAKA_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <!-- set ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 for host, device, and dictionaries -->

--- a/scram-tools.file/tools/alpaka/alpaka.xml
+++ b/scram-tools.file/tools/alpaka/alpaka.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <use name="boost"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <!-- set ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 for host, device, and dictionaries -->

--- a/scram-tools.file/tools/alpgen/alpgen.xml
+++ b/scram-tools.file/tools/alpgen/alpgen.xml
@@ -1,6 +1,6 @@
-<tool name="alpgen" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="ALPGEN_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$ALPGEN_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/alpgen/alpgen.xml
+++ b/scram-tools.file/tools/alpgen/alpgen.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/blackhat/blackhat.xml
+++ b/scram-tools.file/tools/blackhat/blackhat.xml
@@ -1,4 +1,4 @@
-<tool name="blackhat" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
 <lib name="Ampl_eval"/>
 <lib name="BG"/>
 <lib name="BH"/>
@@ -15,10 +15,10 @@
 <lib name="assembly"/>
 <lib name="ratext"/>
 <client>
-<environment name="BLACKHAT_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$BLACKHAT_BASE/lib/blackhat"/>
-<environment name="INCLUDE" default="$BLACKHAT_BASE/include"/>
+<environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+<environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/blackhat"/>
+<environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
 </client>
 <use name="qd"/>
-<runtime name="WORKER_DATA_PATH" value="$BLACKHAT_BASE/share/blackhat/datafiles/" type="path"/>
+<runtime name="WORKER_DATA_PATH" value="$@UC_TOOL@_BASE/share/blackhat/datafiles/" type="path"/>
 </tool>

--- a/scram-tools.file/tools/blackhat/blackhat.xml
+++ b/scram-tools.file/tools/blackhat/blackhat.xml
@@ -15,10 +15,10 @@
 <lib name="assembly"/>
 <lib name="ratext"/>
 <client>
-<environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/blackhat"/>
-<environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+<environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+<environment name="LIBDIR" default="$@TOOL_BASE@/lib/blackhat"/>
+<environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
 </client>
 <use name="qd"/>
-<runtime name="WORKER_DATA_PATH" value="$@UC_TOOL@_BASE/share/blackhat/datafiles/" type="path"/>
+<runtime name="WORKER_DATA_PATH" value="$@TOOL_BASE@/share/blackhat/datafiles/" type="path"/>
 </tool>

--- a/scram-tools.file/tools/boost/boost.xml
+++ b/scram-tools.file/tools/boost/boost.xml
@@ -1,10 +1,10 @@
-<tool name="boost" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_THREAD_LIB@"/>
   <lib name="@BOOST_DATE_TIME_LIB@"/>
   <client>
-    <environment name="BOOST_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$BOOST_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="boost_header"/>
 </tool>

--- a/scram-tools.file/tools/boost/boost.xml
+++ b/scram-tools.file/tools/boost/boost.xml
@@ -3,8 +3,8 @@
   <lib name="@BOOST_THREAD_LIB@"/>
   <lib name="@BOOST_DATE_TIME_LIB@"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="boost_header"/>
 </tool>

--- a/scram-tools.file/tools/bz2lib/bz2lib.xml
+++ b/scram-tools.file/tools/bz2lib/bz2lib.xml
@@ -2,9 +2,9 @@
   <info url="http://sources.redhat.com/bzip2/"/>
   <lib name="bz2"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/bz2lib/bz2lib.xml
+++ b/scram-tools.file/tools/bz2lib/bz2lib.xml
@@ -1,10 +1,10 @@
-<tool name="bz2lib" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://sources.redhat.com/bzip2/"/>
   <lib name="bz2"/>
   <client>
-    <environment name="BZ2LIB_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$BZ2LIB_BASE/lib"/>
-    <environment name="INCLUDE"      default="$BZ2LIB_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/c-ares/c-ares.xml
+++ b/scram-tools.file/tools/c-ares/c-ares.xml
@@ -1,10 +1,10 @@
-<tool name="c-ares" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://c-ares.org/"/>
   <lib name="cares"/>
   <client>
-    <environment name="C_ARES_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$C_ARES_BASE/lib"/>
-    <environment name="INCLUDE" default="$C_ARES_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>
 

--- a/scram-tools.file/tools/c-ares/c-ares.xml
+++ b/scram-tools.file/tools/c-ares/c-ares.xml
@@ -2,9 +2,9 @@
   <info url="https://c-ares.org/"/>
   <lib name="cares"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>
 

--- a/scram-tools.file/tools/catch2/catch2.xml
+++ b/scram-tools.file/tools/catch2/catch2.xml
@@ -1,6 +1,6 @@
-<tool name="catch2" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="CATCH2_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$CATCH2_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/catch2/catch2.xml
+++ b/scram-tools.file/tools/catch2/catch2.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/celeritas/celeritas.xml
+++ b/scram-tools.file/tools/celeritas/celeritas.xml
@@ -4,9 +4,9 @@
   <lib name="celeritas"/>
   <lib name="corecel"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
   </client>
   <flags CXXFLAGS="-Wno-error=missing-braces"/>
   <use name="geant4core"/>

--- a/scram-tools.file/tools/celeritas/celeritas.xml
+++ b/scram-tools.file/tools/celeritas/celeritas.xml
@@ -1,12 +1,12 @@
-<tool name="celeritas" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <info url="https://github.com/celeritas-project/celeritas"/>
   <lib name="accel"/>
   <lib name="celeritas"/>
   <lib name="corecel"/>
   <client>
-    <environment name="CELERITAS_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$CELERITAS_BASE/include"/>
-    <environment name="LIBDIR" default="$CELERITAS_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
   </client>
   <flags CXXFLAGS="-Wno-error=missing-braces"/>
   <use name="geant4core"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,4 +1,4 @@
-<tool name="cepgen" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://cepgen.hepforge.org/"/>
   <lib name="CepGen"/>
   <lib name="CepGenHepMC2"/>
@@ -7,12 +7,12 @@
   <lib name="CepGenProcesses"/>
   <lib name="CepGenPythia6"/>
   <client>
-    <environment name="CEPGEN_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CEPGEN_BASE/lib64"/>
-    <environment name="INCLUDE" default="$CEPGEN_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$CEPGEN_BASE/bin" type="path"/>
-  <runtime name="CEPGEN_PATH" value="$CEPGEN_BASE/share/CepGen"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$@UC_TOOL@_BASE/share/CepGen"/>
   <use name="gsl"/>
   <use name="OpenBLAS"/>
   <use name="hepmc"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -7,12 +7,12 @@
   <lib name="CepGenProcesses"/>
   <lib name="CepGenPythia6"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
-  <runtime name="CEPGEN_PATH" value="$@UC_TOOL@_BASE/share/CepGen"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$@TOOL_BASE@/share/CepGen"/>
   <use name="gsl"/>
   <use name="OpenBLAS"/>
   <use name="hepmc"/>

--- a/scram-tools.file/tools/clang-uml/clang-uml.xml
+++ b/scram-tools.file/tools/clang-uml/clang-uml.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/bkryza/clang-uml/"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <use name="yaml-cpp"/>
   <use name="zlib"/>
 </tool>

--- a/scram-tools.file/tools/clang-uml/clang-uml.xml
+++ b/scram-tools.file/tools/clang-uml/clang-uml.xml
@@ -1,9 +1,9 @@
-<tool name="clang-uml" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/bkryza/clang-uml/"/>
   <client>
-    <environment name="CLANG_UML_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$CLANG_UML_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <use name="yaml-cpp"/>
   <use name="zlib"/>
 </tool>

--- a/scram-tools.file/tools/classlib/classlib.xml
+++ b/scram-tools.file/tools/classlib/classlib.xml
@@ -1,9 +1,9 @@
-  <tool name="classlib" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://cmsmac01.cern.ch/~lat/exports/"/>
     <client>
-      <environment name="CLASSLIB_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$CLASSLIB_BASE/lib"/>
-      <environment name="INCLUDE" default="$CLASSLIB_BASE/include"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
       <flags CPPDEFINES="__STDC_LIMIT_MACROS"/>
       <flags CPPDEFINES="__STDC_FORMAT_MACROS"/>
       <lib name="classlib"/>

--- a/scram-tools.file/tools/classlib/classlib.xml
+++ b/scram-tools.file/tools/classlib/classlib.xml
@@ -1,9 +1,9 @@
   <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://cmsmac01.cern.ch/~lat/exports/"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
       <flags CPPDEFINES="__STDC_LIMIT_MACROS"/>
       <flags CPPDEFINES="__STDC_FORMAT_MACROS"/>
       <lib name="classlib"/>

--- a/scram-tools.file/tools/clhep/clhep.xml
+++ b/scram-tools.file/tools/clhep/clhep.xml
@@ -2,8 +2,8 @@
   <info url="http://wwwinfo.cern.ch/asd/lhc++/clhep"/>
   <lib name="CLHEP"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="clhepheader"/>
 </tool>

--- a/scram-tools.file/tools/clhep/clhep.xml
+++ b/scram-tools.file/tools/clhep/clhep.xml
@@ -1,9 +1,9 @@
-<tool name="clhep" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://wwwinfo.cern.ch/asd/lhc++/clhep"/>
   <lib name="CLHEP"/>
   <client>
-    <environment name="CLHEP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CLHEP_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="clhepheader"/>
 </tool>

--- a/scram-tools.file/tools/clue/clue.xml
+++ b/scram-tools.file/tools/clue/clue.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <use name="alpaka"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"   default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/clue/clue.xml
+++ b/scram-tools.file/tools/clue/clue.xml
@@ -1,7 +1,7 @@
-<tool name="clue" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <use name="alpaka"/>
   <client>
-    <environment name="CLUE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"   default="$CLUE_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"   default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/cmssw/cmssw.xml
+++ b/scram-tools.file/tools/cmssw/cmssw.xml
@@ -1,20 +1,20 @@
-<tool name="cmssw" version="@TOOL_VERSION@" type="scram" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" type="scram" revision="2">
   <client>
-    <environment name="CMSSW_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CMSSW_BASE/biglib/$SCRAM_ARCH"/>
-    <environment name="LIBDIR" default="$CMSSW_BASE/lib/$SCRAM_ARCH"/>
-    <environment name="CMSSW_BINDIR" default="$CMSSW_BASE/bin/$SCRAM_ARCH"/>
-    <environment name="INCLUDE" default="$CMSSW_BASE/src"/>
-    <environment name="INCLUDE" default="$CMSSW_BASE/include/$SCRAM_ARCH/include" handler="warn"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/biglib/$SCRAM_ARCH"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/$SCRAM_ARCH"/>
+    <environment name="CMSSW_BINDIR" default="$@UC_TOOL@_BASE/bin/$SCRAM_ARCH"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/src"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/$SCRAM_ARCH/include" handler="warn"/>
   </client>
-  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/biglib/$SCRAM_ARCH" type="path"/>
-  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@UC_TOOL@_BASE/biglib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@UC_TOOL@_BASE/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="RIVET_ANALYSIS_PATH"      value="$LOCALTOP/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
-  <runtime name="PYTHON3PATH" value="$CMSSW_BASE/lib/$SCRAM_ARCH" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$CMSSW_BASE/src" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$CMSSW_BASE/include/$SCRAM_ARCH/include" type="path" handler="warn"/>
-  <runtime name="CMSSW_FULL_RELEASE_BASE" value="$CMSSW_BASE"/>
+  <runtime name="PYTHON3PATH" value="$@UC_TOOL@_BASE/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$@UC_TOOL@_BASE/src" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include/$SCRAM_ARCH/include" type="path" handler="warn"/>
+  <runtime name="CMSSW_FULL_RELEASE_BASE" value="$@UC_TOOL@_BASE"/>
   @CXXMODULE_DATA@
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/cmssw/cmssw.xml
+++ b/scram-tools.file/tools/cmssw/cmssw.xml
@@ -1,20 +1,20 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" type="scram" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/biglib/$SCRAM_ARCH"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/$SCRAM_ARCH"/>
-    <environment name="CMSSW_BINDIR" default="$@UC_TOOL@_BASE/bin/$SCRAM_ARCH"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/src"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/$SCRAM_ARCH/include" handler="warn"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/biglib/$SCRAM_ARCH"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/$SCRAM_ARCH"/>
+    <environment name="CMSSW_BINDIR" default="$@TOOL_BASE@/bin/$SCRAM_ARCH"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/src"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/$SCRAM_ARCH/include" handler="warn"/>
   </client>
-  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@UC_TOOL@_BASE/biglib/$SCRAM_ARCH" type="path"/>
-  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@UC_TOOL@_BASE/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/biglib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="RIVET_ANALYSIS_PATH"      value="$LOCALTOP/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
-  <runtime name="PYTHON3PATH" value="$@UC_TOOL@_BASE/lib/$SCRAM_ARCH" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@UC_TOOL@_BASE/src" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include/$SCRAM_ARCH/include" type="path" handler="warn"/>
-  <runtime name="CMSSW_FULL_RELEASE_BASE" value="$@UC_TOOL@_BASE"/>
+  <runtime name="PYTHON3PATH" value="$@TOOL_BASE@/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@/src" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@/include/$SCRAM_ARCH/include" type="path" handler="warn"/>
+  <runtime name="CMSSW_FULL_RELEASE_BASE" value="$@TOOL_BASE@"/>
   @CXXMODULE_DATA@
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/collier/collier.xml
+++ b/scram-tools.file/tools/collier/collier.xml
@@ -1,5 +1,5 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/collier/collier.xml
+++ b/scram-tools.file/tools/collier/collier.xml
@@ -1,5 +1,5 @@
-<tool name="collier" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="COLLIER_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/conifer/conifer.xml
+++ b/scram-tools.file/tools/conifer/conifer.xml
@@ -1,7 +1,7 @@
-<tool name="conifer" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="CONIFER_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$CONIFER_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="json"/>
 </tool>

--- a/scram-tools.file/tools/conifer/conifer.xml
+++ b/scram-tools.file/tools/conifer/conifer.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="json"/>
 </tool>

--- a/scram-tools.file/tools/coral/coral.xml
+++ b/scram-tools.file/tools/coral/coral.xml
@@ -1,11 +1,11 @@
-<tool name="coral" version="@TOOL_VERSION@" type="scram" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" type="scram" revision="2">
   <client>
-    <environment name="CORAL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CORAL_BASE/$SCRAM_ARCH/lib"/>
-    <environment name="INCLUDE" default="$CORAL_BASE/include/LCG"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/$SCRAM_ARCH/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/LCG"/>
   </client>
-  <runtime name="PYTHON3PATH" default="$CORAL_BASE/$SCRAM_ARCH/python" type="path"/>
-  <runtime name="PYTHON3PATH" default="$CORAL_BASE/$SCRAM_ARCH/lib" type="path"/>
+  <runtime name="PYTHON3PATH" default="$@UC_TOOL@_BASE/$SCRAM_ARCH/python" type="path"/>
+  <runtime name="PYTHON3PATH" default="$@UC_TOOL@_BASE/$SCRAM_ARCH/lib" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/coral/coral.xml
+++ b/scram-tools.file/tools/coral/coral.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" type="scram" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/$SCRAM_ARCH/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/LCG"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/$SCRAM_ARCH/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/LCG"/>
   </client>
-  <runtime name="PYTHON3PATH" default="$@UC_TOOL@_BASE/$SCRAM_ARCH/python" type="path"/>
-  <runtime name="PYTHON3PATH" default="$@UC_TOOL@_BASE/$SCRAM_ARCH/lib" type="path"/>
+  <runtime name="PYTHON3PATH" default="$@TOOL_BASE@/$SCRAM_ARCH/python" type="path"/>
+  <runtime name="PYTHON3PATH" default="$@TOOL_BASE@/$SCRAM_ARCH/lib" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/cppunit/cppunit.xml
+++ b/scram-tools.file/tools/cppunit/cppunit.xml
@@ -1,9 +1,9 @@
-<tool name="cppunit" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="cppunit"/>
   <client>
-    <environment name="CPPUNIT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CPPUNIT_BASE/lib"/>
-    <environment name="INCLUDE" default="$CPPUNIT_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/cppunit/cppunit.xml
+++ b/scram-tools.file/tools/cppunit/cppunit.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="cppunit"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/cpu_features/cpu_features.xml
+++ b/scram-tools.file/tools/cpu_features/cpu_features.xml
@@ -2,10 +2,10 @@
   <info url="https://github.com/google/cpu_features"/>
   <lib name="cpu_features"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/cpu_features/cpu_features.xml
+++ b/scram-tools.file/tools/cpu_features/cpu_features.xml
@@ -1,11 +1,11 @@
-<tool name="cpu_features" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/google/cpu_features"/>
   <lib name="cpu_features"/>
   <client>
-    <environment name="CPU_FEATURES_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$CPU_FEATURES_BASE/lib64"/>
-    <environment name="INCLUDE" default="$CPU_FEATURES_BASE/include"/>
-    <environment name="BINDIR" default="$CPU_FEATURES_BASE/bin"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
+++ b/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
@@ -3,6 +3,6 @@
   <use name="cuda"/>
   <use name="cuda-stubs"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
+++ b/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
@@ -1,8 +1,8 @@
-<tool name="cuda-compatible-runtime" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://gitlab.cern.ch/cms-patatrack/cuda-compatible-runtime/"/>
   <use name="cuda"/>
   <use name="cuda-stubs"/>
   <client>
-    <environment name="CUDA_COMPATIBLE_RUNTIME_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/cuda/cuda.xml
+++ b/scram-tools.file/tools/cuda/cuda.xml
@@ -5,8 +5,8 @@
   <lib name="cudart"/>
   <lib name="cudadevrt"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="NVCC"      default="$@UC_TOOL@_BASE/bin/nvcc"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="NVCC"      default="$@TOOL_BASE@/bin/nvcc"/>
   </client>
   <flags CUDA_FLAGS="@CUDA_FLAGS@"/>
   <flags REM_CUDA_HOST_CXXFLAGS="-std=%"/>

--- a/scram-tools.file/tools/cuda/cuda.xml
+++ b/scram-tools.file/tools/cuda/cuda.xml
@@ -1,12 +1,12 @@
-<tool name="cuda" version="@TOOL_VERSION@" revision="4">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="5">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <use name="cuda-interface"/>
   <use name="cuda-stubs"/>
   <lib name="cudart"/>
   <lib name="cudadevrt"/>
   <client>
-    <environment name="CUDA_BASE" default="@TOOL_ROOT@"/>
-    <environment name="NVCC"      default="$CUDA_BASE/bin/nvcc"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="NVCC"      default="$@UC_TOOL@_BASE/bin/nvcc"/>
   </client>
   <flags CUDA_FLAGS="@CUDA_FLAGS@"/>
   <flags REM_CUDA_HOST_CXXFLAGS="-std=%"/>

--- a/scram-tools.file/tools/cudnn/cudnn.xml
+++ b/scram-tools.file/tools/cudnn/cudnn.xml
@@ -2,9 +2,9 @@
   <info url="https://docs.nvidia.com/deeplearning/cudnn/index.html"/>
   <lib name="cudnn"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
   </client>
   <use name="cuda"/>
 </tool>

--- a/scram-tools.file/tools/cudnn/cudnn.xml
+++ b/scram-tools.file/tools/cudnn/cudnn.xml
@@ -1,10 +1,10 @@
-<tool name="cudnn" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.nvidia.com/deeplearning/cudnn/index.html"/>
   <lib name="cudnn"/>
   <client>
-    <environment name="CUDNN_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$CUDNN_BASE/include"/>
-    <environment name="LIBDIR" default="$CUDNN_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
   </client>
   <use name="cuda"/>
 </tool>

--- a/scram-tools.file/tools/curl/curl.xml
+++ b/scram-tools.file/tools/curl/curl.xml
@@ -1,11 +1,11 @@
-<tool name="curl" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="curl"/>
   <client>
-    <environment name="CURL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$CURL_BASE/include"/>
-    <environment name="LIBDIR"       default="$CURL_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$CURL_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/curl/curl.xml
+++ b/scram-tools.file/tools/curl/curl.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="curl"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/dablooms/dablooms.xml
+++ b/scram-tools.file/tools/dablooms/dablooms.xml
@@ -1,8 +1,8 @@
-<tool name="dablooms" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="dablooms"/>
   <client>
-    <environment name="DABLOOMS_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$DABLOOMS_BASE/lib"/>
-    <environment name="INCLUDE" default="$DABLOOMS_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/dablooms/dablooms.xml
+++ b/scram-tools.file/tools/dablooms/dablooms.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="dablooms"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/das_client/das_client.xml
+++ b/scram-tools.file/tools/das_client/das_client.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH"       value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH"       value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/das_client/das_client.xml
+++ b/scram-tools.file/tools/das_client/das_client.xml
@@ -1,6 +1,6 @@
-<tool name="das_client" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="DAS_CLIENT_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH"       value="$DAS_CLIENT_BASE/bin" type="path"/>
+  <runtime name="PATH"       value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/davix/davix.xml
+++ b/scram-tools.file/tools/davix/davix.xml
@@ -1,12 +1,12 @@
-  <tool name="davix" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="https://dmc.web.cern.ch/projects/davix/home"/>
     <lib name="davix"/>
     <client>
-      <environment name="DAVIX_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$DAVIX_BASE/lib64"/>
-      <environment name="INCLUDE" default="$DAVIX_BASE/include/davix"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/davix"/>
     </client>
-    <runtime name="PATH" value="$DAVIX_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
     <use name="boost_system"/>
     <use name="libxml2"/>
   </tool>

--- a/scram-tools.file/tools/davix/davix.xml
+++ b/scram-tools.file/tools/davix/davix.xml
@@ -2,11 +2,11 @@
     <info url="https://dmc.web.cern.ch/projects/davix/home"/>
     <lib name="davix"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/davix"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include/davix"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
     <use name="boost_system"/>
     <use name="libxml2"/>
   </tool>

--- a/scram-tools.file/tools/db6/db6.xml
+++ b/scram-tools.file/tools/db6/db6.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="db"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/db6/db6.xml
+++ b/scram-tools.file/tools/db6/db6.xml
@@ -1,10 +1,10 @@
-<tool name="db6" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="db"/>
   <client>
-    <environment name="DB6_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$DB6_BASE/lib"/>
-    <environment name="INCLUDE" default="$DB6_BASE/include"/>
-    <environment name="BINDIR" default="$DB6_BASE/bin"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/dcap/dcap.xml
+++ b/scram-tools.file/tools/dcap/dcap.xml
@@ -1,9 +1,9 @@
-<tool name="dcap" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="dcap"/>
   <client>
-    <environment name="DCAP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$DCAP_BASE/lib"/>
-    <environment name="INCLUDE" default="$DCAP_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/dcap/dcap.xml
+++ b/scram-tools.file/tools/dcap/dcap.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="dcap"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/dd4hep/dd4hep.xml
+++ b/scram-tools.file/tools/dd4hep/dd4hep.xml
@@ -1,4 +1,4 @@
-<tool name="dd4hep" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="DDAlign" />
   <lib name="DDCond" />
   <use name="dd4hep-core"/>

--- a/scram-tools.file/tools/dip/dip.xml
+++ b/scram-tools.file/tools/dip/dip.xml
@@ -1,4 +1,4 @@
-<tool name="dip" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="dip"/>
   <use name="dip-platform-dependent"/>
   <use name="log4cplus"/>

--- a/scram-tools.file/tools/dmtcp/dmtcp.xml
+++ b/scram-tools.file/tools/dmtcp/dmtcp.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://dmtcp.sourceforge.net/"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/dmtcp"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/dmtcp"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/dmtcp/dmtcp.xml
+++ b/scram-tools.file/tools/dmtcp/dmtcp.xml
@@ -1,9 +1,9 @@
-<tool name="dmtcp" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://dmtcp.sourceforge.net/"/>
   <client>
-    <environment name="DMTCP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$DMTCP_BASE/lib"/>
-    <environment name="LIBDIR" default="$DMTCP_BASE/lib/dmtcp"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/dmtcp"/>
   </client>
-  <runtime name="PATH" value="$DMTCP_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/eigen/eigen.xml
+++ b/scram-tools.file/tools/eigen/eigen.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE"   default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include/eigen3"/>
+    <environment name="@TOOL_BASE@"   default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include/eigen3"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags CXXFLAGS="@CMS_EIGEN_CXX_FLAGS@"/>

--- a/scram-tools.file/tools/eigen/eigen.xml
+++ b/scram-tools.file/tools/eigen/eigen.xml
@@ -1,8 +1,8 @@
-<tool name="eigen" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="EIGEN_BASE"   default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$EIGEN_BASE/include"/>
-    <environment name="INCLUDE"      default="$EIGEN_BASE/include/eigen3"/>
+    <environment name="@UC_TOOL@_BASE"   default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include/eigen3"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags CXXFLAGS="@CMS_EIGEN_CXX_FLAGS@"/>

--- a/scram-tools.file/tools/evtgen/evtgen.xml
+++ b/scram-tools.file/tools/evtgen/evtgen.xml
@@ -2,11 +2,11 @@
   <lib name="EvtGen"/>
   <lib name="EvtGenExternal"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="EVTGENDATA" value="$@UC_TOOL@_BASE/share/EvtGen"/>
+  <runtime name="EVTGENDATA" value="$@TOOL_BASE@/share/EvtGen"/>
   <use name="hepmc"/>
   <use name="pythia8"/>
   <use name="tauolapp"/>

--- a/scram-tools.file/tools/evtgen/evtgen.xml
+++ b/scram-tools.file/tools/evtgen/evtgen.xml
@@ -1,12 +1,12 @@
-<tool name="evtgen" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="EvtGen"/>
   <lib name="EvtGenExternal"/>
   <client>
-    <environment name="EVTGEN_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$EVTGEN_BASE/lib"/>
-    <environment name="INCLUDE" default="$EVTGEN_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="EVTGENDATA" value="$EVTGEN_BASE/share/EvtGen"/>
+  <runtime name="EVTGENDATA" value="$@UC_TOOL@_BASE/share/EvtGen"/>
   <use name="hepmc"/>
   <use name="pythia8"/>
   <use name="tauolapp"/>

--- a/scram-tools.file/tools/expat/expat.xml
+++ b/scram-tools.file/tools/expat/expat.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="expat"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/expat/expat.xml
+++ b/scram-tools.file/tools/expat/expat.xml
@@ -1,10 +1,10 @@
-<tool name="expat" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="expat"/>
   <client>
-    <environment name="EXPAT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$EXPAT_BASE/lib"/>
-    <environment name="INCLUDE" default="$EXPAT_BASE/include"/>
-    <environment name="BINDIR" default="$EXPAT_BASE/bin"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/fastjet-contrib/fastjet-contrib.xml
+++ b/scram-tools.file/tools/fastjet-contrib/fastjet-contrib.xml
@@ -1,9 +1,9 @@
-  <tool name="fastjet-contrib" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://fastjet.hepforge.org/contrib/"/>
     <lib name="fastjetcontribfragile"/>
     <client>
-      <environment name="FASTJET_CONTRIB_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$FASTJET_CONTRIB_BASE/lib"/>
-      <environment name="INCLUDE" default="$FASTJET_CONTRIB_BASE/include"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/fastjet-contrib/fastjet-contrib.xml
+++ b/scram-tools.file/tools/fastjet-contrib/fastjet-contrib.xml
@@ -2,8 +2,8 @@
     <info url="http://fastjet.hepforge.org/contrib/"/>
     <lib name="fastjetcontribfragile"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/fastjet/fastjet.xml
+++ b/scram-tools.file/tools/fastjet/fastjet.xml
@@ -6,9 +6,9 @@
     <lib name="siscone_spherical"/>
     <lib name="fastjet"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
     </client>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/fastjet/fastjet.xml
+++ b/scram-tools.file/tools/fastjet/fastjet.xml
@@ -1,4 +1,4 @@
-  <tool name="fastjet" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://fastjet.fr"/>
     <lib name="fastjetplugins"/>
     <lib name="fastjettools"/>
@@ -6,9 +6,9 @@
     <lib name="siscone_spherical"/>
     <lib name="fastjet"/>
     <client>
-      <environment name="FASTJET_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$FASTJET_BASE/lib"/>
-      <environment name="INCLUDE" default="$FASTJET_BASE/include"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
     </client>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/fftjet/fftjet.xml
+++ b/scram-tools.file/tools/fftjet/fftjet.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="fftjet"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/fftjet/fftjet.xml
+++ b/scram-tools.file/tools/fftjet/fftjet.xml
@@ -1,9 +1,9 @@
-<tool name="fftjet" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="fftjet"/>
   <client>
-    <environment name="FFTJET_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$FFTJET_BASE/lib"/>
-    <environment name="INCLUDE" default="$FFTJET_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/fftw3/fftw3.xml
+++ b/scram-tools.file/tools/fftw3/fftw3.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="fftw3"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/fftw3/fftw3.xml
+++ b/scram-tools.file/tools/fftw3/fftw3.xml
@@ -1,9 +1,9 @@
-<tool name="fftw3" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="fftw3"/>
   <client>
-    <environment name="FFTW3_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$FFTW3_BASE/include"/>
-    <environment name="LIBDIR" default="$FFTW3_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/flatbuffers/flatbuffers.xml
+++ b/scram-tools.file/tools/flatbuffers/flatbuffers.xml
@@ -1,9 +1,9 @@
-<tool name="flatbuffers" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="flatbuffers"/>
   <client>
-    <environment name="FLATBUFFERS_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"          default="$FLATBUFFERS_BASE/include"/>
-    <environment name="LIBDIR"           default="$FLATBUFFERS_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"          default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"           default="$@UC_TOOL@_BASE/lib64"/>
   </client>
-  <runtime name="PATH" value="$FLATBUFFERS_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/flatbuffers/flatbuffers.xml
+++ b/scram-tools.file/tools/flatbuffers/flatbuffers.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="flatbuffers"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"          default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"           default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"          default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"           default="$@TOOL_BASE@/lib64"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/fmt/fmt.xml
+++ b/scram-tools.file/tools/fmt/fmt.xml
@@ -2,9 +2,9 @@
   <info url="https://github.com/fmtlib/fmt"/>
   <lib name="fmt"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/fmt/fmt.xml
+++ b/scram-tools.file/tools/fmt/fmt.xml
@@ -1,10 +1,10 @@
-<tool name="fmt" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/fmtlib/fmt"/>
   <lib name="fmt"/>
   <client>
-    <environment name="FMT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$FMT_BASE/lib"/>
-    <environment name="INCLUDE" default="$FMT_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/freetype/freetype.xml
+++ b/scram-tools.file/tools/freetype/freetype.xml
@@ -1,9 +1,9 @@
-<tool name="freetype" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="freetype-cms"/>
   <client>
-    <environment name="FREETYPE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$FREETYPE_BASE/include"/>
-    <environment name="LIBDIR"       default="$FREETYPE_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/freetype/freetype.xml
+++ b/scram-tools.file/tools/freetype/freetype.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="freetype-cms"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/frontier_client/frontier_client.xml
+++ b/scram-tools.file/tools/frontier_client/frontier_client.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="frontier_client"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
-  <runtime name="FRONTIER_CLIENT" value="$@UC_TOOL@_BASE/"/>
+  <runtime name="FRONTIER_CLIENT" value="$@TOOL_BASE@/"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="zlib"/>

--- a/scram-tools.file/tools/frontier_client/frontier_client.xml
+++ b/scram-tools.file/tools/frontier_client/frontier_client.xml
@@ -1,11 +1,11 @@
-<tool name="frontier_client" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="frontier_client"/>
   <client>
-    <environment name="FRONTIER_CLIENT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$FRONTIER_CLIENT_BASE/include"/>
-    <environment name="LIBDIR" default="$FRONTIER_CLIENT_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
-  <runtime name="FRONTIER_CLIENT" value="$FRONTIER_CLIENT_BASE/"/>
+  <runtime name="FRONTIER_CLIENT" value="$@UC_TOOL@_BASE/"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="zlib"/>

--- a/scram-tools.file/tools/gbl/gbl.xml
+++ b/scram-tools.file/tools/gbl/gbl.xml
@@ -1,10 +1,10 @@
-<tool name="gbl" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://www.wiki.terascale.de/index.php/GeneralBrokenLines"/>
   <lib name="GBL"/>
   <client>
-    <environment name="GBL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$GBL_BASE/lib"/>
-    <environment name="INCLUDE" default="$GBL_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="eigen"/>
 </tool>

--- a/scram-tools.file/tools/gbl/gbl.xml
+++ b/scram-tools.file/tools/gbl/gbl.xml
@@ -2,9 +2,9 @@
   <info url="https://www.wiki.terascale.de/index.php/GeneralBrokenLines"/>
   <lib name="GBL"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="eigen"/>
 </tool>

--- a/scram-tools.file/tools/gdb/gdb.xml
+++ b/scram-tools.file/tools/gdb/gdb.xml
@@ -1,6 +1,6 @@
-<tool name="gdb" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="GDB_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$GDB_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gdb/gdb.xml
+++ b/scram-tools.file/tools/gdb/gdb.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gdbm/gdbm.xml
+++ b/scram-tools.file/tools/gdbm/gdbm.xml
@@ -1,9 +1,9 @@
-<tool name="gdbm" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="gdbm"/>
   <client>
-    <environment name="GDBM_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$GDBM_BASE/lib"/>
-    <environment name="INCLUDE" default="$GDBM_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/gdbm/gdbm.xml
+++ b/scram-tools.file/tools/gdbm/gdbm.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="gdbm"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/gdrcopy/gdrcopy.xml
+++ b/scram-tools.file/tools/gdrcopy/gdrcopy.xml
@@ -1,8 +1,8 @@
-<tool name="gdrcopy" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="gdrapi"/>
   <client>
-    <environment name="GDRCOPY_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$GDRCOPY_BASE/include"/>
-    <environment name="LIBDIR"       default="$GDRCOPY_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/gdrcopy/gdrcopy.xml
+++ b/scram-tools.file/tools/gdrcopy/gdrcopy.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="gdrapi"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/geant4-parfullcms/geant4-parfullcms.xml
+++ b/scram-tools.file/tools/geant4-parfullcms/geant4-parfullcms.xml
@@ -1,4 +1,4 @@
-  <tool name="geant4-parfullcms" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <client>
       <environment name="GEANT4_PARFULLCMS" default="@TOOL_ROOT@"/>
     </client>

--- a/scram-tools.file/tools/geant4/geant4.xml
+++ b/scram-tools.file/tools/geant4/geant4.xml
@@ -1,4 +1,4 @@
-<tool name="geant4" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://geant4.web.cern.ch/geant4/"/>
   <use name="geant4core"/>
   <use name="geant4vis"/>

--- a/scram-tools.file/tools/giflib/giflib.xml
+++ b/scram-tools.file/tools/giflib/giflib.xml
@@ -2,11 +2,11 @@
     <info url="http://giflib.sourceforge.net"/>
     <lib name="gif"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/giflib/giflib.xml
+++ b/scram-tools.file/tools/giflib/giflib.xml
@@ -1,12 +1,12 @@
-  <tool name="giflib" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://giflib.sourceforge.net"/>
     <lib name="gif"/>
     <client>
-      <environment name="GIFLIB_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$GIFLIB_BASE/lib"/>
-      <environment name="INCLUDE" default="$GIFLIB_BASE/include"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
     </client>
-    <runtime name="PATH" value="$GIFLIB_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/git-lfs/git-lfs.xml
+++ b/scram-tools.file/tools/git-lfs/git-lfs.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://git-lfs.com/"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/git-lfs/git-lfs.xml
+++ b/scram-tools.file/tools/git-lfs/git-lfs.xml
@@ -1,7 +1,7 @@
-<tool name="git-lfs" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://git-lfs.com/"/>
   <client>
-    <environment name="GIT_LFS_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$GIT_LFS_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/git/git.xml
+++ b/scram-tools.file/tools/git/git.xml
@@ -1,12 +1,12 @@
-<tool name="git" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://git-scm.com"/>
   <client>
-    <environment name="GIT_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$GIT_BASE/bin" type="path"/>
-  <runtime name="PATH" value="$GIT_BASE/libexec/git-core" type="path"/>
-  <runtime name="GIT_TEMPLATE_DIR" value="$GIT_BASE/share/git-core/templates" type="path"/>
-  <runtime name="GIT_SSL_CAINFO" value="$GIT_BASE/share/ssl/certs/ca-bundle.crt" type="path"/>
-  <runtime name="GIT_EXEC_PATH" value="$GIT_BASE/libexec/git-core" type="path"/>
-  <runtime name="PERL5LIB" value="$GIT_BASE@PERL5LIB_PATH@" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/libexec/git-core" type="path"/>
+  <runtime name="GIT_TEMPLATE_DIR" value="$@UC_TOOL@_BASE/share/git-core/templates" type="path"/>
+  <runtime name="GIT_SSL_CAINFO" value="$@UC_TOOL@_BASE/share/ssl/certs/ca-bundle.crt" type="path"/>
+  <runtime name="GIT_EXEC_PATH" value="$@UC_TOOL@_BASE/libexec/git-core" type="path"/>
+  <runtime name="PERL5LIB" value="$@UC_TOOL@_BASE@PERL5LIB_PATH@" type="path"/>
 </tool>

--- a/scram-tools.file/tools/git/git.xml
+++ b/scram-tools.file/tools/git/git.xml
@@ -1,12 +1,12 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://git-scm.com"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/libexec/git-core" type="path"/>
-  <runtime name="GIT_TEMPLATE_DIR" value="$@UC_TOOL@_BASE/share/git-core/templates" type="path"/>
-  <runtime name="GIT_SSL_CAINFO" value="$@UC_TOOL@_BASE/share/ssl/certs/ca-bundle.crt" type="path"/>
-  <runtime name="GIT_EXEC_PATH" value="$@UC_TOOL@_BASE/libexec/git-core" type="path"/>
-  <runtime name="PERL5LIB" value="$@UC_TOOL@_BASE@PERL5LIB_PATH@" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/libexec/git-core" type="path"/>
+  <runtime name="GIT_TEMPLATE_DIR" value="$@TOOL_BASE@/share/git-core/templates" type="path"/>
+  <runtime name="GIT_SSL_CAINFO" value="$@TOOL_BASE@/share/ssl/certs/ca-bundle.crt" type="path"/>
+  <runtime name="GIT_EXEC_PATH" value="$@TOOL_BASE@/libexec/git-core" type="path"/>
+  <runtime name="PERL5LIB" value="$@TOOL_BASE@@PERL5LIB_PATH@" type="path"/>
 </tool>

--- a/scram-tools.file/tools/glimpse/glimpse.xml
+++ b/scram-tools.file/tools/glimpse/glimpse.xml
@@ -1,6 +1,6 @@
-<tool name="glimpse" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="GLIMPSE_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$GLIMPSE_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/glimpse/glimpse.xml
+++ b/scram-tools.file/tools/glimpse/glimpse.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gmake/gmake.xml
+++ b/scram-tools.file/tools/gmake/gmake.xml
@@ -1,4 +1,4 @@
-<tool name="gmake" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
     <environment name="MAKE_BASE" default="@TOOL_ROOT@"/>
   </client>

--- a/scram-tools.file/tools/gnuplot/gnuplot.xml
+++ b/scram-tools.file/tools/gnuplot/gnuplot.xml
@@ -1,7 +1,7 @@
-  <tool name="gnuplot" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://gnuplot.sourceforge.net"/>
     <client>
-      <environment name="GNUPLOT_BASE" default="@TOOL_ROOT@"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="PATH" value="$GNUPLOT_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/gnuplot/gnuplot.xml
+++ b/scram-tools.file/tools/gnuplot/gnuplot.xml
@@ -1,7 +1,7 @@
   <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://gnuplot.sourceforge.net"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/google-benchmark/google-benchmark.xml
+++ b/scram-tools.file/tools/google-benchmark/google-benchmark.xml
@@ -1,10 +1,10 @@
-<tool name="google-benchmark" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/google/benchmark"/>
   <lib name="benchmark"/>
   <client>
-    <environment name="GOOGLE_BENCHMARK_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$GOOGLE_BENCHMARK_BASE/lib64"/>
-    <environment name="INCLUDE"      default="$GOOGLE_BENCHMARK_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/google-benchmark/google-benchmark.xml
+++ b/scram-tools.file/tools/google-benchmark/google-benchmark.xml
@@ -2,9 +2,9 @@
   <info url="https://github.com/google/benchmark"/>
   <lib name="benchmark"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
   </client>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/gosam/gosam.xml
+++ b/scram-tools.file/tools/gosam/gosam.xml
@@ -1,7 +1,7 @@
-<tool name="gosam" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="GOSAM_BASE" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$GOSAM_BASE/bin"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
   </client>
   <runtime name="PATH" default="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gosam/gosam.xml
+++ b/scram-tools.file/tools/gosam/gosam.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
   </client>
   <runtime name="PATH" default="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gosamcontrib/gosamcontrib.xml
+++ b/scram-tools.file/tools/gosamcontrib/gosamcontrib.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="GOSAMCONTRIB_PATH" value="$@UC_TOOL@_BASE" type="path"/>
-  <runtime name="ROOT_PATH" value="$@UC_TOOL@_BASE" type="path"/>
+  <runtime name="GOSAMCONTRIB_PATH" value="$@TOOL_BASE@" type="path"/>
+  <runtime name="ROOT_PATH" value="$@TOOL_BASE@" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gosamcontrib/gosamcontrib.xml
+++ b/scram-tools.file/tools/gosamcontrib/gosamcontrib.xml
@@ -1,10 +1,10 @@
-<tool name="gosamcontrib" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="GOSAMCONTRIB_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$GOSAMCONTRIB_BASE/lib"/>
-    <environment name="INCLUDE" default="$GOSAMCONTRIB_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="GOSAMCONTRIB_PATH" value="$GOSAMCONTRIB_BASE" type="path"/>
-  <runtime name="ROOT_PATH" value="$GOSAMCONTRIB_BASE" type="path"/>
+  <runtime name="GOSAMCONTRIB_PATH" value="$@UC_TOOL@_BASE" type="path"/>
+  <runtime name="ROOT_PATH" value="$@UC_TOOL@_BASE" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/graphviz/graphviz.xml
+++ b/scram-tools.file/tools/graphviz/graphviz.xml
@@ -1,9 +1,9 @@
-<tool name="graphviz" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.research.att.com/sw/tools/graphviz/"/>
   <client>
-    <environment name="GRAPHVIZ_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$GRAPHVIZ_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <use name="expat"/>
   <use name="zlib"/>
   <use name="libjpeg-turbo"/>

--- a/scram-tools.file/tools/graphviz/graphviz.xml
+++ b/scram-tools.file/tools/graphviz/graphviz.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.research.att.com/sw/tools/graphviz/"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <use name="expat"/>
   <use name="zlib"/>
   <use name="libjpeg-turbo"/>

--- a/scram-tools.file/tools/grpc/grpc.xml
+++ b/scram-tools.file/tools/grpc/grpc.xml
@@ -1,12 +1,12 @@
-<tool name="grpc" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/grpc/grpc"/>
   <lib name="grpc"/>
   <lib name="grpc++"/>
   <lib name="grpc++_reflection"/>
   <client>
-    <environment name="GRPC_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$GRPC_BASE/include"/>
-    <environment name="LIBDIR" default="$GRPC_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <flags SYSTEM_INCLUDE="1"/>
   <use name="protobuf"/>

--- a/scram-tools.file/tools/grpc/grpc.xml
+++ b/scram-tools.file/tools/grpc/grpc.xml
@@ -4,9 +4,9 @@
   <lib name="grpc++"/>
   <lib name="grpc++_reflection"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <flags SYSTEM_INCLUDE="1"/>
   <use name="protobuf"/>

--- a/scram-tools.file/tools/gsl/gsl.xml
+++ b/scram-tools.file/tools/gsl/gsl.xml
@@ -2,12 +2,12 @@
   <info url="http://www.gnu.org/software/gsl/gsl.html"/>
   <lib name="gsl"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <use name="OpenBLAS"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/gsl/gsl.xml
+++ b/scram-tools.file/tools/gsl/gsl.xml
@@ -1,13 +1,13 @@
-<tool name="gsl" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.gnu.org/software/gsl/gsl.html"/>
   <lib name="gsl"/>
   <client>
-    <environment name="GSL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$GSL_BASE/lib"/>
-    <environment name="INCLUDE" default="$GSL_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$GSL_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <use name="OpenBLAS"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/hdf5/hdf5.xml
+++ b/scram-tools.file/tools/hdf5/hdf5.xml
@@ -1,11 +1,11 @@
-<tool name="hdf5" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://support.hdfgroup.org/HDF5/"/>
   <lib name="hdf5"/>
   <lib name="hdf5_hl"/>
   <client>
-    <environment name="HDF5_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HDF5_BASE/lib"/>
-    <environment name="INCLUDE" default="$HDF5_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="mpi"/>
 </tool>

--- a/scram-tools.file/tools/hdf5/hdf5.xml
+++ b/scram-tools.file/tools/hdf5/hdf5.xml
@@ -3,9 +3,9 @@
   <lib name="hdf5"/>
   <lib name="hdf5_hl"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="mpi"/>
 </tool>

--- a/scram-tools.file/tools/heaptrack/heaptrack.xml
+++ b/scram-tools.file/tools/heaptrack/heaptrack.xml
@@ -1,8 +1,8 @@
-  <tool name="heaptrack" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="https://invent.kde.org/sdk/heaptrack/"/>
     <client>
-      <environment name="HEAPTRACK_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$HEAPTRACK_BASE/lib"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
     </client>
-    <runtime name="PATH" value="$HEAPTRACK_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/heaptrack/heaptrack.xml
+++ b/scram-tools.file/tools/heaptrack/heaptrack.xml
@@ -1,8 +1,8 @@
   <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="https://invent.kde.org/sdk/heaptrack/"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/hector/hector.xml
+++ b/scram-tools.file/tools/hector/hector.xml
@@ -1,10 +1,10 @@
-<tool name="Hector" version="@TOOL_VERSION@" revision="1">
+<tool name="Hector" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.fynu.ucl.ac.be/themes/he/ggamma/hector/"/>
   <lib name="Hector"/>
   <client>
-    <environment name="HECTOR_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HECTOR_BASE/lib"/>
-    <environment name="INCLUDE" default="$HECTOR_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/hector/hector.xml
+++ b/scram-tools.file/tools/hector/hector.xml
@@ -2,9 +2,9 @@
   <info url="http://www.fynu.ucl.ac.be/themes/he/ggamma/hector/"/>
   <lib name="Hector"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/hepmc/hepmc.xml
+++ b/scram-tools.file/tools/hepmc/hepmc.xml
@@ -2,9 +2,9 @@
   <lib name="HepMCfio"/>
   <lib name="HepMC"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="hepmc_headers"/>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@TOOL_BASE@/include" type="path"/>
 </tool>

--- a/scram-tools.file/tools/hepmc/hepmc.xml
+++ b/scram-tools.file/tools/hepmc/hepmc.xml
@@ -1,10 +1,10 @@
-<tool name="HepMC" version="@TOOL_VERSION@" revision="1">
+<tool name="HepMC" version="@TOOL_VERSION@" revision="2">
   <lib name="HepMCfio"/>
   <lib name="HepMC"/>
   <client>
-    <environment name="HEPMC_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HEPMC_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="hepmc_headers"/>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$HEPMC_BASE/include" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include" type="path"/>
 </tool>

--- a/scram-tools.file/tools/hepmc3/hepmc3.xml
+++ b/scram-tools.file/tools/hepmc3/hepmc3.xml
@@ -2,10 +2,10 @@
   <lib name="HepMC3"/>
   <lib name="HepMC3search"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@TOOL_BASE@/include" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/hepmc3/hepmc3.xml
+++ b/scram-tools.file/tools/hepmc3/hepmc3.xml
@@ -1,11 +1,11 @@
-<tool name="hepmc3" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="HepMC3"/>
   <lib name="HepMC3search"/>
   <client>
-    <environment name="HEPMC3_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HEPMC3_BASE/lib64"/>
-    <environment name="INCLUDE" default="$HEPMC3_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$HEPMC3_BASE/include" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/heppdt/heppdt.xml
+++ b/scram-tools.file/tools/heppdt/heppdt.xml
@@ -2,11 +2,11 @@
   <lib name="HepPDT"/>
   <lib name="HepPID"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="HEPPDT_PARAM_PATH" value="$@UC_TOOL@_BASE"/>
+  <runtime name="HEPPDT_PARAM_PATH" value="$@TOOL_BASE@"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/heppdt/heppdt.xml
+++ b/scram-tools.file/tools/heppdt/heppdt.xml
@@ -1,12 +1,12 @@
-<tool name="heppdt" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="HepPDT"/>
   <lib name="HepPID"/>
   <client>
-    <environment name="HEPPDT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HEPPDT_BASE/lib"/>
-    <environment name="INCLUDE" default="$HEPPDT_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="HEPPDT_PARAM_PATH" value="$HEPPDT_BASE"/>
+  <runtime name="HEPPDT_PARAM_PATH" value="$@UC_TOOL@_BASE"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/herwig7/herwig7.xml
+++ b/scram-tools.file/tools/herwig7/herwig7.xml
@@ -1,4 +1,4 @@
-<tool name="herwig7" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="HerwigAPI"/>
   <client>
     <environment name="HERWIGPP_BASE" default="@TOOL_ROOT@"/>

--- a/scram-tools.file/tools/highfive/highfive.xml
+++ b/scram-tools.file/tools/highfive/highfive.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/BlueBrain/HighFive"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/highfive/highfive.xml
+++ b/scram-tools.file/tools/highfive/highfive.xml
@@ -1,8 +1,8 @@
-<tool name="highfive" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/BlueBrain/HighFive"/>
   <client>
-    <environment name="HIGHFIVE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$HIGHFIVE_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/hls/hls.xml
+++ b/scram-tools.file/tools/hls/hls.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/Xilinx/HLS_arbitrary_Precision_Types"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/hls/hls.xml
+++ b/scram-tools.file/tools/hls/hls.xml
@@ -1,8 +1,8 @@
-<tool name="hls" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/Xilinx/HLS_arbitrary_Precision_Types"/>
   <client>
-    <environment name="HLS_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$HLS_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/hwloc/hwloc.xml
+++ b/scram-tools.file/tools/hwloc/hwloc.xml
@@ -1,12 +1,12 @@
-<tool name="hwloc" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="hwloc"/>
   <client>
-    <environment name="HWLOC_BASE"  default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"     default="$HWLOC_BASE/include/hwloc"/>
-    <environment name="LIBDIR"      default="$HWLOC_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE"  default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"     default="$@UC_TOOL@_BASE/include/hwloc"/>
+    <environment name="LIBDIR"      default="$@UC_TOOL@_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$HWLOC_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 %if 0%{!?without_cuda:1}%{!?without_rocm:1}
-  <runtime name="HWLOC_PLUGINS_PATH" value="$HWLOC_BASE/lib/hwloc" type="path"/>
+  <runtime name="HWLOC_PLUGINS_PATH" value="$@UC_TOOL@_BASE/lib/hwloc" type="path"/>
 %endif
 </tool>

--- a/scram-tools.file/tools/hwloc/hwloc.xml
+++ b/scram-tools.file/tools/hwloc/hwloc.xml
@@ -1,12 +1,12 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="hwloc"/>
   <client>
-    <environment name="@UC_TOOL@_BASE"  default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"     default="$@UC_TOOL@_BASE/include/hwloc"/>
-    <environment name="LIBDIR"      default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@"  default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"     default="$@TOOL_BASE@/include/hwloc"/>
+    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 %if 0%{!?without_cuda:1}%{!?without_rocm:1}
-  <runtime name="HWLOC_PLUGINS_PATH" value="$@UC_TOOL@_BASE/lib/hwloc" type="path"/>
+  <runtime name="HWLOC_PLUGINS_PATH" value="$@TOOL_BASE@/lib/hwloc" type="path"/>
 %endif
 </tool>

--- a/scram-tools.file/tools/hydjet/hydjet.xml
+++ b/scram-tools.file/tools/hydjet/hydjet.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="hydjet"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="pyquen"/>
   <use name="pythia6"/>

--- a/scram-tools.file/tools/hydjet/hydjet.xml
+++ b/scram-tools.file/tools/hydjet/hydjet.xml
@@ -1,8 +1,8 @@
-<tool name="hydjet" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="hydjet"/>
   <client>
-    <environment name="HYDJET_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HYDJET_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="pyquen"/>
   <use name="pythia6"/>

--- a/scram-tools.file/tools/hydjet2/hydjet2.xml
+++ b/scram-tools.file/tools/hydjet2/hydjet2.xml
@@ -1,11 +1,11 @@
-<tool name="hydjet2" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="hydjet2"/>
   <client>
-    <environment name="HYDJET2_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$HYDJET2_BASE/lib64"/>
-    <environment name="INCLUDE" default="$HYDJET2_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="CMSSW_SEARCH_PATH" default="$HYDJET2_BASE/data" type="path"/>
+  <runtime name="CMSSW_SEARCH_PATH" default="$@UC_TOOL@_BASE/data" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="pyquen"/>
   <use name="pythia6"/>

--- a/scram-tools.file/tools/hydjet2/hydjet2.xml
+++ b/scram-tools.file/tools/hydjet2/hydjet2.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="hydjet2"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="CMSSW_SEARCH_PATH" default="$@UC_TOOL@_BASE/data" type="path"/>
+  <runtime name="CMSSW_SEARCH_PATH" default="$@TOOL_BASE@/data" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="pyquen"/>
   <use name="pythia6"/>

--- a/scram-tools.file/tools/igprof/igprof.xml
+++ b/scram-tools.file/tools/igprof/igprof.xml
@@ -1,8 +1,8 @@
   <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://igprof.sourceforge.net/"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/igprof/igprof.xml
+++ b/scram-tools.file/tools/igprof/igprof.xml
@@ -1,8 +1,8 @@
-  <tool name="igprof" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://igprof.sourceforge.net/"/>
     <client>
-      <environment name="IGPROF_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$IGPROF_BASE/lib"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
     </client>
-    <runtime name="PATH" value="$IGPROF_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/intel-vtune/intel-vtune.xml
+++ b/scram-tools.file/tools/intel-vtune/intel-vtune.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@INTEL_VTUNE_INSTALLDIR@"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin64"/>
+    <environment name="@TOOL_BASE@" default="@INTEL_VTUNE_INSTALLDIR@"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin64"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin64" type="path"/>
-  <runtime name="VTUNE_PROFILER_DIR" value="$@UC_TOOL@_BASE"/>
-  <runtime name="VTUNE_PROFILER_2025_DIR" value="$@UC_TOOL@_BASE"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin64" type="path"/>
+  <runtime name="VTUNE_PROFILER_DIR" value="$@TOOL_BASE@"/>
+  <runtime name="VTUNE_PROFILER_2025_DIR" value="$@TOOL_BASE@"/>
 </tool>

--- a/scram-tools.file/tools/intel-vtune/intel-vtune.xml
+++ b/scram-tools.file/tools/intel-vtune/intel-vtune.xml
@@ -1,10 +1,10 @@
-<tool name="intel-vtune" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html"/>
   <client>
-    <environment name="INTEL_VTUNE_BASE" default="@INTEL_VTUNE_INSTALLDIR@"/>
-    <environment name="BINDIR" default="$INTEL_VTUNE_BASE/bin64"/>
+    <environment name="@UC_TOOL@_BASE" default="@INTEL_VTUNE_INSTALLDIR@"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin64"/>
   </client>
-  <runtime name="PATH" value="$INTEL_VTUNE_BASE/bin64" type="path"/>
-  <runtime name="VTUNE_PROFILER_DIR" value="$INTEL_VTUNE_BASE"/>
-  <runtime name="VTUNE_PROFILER_2025_DIR" value="$INTEL_VTUNE_BASE"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin64" type="path"/>
+  <runtime name="VTUNE_PROFILER_DIR" value="$@UC_TOOL@_BASE"/>
+  <runtime name="VTUNE_PROFILER_2025_DIR" value="$@UC_TOOL@_BASE"/>
 </tool>

--- a/scram-tools.file/tools/isal/isal.xml
+++ b/scram-tools.file/tools/isal/isal.xml
@@ -1,10 +1,10 @@
-<tool name="isal" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/intel/isa-l/wiki"/>
   <lib name="isal"/>
   <client>
-    <environment name="ISAL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$ISAL_BASE/lib"/>
-    <environment name="INCLUDE" default="$ISAL_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="eigen"/>
 </tool>

--- a/scram-tools.file/tools/isal/isal.xml
+++ b/scram-tools.file/tools/isal/isal.xml
@@ -2,9 +2,9 @@
   <info url="https://github.com/intel/isa-l/wiki"/>
   <lib name="isal"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="eigen"/>
 </tool>

--- a/scram-tools.file/tools/ittnotify/ittnotify.xml
+++ b/scram-tools.file/tools/ittnotify/ittnotify.xml
@@ -1,9 +1,9 @@
-<tool name="ittnotify" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
  <lib name="ittnotify"/>
  <client>
-    <environment name="ITTNOTIFY_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$ITTNOTIFY_BASE/include"/>
-    <environment name="LIBDIR" default="$ITTNOTIFY_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
  </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   </tool>

--- a/scram-tools.file/tools/ittnotify/ittnotify.xml
+++ b/scram-tools.file/tools/ittnotify/ittnotify.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
  <lib name="ittnotify"/>
  <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
  </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   </tool>

--- a/scram-tools.file/tools/jemalloc-debug/jemalloc-debug.xml
+++ b/scram-tools.file/tools/jemalloc-debug/jemalloc-debug.xml
@@ -1,4 +1,4 @@
-<tool name="jemalloc-debug" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="jemalloc-debug"/>
   <client>
     <environment name="JEMALLOC_BASE" default="@TOOL_ROOT@"/>

--- a/scram-tools.file/tools/jemalloc-prof/jemalloc-prof.xml
+++ b/scram-tools.file/tools/jemalloc-prof/jemalloc-prof.xml
@@ -1,9 +1,9 @@
-<tool name="jemalloc-prof" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="jemalloc-prof"/>
   <client>
-    <environment name="JEMALLOC_PROF_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$JEMALLOC_PROF_BASE/lib"/>
-    <environment name="INCLUDE"        default="$JEMALLOC_PROF_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"        default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <runtime name="PATH" value="$BINDIR" type="path" />

--- a/scram-tools.file/tools/jemalloc-prof/jemalloc-prof.xml
+++ b/scram-tools.file/tools/jemalloc-prof/jemalloc-prof.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="jemalloc-prof"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"        default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <runtime name="PATH" value="$BINDIR" type="path" />

--- a/scram-tools.file/tools/jemalloc/jemalloc.xml
+++ b/scram-tools.file/tools/jemalloc/jemalloc.xml
@@ -1,10 +1,10 @@
-<tool name="jemalloc" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="jemalloc"/>
   <client>
-    <environment name="JEMALLOC_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$JEMALLOC_BASE/lib"/>
-    <environment name="BINDIR"        default="$JEMALLOC_BASE/bin"/>
-    <environment name="INCLUDE"        default="$JEMALLOC_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"        default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="BINDIR"        default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/jemalloc/jemalloc.xml
+++ b/scram-tools.file/tools/jemalloc/jemalloc.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="jemalloc"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="BINDIR"        default="$@UC_TOOL@_BASE/bin"/>
-    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"        default="$@TOOL_BASE@/lib"/>
+    <environment name="BINDIR"        default="$@TOOL_BASE@/bin"/>
+    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/json/json.xml
+++ b/scram-tools.file/tools/json/json.xml
@@ -1,6 +1,6 @@
-<tool name="json" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="JSON_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"   default="$JSON_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"   default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/json/json.xml
+++ b/scram-tools.file/tools/json/json.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"   default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/ktjet/ktjet.xml
+++ b/scram-tools.file/tools/ktjet/ktjet.xml
@@ -2,9 +2,9 @@
   <info url="http://hepforge.cedar.ac.uk/ktjet"/>
   <lib name="KtEvent"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <flags cppdefines="KTDOUBLEPRECISION"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/ktjet/ktjet.xml
+++ b/scram-tools.file/tools/ktjet/ktjet.xml
@@ -1,10 +1,10 @@
-<tool name="ktjet" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://hepforge.cedar.ac.uk/ktjet"/>
   <lib name="KtEvent"/>
   <client>
-    <environment name="KTJET_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$KTJET_BASE/lib"/>
-    <environment name="INCLUDE" default="$KTJET_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <flags cppdefines="KTDOUBLEPRECISION"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/lcov/lcov.xml
+++ b/scram-tools.file/tools/lcov/lcov.xml
@@ -1,7 +1,7 @@
-<tool name="lcov" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://ltp.sourceforge.net/coverage/lcov.php"/>
   <client>
-    <environment name="LCOV_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$LCOV_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/lcov/lcov.xml
+++ b/scram-tools.file/tools/lcov/lcov.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://ltp.sourceforge.net/coverage/lcov.php"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/lhapdf/lhapdf.xml
+++ b/scram-tools.file/tools/lhapdf/lhapdf.xml
@@ -1,12 +1,12 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="LHAPDF"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="LHAPDF_DATA_PATH" value="$@UC_TOOL@_BASE/share/LHAPDF"/>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="LHAPDF_DATA_PATH" value="$@TOOL_BASE@/share/LHAPDF"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/lhapdf/lhapdf.xml
+++ b/scram-tools.file/tools/lhapdf/lhapdf.xml
@@ -1,12 +1,12 @@
-<tool name="lhapdf" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="LHAPDF"/>
   <client>
-    <environment name="LHAPDF_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LHAPDF_BASE/lib"/>
-    <environment name="INCLUDE" default="$LHAPDF_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="LHAPDF_DATA_PATH" value="$LHAPDF_BASE/share/LHAPDF"/>
-  <runtime name="PATH" value="$LHAPDF_BASE/bin" type="path"/>
+  <runtime name="LHAPDF_DATA_PATH" value="$@UC_TOOL@_BASE/share/LHAPDF"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libfabric/libfabric.xml
+++ b/scram-tools.file/tools/libfabric/libfabric.xml
@@ -1,8 +1,8 @@
-<tool name="libfabric" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="fabric"/>
   <client>
-    <environment name="LIBFABRIC_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$LIBFABRIC_BASE/lib"/>
-    <environment name="INCLUDE"        default="$LIBFABRIC_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libfabric/libfabric.xml
+++ b/scram-tools.file/tools/libfabric/libfabric.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="fabric"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libffi/libffi.xml
+++ b/scram-tools.file/tools/libffi/libffi.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="ffi"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libffi/libffi.xml
+++ b/scram-tools.file/tools/libffi/libffi.xml
@@ -1,8 +1,8 @@
-<tool name="libffi" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="ffi"/>
   <client>
-    <environment name="LIBFFI_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBFFI_BASE/lib64"/>
-    <environment name="INCLUDE" default="$LIBFFI_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libjpeg-turbo/libjpeg-turbo.xml
+++ b/scram-tools.file/tools/libjpeg-turbo/libjpeg-turbo.xml
@@ -1,13 +1,13 @@
-<tool name="libjpeg-turbo" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://libjpeg-turbo.virtualgl.org"/>
   <lib name="jpeg"/>
   <lib name="turbojpeg"/>
   <client>
-    <environment name="LIBJPEG_TURBO_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBJPEG_TURBO_BASE/lib64"/>
-    <environment name="INCLUDE" default="$LIBJPEG_TURBO_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$LIBJPEG_TURBO_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libjpeg-turbo/libjpeg-turbo.xml
+++ b/scram-tools.file/tools/libjpeg-turbo/libjpeg-turbo.xml
@@ -3,11 +3,11 @@
   <lib name="jpeg"/>
   <lib name="turbojpeg"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libpciaccess/libpciaccess.xml
+++ b/scram-tools.file/tools/libpciaccess/libpciaccess.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="libpciaccess"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"            default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"           default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"            default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"           default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libpciaccess/libpciaccess.xml
+++ b/scram-tools.file/tools/libpciaccess/libpciaccess.xml
@@ -1,8 +1,8 @@
-<tool name="libpciaccess" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="libpciaccess"/>
   <client>
-    <environment name="LIBPCIACCESS_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"            default="$LIBPCIACCESS_BASE/lib"/>
-    <environment name="INCLUDE"           default="$LIBPCIACCESS_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"            default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"           default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libpng/libpng.xml
+++ b/scram-tools.file/tools/libpng/libpng.xml
@@ -2,9 +2,9 @@
   <info url="http://www.libpng.org/"/>
   <lib name="png"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libpng/libpng.xml
+++ b/scram-tools.file/tools/libpng/libpng.xml
@@ -1,10 +1,10 @@
-<tool name="libpng" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.libpng.org/"/>
   <lib name="png"/>
   <client>
-    <environment name="LIBPNG_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBPNG_BASE/lib"/>
-    <environment name="INCLUDE" default="$LIBPNG_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libtiff/libtiff.xml
+++ b/scram-tools.file/tools/libtiff/libtiff.xml
@@ -1,10 +1,10 @@
-<tool name="libtiff" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.libtiff.org/"/>
   <lib name="tiff"/>
   <client>
-    <environment name="LIBTIFF_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBTIFF_BASE/lib"/>
-    <environment name="INCLUDE" default="$LIBTIFF_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libtiff/libtiff.xml
+++ b/scram-tools.file/tools/libtiff/libtiff.xml
@@ -2,9 +2,9 @@
   <info url="http://www.libtiff.org/"/>
   <lib name="tiff"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libungif/libungif.xml
+++ b/scram-tools.file/tools/libungif/libungif.xml
@@ -2,9 +2,9 @@
   <info url="http://sourceforge.net/projects/libungif"/>
   <lib name="ungif"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libungif/libungif.xml
+++ b/scram-tools.file/tools/libungif/libungif.xml
@@ -1,10 +1,10 @@
-<tool name="libungif" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://sourceforge.net/projects/libungif"/>
   <lib name="ungif"/>
   <client>
-    <environment name="LIBUNGIF_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBUNGIF_BASE/lib"/>
-    <environment name="INCLUDE" default="$LIBUNGIF_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libunwind/libunwind.xml
+++ b/scram-tools.file/tools/libunwind/libunwind.xml
@@ -1,9 +1,9 @@
-<tool name="libunwind" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="unwind"/>
   <client>
-    <environment name="LIBUNWIND_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$LIBUNWIND_BASE/include"/>
-    <environment name="LIBDIR"       default="$LIBUNWIND_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libunwind/libunwind.xml
+++ b/scram-tools.file/tools/libunwind/libunwind.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="unwind"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libuuid/libuuid.xml
+++ b/scram-tools.file/tools/libuuid/libuuid.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="uuid"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libuuid/libuuid.xml
+++ b/scram-tools.file/tools/libuuid/libuuid.xml
@@ -1,9 +1,9 @@
-<tool name="libuuid" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="uuid"/>
   <client>
-    <environment name="LIBUUID_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBUUID_BASE/lib64"/>
-    <environment name="INCLUDE" default="$LIBUUID_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libxml2/libxml2.xml
+++ b/scram-tools.file/tools/libxml2/libxml2.xml
@@ -1,12 +1,12 @@
-<tool name="libxml2" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://xmlsoft.org/"/>
   <lib name="xml2"/>
   <client>
-    <environment name="LIBXML2_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBXML2_BASE/lib"/>
-    <environment name="INCLUDE" default="$LIBXML2_BASE/include/libxml2"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/libxml2"/>
   </client>
-  <runtime name="PATH" value="$LIBXML2_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libxml2/libxml2.xml
+++ b/scram-tools.file/tools/libxml2/libxml2.xml
@@ -2,11 +2,11 @@
   <info url="http://xmlsoft.org/"/>
   <lib name="xml2"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/libxml2"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/libxml2"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libxslt/libxslt.xml
+++ b/scram-tools.file/tools/libxslt/libxslt.xml
@@ -2,8 +2,8 @@
   <info url="http://xmlsoft.org/libxslt"/>
   <lib name="xslt"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/libxslt"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/libxslt"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libxslt/libxslt.xml
+++ b/scram-tools.file/tools/libxslt/libxslt.xml
@@ -1,9 +1,9 @@
-<tool name="libxslt" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://xmlsoft.org/libxslt"/>
   <lib name="xslt"/>
   <client>
-    <environment name="LIBXSLT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBXSLT_BASE/lib"/>
-    <environment name="INCLUDE" default="$LIBXSLT_BASE/include/libxslt"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/libxslt"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libzmq/libzmq.xml
+++ b/scram-tools.file/tools/libzmq/libzmq.xml
@@ -2,8 +2,8 @@
   <info url="https://zeromq.org"/>
   <lib name="zmq"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libzmq/libzmq.xml
+++ b/scram-tools.file/tools/libzmq/libzmq.xml
@@ -1,9 +1,9 @@
-<tool name="libzmq" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://zeromq.org"/>
   <lib name="zmq"/>
   <client>
-    <environment name="LIBZMQ_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LIBZMQ_BASE/lib"/>
-    <environment name="INCLUDE" default="$LIBZMQ_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/llvm/llvm.xml
+++ b/scram-tools.file/tools/llvm/llvm.xml
@@ -1,9 +1,9 @@
   <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <lib name="clang"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
     </client>
     <flags LDFLAGS="-Wl,-undefined -Wl,suppress"/>
     <flags CXXFLAGS="-D_DEBUG -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS"/>

--- a/scram-tools.file/tools/llvm/llvm.xml
+++ b/scram-tools.file/tools/llvm/llvm.xml
@@ -1,9 +1,9 @@
-  <tool name="llvm" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <lib name="clang"/>
     <client>
-      <environment name="LLVM_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$LLVM_BASE/lib64"/>
-      <environment name="INCLUDE" default="$LLVM_BASE/include"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
     </client>
     <flags LDFLAGS="-Wl,-undefined -Wl,suppress"/>
     <flags CXXFLAGS="-D_DEBUG -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS"/>

--- a/scram-tools.file/tools/log4cplus/log4cplus.xml
+++ b/scram-tools.file/tools/log4cplus/log4cplus.xml
@@ -1,8 +1,8 @@
-<tool name="log4cplus" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="log4cplusS"/>
   <client>
-    <environment name="LOG4CPLUS_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"        default="$LOG4CPLUS_BASE/include"/>
-    <environment name="LIBDIR"         default="$LOG4CPLUS_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/log4cplus/log4cplus.xml
+++ b/scram-tools.file/tools/log4cplus/log4cplus.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="log4cplusS"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/lwtnn/lwtnn.xml
+++ b/scram-tools.file/tools/lwtnn/lwtnn.xml
@@ -1,12 +1,12 @@
-<tool name="lwtnn" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/lwtnn/lwtnn"/>
   <lib name="lwtnn"/>
   <client>
-    <environment name="LWTNN_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$LWTNN_BASE/lib"/>
-    <environment name="INCLUDE" default="$LWTNN_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$LWTNN_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="eigen"/>

--- a/scram-tools.file/tools/lwtnn/lwtnn.xml
+++ b/scram-tools.file/tools/lwtnn/lwtnn.xml
@@ -2,11 +2,11 @@
   <info url="https://github.com/lwtnn/lwtnn"/>
   <lib name="lwtnn"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="eigen"/>

--- a/scram-tools.file/tools/lz4/lz4.xml
+++ b/scram-tools.file/tools/lz4/lz4.xml
@@ -1,12 +1,12 @@
-  <tool name="lz4" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="https://github.com/lz4/lz4"/>
     <lib name="lz4"/>
     <client>
-      <environment name="LZ4_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$LZ4_BASE/lib"/>
-      <environment name="INCLUDE" default="$LZ4_BASE/include"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
     </client>
-    <runtime name="PATH" value="$LZ4_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/lz4/lz4.xml
+++ b/scram-tools.file/tools/lz4/lz4.xml
@@ -2,11 +2,11 @@
     <info url="https://github.com/lz4/lz4"/>
     <lib name="lz4"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/madgraph5amcatnlo/madgraph5amcatnlo.xml
+++ b/scram-tools.file/tools/madgraph5amcatnlo/madgraph5amcatnlo.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@UC_TOOL@_BASE" type="path"/>
-  <runtime name="ROOT_PATH" value="$@UC_TOOL@_BASE" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@" type="path"/>
+  <runtime name="ROOT_PATH" value="$@TOOL_BASE@" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="gosamcontrib"/>
 </tool>

--- a/scram-tools.file/tools/madgraph5amcatnlo/madgraph5amcatnlo.xml
+++ b/scram-tools.file/tools/madgraph5amcatnlo/madgraph5amcatnlo.xml
@@ -1,9 +1,9 @@
-<tool name="madgraph5amcatnlo" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="MADGRAPH5AMCATNLO_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="ROOT_INCLUDE_PATH" value="$MADGRAPH5AMCATNLO_BASE" type="path"/>
-  <runtime name="ROOT_PATH" value="$MADGRAPH5AMCATNLO_BASE" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$@UC_TOOL@_BASE" type="path"/>
+  <runtime name="ROOT_PATH" value="$@UC_TOOL@_BASE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="gosamcontrib"/>
 </tool>

--- a/scram-tools.file/tools/mctester/mctester.xml
+++ b/scram-tools.file/tools/mctester/mctester.xml
@@ -1,11 +1,11 @@
-<tool name="mctester" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="HEPEvent"/>
   <lib name="HepMCEvent"/>
   <lib name="MCTester"/>
   <client>
-    <environment name="MCTESTER_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$MCTESTER_BASE/lib"/>
-    <environment name="INCLUDE" default="$MCTESTER_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/mctester/mctester.xml
+++ b/scram-tools.file/tools/mctester/mctester.xml
@@ -3,9 +3,9 @@
   <lib name="HepMCEvent"/>
   <lib name="MCTester"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/md5/md5.xml
+++ b/scram-tools.file/tools/md5/md5.xml
@@ -2,8 +2,8 @@
   <info url="https://tls.mbed.org/md5-source-code"/>
    <lib name="cms-md5"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
     </client>  
 </tool>

--- a/scram-tools.file/tools/md5/md5.xml
+++ b/scram-tools.file/tools/md5/md5.xml
@@ -1,9 +1,9 @@
-<tool name="md5" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://tls.mbed.org/md5-source-code"/>
    <lib name="cms-md5"/>
   <client>
-    <environment name="MD5_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$MD5_BASE/lib"/>
-    <environment name="INCLUDE" default="$MD5_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
     </client>  
 </tool>

--- a/scram-tools.file/tools/meschach/meschach.xml
+++ b/scram-tools.file/tools/meschach/meschach.xml
@@ -2,9 +2,9 @@
   <info url="http://www.meschach.com"/>
   <lib name="meschach"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/meschach/meschach.xml
+++ b/scram-tools.file/tools/meschach/meschach.xml
@@ -1,10 +1,10 @@
-<tool name="meschach" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.meschach.com"/>
   <lib name="meschach"/>
   <client>
-    <environment name="MESCHACH_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$MESCHACH_BASE/lib"/>
-    <environment name="INCLUDE" default="$MESCHACH_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/millepede/millepede.xml
+++ b/scram-tools.file/tools/millepede/millepede.xml
@@ -1,9 +1,9 @@
-<tool name="millepede" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.wiki.terascale.de/index.php/Millepede_II"/>
   <client>
-    <environment name="MILLEPEDE_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$MILLEPEDE_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <use name="sockets"/>
   <use name="pcre"/>
   <use name="zlib"/>

--- a/scram-tools.file/tools/millepede/millepede.xml
+++ b/scram-tools.file/tools/millepede/millepede.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.wiki.terascale.de/index.php/Millepede_II"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <use name="sockets"/>
   <use name="pcre"/>
   <use name="zlib"/>

--- a/scram-tools.file/tools/mozsearch/mozsearch.xml
+++ b/scram-tools.file/tools/mozsearch/mozsearch.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="1.0" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib64"/>
   </client>
   <flags INDEX_FLAGS="
     -Xclang -load

--- a/scram-tools.file/tools/mozsearch/mozsearch.xml
+++ b/scram-tools.file/tools/mozsearch/mozsearch.xml
@@ -1,7 +1,7 @@
-<tool name="mozsearch" version="1.0" revision="1">
+<tool name="@TOOL@" version="1.0" revision="2">
   <client>
-    <environment name="MOZSEARCH_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$MOZSEARCH_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib64"/>
   </client>
   <flags INDEX_FLAGS="
     -Xclang -load

--- a/scram-tools.file/tools/mpi/mpi.xml
+++ b/scram-tools.file/tools/mpi/mpi.xml
@@ -1,3 +1,3 @@
-<tool name="mpi" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <use name="openmpi"/>
 </tool>

--- a/scram-tools.file/tools/mpich/mpich.xml
+++ b/scram-tools.file/tools/mpich/mpich.xml
@@ -2,9 +2,9 @@
   <lib name="mpi"/>
   <lib name="mpicxx"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"     default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"    default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"     default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"    default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/mpich/mpich.xml
+++ b/scram-tools.file/tools/mpich/mpich.xml
@@ -1,10 +1,10 @@
-<tool name="mpich" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="mpi"/>
   <lib name="mpicxx"/>
   <client>
-    <environment name="MPICH_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"     default="$MPICH_BASE/lib"/>
-    <environment name="INCLUDE"    default="$MPICH_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"     default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"    default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$MPICH_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/mxnet-predict/mxnet-predict.xml
+++ b/scram-tools.file/tools/mxnet-predict/mxnet-predict.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="mxnet"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="openblas"/>
   <flags SYSTEM_INCLUDE="1"/>

--- a/scram-tools.file/tools/mxnet-predict/mxnet-predict.xml
+++ b/scram-tools.file/tools/mxnet-predict/mxnet-predict.xml
@@ -1,9 +1,9 @@
-<tool name="mxnet-predict" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="mxnet"/>
   <client>
-    <environment name="MXNET_PREDICT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$MXNET_PREDICT_BASE/include"/>
-    <environment name="LIBDIR" default="$MXNET_PREDICT_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="openblas"/>
   <flags SYSTEM_INCLUDE="1"/>

--- a/scram-tools.file/tools/numactl/numactl.xml
+++ b/scram-tools.file/tools/numactl/numactl.xml
@@ -1,10 +1,10 @@
-<tool name="numactl" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="numa"/>
   <client>
-    <environment name="NUMACTL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$NUMACTL_BASE/include"/>
-    <environment name="LIBDIR"       default="$NUMACTL_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$NUMACTL_BASE/bin" type="path"/>
-  <runtime name="MANPATH" value="$NUMACTL_BASE/share/man" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="MANPATH" value="$@UC_TOOL@_BASE/share/man" type="path"/>
 </tool>

--- a/scram-tools.file/tools/numactl/numactl.xml
+++ b/scram-tools.file/tools/numactl/numactl.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="numa"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
-  <runtime name="MANPATH" value="$@UC_TOOL@_BASE/share/man" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="MANPATH" value="$@TOOL_BASE@/share/man" type="path"/>
 </tool>

--- a/scram-tools.file/tools/onnxruntime/onnxruntime.xml
+++ b/scram-tools.file/tools/onnxruntime/onnxruntime.xml
@@ -1,9 +1,9 @@
-<tool name="onnxruntime" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="onnxruntime"/>
   <client>
-    <environment name="ONNXRUNTIME_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$ONNXRUNTIME_BASE/include"/>
-    <environment name="LIBDIR" default="$ONNXRUNTIME_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="protobuf"/>
   <ifarchitecture name="!slc7_aarch64">

--- a/scram-tools.file/tools/onnxruntime/onnxruntime.xml
+++ b/scram-tools.file/tools/onnxruntime/onnxruntime.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="onnxruntime"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="protobuf"/>
   <ifarchitecture name="!slc7_aarch64">

--- a/scram-tools.file/tools/opencl-cpp/opencl-cpp.xml
+++ b/scram-tools.file/tools/opencl-cpp/opencl-cpp.xml
@@ -1,8 +1,8 @@
-<tool name="opencl-cpp" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.khronos.org/registry/cl/"/>
   <client>
-    <environment name="OPENCL_CPP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$OPENCL_CPP_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="opencl"/>
 </tool>

--- a/scram-tools.file/tools/opencl-cpp/opencl-cpp.xml
+++ b/scram-tools.file/tools/opencl-cpp/opencl-cpp.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.khronos.org/registry/cl/"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="opencl"/>
 </tool>

--- a/scram-tools.file/tools/opencl/opencl.xml
+++ b/scram-tools.file/tools/opencl/opencl.xml
@@ -1,9 +1,9 @@
-<tool name="opencl" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://www.khronos.org/opencl/"/>
   <lib name="OpenCL"/>
   <client>
-    <environment name="OPENCL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$OPENCL_BASE/lib64"/>
-    <environment name="INCLUDE" default="$OPENCL_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/opencl/opencl.xml
+++ b/scram-tools.file/tools/opencl/opencl.xml
@@ -2,8 +2,8 @@
   <info url="https://www.khronos.org/opencl/"/>
   <lib name="OpenCL"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/opencv/opencv.xml
+++ b/scram-tools.file/tools/opencv/opencv.xml
@@ -1,10 +1,10 @@
-<tool name="opencv" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="opencv_core"/>
   <client>
-    <environment name="OPENCV_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$OPENCV_BASE/include"/>
-    <environment name="LIBDIR" default="$OPENCV_BASE/lib"/>
-    <environment name="BINDIR" default="$OPENCV_BASE/bin"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
   </client>
   <use name="libpng"/>
   <use name="libjpeg-turbo"/>

--- a/scram-tools.file/tools/opencv/opencv.xml
+++ b/scram-tools.file/tools/opencv/opencv.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="opencv_core"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
   </client>
   <use name="libpng"/>
   <use name="libjpeg-turbo"/>

--- a/scram-tools.file/tools/openldap/openldap.xml
+++ b/scram-tools.file/tools/openldap/openldap.xml
@@ -1,7 +1,7 @@
-<tool name="openldap" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="OPENLDAP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$OPENLDAP_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="db6"/>
 </tool>

--- a/scram-tools.file/tools/openldap/openldap.xml
+++ b/scram-tools.file/tools/openldap/openldap.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="db6"/>
 </tool>

--- a/scram-tools.file/tools/openloops/openloops.xml
+++ b/scram-tools.file/tools/openloops/openloops.xml
@@ -1,7 +1,7 @@
-<tool name="openloops" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
 <client>
-<environment name="OPENLOOPS_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$OPENLOOPS_BASE/lib"/>
-<runtime name="CMS_OPENLOOPS_PREFIX" value="$OPENLOOPS_BASE" type="path"/>
+<environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+<environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+<runtime name="CMS_OPENLOOPS_PREFIX" value="$@UC_TOOL@_BASE" type="path"/>
 </client>
 </tool>

--- a/scram-tools.file/tools/openloops/openloops.xml
+++ b/scram-tools.file/tools/openloops/openloops.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
 <client>
-<environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-<runtime name="CMS_OPENLOOPS_PREFIX" value="$@UC_TOOL@_BASE" type="path"/>
+<environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+<environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+<runtime name="CMS_OPENLOOPS_PREFIX" value="$@TOOL_BASE@" type="path"/>
 </client>
 </tool>

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -2,10 +2,10 @@
   <lib name="mpi"/>
   <lib name="mpi_cxx"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
-  <runtime name="OPAL_PREFIX" value="$@UC_TOOL@_BASE"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="OPAL_PREFIX" value="$@TOOL_BASE@"/>
 </tool>

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -1,11 +1,11 @@
-<tool name="openmpi" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="mpi"/>
   <lib name="mpi_cxx"/>
   <client>
-    <environment name="OPENMPI_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$OPENMPI_BASE/lib"/>
-    <environment name="INCLUDE"      default="$OPENMPI_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"      default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$OPENMPI_BASE/bin" type="path"/>
-  <runtime name="OPAL_PREFIX" value="$OPENMPI_BASE"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="OPAL_PREFIX" value="$@UC_TOOL@_BASE"/>
 </tool>

--- a/scram-tools.file/tools/oracle/oracle.xml
+++ b/scram-tools.file/tools/oracle/oracle.xml
@@ -2,11 +2,11 @@
   <lib name="clntsh"/>
   @OS_LIBS@
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     <environment name="ORACLE_ADMINDIR" value="@ORACLE_ENV_ROOT@/etc"/>
-    <environment name="LIBDIR" value="$@UC_TOOL@_BASE/lib"/>
-    <environment name="BINDIR" value="$@UC_TOOL@_BASE/bin"/>
-    <environment name="INCLUDE" value="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" value="$@TOOL_BASE@/lib"/>
+    <environment name="BINDIR" value="$@TOOL_BASE@/bin"/>
+    <environment name="INCLUDE" value="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="TNS_ADMIN" default="$ORACLE_ADMINDIR"/>

--- a/scram-tools.file/tools/oracle/oracle.xml
+++ b/scram-tools.file/tools/oracle/oracle.xml
@@ -1,12 +1,12 @@
-<tool name="oracle" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="clntsh"/>
   @OS_LIBS@
   <client>
-    <environment name="ORACLE_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
     <environment name="ORACLE_ADMINDIR" value="@ORACLE_ENV_ROOT@/etc"/>
-    <environment name="LIBDIR" value="$ORACLE_BASE/lib"/>
-    <environment name="BINDIR" value="$ORACLE_BASE/bin"/>
-    <environment name="INCLUDE" value="$ORACLE_BASE/include"/>
+    <environment name="LIBDIR" value="$@UC_TOOL@_BASE/lib"/>
+    <environment name="BINDIR" value="$@UC_TOOL@_BASE/bin"/>
+    <environment name="INCLUDE" value="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="TNS_ADMIN" default="$ORACLE_ADMINDIR"/>

--- a/scram-tools.file/tools/pacparser/pacparser.xml
+++ b/scram-tools.file/tools/pacparser/pacparser.xml
@@ -1,12 +1,12 @@
-<tool name="pacparser" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://code.google.com/p/pacparser/"/>
   <lib name="pacparser"/>
   <client>
-    <environment name="PACPARSER_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PACPARSER_BASE/lib"/>
-    <environment name="INCLUDE" default="$PACPARSER_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$PACPARSER_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/pacparser/pacparser.xml
+++ b/scram-tools.file/tools/pacparser/pacparser.xml
@@ -2,11 +2,11 @@
   <info url="http://code.google.com/p/pacparser/"/>
   <lib name="pacparser"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/pcm_util/pcm_util.xml
+++ b/scram-tools.file/tools/pcm_util/pcm_util.xml
@@ -1,14 +1,14 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/clhep" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/boost" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/tinyxml2" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/cuda" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/tbb" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/HepMC" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/pybind11" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/clhep" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/boost" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/tinyxml2" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/cuda" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/tbb" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/HepMC" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/pybind11" type="path"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@HEPMC_ROOT@/include/hepmc.modulemap" type="path" handler="warn"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@CLHEP_ROOT@/include/clhep.modulemap" type="path" handler="warn"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@TBB_ROOT@/include/module.modulemap" type="path" handler="warn"/>

--- a/scram-tools.file/tools/pcm_util/pcm_util.xml
+++ b/scram-tools.file/tools/pcm_util/pcm_util.xml
@@ -1,14 +1,14 @@
-<tool name="pcm_util" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="PCM_UTIL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$PCM_UTIL_BASE/lib/clhep" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$PCM_UTIL_BASE/lib/boost" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$PCM_UTIL_BASE/lib/tinyxml2" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$PCM_UTIL_BASE/lib/cuda" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$PCM_UTIL_BASE/lib/tbb" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$PCM_UTIL_BASE/lib/HepMC" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$PCM_UTIL_BASE/lib/pybind11" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/clhep" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/boost" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/tinyxml2" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/cuda" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/tbb" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/HepMC" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@UC_TOOL@_BASE/lib/pybind11" type="path"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@HEPMC_ROOT@/include/hepmc.modulemap" type="path" handler="warn"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@CLHEP_ROOT@/include/clhep.modulemap" type="path" handler="warn"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@TBB_ROOT@/include/module.modulemap" type="path" handler="warn"/>

--- a/scram-tools.file/tools/pcre/pcre.xml
+++ b/scram-tools.file/tools/pcre/pcre.xml
@@ -1,10 +1,10 @@
-<tool name="pcre" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.pcre.org"/>
   <lib name="pcre"/>
   <client>
-    <environment name="PCRE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PCRE_BASE/lib"/>
-    <environment name="INCLUDE" default="$PCRE_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/pcre/pcre.xml
+++ b/scram-tools.file/tools/pcre/pcre.xml
@@ -2,9 +2,9 @@
   <info url="http://www.pcre.org"/>
   <lib name="pcre"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/pcre2/pcre2.xml
+++ b/scram-tools.file/tools/pcre2/pcre2.xml
@@ -2,9 +2,9 @@
   <info url="http://www.pcre.org"/>
   <lib name="pcre2"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/pcre2/pcre2.xml
+++ b/scram-tools.file/tools/pcre2/pcre2.xml
@@ -1,10 +1,10 @@
-<tool name="pcre2" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.pcre.org"/>
   <lib name="pcre2"/>
   <client>
-    <environment name="PCRE2_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PCRE2_BASE/lib"/>
-    <environment name="INCLUDE" default="$PCRE2_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/photospp/photospp.xml
+++ b/scram-tools.file/tools/photospp/photospp.xml
@@ -1,12 +1,12 @@
-<tool name="photospp" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <lib name="Photospp"/>
   <lib name="PhotosppHepMC"/>
   <lib name="PhotosppHepMC3"/>
   <lib name="PhotosppHEPEVT"/>
   <client>
-    <environment name="PHOTOSPP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PHOTOSPP_BASE/lib"/>
-    <environment name="INCLUDE" default="$PHOTOSPP_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="hepmc"/>
   <use name="hepmc3"/>

--- a/scram-tools.file/tools/photospp/photospp.xml
+++ b/scram-tools.file/tools/photospp/photospp.xml
@@ -4,9 +4,9 @@
   <lib name="PhotosppHepMC3"/>
   <lib name="PhotosppHEPEVT"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="hepmc"/>
   <use name="hepmc3"/>

--- a/scram-tools.file/tools/professor2/professor2.xml
+++ b/scram-tools.file/tools/professor2/professor2.xml
@@ -1,11 +1,11 @@
-<tool name="professor2" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
 <client>
-<environment name="PROFESSOR2_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$PROFESSOR2_BASE/lib"/>
+<environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+<environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
 </client>
 <use name="py3-numpy"/>
 <use name="root"/>
 <use name="yoda"/>
 <use name="eigen"/>
-<runtime name="PATH" value="$PROFESSOR2_BASE/bin" type="path"/>
+<runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/professor2/professor2.xml
+++ b/scram-tools.file/tools/professor2/professor2.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
 <client>
-<environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+<environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+<environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
 </client>
 <use name="py3-numpy"/>
 <use name="root"/>
 <use name="yoda"/>
 <use name="eigen"/>
-<runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+<runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/protobuf/protobuf.xml
+++ b/scram-tools.file/tools/protobuf/protobuf.xml
@@ -1,12 +1,12 @@
-<tool name="protobuf" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="protobuf"/>
   <client>
-    <environment name="PROTOBUF_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$PROTOBUF_BASE/include"/>
-    <environment name="LIBDIR" default="$PROTOBUF_BASE/lib"/>
-    <environment name="BINDIR" default="$PROTOBUF_BASE/bin"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
   </client>
-  <runtime name="PATH" value="$PROTOBUF_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/protobuf/protobuf.xml
+++ b/scram-tools.file/tools/protobuf/protobuf.xml
@@ -1,12 +1,12 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="protobuf"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/py3-dxr/py3-dxr.xml
+++ b/scram-tools.file/tools/py3-dxr/py3-dxr.xml
@@ -1,7 +1,7 @@
-<tool name="py3-dxr" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="PY3_DXR_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PY3_DXR_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$PY3_DXR_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-dxr/py3-dxr.xml
+++ b/scram-tools.file/tools/py3-dxr/py3-dxr.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-numpy/py3-numpy.xml
+++ b/scram-tools.file/tools/py3-numpy/py3-numpy.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-numpy/py3-numpy.xml
+++ b/scram-tools.file/tools/py3-numpy/py3-numpy.xml
@@ -1,6 +1,6 @@
-<tool name="py3-numpy" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="PY3_NUMPY_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$PY3_NUMPY_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-pybind11/py3-pybind11.xml
+++ b/scram-tools.file/tools/py3-pybind11/py3-pybind11.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/@PYTHON3_LIB_SITE_PACKAGES@/pybind11/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/@PYTHON3_LIB_SITE_PACKAGES@/pybind11/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/py3-pybind11/py3-pybind11.xml
+++ b/scram-tools.file/tools/py3-pybind11/py3-pybind11.xml
@@ -1,6 +1,6 @@
-<tool name="py3-pybind11" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="PY3_PYBIND11_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$PY3_PYBIND11_BASE/@PYTHON3_LIB_SITE_PACKAGES@/pybind11/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/@PYTHON3_LIB_SITE_PACKAGES@/pybind11/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/py3-tensorflow/py3-tensorflow.xml
+++ b/scram-tools.file/tools/py3-tensorflow/py3-tensorflow.xml
@@ -1,6 +1,6 @@
-<tool name="py3-tensorflow" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="PY3_TENSORFLOW_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$PY3_TENSORFLOW_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-tensorflow/py3-tensorflow.xml
+++ b/scram-tools.file/tools/py3-tensorflow/py3-tensorflow.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/pyquen/pyquen.xml
+++ b/scram-tools.file/tools/pyquen/pyquen.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="pyquen"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="pythia6"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/pyquen/pyquen.xml
+++ b/scram-tools.file/tools/pyquen/pyquen.xml
@@ -1,8 +1,8 @@
-<tool name="pyquen" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="pyquen"/>
   <client>
-    <environment name="PYQUEN_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PYQUEN_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="pythia6"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/pythia6/pythia6.xml
+++ b/scram-tools.file/tools/pythia6/pythia6.xml
@@ -1,9 +1,9 @@
-<tool name="pythia6" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <lib name="pythia6"/>
   <lib name="pythia6_dummy"/>
   <client>
-    <environment name="PYTHIA6_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PYTHIA6_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="lhapdf"/>
   <use name="pythia6_headers"/>

--- a/scram-tools.file/tools/pythia6/pythia6.xml
+++ b/scram-tools.file/tools/pythia6/pythia6.xml
@@ -2,8 +2,8 @@
   <lib name="pythia6"/>
   <lib name="pythia6_dummy"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="lhapdf"/>
   <use name="pythia6_headers"/>

--- a/scram-tools.file/tools/pythia8/pythia8.xml
+++ b/scram-tools.file/tools/pythia8/pythia8.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="pythia8"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PYTHIA8DATA" value="$@UC_TOOL@_BASE/share/Pythia8/xmldoc"/>
+  <runtime name="PYTHIA8DATA" value="$@TOOL_BASE@/share/Pythia8/xmldoc"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="hepmc3"/>

--- a/scram-tools.file/tools/pythia8/pythia8.xml
+++ b/scram-tools.file/tools/pythia8/pythia8.xml
@@ -1,11 +1,11 @@
-<tool name="pythia8" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="pythia8"/>
   <client>
-    <environment name="PYTHIA8_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PYTHIA8_BASE/lib"/>
-    <environment name="INCLUDE" default="$PYTHIA8_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PYTHIA8DATA" value="$PYTHIA8_BASE/share/Pythia8/xmldoc"/>
+  <runtime name="PYTHIA8DATA" value="$@UC_TOOL@_BASE/share/Pythia8/xmldoc"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="hepmc3"/>

--- a/scram-tools.file/tools/python/python.xml
+++ b/scram-tools.file/tools/python/python.xml
@@ -1,14 +1,14 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="python@PYTHONV@"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/python@PYTHONV@"/>
-    <environment name="PYTHON_COMPILE" default="$@UC_TOOL@_BASE/lib/python@PYTHONV@/compileall.py"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/python@PYTHONV@"/>
+    <environment name="PYTHON_COMPILE" default="$@TOOL_BASE@/lib/python@PYTHONV@/compileall.py"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PYTHON_VALGRIND_SUPP" value="$@UC_TOOL@_BASE/share/valgrind/valgrind-python.supp" type="path"/>
+  <runtime name="PYTHON_VALGRIND_SUPP" value="$@TOOL_BASE@/share/valgrind/valgrind-python.supp" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/python/python.xml
+++ b/scram-tools.file/tools/python/python.xml
@@ -1,14 +1,14 @@
-<tool name="python" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="python@PYTHONV@"/>
   <client>
-    <environment name="PYTHON_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PYTHON_BASE/lib"/>
-    <environment name="INCLUDE" default="$PYTHON_BASE/include/python@PYTHONV@"/>
-    <environment name="PYTHON_COMPILE" default="$PYTHON_BASE/lib/python@PYTHONV@/compileall.py"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/python@PYTHONV@"/>
+    <environment name="PYTHON_COMPILE" default="$@UC_TOOL@_BASE/lib/python@PYTHONV@/compileall.py"/>
   </client>
-  <runtime name="PATH" value="$PYTHON_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PYTHON_VALGRIND_SUPP" value="$PYTHON_BASE/share/valgrind/valgrind-python.supp" type="path"/>
+  <runtime name="PYTHON_VALGRIND_SUPP" value="$@UC_TOOL@_BASE/share/valgrind/valgrind-python.supp" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/python3/python3.xml
+++ b/scram-tools.file/tools/python3/python3.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="python@PYTHON3V@"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/python@PYTHON3V@"/>
-    <environment name="PYTHON3_COMPILE" default="$@UC_TOOL@_BASE/lib/python@PYTHON3V@/compileall.py"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/python@PYTHON3V@"/>
+    <environment name="PYTHON3_COMPILE" default="$@TOOL_BASE@/lib/python@PYTHON3V@/compileall.py"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/python3/python3.xml
+++ b/scram-tools.file/tools/python3/python3.xml
@@ -1,11 +1,11 @@
-<tool name="python3" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="python@PYTHON3V@"/>
   <client>
-    <environment name="PYTHON3_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$PYTHON3_BASE/lib"/>
-    <environment name="INCLUDE" default="$PYTHON3_BASE/include/python@PYTHON3V@"/>
-    <environment name="PYTHON3_COMPILE" default="$PYTHON3_BASE/lib/python@PYTHON3V@/compileall.py"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/python@PYTHON3V@"/>
+    <environment name="PYTHON3_COMPILE" default="$@UC_TOOL@_BASE/lib/python@PYTHON3V@/compileall.py"/>
   </client>
-  <runtime name="PATH" value="$PYTHON3_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/python_tools/python_tools.xml
+++ b/scram-tools.file/tools/python_tools/python_tools.xml
@@ -1,2 +1,2 @@
-<tool name="python_tools" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
 </tool>

--- a/scram-tools.file/tools/pytorch-cluster/pytorch-cluster.xml
+++ b/scram-tools.file/tools/pytorch-cluster/pytorch-cluster.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/torchcluster/"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torchcluster/"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchcluster"/>

--- a/scram-tools.file/tools/pytorch-cluster/pytorch-cluster.xml
+++ b/scram-tools.file/tools/pytorch-cluster/pytorch-cluster.xml
@@ -1,9 +1,9 @@
-<tool name="pytorch-cluster" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <client>
-    <environment name="PYTORCH_CLUSTER_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$PYTORCH_CLUSTER_BASE/include"/>
-    <environment name="INCLUDE" default="$PYTORCH_CLUSTER_BASE/include/torchcluster/"/>
-    <environment name="LIBDIR" default="$PYTORCH_CLUSTER_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/torchcluster/"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchcluster"/>

--- a/scram-tools.file/tools/pytorch-custom-ops/pytorch-custom-ops.xml
+++ b/scram-tools.file/tools/pytorch-custom-ops/pytorch-custom-ops.xml
@@ -1,4 +1,4 @@
-<tool name="pytorch-custom-ops" version="1.0" revision="1">
+<tool name="@TOOL@" version="1.0" revision="2">
     <use name="pytorch"/>
     <use name="pytorch-scatter"/>
     <use name="pytorch-cluster"/>

--- a/scram-tools.file/tools/pytorch-scatter/pytorch-scatter.xml
+++ b/scram-tools.file/tools/pytorch-scatter/pytorch-scatter.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/torchscatter/"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torchscatter/"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchscatter"/>

--- a/scram-tools.file/tools/pytorch-scatter/pytorch-scatter.xml
+++ b/scram-tools.file/tools/pytorch-scatter/pytorch-scatter.xml
@@ -1,9 +1,9 @@
-<tool name="pytorch-scatter" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <client>
-    <environment name="PYTORCH_SCATTER_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$PYTORCH_SCATTER_BASE/include"/>
-    <environment name="INCLUDE" default="$PYTORCH_SCATTER_BASE/include/torchscatter/"/>
-    <environment name="LIBDIR" default="$PYTORCH_SCATTER_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/torchscatter/"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchscatter"/>

--- a/scram-tools.file/tools/pytorch-sparse/pytorch-sparse.xml
+++ b/scram-tools.file/tools/pytorch-sparse/pytorch-sparse.xml
@@ -1,9 +1,9 @@
-<tool name="pytorch-sparse" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <client>
-    <environment name="PYTORCH_SPARSE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$PYTORCH_SPARSE_BASE/include"/>
-    <environment name="INCLUDE" default="$PYTORCH_SPARSE_BASE/include/torchsparse/"/>
-    <environment name="LIBDIR" default="$PYTORCH_SPARSE_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/torchsparse/"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchsparse"/>

--- a/scram-tools.file/tools/pytorch-sparse/pytorch-sparse.xml
+++ b/scram-tools.file/tools/pytorch-sparse/pytorch-sparse.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/torchsparse/"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torchsparse/"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchsparse"/>

--- a/scram-tools.file/tools/pytorch/pytorch.xml
+++ b/scram-tools.file/tools/pytorch/pytorch.xml
@@ -1,4 +1,4 @@
-<tool name="pytorch" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <lib name="torch"/>
   <lib name="torch_cpu"/>
   <lib name="c10"/>

--- a/scram-tools.file/tools/qd/qd.xml
+++ b/scram-tools.file/tools/qd/qd.xml
@@ -1,9 +1,9 @@
-<tool name="qd" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="qdmod"/>
   <lib name="qd"/>
   <client>
-    <environment name="QD_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$QD_BASE/lib"/>
-    <environment name="INCLUDE" default="$QD_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/qd/qd.xml
+++ b/scram-tools.file/tools/qd/qd.xml
@@ -2,8 +2,8 @@
   <lib name="qdmod"/>
   <lib name="qd"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/rdma-core/rdma-core.xml
+++ b/scram-tools.file/tools/rdma-core/rdma-core.xml
@@ -1,11 +1,11 @@
-<tool name="rdma-core" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
   <client>
-    <environment name="RDMA_CORE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$RDMA_CORE_BASE/lib64"/>
-    <environment name="INCLUDE"        default="$RDMA_CORE_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$RDMA_CORE_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="VERBS_CONFIG_DIR" value="$RDMA_CORE_BASE/etc/libibverbs.d" type="path"/>
+  <runtime name="VERBS_CONFIG_DIR" value="$@UC_TOOL@_BASE/etc/libibverbs.d" type="path"/>
 </tool>

--- a/scram-tools.file/tools/rdma-core/rdma-core.xml
+++ b/scram-tools.file/tools/rdma-core/rdma-core.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE"        default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="VERBS_CONFIG_DIR" value="$@UC_TOOL@_BASE/etc/libibverbs.d" type="path"/>
+  <runtime name="VERBS_CONFIG_DIR" value="$@TOOL_BASE@/etc/libibverbs.d" type="path"/>
 </tool>

--- a/scram-tools.file/tools/re2/re2.xml
+++ b/scram-tools.file/tools/re2/re2.xml
@@ -1,10 +1,10 @@
-<tool name="re2" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/google/re2"/>
   <lib name="re2"/>
   <client>
-    <environment name="RE2_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$RE2_BASE/lib"/>
-    <environment name="INCLUDE" default="$RE2_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>
 

--- a/scram-tools.file/tools/re2/re2.xml
+++ b/scram-tools.file/tools/re2/re2.xml
@@ -2,9 +2,9 @@
   <info url="https://github.com/google/re2"/>
   <lib name="re2"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>
 

--- a/scram-tools.file/tools/rivet/rivet.xml
+++ b/scram-tools.file/tools/rivet/rivet.xml
@@ -1,13 +1,13 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="Rivet"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
-  <runtime name="RIVET_DATA_PATH" value="$@UC_TOOL@_BASE/share/Rivet" type="path"/>
-  <runtime name="PDFPATH" default="$@UC_TOOL@_BASE/share" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="RIVET_DATA_PATH" value="$@TOOL_BASE@/share/Rivet" type="path"/>
+  <runtime name="PDFPATH" default="$@TOOL_BASE@/share" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="hepmc"/>
   <use name="fastjet"/>

--- a/scram-tools.file/tools/rivet/rivet.xml
+++ b/scram-tools.file/tools/rivet/rivet.xml
@@ -1,13 +1,13 @@
-<tool name="rivet" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="Rivet"/>
   <client>
-    <environment name="RIVET_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$RIVET_BASE/lib"/>
-    <environment name="INCLUDE" default="$RIVET_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$RIVET_BASE/bin" type="path"/>
-  <runtime name="RIVET_DATA_PATH" value="$RIVET_BASE/share/Rivet" type="path"/>
-  <runtime name="PDFPATH" default="$RIVET_BASE/share" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="RIVET_DATA_PATH" value="$@UC_TOOL@_BASE/share/Rivet" type="path"/>
+  <runtime name="PDFPATH" default="$@UC_TOOL@_BASE/share" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="hepmc"/>
   <use name="fastjet"/>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -1,14 +1,14 @@
-<tool name="rocm" version="@TOOL_VERSION@" revision="5">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="6">
   <info url="https://rocm.docs.amd.com/en/docs-@TOOL_VERSION@/"/>
   <lib name="amdhip64"/>
   <lib name="hsa-runtime64"/>
   <lib name="rocm_smi64"/>
   <client>
-    <environment name="ROCM_BASE" default="@TOOL_ROOT@"/>
-    <environment name="HIPCC"     default="$ROCM_BASE/bin/hipcc"/>
-    <environment name="BINDIR"    default="$ROCM_BASE/bin"/>
-    <environment name="LIBDIR"    default="$ROCM_BASE/lib"/>
-    <environment name="INCLUDE"   default="$ROCM_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="HIPCC"     default="$@UC_TOOL@_BASE/bin/hipcc"/>
+    <environment name="BINDIR"    default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="LIBDIR"    default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"   default="$@UC_TOOL@_BASE/include"/>
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
   <flags ROCM_FLAGS="@ROCM_FLAGS@"/>
@@ -22,7 +22,7 @@
   <!-- use -isystem instead of -I to silence warnings in the HIP/ROCm headers -->
   <flags SYSTEM_INCLUDE="1"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>
-  <runtime name="PATH" value="$ROCM_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="HSA_XNACK" value="1"/>
   <use name="fmt"/>
 </tool>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -4,11 +4,11 @@
   <lib name="hsa-runtime64"/>
   <lib name="rocm_smi64"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="HIPCC"     default="$@UC_TOOL@_BASE/bin/hipcc"/>
-    <environment name="BINDIR"    default="$@UC_TOOL@_BASE/bin"/>
-    <environment name="LIBDIR"    default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"   default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="HIPCC"     default="$@TOOL_BASE@/bin/hipcc"/>
+    <environment name="BINDIR"    default="$@TOOL_BASE@/bin"/>
+    <environment name="LIBDIR"    default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
   <flags ROCM_FLAGS="@ROCM_FLAGS@"/>
@@ -22,7 +22,7 @@
   <!-- use -isystem instead of -I to silence warnings in the HIP/ROCm headers -->
   <flags SYSTEM_INCLUDE="1"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="HSA_XNACK" value="1"/>
   <use name="fmt"/>
 </tool>

--- a/scram-tools.file/tools/root/root.xml
+++ b/scram-tools.file/tools/root/root.xml
@@ -1,4 +1,4 @@
-<tool name="root" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://root.cern.ch/root/"/>
   <use name="rootphysics"/>
   <flags GENREFLEX_FAILES_ON_WARNS="-failOnWarnings"/>

--- a/scram-tools.file/tools/ruff/ruff.xml
+++ b/scram-tools.file/tools/ruff/ruff.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.astral.sh/ruff/"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>
 

--- a/scram-tools.file/tools/ruff/ruff.xml
+++ b/scram-tools.file/tools/ruff/ruff.xml
@@ -1,8 +1,8 @@
-<tool name="ruff" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://docs.astral.sh/ruff/"/>
   <client>
-    <environment name="RUFF_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$RUFF_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>
 

--- a/scram-tools.file/tools/scitokens-cpp/scitokens-cpp.xml
+++ b/scram-tools.file/tools/scitokens-cpp/scitokens-cpp.xml
@@ -1,4 +1,4 @@
-<tool name="scitokens-cpp" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="SciTokens"/>
   <client>
     <environment name="LIBSCITOKENS_BASE" default="@TOOL_ROOT@"/>

--- a/scram-tools.file/tools/sherpa/sherpa.xml
+++ b/scram-tools.file/tools/sherpa/sherpa.xml
@@ -3,16 +3,16 @@
   <lib name="ToolsMath"/>
   <lib name="ToolsOrg"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/SHERPA-MC"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/SHERPA-MC"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/SHERPA-MC"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/SHERPA-MC"/>
   </client>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include" type="path"/>
-  <runtime name="SHERPA_SHARE_PATH" value="$@UC_TOOL@_BASE/share/SHERPA-MC" type="path"/>
-  <runtime name="SHERPA_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include/SHERPA-MC" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@TOOL_BASE@/include" type="path"/>
+  <runtime name="SHERPA_SHARE_PATH" value="$@TOOL_BASE@/share/SHERPA-MC" type="path"/>
+  <runtime name="SHERPA_INCLUDE_PATH" value="$@TOOL_BASE@/include/SHERPA-MC" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="SHERPA_LIBRARY_PATH" value="$@UC_TOOL@_BASE/lib/SHERPA-MC" type="path"/>
+  <runtime name="SHERPA_LIBRARY_PATH" value="$@TOOL_BASE@/lib/SHERPA-MC" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="HepMC"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/sherpa/sherpa.xml
+++ b/scram-tools.file/tools/sherpa/sherpa.xml
@@ -1,18 +1,18 @@
-<tool name="sherpa" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="SherpaMain"/>
   <lib name="ToolsMath"/>
   <lib name="ToolsOrg"/>
   <client>
-    <environment name="SHERPA_BASE" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$SHERPA_BASE/bin"/>
-    <environment name="LIBDIR" default="$SHERPA_BASE/lib/SHERPA-MC"/>
-    <environment name="INCLUDE" default="$SHERPA_BASE/include/SHERPA-MC"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/SHERPA-MC"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/SHERPA-MC"/>
   </client>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$SHERPA_BASE/include" type="path"/>
-  <runtime name="SHERPA_SHARE_PATH" value="$SHERPA_BASE/share/SHERPA-MC" type="path"/>
-  <runtime name="SHERPA_INCLUDE_PATH" value="$SHERPA_BASE/include/SHERPA-MC" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include" type="path"/>
+  <runtime name="SHERPA_SHARE_PATH" value="$@UC_TOOL@_BASE/share/SHERPA-MC" type="path"/>
+  <runtime name="SHERPA_INCLUDE_PATH" value="$@UC_TOOL@_BASE/include/SHERPA-MC" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="SHERPA_LIBRARY_PATH" value="$SHERPA_BASE/lib/SHERPA-MC" type="path"/>
+  <runtime name="SHERPA_LIBRARY_PATH" value="$@UC_TOOL@_BASE/lib/SHERPA-MC" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="HepMC"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/sigcpp/sigcpp.xml
+++ b/scram-tools.file/tools/sigcpp/sigcpp.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="sigc-3.0"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/sigc++-3.0"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/sigc++-3.0"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/sigcpp/sigcpp.xml
+++ b/scram-tools.file/tools/sigcpp/sigcpp.xml
@@ -1,9 +1,9 @@
-<tool name="sigcpp" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="sigc-3.0"/>
   <client>
-    <environment name="SIGCPP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$SIGCPP_BASE/lib"/>
-    <environment name="INCLUDE" default="$SIGCPP_BASE/include/sigc++-3.0"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/sigc++-3.0"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/sloccount/sloccount.xml
+++ b/scram-tools.file/tools/sloccount/sloccount.xml
@@ -1,7 +1,7 @@
-  <tool name="sloccount" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://www.dwheeler.com/sloccount/"/>
     <client>
-      <environment name="SLOCCOUNT_BASE" default="@TOOL_ROOT@"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="PATH" value="$SLOCCOUNT_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/sloccount/sloccount.xml
+++ b/scram-tools.file/tools/sloccount/sloccount.xml
@@ -1,7 +1,7 @@
   <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://www.dwheeler.com/sloccount/"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/sqlite/sqlite.xml
+++ b/scram-tools.file/tools/sqlite/sqlite.xml
@@ -1,10 +1,10 @@
-<tool name="sqlite" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="sqlite3"/>
   <client>
-    <environment name="SQLITE_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$SQLITE_BASE/lib"/>
-    <environment name="BINDIR" default="$SQLITE_BASE/bin"/>
-    <environment name="INCLUDE" default="$SQLITE_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/sqlite/sqlite.xml
+++ b/scram-tools.file/tools/sqlite/sqlite.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="sqlite3"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/starlight/starlight.xml
+++ b/scram-tools.file/tools/starlight/starlight.xml
@@ -1,11 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="Starlib"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="clhep"/>

--- a/scram-tools.file/tools/starlight/starlight.xml
+++ b/scram-tools.file/tools/starlight/starlight.xml
@@ -1,11 +1,11 @@
-<tool name="starlight" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="Starlib"/>
   <client>
-    <environment name="STARLIGHT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$STARLIGHT_BASE/lib"/>
-    <environment name="INCLUDE" default="$STARLIGHT_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$STARLIGHT_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="clhep"/>

--- a/scram-tools.file/tools/tauolapp/tauolapp.xml
+++ b/scram-tools.file/tools/tauolapp/tauolapp.xml
@@ -5,9 +5,9 @@
   <lib name="TauolaHepMC"/>
   <lib name="TauolaHEPEVT"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/tauolapp/tauolapp.xml
+++ b/scram-tools.file/tools/tauolapp/tauolapp.xml
@@ -1,13 +1,13 @@
-<tool name="tauolapp" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="TauolaCxxInterface"/>
   <lib name="TauolaFortran"/>
   <lib name="TauolaTauSpinner"/>
   <lib name="TauolaHepMC"/>
   <lib name="TauolaHEPEVT"/>
   <client>
-    <environment name="TAUOLAPP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$TAUOLAPP_BASE/lib"/>
-    <environment name="INCLUDE" default="$TAUOLAPP_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/tbb/tbb.xml
+++ b/scram-tools.file/tools/tbb/tbb.xml
@@ -1,10 +1,10 @@
-<tool name="tbb" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://threadingbuildingblocks.org"/>
   <lib name="tbb"/>
   <client>
-    <environment name="TBB_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"   default="$TBB_BASE/lib"/>
-    <environment name="INCLUDE"  default="$TBB_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"   default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE"  default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/tbb/tbb.xml
+++ b/scram-tools.file/tools/tbb/tbb.xml
@@ -2,9 +2,9 @@
   <info url="http://threadingbuildingblocks.org"/>
   <lib name="tbb"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"   default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE"  default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"   default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"  default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/tensorflow-xla-runtime/tensorflow-xla-runtime.xml
+++ b/scram-tools.file/tools/tensorflow-xla-runtime/tensorflow-xla-runtime.xml
@@ -1,7 +1,7 @@
-<tool name="tensorflow-xla-runtime" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="TENSORFLOW_XLA_RUNTIME_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$TENSORFLOW_XLA_RUNTIME_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <lib name="tf_xla_runtime"/>
 

--- a/scram-tools.file/tools/tensorflow-xla-runtime/tensorflow-xla-runtime.xml
+++ b/scram-tools.file/tools/tensorflow-xla-runtime/tensorflow-xla-runtime.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <lib name="tf_xla_runtime"/>
 

--- a/scram-tools.file/tools/tensorflow/tensorflow.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="TF_CPP_MIN_LOG_LEVEL" value="3"/>
   <flags SYSTEM_INCLUDE="1"/>
 </tool>

--- a/scram-tools.file/tools/tensorflow/tensorflow.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow.xml
@@ -1,10 +1,10 @@
-<tool name="tensorflow" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="TENSORFLOW_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$TENSORFLOW_BASE/lib"/>
-    <environment name="INCLUDE" default="$TENSORFLOW_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$TENSORFLOW_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="TF_CPP_MIN_LOG_LEVEL" value="3"/>
   <flags SYSTEM_INCLUDE="1"/>
 </tool>

--- a/scram-tools.file/tools/thepeg/thepeg.xml
+++ b/scram-tools.file/tools/thepeg/thepeg.xml
@@ -2,11 +2,11 @@
   <lib name="ThePEG"/>
   <lib name="LesHouches"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/ThePEG"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/ThePEG"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="THEPEGPATH" value="$@UC_TOOL@_BASE/share/ThePEG"/>
+  <runtime name="THEPEGPATH" value="$@TOOL_BASE@/share/ThePEG"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/thepeg/thepeg.xml
+++ b/scram-tools.file/tools/thepeg/thepeg.xml
@@ -1,12 +1,12 @@
-<tool name="thepeg" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="ThePEG"/>
   <lib name="LesHouches"/>
   <client>
-    <environment name="THEPEG_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$THEPEG_BASE/lib/ThePEG"/>
-    <environment name="INCLUDE" default="$THEPEG_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib/ThePEG"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="THEPEGPATH" value="$THEPEG_BASE/share/ThePEG"/>
+  <runtime name="THEPEGPATH" value="$@UC_TOOL@_BASE/share/ThePEG"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/tinyxml2/tinyxml2.xml
+++ b/scram-tools.file/tools/tinyxml2/tinyxml2.xml
@@ -1,10 +1,10 @@
-<tool name="tinyxml2" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/leethomason/tinyxml2"/>
   <lib name="tinyxml2"/>
   <client>
-    <environment name="TINYXML2_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$TINYXML2_BASE/lib64"/>
-    <environment name="INCLUDE" default="$TINYXML2_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/> 
 </tool>

--- a/scram-tools.file/tools/tinyxml2/tinyxml2.xml
+++ b/scram-tools.file/tools/tinyxml2/tinyxml2.xml
@@ -2,9 +2,9 @@
   <info url="https://github.com/leethomason/tinyxml2"/>
   <lib name="tinyxml2"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/> 
 </tool>

--- a/scram-tools.file/tools/tkonlinesw/tkonlinesw.xml
+++ b/scram-tools.file/tools/tkonlinesw/tkonlinesw.xml
@@ -3,9 +3,9 @@
   <lib name="ICUtils"/>
   <lib name="Fed9UUtils"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" value="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" value="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" value="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" value="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <flags CXXFLAGS="-DCMS_TK_64BITS"/>

--- a/scram-tools.file/tools/tkonlinesw/tkonlinesw.xml
+++ b/scram-tools.file/tools/tkonlinesw/tkonlinesw.xml
@@ -1,11 +1,11 @@
-<tool name="TkOnlineSw" version="@TOOL_VERSION@" revision="1">
+<tool name="TkOnlineSw" version="@TOOL_VERSION@" revision="2">
   <info url="http://www.cern.ch/"/>
   <lib name="ICUtils"/>
   <lib name="Fed9UUtils"/>
   <client>
-    <environment name="TKONLINESW_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" value="$TKONLINESW_BASE/lib"/>
-    <environment name="INCLUDE" value="$TKONLINESW_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" value="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" value="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <flags CXXFLAGS="-DCMS_TK_64BITS"/>

--- a/scram-tools.file/tools/triton-inference-client/triton-inference-client.xml
+++ b/scram-tools.file/tools/triton-inference-client/triton-inference-client.xml
@@ -3,9 +3,9 @@
   <lib name="grpcclient"/> 
   <lib name="tritoncommonmodelconfig"/> 
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"  default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"  default="$@TOOL_BASE@/lib"/>
   </client>
   <use name="protobuf"/>
   <use name="grpc"/>

--- a/scram-tools.file/tools/triton-inference-client/triton-inference-client.xml
+++ b/scram-tools.file/tools/triton-inference-client/triton-inference-client.xml
@@ -1,11 +1,11 @@
-<tool name="triton-inference-client" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/triton-inference-server/client"/>
   <lib name="grpcclient"/> 
   <lib name="tritoncommonmodelconfig"/> 
   <client>
-    <environment name="TRITON_INFERENCE_CLIENT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$TRITON_INFERENCE_CLIENT_BASE/include"/>
-    <environment name="LIBDIR"  default="$TRITON_INFERENCE_CLIENT_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"  default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <use name="protobuf"/>
   <use name="grpc"/>

--- a/scram-tools.file/tools/ucx/ucx.xml
+++ b/scram-tools.file/tools/ucx/ucx.xml
@@ -1,12 +1,12 @@
-<tool name="ucx" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="ucp"/>
   <lib name="uct"/>
   <lib name="ucs"/>
   <lib name="ucm"/>
   <client>
-    <environment name="UCX_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"  default="$UCX_BASE/include"/>
-    <environment name="LIBDIR"   default="$UCX_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"  default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"   default="$@UC_TOOL@_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$UCX_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/ucx/ucx.xml
+++ b/scram-tools.file/tools/ucx/ucx.xml
@@ -4,9 +4,9 @@
   <lib name="ucs"/>
   <lib name="ucm"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"  default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"   default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"  default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"   default="$@TOOL_BASE@/lib"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/utm/utm.xml
+++ b/scram-tools.file/tools/utm/utm.xml
@@ -5,11 +5,11 @@
   <lib name="tmgrammar"/>
   <lib name="tmutil"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="UTM_XSD_DIR" value="$@UC_TOOL@_BASE"/>
+  <runtime name="UTM_XSD_DIR" value="$@TOOL_BASE@"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/utm/utm.xml
+++ b/scram-tools.file/tools/utm/utm.xml
@@ -1,15 +1,15 @@
-<tool name="utm" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="tmeventsetup"/>
   <lib name="tmtable"/>
   <lib name="tmxsd"/>
   <lib name="tmgrammar"/>
   <lib name="tmutil"/>
   <client>
-    <environment name="UTM_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$UTM_BASE/lib"/>
-    <environment name="INCLUDE" default="$UTM_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="UTM_XSD_DIR" value="$UTM_BASE"/>
+  <runtime name="UTM_XSD_DIR" value="$@UC_TOOL@_BASE"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/valgrind/valgrind.xml
+++ b/scram-tools.file/tools/valgrind/valgrind.xml
@@ -1,10 +1,10 @@
-<tool name="valgrind" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="VALGRIND_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$VALGRIND_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$VALGRIND_BASE/bin" type="path"/>
-  <runtime name="VALGRIND_LIB" value="$VALGRIND_BASE/libexec/valgrind"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="VALGRIND_LIB" value="$@UC_TOOL@_BASE/libexec/valgrind"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/valgrind/valgrind.xml
+++ b/scram-tools.file/tools/valgrind/valgrind.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
-  <runtime name="VALGRIND_LIB" value="$@UC_TOOL@_BASE/libexec/valgrind"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="VALGRIND_LIB" value="$@TOOL_BASE@/libexec/valgrind"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/vdt/vdt.xml
+++ b/scram-tools.file/tools/vdt/vdt.xml
@@ -2,7 +2,7 @@
   <lib name="vdt"/>
   <use name="vdt_headers"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/vdt/vdt.xml
+++ b/scram-tools.file/tools/vdt/vdt.xml
@@ -1,8 +1,8 @@
-<tool name="vdt" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="vdt"/>
   <use name="vdt_headers"/>
   <client>
-    <environment name="VDT_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$VDT_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/vecgeom/vecgeom.xml
+++ b/scram-tools.file/tools/vecgeom/vecgeom.xml
@@ -2,8 +2,8 @@
   <info url="https://gitlab.cern.ch/VecGeom/VecGeom"/>
   <lib name="vecgeom"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
   </client>
   <use name="vecgeom_interface"/>
 </tool>

--- a/scram-tools.file/tools/vecgeom/vecgeom.xml
+++ b/scram-tools.file/tools/vecgeom/vecgeom.xml
@@ -1,9 +1,9 @@
-<tool name="vecgeom" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://gitlab.cern.ch/VecGeom/VecGeom"/>
   <lib name="vecgeom"/>
   <client>
-    <environment name="VECGEOM_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$VECGEOM_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
   </client>
   <use name="vecgeom_interface"/>
 </tool>

--- a/scram-tools.file/tools/xerces-c/xerces-c.xml
+++ b/scram-tools.file/tools/xerces-c/xerces-c.xml
@@ -1,10 +1,10 @@
-<tool name="xerces-c" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://xml.apache.org/xerces-c/"/>
   <lib name="xerces-c"/>
   <client>
-    <environment name="XERCES_C_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$XERCES_C_BASE/include"/>
-    <environment name="LIBDIR" default="$XERCES_C_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/xerces-c/xerces-c.xml
+++ b/scram-tools.file/tools/xerces-c/xerces-c.xml
@@ -2,9 +2,9 @@
   <info url="http://xml.apache.org/xerces-c/"/>
   <lib name="xerces-c"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/xgboost/xgboost.xml
+++ b/scram-tools.file/tools/xgboost/xgboost.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="xgboost"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/xgboost/xgboost.xml
+++ b/scram-tools.file/tools/xgboost/xgboost.xml
@@ -1,10 +1,10 @@
-<tool name="xgboost" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="xgboost"/>
   <client>
-    <environment name="XGBOOST_BASE" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$XGBOOST_BASE/bin"/>
-    <environment name="LIBDIR" default="$XGBOOST_BASE/lib64"/>
-    <environment name="INCLUDE" default="$XGBOOST_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="BINDIR" default="$@UC_TOOL@_BASE/bin"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/xpmem/xpmem.xml
+++ b/scram-tools.file/tools/xpmem/xpmem.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="xpmem"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"    default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR"     default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"    default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"     default="$@TOOL_BASE@/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/xpmem/xpmem.xml
+++ b/scram-tools.file/tools/xpmem/xpmem.xml
@@ -1,8 +1,8 @@
-<tool name="xpmem" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="xpmem"/>
   <client>
-    <environment name="XPMEM_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"    default="$XPMEM_BASE/include"/>
-    <environment name="LIBDIR"     default="$XPMEM_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"    default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR"     default="$@UC_TOOL@_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/xrdcl-record/xrdcl-record.xml
+++ b/scram-tools.file/tools/xrdcl-record/xrdcl-record.xml
@@ -1,6 +1,6 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="XRDCL_RECORDER_PLUGIN" value="${@UC_TOOL@_BASE}/lib64/libXrdClRecorder-5.so"/>
+  <runtime name="XRDCL_RECORDER_PLUGIN" value="${@TOOL_BASE@}/lib64/libXrdClRecorder-5.so"/>
 </tool>

--- a/scram-tools.file/tools/xrdcl-record/xrdcl-record.xml
+++ b/scram-tools.file/tools/xrdcl-record/xrdcl-record.xml
@@ -1,6 +1,6 @@
-<tool name="xrdcl-record" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <client>
-    <environment name="XRDCL_RECORD_BASE" default="@TOOL_ROOT@"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="XRDCL_RECORDER_PLUGIN" value="${XRDCL_RECORD_BASE}/lib64/libXrdClRecorder-5.so"/>
+  <runtime name="XRDCL_RECORDER_PLUGIN" value="${@UC_TOOL@_BASE}/lib64/libXrdClRecorder-5.so"/>
 </tool>

--- a/scram-tools.file/tools/xrootd/xrootd.xml
+++ b/scram-tools.file/tools/xrootd/xrootd.xml
@@ -2,12 +2,12 @@
   <lib name="XrdUtils"/>
   <lib name="XrdCl"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/xrootd"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/xrootd/private"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/xrootd"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include/xrootd/private"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
   </client>
-  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="isal"/>

--- a/scram-tools.file/tools/xrootd/xrootd.xml
+++ b/scram-tools.file/tools/xrootd/xrootd.xml
@@ -1,13 +1,13 @@
-<tool name="xrootd" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <lib name="XrdUtils"/>
   <lib name="XrdCl"/>
   <client>
-    <environment name="XROOTD_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$XROOTD_BASE/include/xrootd"/>
-    <environment name="INCLUDE" default="$XROOTD_BASE/include/xrootd/private"/>
-    <environment name="LIBDIR" default="$XROOTD_BASE/lib64"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/xrootd"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include/xrootd/private"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
   </client>
-  <runtime name="PATH" value="$XROOTD_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="isal"/>

--- a/scram-tools.file/tools/xtensor/xtensor.xml
+++ b/scram-tools.file/tools/xtensor/xtensor.xml
@@ -1,8 +1,8 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/QuantStack/xtensor"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="xtl"/>
 </tool>

--- a/scram-tools.file/tools/xtensor/xtensor.xml
+++ b/scram-tools.file/tools/xtensor/xtensor.xml
@@ -1,8 +1,8 @@
-<tool name="xtensor" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/QuantStack/xtensor"/>
   <client>
-    <environment name="XTENSOR_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$XTENSOR_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="xtl"/>
 </tool>

--- a/scram-tools.file/tools/xtl/xtl.xml
+++ b/scram-tools.file/tools/xtl/xtl.xml
@@ -1,7 +1,7 @@
-<tool name="xtl" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/QuantStack/xtl"/>
   <client>
-    <environment name="XTL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$XTL_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/xtl/xtl.xml
+++ b/scram-tools.file/tools/xtl/xtl.xml
@@ -1,7 +1,7 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/QuantStack/xtl"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/xz/xz.xml
+++ b/scram-tools.file/tools/xz/xz.xml
@@ -1,12 +1,12 @@
-  <tool name="xz" version="@TOOL_VERSION@" revision="1">
+  <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
     <info url="http://tukaani.org/xz/"/>
     <lib name="lzma"/>
     <client>
-      <environment name="XZ_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$XZ_BASE/lib"/>
-      <environment name="INCLUDE" default="$XZ_BASE/include"/>
+      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
     </client>
-    <runtime name="PATH" value="$XZ_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/xz/xz.xml
+++ b/scram-tools.file/tools/xz/xz.xml
@@ -2,11 +2,11 @@
     <info url="http://tukaani.org/xz/"/>
     <lib name="lzma"/>
     <client>
-      <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-      <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
     </client>
-    <runtime name="PATH" value="$@UC_TOOL@_BASE/bin" type="path"/>
+    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/yaml-cpp/yaml-cpp.xml
+++ b/scram-tools.file/tools/yaml-cpp/yaml-cpp.xml
@@ -2,8 +2,8 @@
   <info url="https://github.com/jbeder/yaml-cpp/"/>
   <lib name="yaml-cpp"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/yaml-cpp/yaml-cpp.xml
+++ b/scram-tools.file/tools/yaml-cpp/yaml-cpp.xml
@@ -1,9 +1,9 @@
-<tool name="yaml-cpp" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://github.com/jbeder/yaml-cpp/"/>
   <lib name="yaml-cpp"/>
   <client>
-    <environment name="YAML_CPP_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$YAML_CPP_BASE/lib64"/>
-    <environment name="INCLUDE" default="$YAML_CPP_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib64"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/yoda/yoda.xml
+++ b/scram-tools.file/tools/yoda/yoda.xml
@@ -1,10 +1,10 @@
-<tool name="yoda" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="YODA"/>
   <client>
-    <environment name="YODA_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$YODA_BASE/lib"/>
-    <environment name="INCLUDE" default="$YODA_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <use name="root_cxxdefaults"/>
-  <runtime name="PATH"       value="$YODA_BASE/bin" type="path"/>
+  <runtime name="PATH"       value="$@UC_TOOL@_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/yoda/yoda.xml
+++ b/scram-tools.file/tools/yoda/yoda.xml
@@ -1,10 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="YODA"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="root_cxxdefaults"/>
-  <runtime name="PATH"       value="$@UC_TOOL@_BASE/bin" type="path"/>
+  <runtime name="PATH"       value="$@TOOL_BASE@/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/zlib/zlib.xml
+++ b/scram-tools.file/tools/zlib/zlib.xml
@@ -1,9 +1,9 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="z"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/zlib/zlib.xml
+++ b/scram-tools.file/tools/zlib/zlib.xml
@@ -1,9 +1,9 @@
-<tool name="zlib" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="z"/>
   <client>
-    <environment name="ZLIB_BASE" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$ZLIB_BASE/include"/>
-    <environment name="LIBDIR" default="$ZLIB_BASE/lib"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/zstd/zstd.xml
+++ b/scram-tools.file/tools/zstd/zstd.xml
@@ -1,10 +1,10 @@
-<tool name="zstd" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="http://https://facebook.github.io/zstd"/>
   <lib name="zstd"/>
   <client>
-    <environment name="ZSTD_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$ZSTD_BASE/lib"/>
-    <environment name="INCLUDE" default="$ZSTD_BASE/include"/>
+    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
+    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/zstd/zstd.xml
+++ b/scram-tools.file/tools/zstd/zstd.xml
@@ -2,9 +2,9 @@
   <info url="http://https://facebook.github.io/zstd"/>
   <lib name="zstd"/>
   <client>
-    <environment name="@UC_TOOL@_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@UC_TOOL@_BASE/lib"/>
-    <environment name="INCLUDE" default="$@UC_TOOL@_BASE/include"/>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>


### PR DESCRIPTION
This PR simplifies the creation of toolfiles for new externals. For new externals, one can just copy the one of the existing toolfile and just replace the lib name or paths. `get_tools` will automatically replace `@TOOL@` (tool name e.g. abseil-cpp) and `@UC_TOOL@` (upper case toolname e.g. ABSEIL_C) with correct tool name 