### PR TITLE
[ROOT636] Fix relocation of lib/cmake/CppInterOp/CppInterOpConfig.cmake

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -201,3 +201,4 @@ rm -rf build
 %{relocateConfig}etc/notebook/jupyter_notebook_config.py
 %{relocateConfig}include/RConfigOptions.h
 %{relocateConfig}include/compiledata.h
+%{relocateConfig}lib/cmake/CppInterOp/CppInterOpConfig.cmake


### PR DESCRIPTION
Relocate lib/cmake/CppInterOp/CppInterOpConfig.cmake file .
https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-cdab4a/48544/external_checks/relocate/root.txt
```
lib/cmake/CppInterOp/CppInterOpConfig.cmake:  set(_include "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc13/lcg/root/6.36.05-75ace835af434ee4ede120d40862a824/root-6.36.05/interpreter/CppInterOp/include")
lib/cmake/CppInterOp/CppInterOpConfig.cmake:  set(_lib "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc13/lcg/root/6.36.05-75ace835af434ee4ede120d40862a824/build/interpreter/CppInterOp/${shared_lib_dir}/${_lib_prefix}clangCppInterOp${_lib_suffix}")
lib/cmake/CppInterOp/CppInterOpConfig.cmake:  set(_cmake "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc13/lcg/root/6.36.05-75ace835af434ee4ede120d40862a824/build/interpreter/CppInterOp/${shared_lib_dir}/cmake/CppInterOp")
lib/cmake/CppInterOp/CppInterOpConfig.cmake:    set(_static_lib "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc13/lcg/root/6.36.05-75ace835af434ee4ede120d40862a824/build/interpreter/CppInterOp/lib/${_lib_prefix}clangCppInterOp.lib")
```
