### PR TITLE
[G4]Update vecgeom v2.0.0-rc.8 and g4hepem 20251114

### DIFF
--- a/g4hepem.spec
+++ b/g4hepem.spec
@@ -1,4 +1,4 @@
-### RPM external g4hepem 20250220
+### RPM external g4hepem 20251114
 %define tag %{realversion}
 %define branch master
 %define github_user mnovak42

--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,10 +1,10 @@
-### RPM external vecgeom v2.0.0-rc.7
+### RPM external vecgeom v2.0.0-rc.8
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
 
-%define tag 2aa7db7a4f95ec8058696c22dae57679999f8bd3
+%define tag %{realversion}
 %define branch master
 Source: git+https://gitlab.cern.ch/VecGeom/VecGeom.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Patch0: vecgeom-fix-vector


### PR DESCRIPTION
backported vecgeom/g4hepem changes from #10198 (already integrated in G4ADEPT IBs)