### PR TITLE
Update NVIDIA gdrcopy to v2.5.1

### DIFF
--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -1,4 +1,4 @@
-### RPM external gdrcopy 2.4.4
+### RPM external gdrcopy 2.5.1
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 Source: https://github.com/NVIDIA/%{n}/archive/v%{realversion}.tar.gz
 Requires: cuda


### PR DESCRIPTION
Major updates:
  - support for RHEL 10
  - support for Blackwell GPUs

The updates, fixes and changes in v2.5 can be found at https://github.com/NVIDIA/gdrcopy/releases/tag/v2.5 .
The updates, fixes and changes in v2.5.1 can be found at https://github.com/NVIDIA/gdrcopy/releases/tag/v2.5.1 .