### PR TITLE
Update configtag version to V09-08-11

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-08-10
+%define configtag       V09-08-11
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This change allows to properly skip the unit test if not run on supported hardware/gpu.