### PR TITLE
Add the xtd library

### DIFF
--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -152,7 +152,7 @@ Requires: python_tools
 Requires: dablooms
 Requires: zlib
 Requires: rivet
-
+Requires: xtd
 
 # Only for Linux platform.
 %ifos linux

--- a/scram-tools.file/tools/xtd/xtd.xml
+++ b/scram-tools.file/tools/xtd/xtd.xml
@@ -1,0 +1,7 @@
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="1">
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+  </client>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+</tool>

--- a/xtd.spec
+++ b/xtd.spec
@@ -1,0 +1,18 @@
+### RPM external xtd be7dc5807e054ea9a4796c902b5076a7c36ca918
+## NOCOMPILER
+
+%define git_commit %{realversion}
+
+Source: https://github.com/cms-patatrack/%{n}/archive/%{git_commit}.tar.gz
+
+%prep
+%setup -n %{n}-%{git_commit}
+
+%build
+
+%install
+cp -ar LICENSE      %{i}/LICENSE
+cp -ar README.md    %{i}/README.md
+cp -ar include      %{i}/include
+
+%post


### PR DESCRIPTION
xtd aims to wrap C/C++ math functions provided by host and device libraries with a consustent interface.

See https://github.com/cms-patatrack/xtd/blob/master/README.md for more information.

xtd is released under the MPL 2.0 license.