### PR TITLE
Add configuration option to build Celeritas with CUDA

### DIFF
--- a/celeritas.spec
+++ b/celeritas.spec
@@ -6,6 +6,7 @@ Source: git+https://github.com/celeritas-project/celeritas?obj=develop/%{tag}&ex
 %define package_build_flags -Wall -Wextra -pedantic
 ## INCLUDE geant4-deps
 Requires: python3 json geant4
+%{!?without_cuda:Requires: cuda}
 
 %prep
 %setup -n %{n}-%{realversion}
@@ -33,7 +34,12 @@ cmake ../%{n}-%{realversion} \
   -DCELERITAS_BUILD_TESTS=OFF \
   -DCELERITAS_DEBUG=OFF \
   -DCELERITAS_USE_OpenMP=OFF \
+%if 0%{!?without_cuda:1}
+  -DCELERITAS_USE_CUDA=ON \
+  -DCMAKE_CUDA_ARCHITECTURES=$(echo %{cuda_arch} | tr ' ' ';' | sed 's|;;*|;|') \
+%else
   -DCELERITAS_USE_CUDA=OFF \
+%endif
   -DCELERITAS_USE_Geant4=ON \
   -DCELERITAS_USE_HIP=OFF \
   -DCELERITAS_USE_HepMC3=OFF \

--- a/celeritas.spec
+++ b/celeritas.spec
@@ -5,6 +5,7 @@ Source: git+https://github.com/celeritas-project/celeritas?obj=develop/%{tag}&ex
 
 %define package_build_flags -Wall -Wextra -pedantic
 ## INCLUDE geant4-deps
+## INCLUDE cuda-flags
 Requires: python3 json geant4
 %{!?without_cuda:Requires: cuda}
 

--- a/scram-tools.file/tools/vecgeom/vecgeom.xml
+++ b/scram-tools.file/tools/vecgeom/vecgeom.xml
@@ -1,9 +1,10 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://gitlab.cern.ch/VecGeom/VecGeom"/>
-  <lib name="vecgeom"/>
+  <lib name="vecgeom_final"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
   </client>
   <use name="vecgeom_interface"/>
+  <use name="cuda"/>
 </tool>

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -3,12 +3,14 @@
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
+## INCLUDE cuda-flags
 
 %define tag 47dd602df7074fcc78036e93cd639ae6270207fd
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=master/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Patch0: vecgeom-fix-vector
 BuildRequires: cmake gmake
 Requires: xerces-c
+%{!?without_cuda:Requires: cuda}
 %define keep_archives true
 %define vecgeom_backend Scalar
 %define vecgeom_version %(echo %{realversion} | sed -e 's|^v||;s|-.*||')
@@ -45,6 +47,10 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_STATIC_LIBRARY_C_FLAGS="%{build_flags}" \
   -DCMAKE_CXX_FLAGS="%{build_flags}" \
   -DCMAKE_C_FLAGS="%{build_flags}" \
+%if 0%{!?without_cuda:1}
+  -DVECGEOM_ENABLE_CUDA=ON \
+  -DCMAKE_CUDA_ARCHITECTURES=$(echo %{cuda_arch} | tr ' ' ';' | sed 's|;;*|;|') \
+%endif
 %ifarch x86_64
 %if "%{vecgeom_backend}" == "Vc"
   -DVECGEOM_VECTOR="${VECGEOM_VECTOR_INST}" \


### PR DESCRIPTION
The CMS Celeritas integration team (@sanmayphy and @kpedro88 ) has successfully integrated the CPU-only version of Celeritas into the CMSSW detector simulation workflow. We would now like to enable GPU support to begin testing and validating Celeritas offloading on CUDA-capable devices within CMSSW.