### PR TITLE
Upgrade OpenMPI version from 4.1.9 to 5.0.8

### DIFF
--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,8 +1,8 @@
-### RPM external openmpi 4.1.9a1-20250505
+### RPM external openmpi 5.0.8
 ## INITENV SET OPAL_PREFIX %{i}
-%define branch v4.1.x
-%define tag e6d2cb856f3fc649aa01bd5b688a003b3b33db7d
-Source: git+https://github.com/open-mpi/ompi.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+%define branch v5.0.x
+%define tag v%{realversion}
+Source: git+https://github.com/open-mpi/ompi.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 BuildRequires: autotools flex
 %{!?without_cuda:Requires: cuda}
 Requires: libfabric
@@ -28,12 +28,9 @@ AUTOMAKE_JOBS=%{compiling_processes} ./autogen.pl
   --prefix=%i \
   --disable-dependency-tracking \
   --enable-ipv6 \
-  --enable-mpi-cxx \
   --enable-shared \
   --disable-static \
-  --enable-cxx-exceptions \
   --disable-mpi-java \
-  --enable-openib-rdmacm-ibaddr \
   --with-zlib=$ZLIB_ROOT \
   %{!?without_cuda:--with-cuda=$CUDA_ROOT} \
   --with-hwloc=$HWLOC_ROOT \
@@ -47,8 +44,8 @@ AUTOMAKE_JOBS=%{compiling_processes} ./autogen.pl
   --with-cma \
   --without-knem \
   --with-xpmem=$XPMEM_ROOT \
-  --without-x \
   --with-pic \
+  --disable-io-romio \
   --with-gnu-ld \
   --with-pmix=internal
 

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <lib name="mpi"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -1,6 +1,5 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <lib name="mpi"/>
-  <lib name="mpi_cxx"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>


### PR DESCRIPTION
OpenMPI 5.0.8 is the current stable release and provides features would like to take advantage of (e.g. User-Level Fault Mitigation), and that are not available in OpenMPI 4.x

Note that OpenMPI 5.0.8's spec file requires the changes proposed in this pull request to build:
https://github.com/cms-sw/pkgtools/pull/224

