### PR TITLE
data-DQM-DTMonitorClient: Build using default data recipe

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+DQM-DTMonitorClient=V00-01-00
 HLTrigger-HLTfilters=V00-01-00
 PhysicsTools-PyTorch=V00-01-00
 PhysicsTools-PyTorchAlpaka=V00-01-00
@@ -102,7 +103,6 @@ GeneratorInterface-ReggeGribovPartonMCInterface=V00-00-02
 [data-build-github]
 Calibration-Tools=V01-00-00
 CondFormats-JetMETObjects=V01-00-03
-DQM-DTMonitorClient=V00-01-00
 DQM-PhysicsHWW=V01-00-00
 EventFilter-L1TRawToDigi=V01-00-00
 FastSimulation-TrackingRecHitProducer=V01-00-03


### PR DESCRIPTION
Moved DQM-DTMonitorClient to the default section.