### PR TITLE
Add g4vg external to support celeritas and adept

### DIFF
--- a/g4vg.spec
+++ b/g4vg.spec
@@ -1,0 +1,40 @@
+### RPM external g4vg v1.0.5
+%define g4vg_gitversion %(echo %{realversion} | sed -e 's|^v||;s|-.*||')
+%define tag d377c26ea725d35d222f8b8dbd1094d0bb9a7a76
+Source: git+https://github.com/celeritas-project/g4vg?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+
+%define package_build_flags -Wall -Wextra -pedantic
+## INCLUDE geant4-deps
+Requires: geant4 vecgeom
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+
+rm -rf ../build
+mkdir ../build
+cd ../build
+
+cmake ../%{n}-%{realversion} \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_CXX_STANDARD:STRING="%{cms_cxx_standard}" \
+  -DCMAKE_AR=$(which gcc-ar) \
+  -DCMAKE_RANLIB=$(which gcc-ranlib) \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
+  -DCMAKE_CXX_FLAGS="%{build_flags}" \
+  -DCMAKE_C_FLAGS="%{build_flags}" \
+  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="%{build_flags}" \
+  -DCMAKE_STATIC_LIBRARY_C_FLAGS="%{build_flags}" \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DBUILD_SHARED_LIBS=ON
+
+make %{makeprocesses} VERBOSE=1
+
+%install
+cd ../build
+make %{makeprocesses} install VERBOSE=1
+
+%post
+%{relocateConfig}lib64/cmake/G4VG/G4VGConfig.cmake

--- a/scram-tools.file/tools/g4vg/g4vg.xml
+++ b/scram-tools.file/tools/g4vg/g4vg.xml
@@ -1,0 +1,12 @@
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="1">
+  <info url="https://github.com/celeritas-project/g4vg"/>
+  <lib name="g4vg"/>
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+  </client>
+  <use name="geant4core"/>
+  <use name="vecgeom_interface"/>
+  <use name="vecgeom"/>
+</tool>


### PR DESCRIPTION
Currently, g4vg is installed internally as part of the celeritas and adept builds. Making g4vg available as a standalone external package will allow both celeritas and adept to use a common external library. Once this external is successfully added, celeritas will be updated to use the g4vg external accordingly. This change was requested by @kpedro88.