### PR TITLE
Update AXOL1TL to v6.0.0

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 5.0.1
+### RPM external AXOL1TL 6.0.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updated AXOL1TL model to v6. The model is unchanged from AXOL1TL [V5](https://its.cern.ch/jira/browse/CMSLITDPG-1344), only re-trained with 2025 Zero Bias data to account for calibration changes.

v6 release can be found here: https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v6.0.0

Corresponding JIRA ticket: https://its.cern.ch/jira/browse/CMSLITDPG-1506 

Model has been tested and validated in cms-sw. No changes are needed in [relevant cms-sw code](https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc). 

This is targeting 2026 data-taking and will be backported to 16_0_X. 

