### PR TITLE
ThePeg: Patch it to avoid space between quotes and suffix is deprecated in c+23 warnings

### DIFF
--- a/thepeg-cpp23.patch
+++ b/thepeg-cpp23.patch
@@ -1,0 +1,83 @@
+diff --git a/Config/Unitsystem.h b/Config/Unitsystem.h
+index f8ae0bb..f41e7ad 100644
+--- a/Config/Unitsystem.h
++++ b/Config/Unitsystem.h
+@@ -160,10 +160,10 @@ typedef Transverse<Energy> TransverseMomentum;
+ 
+ /// @name Pre-defined basic units.
+ //@{
+-constexpr Length operator "" _mm( long double x ) {
++constexpr Length operator""_mm( long double x ) {
+   return Length{Length::baseunit(), static_cast<double>(x)};
+ }
+-constexpr Length operator "" _mm( unsigned long long x ) {
++constexpr Length operator""_mm( unsigned long long x ) {
+   return Length{Length::baseunit(), static_cast<double>(x)};
+ }
+ 
+@@ -176,24 +176,24 @@ constexpr Length nanometer  = 1.0e-6_mm;
+ constexpr Length picometer  = 1.0e-9_mm;
+ constexpr Length femtometer = 1.0e-12_mm;
+  
+-constexpr Energy operator "" _MeV( long double x ) {
++constexpr Energy operator""_MeV( long double x ) {
+   return Energy{Energy::baseunit(), static_cast<double>(x)};
+ }
+-constexpr Energy operator "" _MeV( unsigned long long x ) {
++constexpr Energy operator""_MeV( unsigned long long x ) {
+   return Energy{Energy::baseunit(), static_cast<double>(x)};
+ }
+ 
+-constexpr Energy operator "" _GeV( long double x ) {
++constexpr Energy operator""_GeV( long double x ) {
+   return Energy{1000_MeV, static_cast<double>(x)};
+ }
+-constexpr Energy operator "" _GeV( unsigned long long x ) {
++constexpr Energy operator""_GeV( unsigned long long x ) {
+   return Energy{1000_MeV, static_cast<double>(x)};
+ }
+ 
+-constexpr Energy operator "" _TeV( long double x ) {
++constexpr Energy operator""_TeV( long double x ) {
+   return Energy{1000_GeV, static_cast<double>(x)};
+ }
+-constexpr Energy operator "" _TeV( unsigned long long x ) {
++constexpr Energy operator""_TeV( unsigned long long x ) {
+   return Energy{1000_GeV, static_cast<double>(x)};
+ }
+ 
+@@ -204,17 +204,17 @@ constexpr Energy TeV = 1_TeV;
+ 
+ 
+ 
+-constexpr Energy2 operator "" _MeV2( long double x ) {
++constexpr Energy2 operator""_MeV2( long double x ) {
+   return Energy2{Energy2::baseunit(),	static_cast<double>(x)};
+ }
+-constexpr Energy2 operator "" _MeV2( unsigned long long x ) {
++constexpr Energy2 operator""_MeV2( unsigned long long x ) {
+   return Energy2{Energy2::baseunit(),	static_cast<double>(x)};
+ }
+ 
+-constexpr Energy2 operator "" _GeV2( long double x ) {
++constexpr Energy2 operator""_GeV2( long double x ) {
+   return Energy2{1.0e+6_MeV2, static_cast<double>(x)};
+ }
+-constexpr Energy2 operator "" _GeV2( unsigned long long x ) {
++constexpr Energy2 operator""_GeV2( unsigned long long x ) {
+   return Energy2{1.0e+6_MeV2, static_cast<double>(x)};
+ }
+ 
+@@ -224,10 +224,10 @@ constexpr Energy2 GeV2 = 1_GeV2;
+ constexpr InvEnergy InvGeV = 1/GeV;
+ 
+ 
+-constexpr Area operator "" _pb( long double x ) {
++constexpr Area operator""_pb( long double x ) {
+   return Area{1.0e-34 * Area::baseunit(), static_cast<double>(x)};
+ }
+-constexpr Area operator "" _pb( unsigned long long x ) {
++constexpr Area operator""_pb( unsigned long long x ) {
+   return Area{1.0e-34 * Area::baseunit(), static_cast<double>(x)};
+ }
+ 

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -6,13 +6,13 @@
 Source: http://www.hepforge.org/archive/thepeg/ThePEG-%{realversion}.tar.bz2
 Patch0: LHEEventNum
 Patch1: thepeg-deprecated-warn
+Patch2: thepeg-cpp23
 
 Requires: lhapdf
 Requires: gsl OpenBLAS
 Requires: hepmc
 Requires: zlib
 Requires: fastjet
-#Requires: rivet
 BuildRequires: autotools
 BuildRequires: lhapdf
 
@@ -26,6 +26,7 @@ BuildRequires: lhapdf
 %setup -q -n ThePEG-%{realversion}
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 
 # Regenerate build scripts
 autoreconf -fiv


### PR DESCRIPTION
This PR proposes to patch thepeg to avoid warnings like
```
  include/ThePEG/Config/Unitsystem.h:163:29: warning: space between quotes and suffix is deprecated in C++23 [-Wdeprecated-literal-operator]
   163 | constexpr Length operator "" _mm( long double x ) {
      |                             ^~
      |                             --
  include/ThePEG/Config/Unitsystem.h:163:29: warning: space between quotes and suffix is deprecated in C++23 [-Wdeprecated-literal-operator]
   163 | constexpr Length operator "" _mm( long double x ) {
```