### PR TITLE
Updated flatbuffers to use flags instead of Patch

### DIFF
--- a/flatbuffers.spec
+++ b/flatbuffers.spec
@@ -5,21 +5,18 @@
 %define branch master
 %define github_user google
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
-Source1: https://patch-diff.githubusercontent.com/raw/google/flatbuffers/pull/7227.diff
-Patch0: flatbuffers-7422
 
 BuildRequires: cmake gmake
 
 %prep
 %setup -n %{n}-%{realversion}
-%patch0 -p1
-patch -p1 <%{_sourcedir}/7227.diff
 
 %build
 rm -rf ../build
 mkdir ../build
 cd ../build
 
+export FLATBUFFERS_CXX_FLAGS="-Wall -pedantic -Wno-unknown-warning-option -Werror -Wextra -Werror=shadow -Wno-error=stringop-overflow"
 cmake ../%{n}-%{realversion} \
    -DCMAKE_BUILD_TYPE=Release \
   -DFLATBUFFERS_BUILD_CPP17=ON \


### PR DESCRIPTION
The CMakelists.txt has FLATBUFFERS_CXX_FLAGS which we can use to export flags
https://github.com/google/flatbuffers/blob/v24.3.25/CMakeLists.txt#L284
```txt
  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLATBUFFERS_CXX_FLAGS}")
```
Instead of applying a previous patch for the same.
```diff
   set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Werror=shadow")
+    "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wno-unknown-warning-option -Werror -Wextra -Werror=shadow -Wno-error=stringop-overflow")
   set(FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wold-style-cast")
   ```