### PR TITLE
Drop stdcxx-fs toolfile: It is part of stdc++ since c++17

### DIFF
--- a/scram-tools.file/tools/gcc/stdcxx-fs.xml
+++ b/scram-tools.file/tools/gcc/stdcxx-fs.xml
@@ -1,3 +1,0 @@
-  <tool name="stdcxx-fs" version="@TOOL_VERSION@" revision="1">
-    <lib name="stdc++fs"/>
-  </tool>


### PR DESCRIPTION
See https://github.com/cms-sw/cmssw/pull/50187