### PR TITLE
Update Catch2 from v2 to v3

### DIFF
--- a/catch2.spec
+++ b/catch2.spec
@@ -12,13 +12,17 @@ rm -rf build && mkdir build && cd build
 
 cmake ../Catch2-%{realversion} \
   -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_INSTALL_PREFIX="%{i}" \
   -DCATCH_INSTALL_HELPERS=ON \
   -DCATCH_INSTALL_EXTRAS=ON \
   -DCMAKE_INSTALL_COMPONENT="devel"
 
-make %{makeprocesses}
+make %{makeprocesses} VERBOSE=1
 
 %install
 cd %{_builddir}/build
 make install
+
+%post
+%{relocateConfig}share/pkgconfig/catch2*.pc

--- a/catch2.spec
+++ b/catch2.spec
@@ -1,10 +1,24 @@
-### RPM external catch2 2.13.6
-Source: https://raw.githubusercontent.com/catchorg/Catch2/v%{realversion}/single_include/catch2/catch.hpp
+### RPM external catch2 3.11.0
+
+Source: https://github.com/catchorg/Catch2/archive/refs/tags/v%{realversion}.tar.gz
+BuildRequires: cmake gmake
 
 %prep
+%setup -n Catch2-%{realversion}
 
 %build
+cd %{_builddir}
+rm -rf build && mkdir build && cd build
+
+cmake ../Catch2-%{realversion} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="%{i}" \
+  -DCATCH_INSTALL_HELPERS=ON \
+  -DCATCH_INSTALL_EXTRAS=ON \
+  -DCMAKE_INSTALL_COMPONENT="devel"
+
+make %{makeprocesses}
 
 %install
-mkdir %{i}/include
-cp %{_sourcedir}/catch.hpp %{i}/include/
+cd %{_builddir}/build
+make install

--- a/scram-tools.file/tools/catch2/catch2.xml
+++ b/scram-tools.file/tools/catch2/catch2.xml
@@ -1,6 +1,9 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
+  <lib name="Catch2Main"/>
+  <lib name="Catch2"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE"     default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib64"/>
   </client>
 </tool>


### PR DESCRIPTION
This update bumps Catch2 from version v2 to v3,

This PR includes
- Changes to catch2.spec to use the new CMake-based v3 build system.
- Changes to catch2.xml to detect and register the correct libraries (Catch2 and Catch2Main) for SCRAM.