### PR TITLE
Fix for various relocation issues

### DIFF
--- a/c-blosc2.spec
+++ b/c-blosc2.spec
@@ -28,3 +28,4 @@ ninja -v %{makeprocesses} install
 
 %post
 %{relocateConfig}lib64/pkgconfig/blosc2.pc
+%{relocateConfig}lib64/cmake/Blosc2/Blosc2Targets.cmake

--- a/celeritas.spec
+++ b/celeritas.spec
@@ -56,3 +56,4 @@ make %{makeprocesses} install VERBOSE=1
 
 %post
 %{relocateConfig}lib64/cmake/Celeritas/CeleritasConfig.cmake
+%{relocateConfig}lib64/cmake/G4VG/G4VGConfig.cmake

--- a/libunwind.spec
+++ b/libunwind.spec
@@ -22,3 +22,6 @@ make %{makeprocesses}
 make %{makeprocesses} install
 [ -d %{i}/lib64 ] && mv %{i}/lib64 %{i}/lib
 %define drop_files %{i}/share/man %{i}/lib/pkgconfig %{i}/lib/*.a
+
+%post
+%{relocateConfig}libexec/libunwind/test-runner

--- a/madgraph5amcatnlo.spec
+++ b/madgraph5amcatnlo.spec
@@ -56,6 +56,7 @@ sed -ideleteme 's|#!.*/bin/python|#!/usr/bin/env python|' \
 find %{i} -name '*deleteme' -delete
 rm -f %{i}/basiceventgeneration/*.log
 rm -f %{i}/basiceventgeneration/Source/StdHEP/log.mcfio.*
+rm -f %{i}/MG5_debug
 
 %post
 %relocateConfigAll . py.py

--- a/openmpi.spec
+++ b/openmpi.spec
@@ -67,4 +67,5 @@ make install
 find %{i}/lib/ -name '*.la' -delete
 
 %post
-%{relocateConfig}share/openmpi/*-wrapper-data.txt
+%{relocateConfig}share/*/*-wrapper-data.txt
+%{relocateConfig}include/pmix/src/include/pmix_config.h

--- a/pip/pyzmq.file
+++ b/pip/pyzmq.file
@@ -11,4 +11,3 @@ library_dirs = $LIBZMQ_ROOT/lib\
 EOF
 
 %define PipPreBuild  export CMAKE_BUILD_PARALLEL_LEVEL=%{compiling_processes}
-%define PipPostPost %{relocateConfig}lib/python*/site-packages/zmq/utils/*.json


### PR DESCRIPTION
Force rebuild of all packages shows that there are some text files in few packages we have build paths. This PR addresses all those [relocation issues](https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-e0b45c/48141/summary.html)