### PR TITLE
Updated Geant4.spec to v11.3.ref09

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
-### RPM external geant4 11.3.ref07
-%define tag 5abed18b8d0e8564416e6288cefb4e3f7941b3b5
+### RPM external geant4 11.3.ref09
+%define tag 0eef0d9ac0fb44bff98dabfe008cf8a3149e91db
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz

--- a/scram-tools.file/tools/geant4/geant4core.xml
+++ b/scram-tools.file/tools/geant4/geant4core.xml
@@ -14,7 +14,8 @@
   <lib name="G4mctruth"/>
   <lib name="G4gdml"/>
   <lib name="G4physicslists"/>
-  <lib name="G4processes"/>
+  <lib name="G4processes_core"/>
+  <lib name="G4processes_hadronic"/>
   <lib name="G4readout"/>
   <lib name="G4run"/>
   <lib name="G4tracking"/>


### PR DESCRIPTION
Resolves [Migration of Geant4 branches to Geant4 11.3.ref09 #96](https://github.com/cms-externals/geant4/issues/96)