### PR TITLE
Add new "Mille" package to externals, update Millepede-II and GBL 

### DIFF
--- a/gbl.spec
+++ b/gbl.spec
@@ -11,7 +11,8 @@ Requires: mille
 
 %prep
 %setup -q -n %{n}-%{realversion}
-sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' cpp/CMakeLists.txt
+grep -q 'CMAKE_CXX_STANDARD  *17' cpp/CMakeLists.txt
+sed -i -e 's|CMAKE_CXX_STANDARD  *17|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' cpp/CMakeLists.txt
 
 %build
 rm -rf build
@@ -25,6 +26,7 @@ cmake ../cpp \
   -DCMAKE_VERBOSE_MAKEFILE=ON \
   -DEIGEN3_INCLUDE_DIR=${EIGEN_ROOT}/include/eigen3 \
   -DSUPPORT_ROOT=False \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS %{selected_microarch}"
 
 make %{makeprocesses}

--- a/gbl.spec
+++ b/gbl.spec
@@ -1,16 +1,16 @@
-### RPM external gbl V03-01-01
+### RPM external gbl test-04-00-00 
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
-%define tag 59c2d99ea96bc739321fd251096504c91467be24
-Source: git+https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+%define tag 557a04237f121f5d444f7d8b69882d75b00ad5cb
+Source: git+https://gitlab.desy.de/millepede/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Source99: scram-tools.file/tools/eigen/env
 
 BuildRequires: cmake
 Requires: eigen
+Requires: mille
 
 %prep
 %setup -q -n %{n}-%{realversion}
-grep -q 'CMAKE_CXX_STANDARD  *11' cpp/CMakeLists.txt
 sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' cpp/CMakeLists.txt
 
 %build

--- a/gbl.spec
+++ b/gbl.spec
@@ -1,7 +1,7 @@
-### RPM external gbl test-04-00-00 
+### RPM external gbl V04-00-00
 ## INCLUDE cpp-standard
 ## INCLUDE microarch_flags
-%define tag 557a04237f121f5d444f7d8b69882d75b00ad5cb
+%define tag 6e60cdf1f1a296ce0a4e08833ebbfa58e9ad2787
 Source: git+https://gitlab.desy.de/millepede/general-broken-lines.git?obj=main/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 Source99: scram-tools.file/tools/eigen/env
 

--- a/mille.spec
+++ b/mille.spec
@@ -1,4 +1,4 @@
-### RPM external mille V00-01-01
+### RPM external mille V00-01-02
 ## INCLUDE cpp-standard
 Source: https://gitlab.desy.de/millepede/Mille/-/archive/%{realversion}/%{n}-%{realversion}.tar.gz
 BuildRequires: cmake

--- a/mille.spec
+++ b/mille.spec
@@ -27,4 +27,3 @@ make install PREFIX=%{i}
 
 %post
 %{relocateConfig}milleStandaloneSetup.sh
-%{relocateConfig}cmake/MilleConfig.cmake

--- a/mille.spec
+++ b/mille.spec
@@ -1,0 +1,25 @@
+### RPM external mille V00-01-01
+## INCLUDE cpp-standard
+Source: https://gitlab.desy.de/millepede/Mille/-/archive/%{realversion}/%{n}-%{realversion}.tar.gz
+BuildRequires: cmake
+Requires: zlib
+Requires: root
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf build
+mkdir build
+cd build
+cmake \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  ../
+make 
+
+%install
+cd build
+make install PREFIX=%{i}
+
+%post
+%{relocateConfig}cmake/MilleConfig.cmake

--- a/mille.spec
+++ b/mille.spec
@@ -1,4 +1,4 @@
-### RPM external mille V00-01-02
+### RPM external mille V01-00-00
 ## INCLUDE cpp-standard
 Source: https://gitlab.desy.de/millepede/Mille/-/archive/%{realversion}/%{n}-%{realversion}.tar.gz
 BuildRequires: cmake

--- a/mille.spec
+++ b/mille.spec
@@ -1,5 +1,7 @@
 ### RPM external mille V01-00-00
 ## INCLUDE cpp-standard
+## INITENV +PATH PYTHON3PATH %{i}/python
+
 Source: https://gitlab.desy.de/millepede/Mille/-/archive/%{realversion}/%{n}-%{realversion}.tar.gz
 BuildRequires: cmake
 Requires: zlib
@@ -9,17 +11,20 @@ Requires: root
 %setup -n %{n}-%{realversion}
 
 %build
-rm -rf build
-mkdir build
-cd build
+rm -rf ../build
+mkdir ../build
+cd ../build
 cmake \
+  -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=%{i} \
-  ../
-make 
-
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
+  -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
+  ../%{n}-%{realversion}
+make  %{makeprocesses} VERBOSE=1
 %install
-cd build
+cd ../build
 make install PREFIX=%{i}
 
 %post
+%{relocateConfig}milleStandaloneSetup.sh
 %{relocateConfig}cmake/MilleConfig.cmake

--- a/millepede.spec
+++ b/millepede.spec
@@ -1,14 +1,26 @@
-### RPM external millepede V04-16-00
+### RPM external millepede test-05-00-00 
+## INCLUDE cpp-standard
 Source: https://gitlab.desy.de/millepede/millepede-ii/-/archive/%{realversion}/%{n}-ii-%{realversion}.tar.gz
