### PR TITLE
[G4] Update vecgeom version to v2.0.0-rc.9

### DIFF
--- a/vecgeom.spec
+++ b/vecgeom.spec
@@ -1,4 +1,4 @@
-### RPM external vecgeom v2.0.0-rc.8
+### RPM external vecgeom v2.0.0-rc.9
 ## INCLUDE compilation_flags
 ## INCLUDE compilation_flags_lto
 ## INCLUDE cpp-standard


### PR DESCRIPTION
backport of #10206 

Backport is from G4ADEPT IBs in to Geant4 special IBs