### PR TITLE
[G4AdePT] update VecGeom to rc9

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,4 +1,4 @@
-### RPM external vecgeom v2.0.0-rc.8
+### RPM external vecgeom v2.0.0-rc.9
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard


### PR DESCRIPTION
This PR updates VecGeom to rc9, which includes an important bug fix that was discovered in rc8.