### PR TITLE
Geant4: Fix typo in member variable assignment

### DIFF
--- a/geant4.spec
+++ b/geant4.spec
@@ -1,5 +1,5 @@
 ### RPM external geant4 11.2.2
-%define tag e1c646ceca4bd407f6d10c0728e11b69dcffdcc0
+%define tag 5c95b0c974c8dda3d7255f403d4805af1801682f
 %define branch cms/v%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%github_user/%{n}.git?obj=%{branch}/%{tag}&export=%{n}.%{realversion}&output=/%{n}.%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Integrated https://github.com/cms-externals/geant4/pull/102

There was a bug/typo in geant4 code which GCC 14 and earlier did not catch but with GCC15 we get build errors. As CMS does not use this part of Geant4 code so it should be safe to get this in default 16.0.X Its