### PR TITLE
Update ROCm to version 6.4.3 [15.1.x]

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -1,4 +1,4 @@
-### RPM external rocm 6.3.2
+### RPM external rocm 6.4.3
 ## INCLUDE cpp-standard
 ## INITENV SET HIP_PATH %{i}
 
@@ -15,45 +15,46 @@
 # without any .0 in the directory name
 %define repoversion %(echo %{realversion} | sed -e's/\.0$//')
 
-# ROCm branch, e.g. 5.6.x, 6.2.x
-%define rocm_branch %(echo %{realversion} | cut -d. -f1-2).x
+# ROCm branch, e.g. 5.6, 6.2
+%define rocm_branch %(echo %{realversion} | cut -d. -f1-2)
 
 # git branch, tag and directory name for rocprofiler-register
-%define rocprofiler_register_branch rocm-%{rocm_branch}
+%define rocprofiler_register_branch release/rocm-rel-%{rocm_branch}
 %define rocprofiler_register_tag    rocm-%{realversion}
 %define rocprofiler_register_pkg    rocprofiler-register-%{rocprofiler_register_tag}
 
-Source0: https://%{repository}/%{repoversion}/main/amd-smi-lib-24.7.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source1: https://%{repository}/%{repoversion}/main/comgr-2.8.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source2: https://%{repository}/%{repoversion}/main/hip-devel-6.3.42134.60302-66.el%{rhel}.%{_arch}.rpm
-Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-6.3.42134.60302-66.el%{rhel}.%{_arch}.rpm
-Source4: https://%{repository}/%{repoversion}/main/hipcc-1.1.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source5: https://%{repository}/%{repoversion}/main/hsa-rocr-1.14.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source6: https://%{repository}/%{repoversion}/main/hsa-rocr-devel-1.14.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source7: https://%{repository}/%{repoversion}/main/openmp-extras-devel-18.63.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source8: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-18.63.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source9: https://%{repository}/%{repoversion}/main/rocm-core-6.3.2.60302-66.el%{rhel}.%{_arch}.rpm
-Source10: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.77.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source11: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source12: https://%{repository}/%{repoversion}/main/rocm-llvm-18.0.0.25012.60302-66.el%{rhel}.%{_arch}.rpm
-Source13: https://%{repository}/%{repoversion}/main/rocm-smi-lib-7.4.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source14: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source15: https://%{repository}/%{repoversion}/main/rocprim-devel-3.3.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source16: https://%{repository}/%{repoversion}/main/rocprofiler-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source17: https://%{repository}/%{repoversion}/main/rocprofiler-compute-3.0.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source18: https://%{repository}/%{repoversion}/main/rocprofiler-devel-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source19: https://%{repository}/%{repoversion}/main/rocprofiler-docs-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source20: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.60302.60302-66.el%{rhel}.%{_arch}.rpm
-Source21: https://%{repository}/%{repoversion}/main/rocprofiler-register-0.4.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source22: https://%{repository}/%{repoversion}/main/rocprofiler-systems-0.1.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source23: https://%{repository}/%{repoversion}/main/hipcub-devel-3.3.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source24: https://%{repository}/%{repoversion}/main/rocthrust-devel-3.3.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source25: https://%{repository}/%{repoversion}/main/hiprand-2.11.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source26: https://%{repository}/%{repoversion}/main/hiprand-devel-2.11.1.60302-66.el%{rhel}.%{_arch}.rpm
-Source27: https://%{repository}/%{repoversion}/main/rocrand-3.2.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source28: https://%{repository}/%{repoversion}/main/rocrand-devel-3.2.0.60302-66.el%{rhel}.%{_arch}.rpm
-Source29: https://%{repository}/%{repoversion}/main/rccl-2.21.5.60302-66.el%{rhel}.%{_arch}.rpm
-Source30: https://%{repository}/%{repoversion}/main/rccl-devel-2.21.5.60302-66.el%{rhel}.%{_arch}.rpm
+Source0: https://%{repository}/%{repoversion}/main/amd-smi-lib-25.5.1.60403-128.el%{rhel}.%{_arch}.rpm
+Source1: https://%{repository}/%{repoversion}/main/comgr-3.0.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source2: https://%{repository}/%{repoversion}/main/hip-devel-6.4.43484.60403-128.el%{rhel}.%{_arch}.rpm
+Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-6.4.43484.60403-128.el%{rhel}.%{_arch}.rpm
+Source4: https://%{repository}/%{repoversion}/main/hipcc-1.1.1.60403-128.el%{rhel}.%{_arch}.rpm
+Source5: https://%{repository}/%{repoversion}/main/hsa-rocr-1.15.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source6: https://%{repository}/%{repoversion}/main/hsa-rocr-devel-1.15.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source7: https://%{repository}/%{repoversion}/main/openmp-extras-devel-18.63.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source8: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-18.63.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source9: https://%{repository}/%{repoversion}/main/rocm-core-6.4.3.60403-128.el%{rhel}.%{_arch}.rpm
+Source10: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.77.2.60403-128.el%{rhel}.%{_arch}.rpm
+Source11: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source12: https://%{repository}/%{repoversion}/main/rocm-llvm-19.0.0.25224.60403-128.el%{rhel}.%{_arch}.rpm
+Source13: https://%{repository}/%{repoversion}/main/rocm-smi-lib-7.7.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source14: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source15: https://%{repository}/%{repoversion}/main/rocprim-devel-3.4.1.60403-128.el%{rhel}.%{_arch}.rpm
+Source16: https://%{repository}/%{repoversion}/main/rocprofiler-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
+Source17: https://%{repository}/%{repoversion}/main/rocprofiler-compute-3.1.1.60403-128.el%{rhel}.%{_arch}.rpm
+Source18: https://%{repository}/%{repoversion}/main/rocprofiler-devel-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
+Source19: https://%{repository}/%{repoversion}/main/rocprofiler-docs-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
+Source20: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
+Source21: https://%{repository}/%{repoversion}/main/rocprofiler-register-0.4.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source22: https://%{repository}/%{repoversion}/main/rocprofiler-systems-1.0.2.60403-128.el%{rhel}.%{_arch}.rpm
+Source23: https://%{repository}/%{repoversion}/main/hipcub-devel-3.4.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source24: https://%{repository}/%{repoversion}/main/rocthrust-devel-3.3.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source25: https://%{repository}/%{repoversion}/main/hiprand-2.12.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source26: https://%{repository}/%{repoversion}/main/hiprand-devel-2.12.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source27: https://%{repository}/%{repoversion}/main/rocrand-3.3.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source28: https://%{repository}/%{repoversion}/main/rocrand-devel-3.3.0.60403-128.el%{rhel}.%{_arch}.rpm
+Source29: https://%{repository}/%{repoversion}/main/rccl-2.22.3.60403-128.el%{rhel}.%{_arch}.rpm
+Source30: https://%{repository}/%{repoversion}/main/rccl-devel-2.22.3.60403-128.el%{rhel}.%{_arch}.rpm
+Source31: https://%{repository}/%{repoversion}/main/rocshmem-devel-2.0.1.60403-128.el%{rhel}.%{_arch}.rpm
 
 # sources for rocprofiler-register
 Source99: git+https://github.com/ROCm/rocprofiler-register.git?obj=%{rocprofiler_register_branch}/%{rocprofiler_register_tag}&export=%{rocprofiler_register_pkg}&submodules=1&output=/%{rocprofiler_register_pkg}.tgz
