### PR TITLE
[Sherpa]Apply the upstream patch to avoid setting env

### DIFF
--- a/sherpa-setenv.patch
+++ b/sherpa-setenv.patch
@@ -1,0 +1,28 @@
+diff --git a/ATOOLS/Org/Exception.H b/ATOOLS/Org/Exception.H
+index 3306a31..33ec262 100644
+--- a/ATOOLS/Org/Exception.H
++++ b/ATOOLS/Org/Exception.H
+@@ -119,7 +119,7 @@ namespace ATOOLS {
+ 
+ }// end of namespace ATOOLS
+ 
+-#if defined(__sgi) || defined(__GNUC__)
++#if defined(__GNUC__)
+ #define THROW(exception,message)			\
+   throw(ATOOLS::Exception(ATOOLS::ex::exception,	\
+ 			  message,__PRETTY_FUNCTION__));
+diff --git a/ATOOLS/Org/Run_Parameter.C b/ATOOLS/Org/Run_Parameter.C
+index bdd3b4a..ce5a807 100644
+--- a/ATOOLS/Org/Run_Parameter.C
++++ b/ATOOLS/Org/Run_Parameter.C
+@@ -231,10 +231,6 @@ void Run_Parameter::Init(std::string path,std::string file,int argc,char* argv[]
+ 		<<"   SHERPA_LIB_PATH = "<<gen.m_variables["SHERPA_LIB_PATH"]<<"\n"
+ 		<<"   SHERPA_DAT_PATH = "<<gen.m_variables["SHERPA_DAT_PATH"]<<"\n"
+ 		<<"}"<<std::endl;
+-#ifndef __sgi
+-  setenv(LD_PATH_NAME,(gen.m_variables[LD_PATH_NAME]+std::string(":")+
+-			    gen.m_variables["SHERPA_LIB_PATH"]).c_str(),1);
+-#endif
+   gen.m_variables["EVENT_GENERATION_MODE"]="-1";
+   gen.m_analysis           = dr.GetValue<int>("ANALYSIS",0);
+   dr.SetAllowUnits(true);

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -4,6 +4,8 @@ Requires: hepmc lhapdf blackhat sqlite python3 fastjet openmpi
 BuildRequires: mcfm swig autotools
 Patch0: sherpa-2.2.10-hepmcshort
 Patch1: sherpa-cpp20
+#Avoid calling setenv: https://gitlab.com/sherpa-team/sherpa/-/commit/6ead62d7a2758612f8965fb5b61df8c012cf9cae.diff
+Patch2: sherpa-setenv
 
 %{!?without_openloops:Requires: openloops}
 
@@ -23,6 +25,7 @@ perl -p -i -e 's|-rdynamic||g' configure AddOns/Analysis/Scripts/Makefile.in
 
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 
 %build
 export PYTHON=$(which python3)


### PR DESCRIPTION
See https://github.com/cms-sw/cmsdist/pull/10058#issuecomment-3255956279 for details

Couple of DEVEL IBs relvals fail as in that integration build we track and fail when someone call `setenv` (which is not thread safe). Looks like Sherpa is calling `setenv` ( see https://github.com/cms-sw/cmsdist/pull/10058#issuecomment-3255956279 ). The `setenv` call is made [here]( https://gitlab.com/sherpa-team/sherpa/-/blob/v2.2.15/ATOOLS/Org/Run_Parameter.C?ref_type=tags#L234-237) which has been removed in newer sherpa versions (v3.0.0 and above) via https://gitlab.com/sherpa-team/sherpa/-/commit/6ead62d7a2758612f8965fb5b61df8c012cf9cae change. This PR proposes to include this change in our sherpa version to avoid `setenv` calls.

@cms-sw/generators-l2 , can you please review this change ? May be we can move to sherpa v3?