### PR TITLE
[G4ADEPT] vecgeom update to v2.0.0-rc.7

### DIFF
--- a/vecgeom-fix-vector.patch
+++ b/vecgeom-fix-vector.patch
@@ -20,13 +20,3 @@ index dad4bdc..2886ead 100644
  endif()
  
  enum_option(VECGEOM_VECTOR DOC "Vector instruction set to be used"
-@@ -964,7 +964,7 @@ install(EXPORT VecGeomTargets
- 
- ################################################################################
- # Doxygen documentation
--find_package(Doxygen)
-+#find_package(Doxygen)
- if(DOXYGEN_FOUND)
-   set(DOXYFILE_OUTPUT_DIR  ${PROJECT_BINARY_DIR}/doxygen)
-   foreach(d doc/doxygen VecGeom persistency scripts source)
-   

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,11 +1,11 @@
-### RPM external vecgeom v2.0.0-rc.6
+### RPM external vecgeom v2.0.0-rc.7
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
 ## INCLUDE cuda-flags
 
-%define tag 66be96401f3d3bcbd4dd8f9731fae825b12b003e
+%define tag 2aa7db7a4f95ec8058696c22dae57679999f8bd3
 %define branch master
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Patch0: vecgeom-fix-vector


### PR DESCRIPTION
Including https://github.com/cms-sw/cmsdist/pull/10099 for G4ADEPT IBs