### PR TITLE
cms-common: Fix for 00-no-biglib hook and cmsTraceFunction with abort option

### DIFF
--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1253
+## REVISION 1254
 ## NOCOMPILER
 
-%define tag 83d2509d24724fa0c3c431af46ae59ef273c3fc2
+%define tag 7700a555b0e24da8ae9b91726e89104023303cbe
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep

--- a/cms-common.spec
+++ b/cms-common.spec
@@ -1,8 +1,8 @@
 ### RPM cms cms-common 1.0
-## REVISION 1254
+## REVISION 1255
 ## NOCOMPILER
 
-%define tag 7700a555b0e24da8ae9b91726e89104023303cbe
+%define tag ac5bdc65fd10fdcc5b52cf855b7c67c92bf8627e
 Source:  git+https://github.com/cms-sw/cms-common.git?obj=master/%{tag}&export=%{n}-%{realversion}-%{tag}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 %prep


### PR DESCRIPTION
`00-no-biglib` site hook was using `/usr/bin/bash` which is not available under `cmssw-el6`which was causing error message like [a] at scram proejct time
```
Singularity> scram p CMSSW_10_2_28
/cvmfs/cms.cern.ch/etc/scramrc/SCRAM/hooks/project-hook: /cvmfs/cms.cern.ch/etc/scramrc/SCRAM/hooks/project/00-no-biglib: /usr/bin/bash: bad interpreter: No such file or directory
```