### PR TITLE
openmpi: Set needed env to avoid openmpi calling setenv at runtime

### DIFF
--- a/openmpi-opt.file
+++ b/openmpi-opt.file
@@ -1,0 +1,2 @@
+%define HFI_NO_BACKTRACE 1
+%define IPATH_NO_BACKTRACE 1

--- a/openmpi-setenv-fix.patch
+++ b/openmpi-setenv-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/ompi/runtime/ompi_mpi_init.c b/ompi/runtime/ompi_mpi_init.c
+index 19c0999..66e6553 100644
+--- a/ompi/runtime/ompi_mpi_init.c
++++ b/ompi/runtime/ompi_mpi_init.c
+@@ -349,8 +349,10 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
+     /* deal with OPAL_PREFIX to ensure that an internal PMIx installation
+      * is also relocated if necessary */
+ #if OPAL_USING_INTERNAL_PMIX
+-    if (NULL != (evar = getenv("OPAL_PREFIX"))) {
+-        opal_setenv("PMIX_PREFIX", evar, true, &environ);
++    if (NULL == getenv("PMIX_PREFIX")) {
++        if (NULL != (evar = getenv("OPAL_PREFIX"))) {
++            opal_setenv("PMIX_PREFIX", evar, true, &environ);
++        }
+     }
+ #endif
+ 

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,5 +1,7 @@
 ### RPM external openmpi 5.0.8
+## INCLUDE openmpi-opt
 ## INITENV SET OPAL_PREFIX %{i}
+## INITENV SET PMIX_PREFIX %{i}
 %define branch v5.0.x
 %define tag v%{realversion}
 Source: git+https://github.com/open-mpi/ompi.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
@@ -21,6 +23,10 @@ Requires: zlib
 
 %prep
 %setup -q -n %{n}-%{realversion}
+
+#Make sure IPATH_NO_BACKTRACE and HFI_NO_BACKTRACE default values match what we expect (see cmsdist/openmpi-opt.file)
+grep ' opal_setenv("IPATH_NO_BACKTRACE", "%{IPATH_NO_BACKTRACE}", true, &environ)' opal/runtime/opal_init.c
+grep ' opal_setenv("HFI_NO_BACKTRACE", "%{HFI_NO_BACKTRACE}", true, &environ)' opal/runtime/opal_init.c
 
 AUTOMAKE_JOBS=%{compiling_processes} ./autogen.pl
 

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -5,6 +5,7 @@
 %define branch v5.0.x
 %define tag v%{realversion}
 Source: git+https://github.com/open-mpi/ompi.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
+Patch0: openmpi-setenv-fix
 BuildRequires: autotools flex
 %{!?without_cuda:Requires: cuda}
 Requires: libfabric
@@ -23,6 +24,7 @@ Requires: zlib
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 #Make sure IPATH_NO_BACKTRACE and HFI_NO_BACKTRACE default values match what we expect (see cmsdist/openmpi-opt.file)
 grep ' opal_setenv("IPATH_NO_BACKTRACE", "%{IPATH_NO_BACKTRACE}", true, &environ)' opal/runtime/opal_init.c

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="4">
   <lib name="mpi"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="4">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <lib name="mpi"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
@@ -12,6 +12,6 @@
   <runtime name="HFI_NO_BACKTRACE" value="%{HFI_NO_BACKTRACE}"/>
 %endif
 %if "%{?IPATH_NO_BACKTRACE:set}" == "set"
-  <runtime name="HFI_NO_BACKTRACE" value="%{HFI_NO_BACKTRACE}"/>
+  <runtime name="IPATH_NO_BACKTRACE" value="%{IPATH_NO_BACKTRACE}"/>
 %endif
 </tool>

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -7,4 +7,11 @@
   </client>
   <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="OPAL_PREFIX" value="$@TOOL_BASE@"/>
+  <runtime name="PMIX_PREFIX" value="$@TOOL_BASE@"/>
+%if "%{?HFI_NO_BACKTRACE:set}" == "set"
+  <runtime name="HFI_NO_BACKTRACE" value="%{HFI_NO_BACKTRACE}"/>
+%endif
+%if "%{?IPATH_NO_BACKTRACE:set}" == "set"
+  <runtime name="HFI_NO_BACKTRACE" value="%{HFI_NO_BACKTRACE}"/>
+%endif
 </tool>

--- a/toolflags.file
+++ b/toolflags.file
@@ -7,6 +7,7 @@
 ## INCLUDE vecgeom-opt
 ## INCLUDE microarch_flags
 ## INCLUDE frame_pointer-opt
+## INCLUDE openmpi-opt
 
 %if "%{default_microarch_name}" == ""
   %if "%{arch_build_flags}"


### PR DESCRIPTION
This change set the following env variables
 - `HFI_NO_BACKTRACE=1`:  Default is`1` if not set (https://github.com/open-mpi/ompi/blob/main/opal/runtime/opal_init.c#L116-L118)
 - `IPATH_NO_BACKTRACE=1`: Default is also `1` if not set (https://github.com/open-mpi/ompi/blob/main/opal/runtime/opal_init.c#L113-L115)
 - `PMIX_PREFIX=install_path` 

This should be enough for openmpi to not call `setenv` at runtime

FYI @makortel , hopefully this should fix the failiing DEVEL IBs relvals