### PR TITLE
Drop meschach from cms software stack

### DIFF
--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tools 4.0
+### RPM cms cmssw-tools 5.0
 # With cmsBuild, change the above version only when a new tool is added
 
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cms-cat cmssw-osenv cms-git-tools SCRAMV2


### PR DESCRIPTION
As [Alignment/Cocoa packages are now removed](https://github.com/cms-sw/cmssw/pull/50016) from CMSSW 16.1.X, so lets also drop `meschach ` external too 