### PR TITLE
[OpenMPI] Add OMPI_MCA_accelerator runtime variable

### DIFF
--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="3">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="4">
   <lib name="mpi"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
@@ -8,6 +8,7 @@
   <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <runtime name="OPAL_PREFIX" value="$@TOOL_BASE@"/>
   <runtime name="PMIX_PREFIX" value="$@TOOL_BASE@"/>
+  <runtime name="OMPI_MCA_accelerator" value="null"/>
 %if "%{?HFI_NO_BACKTRACE:set}" == "set"
   <runtime name="HFI_NO_BACKTRACE" value="%{HFI_NO_BACKTRACE}"/>
 %endif


### PR DESCRIPTION
This change sets `OMPI_MCA_accelerator=null` for cmssw runtime environment (`cmsenv`) which will not initialize OpenMPI for any accelerator. This is need to avoid calling `setenv()` during the open mpi initialization. See https://github.com/cms-sw/cmssw/issues/49332 for detail discussion.

