### PR TITLE
acts: use geant4-deps file automatically get vecgeom if enabled

### DIFF
--- a/acts.spec
+++ b/acts.spec
@@ -1,10 +1,8 @@
 ### RPM external acts v44.0.1
-## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
-## INCLUDE compilation_flags
-## INCLUDE compilation_flags_lto
 ## INCLUDE cuda-flags
 ## INCLUDE rocm-flags
+## INCLUDE geant4-deps
 
 %define tag         cc436985e
 %define branch      cms/%{realversion}


### PR DESCRIPTION
Improve `acts` recipe so that it gets all the reps of geant4 specially when geant4 is build with vecgeom enabled. With new version of geant4, build fails due to missing vecgeom in acts.  See https://github.com/cms-sw/cmsdist/pull/10185#issuecomment-3508299991
```
CMake Error at /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02914/el8_amd64_gcc13/external/cmake/3.31.7-62f307011423a7f6b44229944c8e4c9c/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  By not providing "FindVecGeom.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "VecGeom", but
  CMake did not find one.

  Could not find a package configuration file provided by "VecGeom"
  (requested version 2.0.0) with any of the following names:

    VecGeomConfig.cmake
    vecgeom-config.cmake

  Add the installation prefix of "VecGeom" to CMAKE_PREFIX_PATH or set
  "VecGeom_DIR" to a directory containing one of the above files.  If
  "VecGeom" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/geant4/11.4.cand00-915d6930ba5640e63499c07610f636f6/lib64/cmake/Geant4/Geant4Config.cmake:316 (find_dependency)
  CMakeLists.txt:458 (find_package)
```
