### PR TITLE
Update LLVM version 21 for 16.1.X

### DIFF
--- a/clang-uml-clang21.patch
+++ b/clang-uml-clang21.patch
@@ -1,0 +1,32 @@
+diff --git a/tests/test_clang_util.cc b/tests/test_clang_util.cc
+index 3197efa..2117824 100644
+--- a/tests/test_clang_util.cc
++++ b/tests/test_clang_util.cc
+@@ -144,14 +144,14 @@ TEST_CASE("Test diagnostic_consumer")
+     auto fs = llvm::vfs::getRealFileSystem();
+     FileSystemOptions file_opts;
+     FileManager file_mgr(file_opts, fs);
+-    auto diagnostic_engine = DiagnosticsEngine(
+-        llvm::IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()),
+-        new DiagnosticOptions());
++    auto diagIDs1 = llvm::makeIntrusiveRefCnt<clang::DiagnosticIDs>();
++    clang::DiagnosticOptions diagOpts1;
++    auto diagnostic_engine = clang::DiagnosticsEngine(diagIDs1, diagOpts1);
+     SourceManager source_mgr(diagnostic_engine, file_mgr);
+ 
+-    DiagnosticsEngine diag_engine(
+-        llvm::IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()),
+-        new DiagnosticOptions());
++    auto diagIDs2 = llvm::makeIntrusiveRefCnt<clang::DiagnosticIDs>();
++    clang::DiagnosticOptions diagOpts2;
++    clang::DiagnosticsEngine diag_engine(diagIDs2, diagOpts2);
+ 
+     diag_engine.setClient(&consumer, false);
+     auto id_note = diag_engine.getCustomDiagID(
+@@ -198,4 +198,4 @@ TEST_CASE("Test diagnostic_consumer")
+     CHECK(consumer.diagnostics.size() == 4);
+     CHECK(consumer.diagnostics[3].level == DiagnosticsEngine::Fatal);
+     CHECK(consumer.diagnostics[3].description == "test fatal message");
+-}
+\ No newline at end of file
++}

--- a/clang-uml.spec
+++ b/clang-uml.spec
@@ -1,15 +1,17 @@
-### RPM external clang-uml 0.5.2
+### RPM external clang-uml 0.6.2x
 
-%define tag cd6dce2b0b34d55534d3de512ab088b9ad71bc76
+%define tag 5e2993e75ebc88af6cb239f2ffae88da7431cb0d
 %define branch master
 
 %define github_user bkryza
 Source: git+https://github.com/%{github_user}/clang-uml.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Patch0: clang-uml-clang21
 BuildRequires: cmake ninja 
-Requires: yaml-cpp llvm zlib
+Requires: yaml-cpp llvm zlib zstd libxml2
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 rm -rf ../build
@@ -28,7 +30,8 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_CXX_FLAGS="-Wno-sign-compare" \
 %endif
   -DGIT_VERSION="%{realversion}" \
-  -DCMAKE_PREFIX_PATH="${YAML_CPP_ROOT}/lib64/cmake/yaml-cpp;${ZLIB_ROOT}"
+  -DCMAKE_EXE_LINKER_FLAGS="-L${YAML_CPP_ROOT}/lib64" \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
 
 ninja -v %{makeprocesses}
 

--- a/llvm.spec
+++ b/llvm.spec
@@ -1,4 +1,4 @@
-### RPM external llvm 18.1.6
+### RPM external llvm 21.1.4
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/lib64/python%{cms_python3_major_minor_version}/site-packages
 
@@ -6,10 +6,10 @@ BuildRequires: cmake ninja
 Requires: gcc zlib python3 libxml2 zstd libunwind
 %{!?without_cuda:Requires: cuda}
 
-%define llvmCommit 02c7568fc9f555b2c72fc169c8c68e2116d97382
-%define llvmBranch cms/release/18.x/1118c2e
-%define iwyuCommit 377eaef70cdda47368939f4d9beabfabe3f628f0
-%define iwyuBranch clang_18
+%define llvmCommit 3063d23cfa249166b2e0c33a02c7300c20ffb2d
+%define llvmBranch cms/llvmorg-21.1.4
+%define iwyuCommit 791e69ea4662cb3e74e8128fd5fd69bd7f4ea6b3
+%define iwyuBranch clang_21
 
 Source0: git+https://github.com/cms-externals/llvm-project.git?obj=%{llvmBranch}/%{llvmCommit}&export=llvm-%{realversion}-%{llvmCommit}&module=llvm-%{realversion}-%{llvmCommit}&output=/llvm-%{realversion}-%{llvmCommit}.tgz
 Source1: git+https://github.com/include-what-you-use/include-what-you-use.git?obj=%{iwyuBranch}/%{iwyuCommit}&export=iwyu-%{realversion}-%{iwyuCommit}&module=iwyu-%{realversion}-%{iwyuCommit}&output=/iwyu-%{realversion}-%{iwyuCommit}.tgz
