### PR TITLE
Update AdePT v0.1.9 alpha

### DIFF
--- a/adept.spec
+++ b/adept.spec
@@ -1,4 +1,4 @@
-### RPM external adept v0.1.8-alpha
+### RPM external adept v0.1.9-alpha
 %define tag %{realversion}
 %define branch master
 %define github_user apt-sim

--- a/g4hepem.spec
+++ b/g4hepem.spec
@@ -1,4 +1,4 @@
-### RPM external g4hepem 20250610
+### RPM external g4hepem 20251114
 %define tag %{realversion}
 %define branch master
 %define github_user mnovak42

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,4 +1,4 @@
-### RPM external vecgeom v2.0.0-rc.7
+### RPM external vecgeom v2.0.0-rc.8
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -5,7 +5,7 @@
 ## INCLUDE microarch_flags
 ## INCLUDE cuda-flags
 
-%define tag 2aa7db7a4f95ec8058696c22dae57679999f8bd3
+%define tag %{realversion}
 %define branch master
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Patch0: vecgeom-fix-vector


### PR DESCRIPTION
This PR updates AdePT to the latest version, which includes Woodcock tracking, to accelerate the simulation in the HGCAL.

Updates in G4HepEm and VecGeom are also needed for that version.

It would be fantastic if this version made it into the next IB!