### PR TITLE
OpenLDAP: Added missing dependency on uuid

### DIFF
--- a/openldap.spec
+++ b/openldap.spec
@@ -19,8 +19,8 @@ chmod +x ./build/config.{sub,guess}
   --with-tls=openssl \
   --disable-static \
   --disable-slapd \
-  CPPFLAGS="-I${DB6_ROOT}/include" \
-  LDFLAGS="-L${DB6_ROOT}/lib"
+  CPPFLAGS="-I${DB6_ROOT}/include -I${LIBUUID_ROOT}/include" \
+  LDFLAGS="-L${DB6_ROOT}/lib -L${LIBUUID_ROOT}/lib"
 make depend
 make
 

--- a/openldap.spec
+++ b/openldap.spec
@@ -1,7 +1,7 @@
 ### RPM external openldap 2.5.19
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib
 Source: ftp://ftp.openldap.org/pub/OpenLDAP/%{n}-release/%{n}-%{realversion}.tgz
-Requires: db6
+Requires: db6 libuuid
 
 %prep
 %setup -q -n %{n}-%{realversion}


### PR DESCRIPTION
Testing full rebuild of CMS software stack showed that `openldap` was missing dependency on `libuuid` which was picked up from system.