@@ -70,6 +70,7 @@ ninja -v %{makeprocesses} install
 
 #Create libomp symlink
 host_triple=$(gcc -dumpmachine)
+ln -s ${host_triple}/libomp.so %{i}/lib64/libomp.so
 
 BINDINGS_PATH=%{i}/lib64/python%{cms_python3_major_minor_version}/site-packages
 PKG_INFO_FILE=$BINDINGS_PATH/clang-%{realversion}-py%{cms_python3_major_minor_version}.egg-info/PKG-INFO

--- a/mozsearch-clang21.patch
+++ b/mozsearch-clang21.patch
@@ -1,0 +1,62 @@
+diff --git a/clang-plugin/MozsearchIndexer.cpp b/clang-plugin/MozsearchIndexer.cpp
+index a601b05..380cbcd 100644
+--- a/clang-plugin/MozsearchIndexer.cpp
++++ b/clang-plugin/MozsearchIndexer.cpp
+@@ -1485,7 +1485,9 @@ public:
+       QualType CanonicalFieldType = FieldType.getCanonicalType();
+       LangOptions langOptions;
+       PrintingPolicy Policy(langOptions);
++#if LLVM_VERSION_MAJOR < 21
+       Policy.PrintCanonicalTypes = true;
++#endif
+       J.attribute("type", CanonicalFieldType.getAsString(Policy));
+ 
+       const TagDecl *tagDecl = CanonicalFieldType->getAsTagDecl();
+diff --git a/clang-plugin/from-clangd/HeuristicResolver.cpp b/clang-plugin/from-clangd/HeuristicResolver.cpp
+index 719094d..54184a4 100644
+--- a/clang-plugin/from-clangd/HeuristicResolver.cpp
++++ b/clang-plugin/from-clangd/HeuristicResolver.cpp
+@@ -27,7 +27,7 @@ const auto StaticFilter = [](const NamedDecl *D) {
+ };
+ const auto ValueFilter = [](const NamedDecl *D) { return isa<ValueDecl>(D); };
+ const auto TypeFilter = [](const NamedDecl *D) { return isa<TypeDecl>(D); };
+-const auto TemplateFilter = [](const NamedDecl *D) {
++[[maybe_unused]] const auto TemplateFilter = [](const NamedDecl *D) {
+   return isa<TemplateDecl>(D);
+ };
+ 
+@@ -203,12 +203,22 @@ std::vector<const NamedDecl *> HeuristicResolver::resolveDependentNameType(
+       DNT->getIdentifier(), TypeFilter);
+ }
+ 
++
++#include "clang/Basic/Version.h"
+ std::vector<const NamedDecl *>
+ HeuristicResolver::resolveTemplateSpecializationType(
+     const DependentTemplateSpecializationType *DTST) const {
++#if LLVM_VERSION_MAJOR >= 21
++    // In LLVM 21+, DependentTemplateSpecializationType no longer exposes
++    // getQualifier(), getIdentifier(), or getTemplateName().
++    // We can’t meaningfully resolve it here — return an empty result.
++    return {};
++#else
++  // Legacy LLVM ≤ 20 path.
+   return resolveDependentMember(
+       resolveNestedNameSpecifierToType(DTST->getQualifier()),
+       DTST->getIdentifier(), TemplateFilter);
++#endif
+ }
+ 
+ std::vector<const NamedDecl *>
+@@ -249,8 +259,11 @@ const Type *HeuristicResolver::resolveNestedNameSpecifierToType(
+   // that may be dependent as well, so for convenience handle
+   // the TypeSpec cases too.
+   switch (NNS->getKind()) {
++#if LLVM_VERSION_MAJOR >= 21
+   case NestedNameSpecifier::TypeSpec:
++#else
+   case NestedNameSpecifier::TypeSpecWithTemplate:
++#endif
+     return NNS->getAsType();
+   case NestedNameSpecifier::Identifier: {
+     return resolveDeclsToType(

--- a/mozsearch.spec
+++ b/mozsearch.spec
@@ -1,17 +1,19 @@
-### RPM external mozsearch 20240514
+### RPM external mozsearch 20251022
 
-%define tag d697005b97f28d493a24887ed25fd2e68839c716
+%define tag 1c886cc95c4e811709e97f711d7691ff8b87bda9
 %define branch master
 
 %define github_user mozsearch
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 Patch0: mozsearch-gcc-toolchain
+Patch1: mozsearch-clang21
 BuildRequires: gmake
 Requires: llvm
 
 %prep
 %setup -n %{n}-%{realversion}
 %patch0 -p1
+%patch1 -p1
 
 %build
 cd clang-plugin

--- a/py3-dxr.spec
+++ b/py3-dxr.spec
@@ -2,8 +2,8 @@
 ## INITENV +PATH PYTHON3PATH %i/${PYTHON3_LIB_SITE_PACKAGES}
 Requires: zlib llvm sqlite
 Requires: py3-Jinja2 py3-parsimonious py3-pysqlite3 py3-Pygments
-%define dxrCommit 737d3b0570e5e4a7845e8cba7c0b000d2911f24e
-%define branch cms/6ea764102a/clang18
+%define dxrCommit b55cf0eeacc494adc575562eac290b3e4871a6ac
+%define branch cms/clang21
 
 Source0: git+https://github.com/cms-externals/dxr.git?obj=%{branch}/%{dxrCommit}&export=dxr-%{dxrCommit}&module=dxr-%dxrCommit&output=/dxr-%{dxrCommit}.tgz
 %define keep_archives true

--- a/vecgeom-clang19.patch
+++ b/vecgeom-clang19.patch
@@ -1,0 +1,172 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 495795d..3fcaace 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -224,7 +224,7 @@ cmake_dependent_option(VECGEOM_TEST_COVERAGE "Enable coverage testing flags" OFF
+ 
+ ################################################################################
+ # Minimum version of VecCore we need.
+-set(VecCore_VERSION "0.8.0")
++set(VecCore_VERSION "0.8.2")
+ 
+ # Enable/Disable build/use of builtin veccore
+ if(VECGEOM_BUILTIN_VECCORE)
+diff --git a/cmake/modules/BuiltinVecCore.cmake b/cmake/modules/BuiltinVecCore.cmake
+index 7e6d09b..d45fe49 100644
+--- a/cmake/modules/BuiltinVecCore.cmake
++++ b/cmake/modules/BuiltinVecCore.cmake
+@@ -41,9 +41,9 @@ function (build_external_project target globpattern ) #FOLLOWING ARGUMENTS are t
+ endfunction()
+ 
+ 
+-set(VecCore_PROJECT "VecCore-${VecCore_VERSION}")
+-set(VecCore_SRC_URI "http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources")
+-set(VecCore_SRC_MD5 "3e5b84d1b502ab7c7047c4b494ce640a")
++set(VecCore_PROJECT "VecCore-v${VecCore_VERSION}")
++set(VecCore_SRC_URI "https://gitlab.cern.ch/VecGeom/VecCore/-/archive")
++set(VecCore_SRC_MD5 "c91d00f16ea1fbfad0101e11b2386e34")
+ set(VecCore_DESTDIR "${PROJECT_BINARY_DIR}/installExternals/${VecCore_PROJECT}")
+ set(VecCore_ROOTDIR "${VecCore_DESTDIR}/${CMAKE_INSTALL_PREFIX}")
+ set(VecCore_SRC_TAG "v${VecCore_VERSION}")
+@@ -55,7 +55,7 @@ endif()
+ 
+ build_external_project(${VecCore_PROJECT}
+   "${VecCore_ROOTDIR}/include/VecCore/*.h;${VecCore_ROOTDIR}/include/VecCore/VecCore;${VecCore_ROOTDIR}/include/VecCore/Backend/*.h"
+-  "URL \"${VecCore_SRC_URI}/VecCore-${VecCore_VERSION}.tar.gz\"
++  "URL \"${VecCore_SRC_URI}/VecCore-v${VecCore_VERSION}.tar.gz ${VecCore_SRC_URI}/v${VecCore_VERSION}/VecCore-v${VecCore_VERSION}.tar.gz\"
+   URL_MD5 ${VecCore_SRC_MD5}
+   #GIT_REPOSITORY \"${VecCore_SRC_URI}\"
+   #GIT_TAG \"${VecCore_SRC_TAG}\"
+diff --git a/VecGeom/volumes/SpecializedPlacedVolImplHelper.h b/VecGeom/volumes/SpecializedPlacedVolImplHelper.h
+index 5f63971..496d177 100644
+--- a/VecGeom/volumes/SpecializedPlacedVolImplHelper.h
++++ b/VecGeom/volumes/SpecializedPlacedVolImplHelper.h
+@@ -153,7 +153,7 @@ public:
+ #endif
+     Transformation3D const *tr = this->GetTransformation();
+     Precision output(-1.);
+-    Specialization::template DistanceToOut(*this->GetUnplacedStruct(), tr->Transform<transC, rotC>(point),
++    Specialization::template DistanceToOut<>(*this->GetUnplacedStruct(), tr->Transform<transC, rotC>(point),
+                                            tr->TransformDirection<rotC>(direction), stepMax, output);
+ 
+ #ifdef VECGEOM_DISTANCE_DEBUG
+diff --git a/VecGeom/volumes/UnplacedVolumeImplHelper.h b/VecGeom/volumes/UnplacedVolumeImplHelper.h
+index 4b2f7b2..7cbf855 100644
+--- a/VecGeom/volumes/UnplacedVolumeImplHelper.h
++++ b/VecGeom/volumes/UnplacedVolumeImplHelper.h
+@@ -98,7 +98,7 @@ public:
+     assert(d.IsNormalized() && " direction not normalized in call to  DistanceToOut ");
+ #endif
+     Precision output = kInfLength;
+-    Implementation::template DistanceToOut(((UnplacedVolume_t *)this)->UnplacedVolume_t::GetStruct(), p, d, step_max,
++    Implementation::template DistanceToOut<>(((UnplacedVolume_t *)this)->UnplacedVolume_t::GetStruct(), p, d, step_max,
+                                            output);
+ 
+ // detect -inf responses which are often an indication for a real bug
+diff --git a/VecGeom/volumes/kernel/ImplAsImplementation.h b/VecGeom/volumes/kernel/ImplAsImplementation.h
+index a9d2cae..8cd3428 100644
+--- a/VecGeom/volumes/kernel/ImplAsImplementation.h
++++ b/VecGeom/volumes/kernel/ImplAsImplementation.h
+@@ -51,7 +51,7 @@ struct IndirectImplementation {
+   VECCORE_ATT_HOST_DEVICE
+   static void Contains(UnplacedStruct_t const &s, Vector3D<Real_v> const &point, Bool_v &inside)
+   {
+-    DispatchingImplementation::template Contains(s, point, inside);
++    DispatchingImplementation::template Contains<>(s, point, inside);
+   }
+ 
+   template <typename Real_v, typename Inside_t>
+@@ -59,7 +59,7 @@ struct IndirectImplementation {
+   VECCORE_ATT_HOST_DEVICE
+   static void Inside(UnplacedStruct_t const &s, Vector3D<Real_v> const &point, Inside_t &inside)
+   {
+-    DispatchingImplementation::template Inside(s, point, inside);
++    DispatchingImplementation::template Inside<>(s, point, inside);
+   }
+ 
+   template <typename Real_v>
+@@ -68,7 +68,7 @@ struct IndirectImplementation {
+   static void DistanceToIn(UnplacedStruct_t const &s, Vector3D<Real_v> const &point, Vector3D<Real_v> const &direction,
+                            Real_v const &stepMax, Real_v &distance)
+   {
+-    DispatchingImplementation::template DistanceToIn(s, point, direction, stepMax, distance);
++    DispatchingImplementation::template DistanceToIn<>(s, point, direction, stepMax, distance);
+   }
+ 
+   template <typename Real_v>
+@@ -77,7 +77,7 @@ struct IndirectImplementation {
+   static void DistanceToOut(UnplacedStruct_t const &s, Vector3D<Real_v> const &point, Vector3D<Real_v> const &direction,
+                             Real_v const &stepMax, Real_v &distance)
+   {
+-    DispatchingImplementation::template DistanceToOut(s, point, direction, stepMax, distance);
++    DispatchingImplementation::template DistanceToOut<>(s, point, direction, stepMax, distance);
+   }
+ 
+   template <typename Real_v>
+@@ -85,7 +85,7 @@ struct IndirectImplementation {
+   VECCORE_ATT_HOST_DEVICE
+   static void SafetyToIn(UnplacedStruct_t const &s, Vector3D<Real_v> const &point, Real_v &safety)
+   {
+-    DispatchingImplementation::template SafetyToIn(s, point, safety);
++    DispatchingImplementation::template SafetyToIn<>(s, point, safety);
+   }
+ 
+   template <typename Real_v>
+@@ -93,7 +93,7 @@ struct IndirectImplementation {
+   VECCORE_ATT_HOST_DEVICE
+   static void SafetyToOut(UnplacedStruct_t const &s, Vector3D<Real_v> const &point, Real_v &safety)
+   {
+-    DispatchingImplementation::template SafetyToOut(s, point, safety);
++    DispatchingImplementation::template SafetyToOut<>(s, point, safety);
+   }
+ 
+   template <typename Real_v>
+@@ -102,7 +102,7 @@ struct IndirectImplementation {
+   static Vector3D<Real_v> NormalKernel(UnplacedStruct_t const &s, Vector3D<Real_v> const &point,
+                                        typename vecCore::Mask_v<Real_v> &valid)
+   {
+-    DispatchingImplementation::template NormalKernel(s, point, valid);
++    DispatchingImplementation::template NormalKernel<>(s, point, valid);
+   }
+ };
+ 
+diff --git a/VecGeom/volumes/kernel/PolyhedronImplementation.h b/VecGeom/volumes/kernel/PolyhedronImplementation.h
+index 9a1a016..9f0de05 100644
+--- a/VecGeom/volumes/kernel/PolyhedronImplementation.h
++++ b/VecGeom/volumes/kernel/PolyhedronImplementation.h
+@@ -689,7 +689,7 @@ bool PolyhedronImplementation<innerRadiiT, phiCutoutT>::ScalarContainsKernel(Unp
+   {
+     bool inBounds;
+     // Correct tube algorithm obtained from trait class
+-    HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template Contains(
++    HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template Contains<>(
+         unplaced.fBoundingTube, Vector3D<Precision>(point[0], point[1], point[2] - unplaced.fBoundingTubeOffset),
+         inBounds);
+     if (!inBounds) return false;
+@@ -753,7 +753,7 @@ Inside_t PolyhedronImplementation<innerRadiiT, phiCutoutT>::ScalarInsideKernel(U
+     // FIX: the bounding tube was wrong. Since the fast UnplacedContains is
+     // used for early return, the bounding tube has to be larger than the
+     // ideal bounding tube to account for the tolerance (offset was wrong)
+-    HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template Contains(
++    HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template Contains<>(
+         unplaced.fBoundingTube, Vector3D<Precision>(point[0], point[1], point[2] - unplaced.fBoundingTubeOffset),
+         inBounds);
+     if (!inBounds) return EInside::kOutside;
+@@ -904,7 +904,7 @@ Precision PolyhedronImplementation<innerRadiiT, phiCutoutT>::ScalarDistanceToInK
+   Precision tubeDistance = 0.;
+   {
+     Vector3D<Precision> boundsPoint(point[0], point[1], point[2] - unplaced.fBoundingTubeOffset);
+-    HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template Contains(unplaced.fBoundingTube, boundsPoint, inBounds);
++    HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template Contains<>(unplaced.fBoundingTube, boundsPoint, inBounds);
+     // If the point is inside the bounding tube, the result of DistanceToIn is
+     // unreliable and cannot be used to reject rays.
+     // TODO: adjust tube DistanceToIn function to correctly return a negative
+@@ -913,7 +913,7 @@ Precision PolyhedronImplementation<innerRadiiT, phiCutoutT>::ScalarDistanceToInK
+     if (!inBounds) {
+       // If the point is outside the bounding tube, check if the ray misses
+       // the bounds
+-      HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template DistanceToIn(unplaced.fBoundingTube, boundsPoint,
++      HasInnerRadiiTraits<innerRadiiT>::TubeKernels::template DistanceToIn<>(unplaced.fBoundingTube, boundsPoint,
+                                                                            direction, stepMax, tubeDistance);
+       if (tubeDistance == InfinityLength<Precision>()) {
+         return InfinityLength<Precision>();


### PR DESCRIPTION
backport LLVM 21 from CLANG_X IBs to default 16.1.X.
Note that we already have applied clang-tidy changes using LLVM 21 to cmssw master branch. After integrating this version, we will open new PRs to run clang-format using llvm21. We can not open format changes using llvm21 as old llcm 18 will revert those changes. So we have to integrate this first

backport of #10142