### PR TITLE
Force include cuda for CPP23_X

### DIFF
--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -161,7 +161,7 @@ Requires: xtd
 %ifos linux
 Requires: openldap
 Requires: gperftools
-Requires: cuda
+## FORCE_REQUIRES cuda
 %{!?without_cuda:Requires: cuda cuda-compatible-runtime gdrcopy cudnn}
 
 Requires: alpaka

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -161,6 +161,7 @@ Requires: xtd
 %ifos linux
 Requires: openldap
 Requires: gperftools
+Requires: cuda
 %{!?without_cuda:Requires: cuda cuda-compatible-runtime gdrcopy cudnn}
 
 Requires: alpaka


### PR DESCRIPTION
For CPP23_X IBs, lets force add cuda in cmssw dependency even if `--build-without cuda` is set.