### PR TITLE
Update TOPO.spec for version 5.0.0

### DIFF
--- a/TOPO.spec
+++ b/TOPO.spec
@@ -1,7 +1,5 @@
-### RPM external TOPO 0.1.0
-# to be used in future Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
-%define tag 1e9a692ccfa92cee5a87bbc94eb902b9f560870b
-Source: git+https://github.com/cms-hls4ml/%{n}.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+### RPM external TOPO 5.0.0
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake
 


### PR DESCRIPTION
This updates the L1 ML TOPO version to the latest one available, moving from tagging a commit to the release: https://github.com/cms-hls4ml/TOPO/releases/tag/v5.0.0

See https://its.cern.ch/jira/browse/CMSLITDPG-1504 for details about the inclusion in the L1 Menu.

cc @quinnanm @BenjaminRS @LukasEbeling