@@ -101,6 +102,7 @@ rpm2cpio %{SOURCE27} | cpio -idmv
 rpm2cpio %{SOURCE28} | cpio -idmv
 rpm2cpio %{SOURCE29} | cpio -idmv
 rpm2cpio %{SOURCE30} | cpio -idmv
+rpm2cpio %{SOURCE31} | cpio -idmv
 
 # build rocprofiler-register
 sed -i -e 's|add_subdirectory(external)|find_package(fmt REQUIRED)\nadd_subdirectory(external)|' src/%{rocprofiler_register_pkg}/CMakeLists.txt


### PR DESCRIPTION
Add rocSHMEM development library.

For the changes since ROCm 6.3.2, see:
  - [ROCm 6.3.3 release notes](https://rocm.docs.amd.com/en/docs-6.3.3/about/release-notes.html)
  - [ROCm 6.4.0 release notes](https://rocm.docs.amd.com/en/docs-6.4.0/about/release-notes.html)
  - [ROCm 6.4.1 release notes](https://rocm.docs.amd.com/en/docs-6.4.1/about/release-notes.html)
  - [ROCm 6.4.2 release notes](https://rocm.docs.amd.com/en/docs-6.4.2/about/release-notes.html)
  - [ROCm 6.4.3 release notes](https://rocm.docs.amd.com/en/docs-6.4.3/about/release-notes.html)
