### PR TITLE
[16_0_X] Update AXOL1TL to v6.0.2 (backport)

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 6.0.1
+### RPM external AXOL1TL 6.0.2
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updates the AXOL1TL model tag to 6.0.2 to fix incorrect input scaling.

Release: https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v6.0.2

Corresponding JIRA ticket: https://its.cern.ch/jira/browse/CMSLITDPG-1506

Model binary was verified to run in cms-sw and fix was confirmed.

This is a backport of https://github.com/cms-sw/cmsdist/pull/10327