### PR TITLE
toolfile fix: make sure there is new line at the end of toolfile

### DIFF
--- a/scram/tool-conf-src.file
+++ b/scram/tool-conf-src.file
@@ -169,10 +169,11 @@ for type in selected available ; do
   [ -d %{i}/tools/${type} ] || continue
   for xml in $(ls %{i}/tools/${type}/*.xml) ; do
     tool=$(basename $xml)
-    echo "cat << \\EOF_TOOLFILE >> %%{i}/tools/${type}/${tool}" >> %{i}/tools/${type}.tmpl
-    cat $xml            >> %{i}/tools/${type}.tmpl
-    echo "EOF_TOOLFILE" >> %{i}/tools/${type}.tmpl
-    echo ""             >> %{i}/tools/${type}.tmpl
+    echo "cat << \\EOF_TOOLFILE >> %%{i}/tools/${type}/${tool}" > tmp-tool.txt
+    cat $xml                     >> tmp-tool.txt
+    echo -e "\nEOF_TOOLFILE\n"   >> tmp-tool.txt
+    grep -v '^\s*$' tmp-tool.txt >> %{i}/tools/${type}.tmpl
+    rm -f tmp-tool.txt
   done
   rm -rf %{i}/tools/${type}
 done

--- a/scram/toolfile-src.file
+++ b/scram/toolfile-src.file
@@ -20,10 +20,11 @@ touch ${tmpl}
 if [ -d %{i}/tools/selected ] ; then
   for xml in $(ls %{i}/tools/selected/*.xml) ; do
     tool=$(basename $xml)
-    echo "cat << \\EOF_TOOLFILE >> %%{i}/etc/scram.d/${tool}" >> ${tmpl}
-    cat $xml            >> ${tmpl}
-    echo "EOF_TOOLFILE" >> ${tmpl}
-    echo ""             >> ${tmpl}
+    echo "cat << \\EOF_TOOLFILE >> %%{i}/etc/scram.d/${tool}" > tmp-tool.txt
+    cat $xml                     >> tmp-tool.txt
+    echo -e "\nEOF_TOOLFILE\n"   >> tmp-tool.txt
+    grep -v '^\s*$' tmp-tool.txt >> ${tmpl}
+    rm -f tmp-tool.txt
   done
 fi
 


### PR DESCRIPTION
The scram toolfile does not have new line at the end then generating toolfile or tool-conf fails. This change makes sure that we always add new line if it is missing