### PR TITLE
Do not use `-Ofast`

### DIFF
--- a/scram-tools.file/tools/gcc/ofast-flag.xml
+++ b/scram-tools.file/tools/gcc/ofast-flag.xml
@@ -1,12 +1,24 @@
-  <tool name="ofast-flag" version="1.0" revision="1">
-    <flags CXXFLAGS="-Ofast -fno-reciprocal-math"/>
-    <ifarch match="ppc64le|amd64|x86_64">
-      <flags CXXFLAGS="-mrecip=none"/>
-    </ifarch>
-    <ifarchitecture name="slc6_">
-      <ifcompiler name="llvm">
-        <flags CXXFLAGS="-fno-builtin"/>
-      </ifcompiler>
-    </ifarchitecture>
-    <flags NO_RECURSIVE_EXPORT="1"/>
-  </tool>
+<tool name="ofast-flag" version="2.0" revision="1">
+  <!--
+  As of GCC version 13.3.0, `-Ofast` enables (directly or indirectly):
+    - `-fallow-store-data-races`
+    - `-fno-semantic-interposition`
+    - `-fno-math-errno`
+    - `-funsafe-math-optimizations`
+    - `-ffinite-math-only`
+    - `-fno-rounding-math` (enabled by default)
+    - `-fno-signaling-nans` (enabled by default)
+    - `-fcx-limited-range`
+    - `-fexcess-precision=fast`
+    - `-fno-signed-zeros`
+    - `-fno-trapping-math`
+    - `-fassociative-math`
+    - `-freciprocal-math` (disabled in cms-sw/cmsdist#8280)
+  We disable `-fallow-store-data-races`, `-funsafe-math-optimizations`, `-ffinite-math-only` and `-freciprocal-math` (see cms-sw/cmsdist#8280).
+  -->
+  <flags CXXFLAGS="-fno-semantic-interposition -fno-math-errno -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -fno-signed-zeros -fno-trapping-math -fassociative-math -fno-reciprocal-math"/>
+  <ifarch match="ppc64le|amd64|x86_64">
+    <flags CXXFLAGS="-mrecip=none"/>
+  </ifarch>
+  <flags NO_RECURSIVE_EXPORT="1"/>
+</tool>

--- a/xz-bootstrap.spec
+++ b/xz-bootstrap.spec
@@ -5,7 +5,7 @@ Source0: http://tukaani.org/xz/xz-%{realversion}.tar.gz
 %setup -n xz-%{realversion}
 
 %build
-./configure CFLAGS='-fPIC -D_FILE_OFFSET_BITS=64 -Ofast' --prefix=%{i} --disable-static
+./configure CFLAGS='-fPIC -D_FILE_OFFSET_BITS=64 -O3' --prefix=%{i} --disable-static
 make %{makeprocesses}
 
 %install

--- a/xz.spec
+++ b/xz.spec
@@ -7,7 +7,7 @@ BuildRequires: autotools
 %setup -n %{n}-%{realversion}
 
 %build
-./configure CFLAGS='-fPIC -Ofast' --prefix=%{i} --disable-static --disable-nls --disable-rpath --disable-dependency-tracking --disable-doc
+./configure CFLAGS='-fPIC -O3' --prefix=%{i} --disable-static --disable-nls --disable-rpath --disable-dependency-tracking --disable-doc
 make %{makeprocesses}
 
 %install


### PR DESCRIPTION
`-Ofast` implies `-funsafe-math-optimizations`, which affects the global FP state for all programs: when used at link time, it may include libraries or startup files that change the default FPU control word or other similar optimisations.

`-Ofast` enables, directly or indirectly:
  - ❌ `-fallow-store-data-races`
  - ✔ `-fno-semantic-interposition`
  - ✔ `-fno-math-errno`
  - ❌ `-funsafe-math-optimizations`
  - ❌ `-ffinite-math-only`
  - ✔ `-fno-rounding-math` (_default_)
  - ✔ `-fno-signaling-nans` (_default_)
  - ❔ `-fcx-limited-range`
  - ✔ `-fexcess-precision=fast`
  - ✔ `-fno-signed-zeros`
  - ✔ `-fno-trapping-math`
  - ✔ `-fassociative-math`
  - ❌ `-freciprocal-math` (https://github.com/cms-sw/cmsdist/pull/8280)

We should not use `-fallow-store-data-races`, `-ffinite-math-only`.

We should not use `-funsafe-math-optimizations` at link time, as it affects the global FP state. It's probably easier to replace it with the individual options `-fno-signed-zeros`, `-fno-trapping-math` and `-fassociative-math`.

We may revisit `-fcx-limited-range` if we do use Complex arithmetics.

`-freciprocal-math` was already disabled explicitly, see cms-sw/cmsdist#8280.
