### PR TITLE
Some Relvals are failing due to `ExternalFailure` in gcc15 IBs

### DIFF
--- a/hydjet-format-fix.patch
+++ b/hydjet-format-fix.patch
@@ -1,0 +1,18 @@
+diff --git a/src/hydjet1_9.f b/src/hydjet1_9.f
+index 75136a5..58f42a0 100644
+--- a/src/hydjet1_9.f
++++ b/src/hydjet1_9.f
+@@ -508,11 +508,11 @@ c      end do
+ 
+        write(6,3) INT(VA),INT(VB),INT(VC)
+ 3      format(1x,'%%                      This is HYDJET version ',I1.1,
+-     >'.',I1.1,'.',I1.1'                        %%')
++     >'.',I1.1,'.',I1.1,'                        %%')
+ 
+        write(6,5) INT(VAP),INT(VBP),INT(VCP)
+ 5      format(1x,'%%                      with using PYQUEN version ',I1
+-     >.1,'.',I1.1,'.',I1.1'                     %%')
++     >.1,'.',I1.1,'.',I1.1,'                     %%')
+ 
+        write(6,*) '%%         Corresponding author: Igor Lokhtin (Igor.L
+      >okhtin@cern.ch)        %%' 

--- a/hydjet.spec
+++ b/hydjet.spec
@@ -2,6 +2,8 @@
 
 Source: http://cern.ch/lokhtin/hydro/%{n}-%{realversion}.tar.gz
 
+Patch0: hydjet-format-fix
+
 BuildRequires: cmake gmake
 
 Requires: pyquen pythia6 lhapdf
@@ -9,9 +11,9 @@ Requires: pyquen pythia6 lhapdf
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
-
 cmake . -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_BUILD_TYPE=Release -DPYQUEN_DIR=${PYQUEN_ROOT} -DPYTHIA6_DIR=${PYTHIA6_ROOT} -DLHAPDF_ROOT_DIR=${LHAPDF_ROOT}
 cmake --build . --clean-first -- %{makeprocesses}
 


### PR DESCRIPTION
```BASH
At line 509 of file /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el9_amd64_gcc15/external/hydjet/1.9.3-dd1a63377b688d3b5e39798945a64096/external+hydjet+1.9.3-dd1a63377b688d3b5e39798945a64096-1-build/hydjet-1.9.3/src/hydjet1_9.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is HYDJET version ',I1.1,'.',I1.1,'.',I1.1'   
                                                                                                        ^
2079943_1 process: early exit called: unlock 20-Feb-2026 17:37:16 CET
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
At line 509 of file /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el9_amd64_gcc15/external/hydjet/1.9.3-dd1a63377b688d3b5e39798945a64096/external+hydjet+1.9.3-dd1a63377b688d3b5e39798945a64096-1-build/hydjet-1.9.3/src/hydjet1_9.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is HYDJET version ',I1.1,'.',I1.1,'.',I1.1'   
                                                                                                        ^
At line 509 of file /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el9_amd64_gcc15/external/hydjet/1.9.3-dd1a63377b688d3b5e39798945a64096/external+hydjet+1.9.3-dd1a63377b688d3b5e39798945a64096-1-build/hydjet-1.9.3/src/hydjet1_9.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is HYDJET version ',I1.1,'.',I1.1,'.',I1.1'   
                                                                                                        ^
2079943_2 process: early exit called: unlock 20-Feb-2026 17:37:16 CET
```
Created a patch for adding this in hydjet