### PR TITLE
RISCV64 updates; allow to use rpm/rpmbuild from system

### DIFF
--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -48,7 +48,8 @@ platformBuildSeeds+=" libX11-devel libXpm-devel libXft-devel mesa-libGLU-devel"
 
 %if 0%{?fedora:1}
 platformSeeds=$(echo ${platformSeeds} | sed 's| glibc-headers | glibc-devel |')
-platformSeeds+=" java-21-openjdk-devel"
+platformSeeds+=" java-21-openjdk-devel libbrotli"
+platformBuildSeeds+=" brotli-devel"
 %else
 %if 0%{?rhel} >= 9
 platformBuildSeeds+=" brotli-devel java-17-openjdk-devel"

--- a/bootstrap-driver.spec
+++ b/bootstrap-driver.spec
@@ -46,6 +46,10 @@ platformBuildSeeds="  git patch make zip unzip bzip2 which rsync"
 platformBuildSeeds+=" openssl-devel libxcrypt-devel"
 platformBuildSeeds+=" libX11-devel libXpm-devel libXft-devel mesa-libGLU-devel"
 
+%if 0%{?fedora:1}
+platformSeeds=$(echo ${platformSeeds} | sed 's| glibc-headers | glibc-devel |')
+platformSeeds+=" java-21-openjdk-devel"
+%else
 %if 0%{?rhel} >= 9
 platformBuildSeeds+=" brotli-devel java-17-openjdk-devel"
 %if 0%{?rhel} >= 10
@@ -53,6 +57,12 @@ platformSeeds=$(echo ${platformSeeds} | sed 's| glibc-headers | glibc-devel |')
 %endif
 %else
 platformBuildSeeds+=" java-1.8.0-openjdk-devel"
+%endif
+%endif
+
+%ifarch riscv64
+platformSeeds+=" rpm"
+platformBuildSeeds+=" rpm-build"
 %endif
 
 #Various packages required by xrootd with krb5 enabled

--- a/system/cmsdist_packages.py
+++ b/system/cmsdist_packages.py
@@ -1,0 +1,16 @@
+def packages(virtual_packages, *args):
+  from os.path import dirname, join, basename
+  from glob import glob
+  opts = None
+  if hasattr(args[0], "useSystemTools"):
+    opts = args[0]
+  else:
+    opts = args[0].options
+  overrideSysTools = list(opts.useSystemTools) + list(opts.overrideSystemTools)
+  if not overrideSysTools:
+    return
+  for spec in glob(join(dirname(__file__), "*.spec")):
+    pkg = basename(spec)[:-5]
+    if pkg in overrideSysTools:
+      virtual_packages[pkg] = "cat %s" % spec
+  return

--- a/system/rpm.spec
+++ b/system/rpm.spec
@@ -1,0 +1,33 @@
+%define rpm_version %(rpm --version | grep RPM | sed 's|.* ||')
+### RPM external rpm %{rpm_version}
+## NOCOMPILER
+## NO_AUTO_DEPENDENCY
+## INITENV SET CMSPKG_SYSTEM_RPM 1
+
+AutoReqProv: no
+
+%prep
+
+%build
+
+%install
+mkdir %{i}/bin
+pushd %{i}/bin
+cat <<EOF > rpm
+#!/bin/bash
+cmd=\$(basename \$0)
+REALRPM="/usr/bin"
+for p in /usr/bin /usr/sbin /bin; do
+  if [[ -x "\$p/\$cmd" ]]; then
+    REALRPM="\$p"
+    break
+  fi
+done
+\$REALRPM/\$cmd --dbpath %{cmsroot}/%{cmsplatf}/var/lib/rpm "\$@"
+EOF
+chmod +x rpm
+ln -s rpm rpmdb
+popd
+
+%post
+%{relocateConfig}bin/rpm


### PR DESCRIPTION
These changes along with https://github.com/cms-sw/pkgtools/pull/230 supports riscv64 bootstrapping. 