### PR TITLE
 For gcc15 added cuda 13.1.0 as this release introduces support for G…

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,8 +1,8 @@
-### RPM external cuda 12.9.1
+### RPM external cuda 13.1.0
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm
-%define driversversion 575.57.08
+%define driversversion 590.44.01
 
 %ifarch x86_64
 Source0: https://developer.download.nvidia.com/compute/cuda/%{realversion}/local_installers/%{n}_%{realversion}_%{driversversion}_linux.run
@@ -23,7 +23,9 @@ mkdir %_builddir/build %_builddir/tmp
 
 # extract and repackage the CUDA runtime
 cd %_builddir/
+touch /tmp/cuda-installer.log
 /bin/sh %{SOURCE0} --silent --override --tmpdir=%_builddir/tmp --installpath=%_builddir/build --toolkit --keep
+rm -f /tmp/cuda-installer.log
 
 # create target directory structure
 mkdir -p %{i}/include

--- a/cuda.spec
+++ b/cuda.spec
@@ -23,8 +23,15 @@ mkdir %_builddir/build %_builddir/tmp
 
 # extract and repackage the CUDA runtime
 cd %_builddir/
+
+# The CUDA installer attempts to write to /tmp/cuda-installer.log, but this file may be created by another user, causing permission 
+# errors during installation.
+# Create /tmp/cuda-installer.log before installation to ensure the current user has write permissions
+# For reference see issue at https://forums.developer.nvidia.com/t/change-the-path-of-install-log-when-installing-cuda-toolkit/183179
 touch /tmp/cuda-installer.log
 /bin/sh %{SOURCE0} --silent --override --tmpdir=%_builddir/tmp --installpath=%_builddir/build --toolkit --keep
+
+# Remove /tmp/cuda-installer.log after installation to clean up the temporary log file
 rm -f /tmp/cuda-installer.log
 
 # create target directory structure

--- a/cudnn.spec
+++ b/cudnn.spec
@@ -1,7 +1,7 @@
 ### RPM external cudnn 9.9.0.52
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
-%define cudaver 12
+%define cudaver 13
 
 # NVIDIA uses sbsa for aarch64, and the standard architecture name for ppc64le and x86_64
 %ifarch aarch64


### PR DESCRIPTION
Added CUDA 13.1.0 support since CUDA 13.x introduces compatibility
with GCC 15 and Clang 20, which is required for newer toolchains.

Additionally, address a known CUDA installer issue related to the
default log file path (/tmp/cuda-installer.log). When the file is
created by another user, subsequent installations may fail due to
permission errors.

To avoid this, explicitly create the required directory before the
installation and clean it up afterward. This ensures the installer
can write logs safely in multi-user build environments.

References:
- https://developer.nvidia.com/blog/whats-new-and-important-in-cuda-toolkit-13-0/#:~:text=The%20CUDA%20Toolkit%2013.0%20release%20introduces%20support,removes%20support%20for%20ICC%20and%20MSVC%202017
- Known installer issue with cuda-installer.log
  https://forums.developer.nvidia.com/t/change-the-path-of-install-log-when-installing-cuda-toolkit/183179