### PR TITLE
Update alpaka to 2.0.0 "Concepts Ahead"

### DIFF
--- a/alpaka.spec
+++ b/alpaka.spec
@@ -1,10 +1,9 @@
-### RPM external alpaka 1.3.0
+### RPM external alpaka 2.0.0
 ## NOCOMPILER
 
 %define git_commit %{realversion}
 
 Source: https://github.com/cms-externals/%{n}/archive/%{git_commit}.tar.gz
-Requires: boost
 
 %prep
 %setup -n %{n}-%{git_commit}

--- a/scram-tools.file/tools/alpaka/alpaka.xml
+++ b/scram-tools.file/tools/alpaka/alpaka.xml
@@ -1,5 +1,4 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
-  <use name="boost"/>
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
@@ -13,4 +12,12 @@
   <flags CXXFLAGS="-DALPAKA_DISABLE_VENDOR_RNG"/>
   <flags CUDA_FLAGS="-DALPAKA_DISABLE_VENDOR_RNG"/>
   <flags GENREFLEX_CPPFLAGS="-DALPAKA_DISABLE_VENDOR_RNG"/>
+  <!-- enable the use of std::atomic_ref -->
+  <flags CXXFLAGS="-DALPAKA_HAS_STD_ATOMIC_REF"/>
+  <flags CUDA_FLAGS="-DALPAKA_HAS_STD_ATOMIC_REF"/>
+  <flags GENREFLEX_CPPFLAGS="-DALPAKA_HAS_STD_ATOMIC_REF"/>
+  <!-- std::call_once is implemented using a pthread weak symbol on EL8 -->
+  <ifarchitecture name="el8">
+    <flags LDFLAGS="-Wl,-no-as-needed -lpthread -Wl,-as-needed"/>
+  </ifarchitecture>
 </tool>


### PR DESCRIPTION
This version introduces C++20 compatibility and removes the dependency on Boost.

See [here](https://github.com/alpaka-group/alpaka/releases/tag/2.0.0) for the release notes, and [here](https://github.com/alpaka-group/alpaka/pulls?q=milestone%3A2.0.0) for the full list of changes in the 2.0.0 release.