### PR TITLE
xrootd: update to version 5.8.4

### DIFF
--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.7.2
+### RPM external xrootd 5.8.4
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 


### PR DESCRIPTION
Xrootd 5.8.4 worked fine for DEVEL IBs, so lets get this in for normal IBs

backport of #10053