### PR TITLE
[10_6_X] Update tag for Configuration-Generator to V01-11-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,7 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
-Configuration-Generator=V01-10-00
+Configuration-Generator=V01-11-00
 PhysicsTools-PatUtils=V00-05-00
 GeneratorInterface-EvtGenInterface=V02-12-00
 Alignment-OfflineValidation=V00-01-00


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/10284.