### PR TITLE
Update hwloc to v2.12.2

### DIFF
--- a/hwloc.spec
+++ b/hwloc.spec
@@ -1,4 +1,4 @@
-### RPM external hwloc 2.12.0
+### RPM external hwloc 2.12.2
 %define mainversion %(echo %{realversion} | cut -d. -f1-2)
 Source: https://download.open-mpi.org/release/%{n}/v%{mainversion}/%{n}-%{realversion}.tar.bz2
 


### PR DESCRIPTION
See https://raw.githubusercontent.com/open-mpi/hwloc/v2.12/NEWS for the changes since v2.12.0:

Version 2.12.2
--------------
* Fix hwloc-gather-topology failure because of MemoryModules when running as root.
* Fix HWLOC_LOCAL_NUMANODE_FLAG_INTERSECT_LOCALITY for empty input cpuset.
* Fix hwloc_distances_get_by_name() for distances with no kinds.
* Initialize distances grouping configuration for duplicated topology.
* Improve Windows CMake build to support ARM64.

Version 2.12.1
--------------
* Add hwloc-calc's --default-nodes option to hwloc-bind and hwloc-info.
* Improve the --best-memattr "default" fallback, try to use "default" memory nodes, and add verbose messages and warnings if some performance info are incomplete or missing.
* Fix CPU and memory binding on different locations,
* Add HWLOC_LOCAL_NUMANODE_FLAG_INTERSECT_LOCALITY and enable it by default in hwloc-calc --local-memory for finding local NUMA nodes that do not exactly match input locations.
* Fix a possible crash in the x86 backend when Qemu is configured to expose multicore/thread CPUs that are actually single-core/thread.
