### PR TITLE
Update ROCm to version 7.0.0

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -1,15 +1,8 @@
-### RPM external rocm 6.4.3
+### RPM external rocm 7.0.0
 ## INCLUDE cpp-standard
 ## INITENV SET HIP_PATH %{i}
 
-%if 0%{?rhel} == 7
-# allow rpm2cpio dependency on the bootstrap bundle
-%undefine drop_bootstrap_lib
-%define drop_bootstrap_lib true
-%define repository repo.radeon.com/rocm/yum
-%else
 %define repository repo.radeon.com/rocm/rhel%{rhel}
-%endif
 
 # AMD repositories are numbered 6.2, 6.2.1, 6.2.2, ..., 6.3
 # without any .0 in the directory name
@@ -23,38 +16,38 @@
 %define rocprofiler_register_tag    rocm-%{realversion}
 %define rocprofiler_register_pkg    rocprofiler-register-%{rocprofiler_register_tag}
 
-Source0: https://%{repository}/%{repoversion}/main/amd-smi-lib-25.5.1.60403-128.el%{rhel}.%{_arch}.rpm
-Source1: https://%{repository}/%{repoversion}/main/comgr-3.0.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source2: https://%{repository}/%{repoversion}/main/hip-devel-6.4.43484.60403-128.el%{rhel}.%{_arch}.rpm
-Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-6.4.43484.60403-128.el%{rhel}.%{_arch}.rpm
-Source4: https://%{repository}/%{repoversion}/main/hipcc-1.1.1.60403-128.el%{rhel}.%{_arch}.rpm
-Source5: https://%{repository}/%{repoversion}/main/hsa-rocr-1.15.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source6: https://%{repository}/%{repoversion}/main/hsa-rocr-devel-1.15.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source7: https://%{repository}/%{repoversion}/main/openmp-extras-devel-18.63.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source8: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-18.63.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source9: https://%{repository}/%{repoversion}/main/rocm-core-6.4.3.60403-128.el%{rhel}.%{_arch}.rpm
-Source10: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.77.2.60403-128.el%{rhel}.%{_arch}.rpm
-Source11: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source12: https://%{repository}/%{repoversion}/main/rocm-llvm-19.0.0.25224.60403-128.el%{rhel}.%{_arch}.rpm
-Source13: https://%{repository}/%{repoversion}/main/rocm-smi-lib-7.7.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source14: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source15: https://%{repository}/%{repoversion}/main/rocprim-devel-3.4.1.60403-128.el%{rhel}.%{_arch}.rpm
-Source16: https://%{repository}/%{repoversion}/main/rocprofiler-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
-Source17: https://%{repository}/%{repoversion}/main/rocprofiler-compute-3.1.1.60403-128.el%{rhel}.%{_arch}.rpm
-Source18: https://%{repository}/%{repoversion}/main/rocprofiler-devel-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
-Source19: https://%{repository}/%{repoversion}/main/rocprofiler-docs-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
-Source20: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.60403.60403-128.el%{rhel}.%{_arch}.rpm
-Source21: https://%{repository}/%{repoversion}/main/rocprofiler-register-0.4.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source22: https://%{repository}/%{repoversion}/main/rocprofiler-systems-1.0.2.60403-128.el%{rhel}.%{_arch}.rpm
-Source23: https://%{repository}/%{repoversion}/main/hipcub-devel-3.4.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source24: https://%{repository}/%{repoversion}/main/rocthrust-devel-3.3.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source25: https://%{repository}/%{repoversion}/main/hiprand-2.12.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source26: https://%{repository}/%{repoversion}/main/hiprand-devel-2.12.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source27: https://%{repository}/%{repoversion}/main/rocrand-3.3.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source28: https://%{repository}/%{repoversion}/main/rocrand-devel-3.3.0.60403-128.el%{rhel}.%{_arch}.rpm
-Source29: https://%{repository}/%{repoversion}/main/rccl-2.22.3.60403-128.el%{rhel}.%{_arch}.rpm
-Source30: https://%{repository}/%{repoversion}/main/rccl-devel-2.22.3.60403-128.el%{rhel}.%{_arch}.rpm
-Source31: https://%{repository}/%{repoversion}/main/rocshmem-devel-2.0.1.60403-128.el%{rhel}.%{_arch}.rpm
+Source0: https://%{repository}/%{repoversion}/main/amd-smi-lib-26.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source1: https://%{repository}/%{repoversion}/main/comgr-3.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source2: https://%{repository}/%{repoversion}/main/hip-devel-7.0.51831.70000-38.el%{rhel}.%{_arch}.rpm
+Source3: https://%{repository}/%{repoversion}/main/hip-runtime-amd-7.0.51831.70000-38.el%{rhel}.%{_arch}.rpm
+Source4: https://%{repository}/%{repoversion}/main/hipcc-1.1.1.70000-38.el%{rhel}.%{_arch}.rpm
+Source5: https://%{repository}/%{repoversion}/main/hsa-rocr-1.18.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source6: https://%{repository}/%{repoversion}/main/hsa-rocr-devel-1.18.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source7: https://%{repository}/%{repoversion}/main/openmp-extras-devel-20.70.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source8: https://%{repository}/%{repoversion}/main/openmp-extras-runtime-20.70.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source9: https://%{repository}/%{repoversion}/main/rocm-core-7.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source10: https://%{repository}/%{repoversion}/main/rocm-dbgapi-0.77.3.70000-38.el%{rhel}.%{_arch}.rpm
+Source11: https://%{repository}/%{repoversion}/main/rocm-device-libs-1.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source12: https://%{repository}/%{repoversion}/main/rocm-llvm-20.0.0.25314.70000-38.el%{rhel}.%{_arch}.rpm
+Source13: https://%{repository}/%{repoversion}/main/rocm-smi-lib-7.8.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source14: https://%{repository}/%{repoversion}/main/rocminfo-1.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source15: https://%{repository}/%{repoversion}/main/rocprim-devel-4.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source16: https://%{repository}/%{repoversion}/main/rocprofiler-2.0.70000.70000-38.el%{rhel}.%{_arch}.rpm
+Source17: https://%{repository}/%{repoversion}/main/rocprofiler-compute-3.2.3.70000-38.el%{rhel}.%{_arch}.rpm
+Source18: https://%{repository}/%{repoversion}/main/rocprofiler-devel-2.0.70000.70000-38.el%{rhel}.%{_arch}.rpm
+Source19: https://%{repository}/%{repoversion}/main/rocprofiler-docs-2.0.70000.70000-38.el%{rhel}.%{_arch}.rpm
+Source20: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.70000.70000-38.el%{rhel}.%{_arch}.rpm
+Source21: https://%{repository}/%{repoversion}/main/rocprofiler-register-0.5.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source22: https://%{repository}/%{repoversion}/main/rocprofiler-systems-1.1.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source23: https://%{repository}/%{repoversion}/main/hipcub-devel-4.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source24: https://%{repository}/%{repoversion}/main/rocthrust-devel-4.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source25: https://%{repository}/%{repoversion}/main/hiprand-3.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source26: https://%{repository}/%{repoversion}/main/hiprand-devel-3.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source27: https://%{repository}/%{repoversion}/main/rocrand-4.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source28: https://%{repository}/%{repoversion}/main/rocrand-devel-4.0.0.70000-38.el%{rhel}.%{_arch}.rpm
+Source29: https://%{repository}/%{repoversion}/main/rccl-2.26.6.70000-38.el%{rhel}.%{_arch}.rpm
+Source30: https://%{repository}/%{repoversion}/main/rccl-devel-2.26.6.70000-38.el%{rhel}.%{_arch}.rpm
+Source31: https://%{repository}/%{repoversion}/main/rocshmem-devel-3.0.0.70000-38.el%{rhel}.%{_arch}.rpm
 
 # sources for rocprofiler-register
 Source99: git+https://github.com/ROCm/rocprofiler-register.git?obj=%{rocprofiler_register_branch}/%{rocprofiler_register_tag}&export=%{rocprofiler_register_pkg}&submodules=1&output=/%{rocprofiler_register_pkg}.tgz


### PR DESCRIPTION
For the changes since ROCm 6.4.3, see the [ROCm 7.0.0 release notes](https://rocm.docs.amd.com/en/docs-7.0.0/about/release-notes.html).