### PR TITLE
hydjet: Patched to fix the format string

### DIFF
--- a/hydjet-gcc15.patch
+++ b/hydjet-gcc15.patch
@@ -1,0 +1,18 @@
+diff --git a/src/hydjet1_9.f b/src/hydjet1_9.f
+index 75136a5..58f42a0 100644
+--- a/src/hydjet1_9.f
++++ b/src/hydjet1_9.f
+@@ -508,11 +508,11 @@ c      end do
+ 
+        write(6,3) INT(VA),INT(VB),INT(VC)
+ 3      format(1x,'%%                      This is HYDJET version ',I1.1,
+-     >'.',I1.1,'.',I1.1'                        %%')
++     >'.',I1.1,'.',I1.1,'                        %%')
+ 
+        write(6,5) INT(VAP),INT(VBP),INT(VCP)
+ 5      format(1x,'%%                      with using PYQUEN version ',I1
+-     >.1,'.',I1.1,'.',I1.1'                     %%')
++     >.1,'.',I1.1,'.',I1.1,'                     %%')
+ 
+        write(6,*) '%%         Corresponding author: Igor Lokhtin (Igor.L
+      >okhtin@cern.ch)        %%' 

--- a/hydjet.spec
+++ b/hydjet.spec
@@ -1,5 +1,5 @@
 ### RPM external hydjet 1.9.3
-
+Patch0: hydjet-gcc15
 Source: http://cern.ch/lokhtin/hydro/%{n}-%{realversion}.tar.gz
 
 BuildRequires: cmake gmake
@@ -9,6 +9,7 @@ Requires: pyquen pythia6 lhapdf
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 


### PR DESCRIPTION
In GCC 15, many workflows are failing with error [a] This change applies the patch for hydjet to fix the format string ( added missing `,`). Local tests confirms that this fixes these failing relvals [b]

[a]
```
%MSG
%MSG-s ExternalProcess:  ExternalGeneratorFilter:generator@beginStream  20-Feb-2026 17:37:15 CET pre-events
2 starting external process 

%MSG
2079943_1 process: initializing 20-Feb-2026 17:37:15 CET
2079943_3 process: initializing 20-Feb-2026 17:37:16 CET
2079943_2 process: initializing 20-Feb-2026 17:37:16 CET
2079943_0 process: initializing 20-Feb-2026 17:37:16 CET
At line 509 of file /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el9_amd64_gcc15/external/hydjet/1.9.3-dd1a63377b688d3b5e39798945a64096/external+hydjet+1.9.3-dd1a63377b688d3b5e39798945a64096-1-build/hydjet-1.9.3/src/hydjet1_9.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is HYDJET version ',I1.1,'.',I1.1,'.',I1.1'   
                                                                                                        ^
2079943_1 process: early exit called: unlock 20-Feb-2026 17:37:16 CET
```

[b]
```
141.201_HydjetQ_B12_5362GeV_2023_ppReco Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Feb 23 11:07:57 2026-date Mon Feb 23 11:00:11 2026; exit: 0 0 0 0
148.0_HydjetQ_MinBias_XeXe_5442GeV_2017 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Feb 23 11:07:40 2026-date Mon Feb 23 11:00:12 2026; exit: 0 0 0 0
162.0_HydjetQ_B12_5362GeV_2025 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Mon Feb 23 11:07:57 2026-date Mon Feb 23 11:00:12 2026; exit: 0 0 0 0 0
3 3 3 3 1 tests passed, 0 0 0 0 0 failed
```