### PR TITLE
[do not merge] Update OpenMPI to v5.0.10-rc2

### DIFF
--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 5.0.9
+### RPM external openmpi 5.0.10rc2
 ## INCLUDE openmpi-opt
 ## INITENV SET OPAL_PREFIX %{i}
 ## INITENV SET PMIX_PREFIX %{i}


### PR DESCRIPTION
Test OpenMPI v5.0.10-rc2, in view of the final release being cut in the coming weeks.