### PR TITLE
Update UCX to version 1.19.0

### DIFF
--- a/ucx.spec
+++ b/ucx.spec
@@ -1,4 +1,4 @@
-### RPM external ucx 1.18.1
+### RPM external ucx 1.19.0
 Source: https://github.com/openucx/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: autotools
 %{!?without_cuda:Requires: cuda gdrcopy}

--- a/ucx.spec
+++ b/ucx.spec
@@ -28,9 +28,12 @@ Requires: xpmem
   --enable-mt \
   --with-pic \
   --with-gnu-ld \
-  --with-avx \
+%ifarch x86_64
+  --with-march=x86-64-v2 \
   --with-sse41 \
   --with-sse42 \
+  --without-avx \
+%endif
   --without-go \
   --without-java \
 %if 0%{!?without_cuda:1}


### PR DESCRIPTION
Update UCX to version 1.19.0, and disable the use of AVX instructions to support `x86-64-v2`.

See [the release page](https://github.com/openucx/ucx/releases/tag/v1.19.0) for the new features and bug fixes included in the release.