### PR TITLE
Integrate Acts v44.0.1 (with minimal changes) as an external

### DIFF
--- a/acts.spec
+++ b/acts.spec
@@ -1,0 +1,123 @@
+### RPM external acts v44.0.1
+## INCLUDE cpp-standard
+## INCLUDE microarch_flags
+## INCLUDE compilation_flags
+## INCLUDE compilation_flags_lto
+## INCLUDE cuda-flags
+## INCLUDE rocm-flags
+
+%define tag         2d4cf6938
+%define branch      cms/%{realversion}
+%define github_user cms-externals
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source99: scram-tools.file/tools/eigen/env
+
+# Do not build the Acts and Traccc tests
+%define build_test 0
+
+# ROCm support is not yet building correctly
+%define without_rocm 1
+
+BuildRequires: cmake
+Requires: boost
+Requires: dd4hep
+Requires: eigen
+Requires: expat
+Requires: geant4
+Requires: json
+Requires: python3
+Requires: root
+Requires: xerces-c
+Requires: zlib
+%{!?without_cuda:Requires: cuda}
+%{!?without_rocm:Requires: rocm}
+%if %{build_test}
+# These are ony used to build the examples and unit tests
+Requires: hepmc3
+Requires: tbb
+%endif
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build
+mkdir ../build
+cd ../build
+source %{_sourcedir}/env
+
+%define cuda_enabled %{?without_cuda:OFF}%{!?without_cuda:ON}
+%define rocm_enabled %{?without_rocm:OFF}%{!?without_rocm:ON}
+
+# Notes:
+#   - gcc-ar and gcc-ranlib are needed to build static libraries with LTO support.
+#   - building with RPATH enabled is necessary to build and run the tests; set CMAKE_SKIP_INSTALL_RPATH to strip the RPATH
+#     information after installing the libraries.
+#   - HIP/ROCm support is not yet working correctly.
+
+cmake ../%{n}-%{realversion} \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
+  -DCMAKE_CXX_COMPILER="$GCC_ROOT/bin/g++" \
+  -DCMAKE_CXX_STANDARD="%{cms_cxx_standard}" \
+  -DCMAKE_CXX_FLAGS="-fPIC $CMS_EIGEN_CXX_FLAGS %{arch_build_flags} %{selected_microarch} %{lto_build_flags}" \
+  -DCMAKE_AR="$GCC_ROOT/bin/gcc-ar" \
+  -DCMAKE_RANLIB="$GCC_ROOT/bin/gcc-ranlib" \
+  -DCMAKE_BUILD_TYPE="Release" \
+  -DCMAKE_INSTALL_PREFIX="%{i}" \
+  -DCMAKE_SKIP_INSTALL_RPATH="ON" \
+  -DCMAKE_CUDA_ARCHITECTURES="$(echo %{cuda_arch} | sed -e 's/ \+/;/g')" \
+  -DCMAKE_CUDA_FLAGS="-Wno-deprecated-gpu-targets --threads 0" \
+  -DCMAKE_HIP_ARCHITECTURES="$(echo %{rocm_archs} | sed -e 's/ \+/;/g')" \
+  -DAMDGPU_TARGETS="$(echo %{rocm_archs} | sed -e 's/ \+/;/g')" \
+  -DBUILD_SHARED_LIBS="ON" \
+  -DACTS_NLOHMANNJSON_SOURCE="" \
+  -DACTS_USE_SYSTEM_NLOHMANN_JSON="ON" \
+  -DACTS_BUILD_PLUGIN_ACTSVG="ON" \
+  -DACTS_BUILD_PLUGIN_JSON="ON" \
+  -DACTS_BUILD_PLUGIN_ROOT="ON" \
+  -DACTS_BUILD_PLUGIN_DD4HEP="ON" \
+  -DACTS_BUILD_PLUGIN_GEANT4="ON" \
+  -DACTS_BUILD_PLUGIN_TRACCC="ON" \
+  -DACTS_ENABLE_LOG_FAILURE_THRESHOLD="ON" \
+  -DCOVFIE_PLATFORM_CPU="ON" \
+  -DCOVFIE_PLATFORM_CUDA="%{cuda_enabled}" \
+  -DCOVFIE_PLATFORM_HIP="%{rocm_enabled}" \
+  -DDETRAY_SETUP_NLOHMANN="ON" \
+  -DDETRAY_USE_SYSTEM_NLOHMANN="ON" \
+  -DDETRAY_BUILD_HOST="ON" \
+  -DDETRAY_BUILD_CUDA="%{cuda_enabled}" \
+  -DDETRAY_BUILD_HIP="%{rocm_enabled}" \
+  -DTRACCC_BUILD_CUDA="%{cuda_enabled}" \
+  -DTRACCC_BUILD_HIP="%{rocm_enabled}" \
+  -DTRACCC_SETUP_THRUST="%{cuda_enabled}" \
+  -DTRACCC_SETUP_ROCTHRUST="%{rocm_enabled}" \
+  -DTRACCC_USE_SYSTEM_THRUST="%{cuda_enabled}" \
+  -DTRACCC_USE_SYSTEM_ROCTHRUST="%{rocm_enabled}" \
+  -DVECMEM_BUILD_CUDA_LIBRARY="%{cuda_enabled}" \
+  -DVECMEM_BUILD_HIP_LIBRARY="%{rocm_enabled}" \
+%if %{build_test}
+  -DACTS_BUILD_UNITTESTS="ON" \
+  -DACTS_BUILD_INTEGRATIONTESTS="ON" \
+  -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS="ON" \
+  -DTRACCC_BUILD_TESTING="ON" \
+%endif
+  -L
+
+make %{makeprocesses} VERBOSE=1
+
+%install
+cd ../build
+make install VERBOSE=1
+
+%if %{build_test}
+# download the traccc test data file to the .../data directory
+mkdir -p %{i}/data
+./_deps/traccc-src/data/traccc_data_get_files.sh -o %{i}/data
+%endif
+
+# remove the scripts used to set the Acts environment variables
+rm %{i}/bin/this_acts.sh
+rm %{i}/bin/this_acts_withdeps.sh
+
+%post
+%{relocateConfig}lib64/cmake/*/*.cmake

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -8,6 +8,7 @@ Requires: AXOL1TL
 Requires: TOPO
 Requires: CICADA
 Requires: OpenBLAS
+Requires: acts
 Requires: celeritas
 Requires: crab
 Requires: cmssw-wm-tools

--- a/scram-tools.file/tools/acts/acts-common.xml
+++ b/scram-tools.file/tools/acts/acts-common.xml
@@ -1,0 +1,11 @@
+<tool name="acts-common" version="@TOOL_VERSION@" revision="1">
+  <!-- common tool that defines the directories and common flags for all Acts tool -->
+  <info url="https://acts.readthedocs.io/en/latest/index.html"/>
+  <flags CXXFLAGS="-Wno-missing-braces"/>
+  <flags CXXFLAGS="-DACTS_ENABLE_LOG_FAILURE_THRESHOLD"/>
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/acts/acts-core.xml
+++ b/scram-tools.file/tools/acts/acts-core.xml
@@ -1,0 +1,7 @@
+<tool name="acts-core" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/index.html"/>
+  <lib name="ActsCore"/>
+  <use name="acts-common"/>
+  <use name="boost_header"/>
+  <use name="eigen"/>
+</tool>

--- a/scram-tools.file/tools/acts/acts-covfie.xml
+++ b/scram-tools.file/tools/acts/acts-covfie.xml
@@ -1,0 +1,6 @@
+<tool name="acts-covfie" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/plugins/plugins.html"/>
+  <lib name="ActsPluginCovfie"/>
+  <use name="acts-core"/>
+  <use name="covfie"/>
+</tool>

--- a/scram-tools.file/tools/acts/acts-dd4hep.xml
+++ b/scram-tools.file/tools/acts/acts-dd4hep.xml
@@ -1,0 +1,18 @@
+<tool name="acts-dd4hep" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/plugins/dd4hep.html"/>
+  <lib name="ActsPluginDD4hep"/>
+  <use name="acts-core"/>
+  <use name="acts-root"/>
+  <use name="dd4hep-core"/>
+  <use name="rootcling"/>
+  <use name="rootcore"/>
+  <use name="rootgeom"/>
+  <use name="roothistmatrix"/>
+  <use name="rootimt"/>
+  <use name="rootmath"/>
+  <use name="rootphysics"/>
+  <use name="rootrint"/>
+  <use name="rootrio"/>
+  <use name="rootthread"/>
+  <use name="xerces-c"/>
+</tool>

--- a/scram-tools.file/tools/acts/acts-detray.xml
+++ b/scram-tools.file/tools/acts/acts-detray.xml
@@ -1,0 +1,8 @@
+<tool name="acts-detray" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/acts-project/detray"/>
+  <lib name="ActsPluginDetray"/>
+  <use name="acts-core"/>
+  <use name="actsvg"/>
+  <use name="detray"/>
+  <use name="vecmem"/>
+</tool>

--- a/scram-tools.file/tools/acts/acts-geant4.xml
+++ b/scram-tools.file/tools/acts/acts-geant4.xml
@@ -1,0 +1,12 @@
+<tool name="acts-geant4" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/plugins/geant4.html"/>
+  <lib name="ActsPluginGeant4"/>
+  <use name="acts-core"/>
+  <use name="acts-root"/>
+  <use name="clhep"/>
+  <use name="expat"/>
+  <use name="geant4core"/>
+  <use name="geant4vis"/>
+  <use name="xerces-c"/>
+  <use name="zlib"/>
+</tool>

--- a/scram-tools.file/tools/acts/acts-json.xml
+++ b/scram-tools.file/tools/acts/acts-json.xml
@@ -1,0 +1,6 @@
+<tool name="acts-json" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/plugins/json.html"/>
+  <lib name="ActsPluginJson"/>
+  <use name="acts-core"/>
+  <use name="json"/>
+</tool>

--- a/scram-tools.file/tools/acts/acts-root.xml
+++ b/scram-tools.file/tools/acts/acts-root.xml
@@ -1,0 +1,13 @@
+<tool name="acts-root" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/plugins/root.html"/>
+  <lib name="ActsPluginRoot"/>
+  <use name="acts-core"/>
+  <use name="rootcling"/>
+  <use name="rootcore"/>
+  <use name="rootgeom"/>
+  <use name="roothistmatrix"/>
+  <use name="rootimt"/>
+  <use name="rootmathcore"/>
+  <use name="rootrio"/>
+  <use name="rootthread"/>
+</tool>

--- a/scram-tools.file/tools/acts/acts-svg.xml
+++ b/scram-tools.file/tools/acts/acts-svg.xml
@@ -1,0 +1,6 @@
+<tool name="acts-svg" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/plugins/plugins.html"/>
+  <lib name="ActsPluginActSVG"/>
+  <use name="acts-core"/>
+  <use name="actsvg"/>
+</tool>

--- a/scram-tools.file/tools/acts/actsvg.xml
+++ b/scram-tools.file/tools/acts/actsvg.xml
@@ -1,0 +1,6 @@
+<tool name="actsvg" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/acts-project/actsvg/blob/main/README.md"/>
+  <lib name="actsvg_core"/>
+  <lib name="actsvg_meta"/>
+  <use name="acts-common"/>
+</tool>

--- a/scram-tools.file/tools/acts/covfie.xml
+++ b/scram-tools.file/tools/acts/covfie.xml
@@ -1,0 +1,4 @@
+<tool name="covfie" version="@TOOL_VERSION@" revision="1">
+  <info url="https://covfie.readthedocs.io/en/latest/"/>
+  <use name="acts-common"/>
+</tool>

--- a/scram-tools.file/tools/acts/detray.xml
+++ b/scram-tools.file/tools/acts/detray.xml
@@ -1,0 +1,7 @@
+<tool name="detray" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/acts-project/detray/blob/main/README.md"/>
+  <use name="acts-common"/>
+  <use name="json"/>
+  <flags CXXFLAGS="-DDETRAY_ALGEBRA_ARRAY"/>
+  <flags CXXFLAGS="-DDETRAY_CUSTOM_SCALARTYPE=double"/>
+</tool>

--- a/scram-tools.file/tools/acts/traccc-cuda.xml
+++ b/scram-tools.file/tools/acts/traccc-cuda.xml
@@ -1,0 +1,8 @@
+<tool name="traccc-cuda" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/acts-project/traccc/"/>
+  <lib name="traccc_cuda"/>
+  <use name="acts-core"/>
+  <use name="cuda"/>
+  <use name="vecmem"/>
+  <use name="vecmem-cuda"/>
+</tool>

--- a/scram-tools.file/tools/acts/traccc-io.xml
+++ b/scram-tools.file/tools/acts/traccc-io.xml
@@ -1,0 +1,10 @@
+<tool name="traccc-io" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/acts-project/traccc/"/>
+  <lib name="traccc_io"/>
+  <use name="acts-core"/>
+  <use name="acts-json"/>
+  <use name="traccc"/>
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/acts/traccc-performance.xml
+++ b/scram-tools.file/tools/acts/traccc-performance.xml
@@ -1,0 +1,16 @@
+<tool name="traccc-performance" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/acts-project/traccc/"/>
+  <lib name="traccc_performance"/>
+  <use name="acts-core"/>
+  <use name="cuda"/>
+  <use name="traccc"/>
+  <use name="traccc-io"/>
+  <use name="vecmem"/>
+  <use name="rootcling"/>
+  <use name="roothistmatrix"/>
+  <use name="rootimt"/>
+  <use name="rootmathcore"/>
+  <use name="rootcore"/>
+  <use name="rootthread"/>
+  <use name="rootrio"/>
+</tool>

--- a/scram-tools.file/tools/acts/traccc.xml
+++ b/scram-tools.file/tools/acts/traccc.xml
@@ -1,0 +1,12 @@
+<tool name="traccc" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/acts-project/traccc/"/>
+  <lib name="traccc_core"/>
+  <use name="acts-common"/>
+  <use name="covfie"/>
+  <use name="detray"/>
+  <use name="vecmem"/>
+  <flags CXXFLAGS="-DALGEBRA_PLUGINS_INCLUDE_ARRAY"/>
+  <flags CXXFLAGS="-DTRACCC_CUSTOM_SCALARTYPE=double"/>
+  <flags CXXFLAGS="-DTRACCC_HAVE_NVTX"/>
+  <flags CXXFLAGS="-DTRACCC_HAVE_ROOT"/>
+</tool>

--- a/scram-tools.file/tools/acts/vecmem-cuda.xml
+++ b/scram-tools.file/tools/acts/vecmem-cuda.xml
@@ -1,0 +1,6 @@
+<tool name="vecmem-cuda" version="@TOOL_VERSION@" revision="1">
+  <info url="github.com/acts-project/vecmem/blob/main/README.md"/>
+  <lib name="vecmem_cuda"/>
+  <use name="cuda"/>
+  <use name="vecmem"/>
+</tool>

--- a/scram-tools.file/tools/acts/vecmem-rocm.xml
+++ b/scram-tools.file/tools/acts/vecmem-rocm.xml
@@ -1,0 +1,6 @@
+<tool name="vecmem-rocm" version="@TOOL_VERSION@" revision="1">
+  <info url="github.com/acts-project/vecmem/blob/main/README.md"/>
+  <lib name="vecmem_hip"/>
+  <use name="rocm"/>
+  <use name="vecmem"/>
+</tool>

--- a/scram-tools.file/tools/acts/vecmem.xml
+++ b/scram-tools.file/tools/acts/vecmem.xml
@@ -1,0 +1,8 @@
+<tool name="vecmem" version="@TOOL_VERSION@" revision="1">
+  <info url="github.com/acts-project/vecmem/blob/main/README.md"/>
+  <lib name="vecmem_core"/>
+  <use name="acts-common"/>
+  <flags CXXFLAGS="-DVECMEM_DEBUG_MSG_LVL=0"/>
+  <flags CXXFLAGS="-DVECMEM_HAVE_PMR_MEMORY_RESOURCE"/>
+  <flags CXXFLAGS="-DVECMEM_SUPPORT_POSIX_ATOMIC_REF"/>
+</tool>


### PR DESCRIPTION
Following the approval of the work by Lorenzo on "Enhancing CMS Passive Material Modeling in Track Reconstruction Using ACTS" ([link](https://indico.cern.ch/event/1567991/#48-pre-approval-enhancing-cms)), add ACTS as an external to CMSSW to simplify further developments.

Enable the plugins for SVG, Json, Root, DD4Hep, Geant4, Covfie, and Detray, and define individual tools for each Acts plugin and external library.

Backport acts-project/acts#4357 to the v44.0.x branch: implement the Gen3 geometry to detray conversion.

Backport acts-project/acts#4757 to the v44.0.x branch: Update namespace for Nlohmann Json v3.11 and later.

Backport acts-project/acts#4758 to the v44.0.x branch: update Traccc to v0.26.0 to be compatible with Acts v44.0.x, with the corresponding external updates:
  - detary v0.103.0
  - covfie v0.15.2
  - vecmem v1.21.0
  - algebra plugins v0.28.0

Target the CUDA and ROCm architectures supported by CMSSW.
