### PR TITLE
[16_0_X] Updating UTM to 0.14.1 with patch fixes

### DIFF
--- a/utm.spec
+++ b/utm.spec
@@ -1,4 +1,4 @@
-### RPM external utm utm_0.14.0
+### RPM external utm utm_0.14.1
 Source: git+https://gitlab.cern.ch/cms-l1t-utm/utm.git?obj=master/%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: gmake
 Requires: xerces-c boost


### PR DESCRIPTION
Updating the UTM to 0.14.1 as a patch to fix:
 - copy missing XSD files to install location
 - fixed version number for XDAQ build
More information can be found [uGT Trigger Menu Library Release Notes for 0.14.1](https://globaltrigger.web.cern.ch/globaltrigger/release/utm/latest_doc/html/releaseNotes/v0_14_1.html) and the [gitlab tree](https://gitlab.cern.ch/cms-l1t-utm/utm/tree/utm_0.14.1).

backport of #10343 