### PR TITLE
[16_0_X] Update AXOL1TL to v6.0.3 (backport)

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 6.0.2
+### RPM external AXOL1TL 6.0.3
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updates the AXOL1TL model tag to 6.0.3 to fix emulator divergence at large scores

Release: https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v6.0.3

JIRA ticket describing issue+fix: https://its.cern.ch/jira/browse/CMSLITDPG-1508

Model binary was verified to run in cms-sw and fix was confirmed.

This is targeting 2026 data-taking and will be backported to 16_0_X.

This is a backport of https://github.com/cms-sw/cmsdist/pull/10349