### PR TITLE
[16_0_X] Update AXOL1TL to v6.0.1 (backport)

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 5.0.1
+### RPM external AXOL1TL 6.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updates the AXOL1TL model tag to 6.0.1 to include the fixes suggested by @missirol :https://github.com/cms-hls4ml/AXOL1TL/pull/11

Implemented suggestions include:

(most importantly) Makefile now builds v6 (correct model version)
AXOL1TL_v6/ directory now matches other model versions, including Makefile
AXOL1TL_v6/GTADModel_v6/NN/ap_types has been removed
Corresponding JIRA ticket: https://its.cern.ch/jira/browse/CMSLITDPG-1506

Release: https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v6.0.1

Model binary was verified to run in cms-sw.

This is a backport of https://github.com/cms-sw/cmsdist/pull/10307