### PR TITLE
configtag V09-08-12 which contains fix for cuda source file dependency

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-08-11
+%define configtag       V09-08-12
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This should fix the cuda source files (.cu) source dependency issue we have seen in https://github.com/cms-sw/cmssw/pull/49230#issuecomment-3455913861 . compilter was dumping `path/objectfile.cu.o :` while https://github.com/cms-sw/cmssw-config/blob/scramv3/SCRAM/findDependencies.py was expecting `path/objectfile.cu.o:`  i.e. no space before `:`. New config tag contains a fix for this