### PR TITLE
[do not merge] Enable the Acts and Traccc tests

### DIFF
--- a/acts.spec
+++ b/acts.spec
@@ -12,8 +12,8 @@
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 Source99: scram-tools.file/tools/eigen/env
 
-# Do not build the Acts and Traccc tests
-%define build_test 0
+# Build the Acts and Traccc tests
+%define build_test 1
 
 # ROCm support is not yet building correctly
 %define without_rocm 1

--- a/acts.spec
+++ b/acts.spec
@@ -20,6 +20,7 @@ Source99: scram-tools.file/tools/eigen/env
 
 BuildRequires: cmake
 Requires: boost
+Requires: bz2lib
 Requires: dd4hep
 Requires: eigen
 Requires: expat


### PR DESCRIPTION
Download the Traccc tests data to `${ACTS_BASE}/data` and set `TRACCC_TEST_DATA_DIR`.
Build the Acts unit tests and integration tests, some examples, and the Traccc tests.
