### PR TITLE
Updating EMTF NN to v1.0.1

### DIFF
--- a/EMTF_NN.spec
+++ b/EMTF_NN.spec
@@ -1,4 +1,4 @@
-### RPM external EMTF_NN 1.0.0
+### RPM external EMTF_NN 1.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/EMTF_NN.spec
+++ b/EMTF_NN.spec
@@ -1,4 +1,4 @@
-### RPM external EMTF_NN 1.0.1
+### RPM external EMTF_NN 1.0.2
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
EMTF NN model v1.0.1

model release: https://github.com/cms-hls4ml/EMTF_NN/releases/tag/v1.0.1