### PR TITLE
16.0.X: Updated root to tip of branch v6-36-00-patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag f72ca89c8bf8b759ee7cfe89c4b9d180d7af9a37
-%define branch cms/v6-36-00-patches/56a08b5632f
+%define tag b604457f284c12d1af9f2c7dbf28f28ed76074e6
+%define branch cms/v6-36-00-patches/938e58c1151
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/root.spec
+++ b/root.spec
@@ -1,4 +1,4 @@
-### RPM lcg root 6.36.05
+### RPM lcg root 6.36.07
 ## INITENV +PATH PYTHON3PATH %{i}/lib
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags


### PR DESCRIPTION
Update ROOT to its latest changes from v6-36-00-patches branch. This also includes the fix for DQM bin-by-bin comparison failure we had seen after moving to ROOT 6.36 for 16.0.X ( https://github.com/cms-sw/cmssw/issues/49452 ).

This contains https://github.com/root-project/root/compare/56a08b5632fe8ab4fb1929cf8bc0d9550d3a67d6...v6-36-00-patches commits on top of what we already have in our default IBs. 
