### PR TITLE
[10.6] Update tag for GeneratorInterface-EvtGenInterface to V02-12-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -5,7 +5,7 @@
 [default]
 Configuration-Generator=V01-10-00
 PhysicsTools-PatUtils=V00-05-00
-GeneratorInterface-EvtGenInterface=V02-10-00
+GeneratorInterface-EvtGenInterface=V02-12-00
 Alignment-OfflineValidation=V00-01-00
 CalibPPS-ESProducers=V01-03-00
 RecoMET-METPUSubtraction=V01-01-00


### PR DESCRIPTION
backport of #9946

As requested [here](https://github.com/cms-data/GeneratorInterface-EvtGenInterface/pull/28#issuecomment-3191510108)
New pdl files with new Bs and Bs* mass points for MC production. 

@cms-sw/orp-l2 , this is already in 15.1.X, should we include this change in all open release cycles (10.6 and above)?