-Requires: zlib
+BuildRequires: cmake
+Requires: root
+Requires: mille
 
 %prep
 %setup -n %{n}-ii-%{realversion}
 
 %build
-make \
-  ZLIB_INCLUDES_DIR="${ZLIB_ROOT}/include" \
-  ZLIB_LIBS_DIR="${ZLIB_ROOT}/lib"
+rm -rf build
+mkdir build
+cd build
+cmake \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DLAPACK_OPENBLAS=off \
+  ../
+make 
 
 %install
+cd build
 make install PREFIX=%{i}
+
+%post
+%{relocateConfig}cmake/millepedeIIConfig.cmake

--- a/millepede.spec
+++ b/millepede.spec
@@ -9,18 +9,21 @@ Requires: mille
 %setup -n %{n}-ii-%{realversion}
 
 %build
-rm -rf build
-mkdir build
-cd build
+rm -rf ../build
+mkdir ../build
+cd ../build
 cmake \
   -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
+  -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   -DLAPACK_OPENBLAS=off \
-  ../
-make 
+  ../%{n}-ii-%{realversion}
+make %{makeprocesses} VERBOSE=1
 
 %install
-cd build
+cd ../build
 make install PREFIX=%{i}
 
 %post
-%{relocateConfig}cmake/millepedeIIConfig.cmake
+%{relocateConfig}mp2setup.sh
+%{relocateConfig}millepedeIIConfig.cmake

--- a/millepede.spec
+++ b/millepede.spec
@@ -1,4 +1,4 @@
-### RPM external millepede test-05-00-00 
+### RPM external millepede V05-00-00 
 ## INCLUDE cpp-standard
 Source: https://gitlab.desy.de/millepede/millepede-ii/-/archive/%{realversion}/%{n}-ii-%{realversion}.tar.gz
 BuildRequires: cmake

--- a/millepede.spec
+++ b/millepede.spec
@@ -26,4 +26,3 @@ make install PREFIX=%{i}
 
 %post
 %{relocateConfig}mp2setup.sh
-%{relocateConfig}millepedeIIConfig.cmake

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -4,7 +4,7 @@ Source: none
 
 Requires: root curl python3 xrootd llvm hdf5 yoda opencv triton-inference-client
 Requires: professor2 rivet frontier_client onnxruntime openldap pacparser
-
+Requires: mille 
 Requires: py3-multidict
 Requires: py3-anyio
 Requires: py3-sniffio

--- a/scram-tools.file/tools/gbl/gbl.xml
+++ b/scram-tools.file/tools/gbl/gbl.xml
@@ -1,4 +1,4 @@
-ge<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://www.wiki.terascale.de/index.php/GeneralBrokenLines"/>
   <lib name="GBL"/>
   <client>

--- a/scram-tools.file/tools/gbl/gbl.xml
+++ b/scram-tools.file/tools/gbl/gbl.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
+ge<tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
   <info url="https://www.wiki.terascale.de/index.php/GeneralBrokenLines"/>
   <lib name="GBL"/>
   <client>
@@ -7,4 +7,5 @@
     <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
   </client>
   <use name="eigen"/>
+  <use name="mille"/>
 </tool>

--- a/scram-tools.file/tools/mille/mille.xml
+++ b/scram-tools.file/tools/mille/mille.xml
@@ -1,0 +1,15 @@
+<tool name="@TOOL@" version="@TOOL_VERSION@" revision="1">
+  <info url="https://millepede.pages.desy.de/Mille/"/>
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+  </client>
+  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <lib name="Mille2"/>
+  <lib name="MilleC"/>
+  <use name="sockets"/>
+  <use name="pcre"/>
+  <use name="root"/>
+  <use name="zlib"/>
+</tool>

--- a/scram-tools.file/tools/millepede/millepede.xml
+++ b/scram-tools.file/tools/millepede/millepede.xml
@@ -1,10 +1,11 @@
 <tool name="@TOOL@" version="@TOOL_VERSION@" revision="2">
-  <info url="http://www.wiki.terascale.de/index.php/Millepede_II"/>
+  <info url="https://millepede.pages.desy.de/millepede-ii/"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
   <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
   <use name="sockets"/>
   <use name="pcre"/>
-  <use name="zlib"/>
+  <use name="root"/>
+  <use name="mille"/>
 </tool>


### PR DESCRIPTION
This PR updates the tracker alignment packages Millepede-II and GBL to use a new, common implementation of the "Mille" library responsible for writing and reading the alignment fit inputs to/from disk. The common [Mille package](https://gitlab.desy.de/millepede/mille) is added as a new external package, and dependencies on it introduced to the Millepede-II and GBL spec files. 

See [slides](https://indico.cern.ch/event/1628654/#49-millepede-ii-updates) for details on the new package. 

Changes require updates to CMSSW, as some API calls change. These are in PR [#49963](https://github.com/cms-sw/cmssw/pull/49963). 

Together, the changes pass the unit and runTheMatrix tests (few exceptions related to DAS / missing inputs, unrelated to PR). 
In addition, changes were validated by running a full tracker alignment with the modified externals & CMSSW on lxplus8. 