### PR TITLE
[GCC15] convert array bound errors to warnings

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -43,9 +43,7 @@ GCC_CXXFLAGS="$GCC_CXXFLAGS -Xassembler --compress-debug-sections"
 #FIXME: GCC 12/13/14 workaround
 if [[ "$GCC_VERSION" =~ ^12\.[23]\. ]] ; then
   GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"
-elif [[ "$GCC_VERSION" =~ ^13\. ]] ; then
-  GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"  
-elif [[ "$GCC_VERSION" =~ ^14\. ]] ; then
+elif [[ "$GCC_VERSION" =~ ^1[345]\. ]] ; then
   GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"  
 fi
 


### PR DESCRIPTION
Just like GCC 13 and 14, convert gcc array-bound errors to warnings. GCC 13 and above generate false positive array-bound errors like [a]

[a]
```
In function 'g',
    inlined from 'g' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:310:35,
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:363:35,
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/Expression.h:154:16,
    inlined from 'Evaluate' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/HelperOps.h:61:36,
    inlined from 'operator=' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/SMatrix.icc:170:36,
    inlined from '__ct ' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/SMatrix.icc:108:13,
    inlined from 'Similarity' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:739:41,
    inlined from 'updateOffline1D' at src/L1Trigger/Phase2L1GMT/src/KMTFCore.cc:665:36:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:309:22: error: array subscript 'const struct MatRepStd[0]' is partly outside array bounds of 'struct Matrix13[1]' [-Werror=array-bounds=]
   309 |     return lhs(i, I) * rhs(I , j) +
      |                      ^
src/L1Trigger/Phase2L1GMT/src/KMTFCore.cc: In member function 'updateOffline1D':
src/L1Trigger/Phase2L1GMT/src/KMTFCore.cc:657:12: note: object 'H' of size 24
  657 |   Matrix13 H;
      |            ^
In function 'g',
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:363:35,
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/Expression.h:154:16,
    inlined from 'g' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:334:26,
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:363:35,
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/Expression.h:154:16,
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/Expression.h:248:43,
    inlined from 'operator()' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/Expression.h:154:16,
    inlined from 'Evaluate' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/HelperOps.h:61:36,
    inlined from 'operator=' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/SMatrix.icc:170:36,
    inlined from '__ct ' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/SMatrix.icc:108:13,
    inlined from 'updateOffline1D' at src/L1Trigger/Phase2L1GMT/src/KMTFCore.cc:676:42:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/lcg/root/6.36.07-f49e3dc2e35fc97a7392769e6f8c216c/include/Math/MatrixFunctions.h:309:22: error: array subscript 'const struct MatRepStd[0]' is partly outside array bounds of 'struct Matrix13[1]' [-Werror=array-bounds=]
   309 |     return lhs(i, I) * rhs(I , j) +
      |                      ^
```