### PR TITLE
[ROOT6] Updated root to tip of branch master: LLVM 20

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag a11295016a30381212382104c1fd9a5a76051eae
-%define branch cms/master/c3f701983c
+%define tag 42de9a7b7b4724ee211324a8d6ee43a2c3c469de
+%define branch cms/master/d3a49a1872c
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Testing latest root master branch changes which now uses [LLVM 20](https://github.com/root-project/root/pull/19242)