### PR TITLE
pyquen and hydjet2: Patched to fix the format string

### DIFF
--- a/hydjet2-gcc15.patch
+++ b/hydjet2-gcc15.patch
@@ -1,0 +1,18 @@
+diff --git a/src/progs_fortran.f b/src/progs_fortran.f
+index 2ed348d..6ff2fd0 100644
+--- a/src/progs_fortran.f
++++ b/src/progs_fortran.f
+@@ -524,11 +524,11 @@ c--
+ 
+        write(6,3) INT(VA),INT(VB),INT(VC)
+ 3      format(1x,'%%                      This is HYDJET++ version 
+-     >',I1.1,'.',I1.1,'.',I1.1'                       %%')
++     >',I1.1,'.',I1.1,'.',I1.1,'                       %%')
+ 
+        write(6,5) INT(VAP),INT(VBP),INT(VCP)
+ 5      format(1x,'%%                      Powered by PYQUEN version ',
+-     >I1.1,'.',I1.1,'.',I1.1'                      %%')
++     >I1.1,'.',I1.1,'.',I1.1,'                      %%')
+ 
+        write(6,*) '%%      Corresponding authors: Igor Lokhtin (Igor.
+      >Lokhtin@cern.ch)           %%'

--- a/hydjet2.spec
+++ b/hydjet2.spec
@@ -1,7 +1,7 @@
 ### RPM external hydjet2 2.4.4 
 
 Source: http://lav01.sinp.msu.ru/~igor/hydjet++/%{n}-%{realversion}.tar.gz
-
+Patch0: hydjet2-gcc15
 
 BuildRequires: cmake gmake
 
@@ -10,6 +10,7 @@ Requires: pyquen pythia6 lhapdf root
 
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 

--- a/pyquen-gcc15.patch
+++ b/pyquen-gcc15.patch
@@ -1,0 +1,13 @@
+diff --git a/src/pyquen1_5.f b/src/pyquen1_5.f
+index d3ce5b7..08ac191 100644
+--- a/src/pyquen1_5.f
++++ b/src/pyquen1_5.f
+@@ -536,7 +536,7 @@
+        write(6,*) '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
+ 
+        write(6,3) INT(VA),INT(VB),INT(VC)
+-3      format(1x,'%%                      This is PYQUEN version ',I1.1,'.',I1.1,'.',I1.1'                        %%')
++3      format(1x,'%%                      This is PYQUEN version',I1.1,'.',I1.1,'.',I1.1,'                        %%')
+ 
+        write(6,*) '%%         Corresponding author: Igor Lokhtin (Igor.Lokhtin@cern.ch)        %%' 
+        write(6,*) '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'     

--- a/pyquen.spec
+++ b/pyquen.spec
@@ -1,14 +1,15 @@
 ### RPM external pyquen 1.5.4
 
 Source: http://lokhtin.web.cern.ch/lokhtin/%{n}/%{n}-%{realversion}.tar.gz
+Patch0: pyquen-gcc15
 
 BuildRequires: cmake gmake
 
 Requires: pythia6 lhapdf
 
-
 %prep
 %setup -q -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 


### PR DESCRIPTION
Relval 158.5 failing on GCC 15 IBs with
```BASH
At line 525 of file /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el9_amd64_gcc15/external/hydjet2/2.4.4-8f0193dc2e7a6b91ec32a8932329ef25/external+hydjet2+2.4.4-8f0193dc2e7a6b91ec32a8932329ef25-1-build/hydjet2-2.4.4/src/progs_fortran.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is HYDJET++ version ',I1.1,'.',I1.1,'.',I1.1
```

Relval 577.0 failing on GCC15 IBs with similar error in pyquen.
```BASH
At line 538 of file /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el9_amd64_gcc15/external/pyquen/1.5.4-98f91078b09d5598c6061677b378ab41/external+pyquen+1.5.4-98f91078b09d5598c6061677b378ab41-1-build/pyquen-1.5.4/src/pyquen1_5.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is PYQUEN version ',I1.1,'.',I1.1,'.',I1.1'   
                                                                                                        ^
At line 538 of file /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el9_amd64_gcc15/external/pyquen/1.5.4-98f91078b09d5598c6061677b378ab41/external+pyquen+1.5.4-98f91078b09d5598c6061677b378ab41-1-build/pyquen-1.5.4/src/pyquen1_5.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is PYQUEN version ',I1.1,'.',I1.1,'.',I1.1'   
                                                                                                        ^
At line 538 of file /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el9_amd64_gcc15/external/pyquen/1.5.4-98f91078b09d5598c6061677b378ab41/external+pyquen+1.5.4-98f91078b09d5598c6061677b378ab41-1-build/pyquen-1.5.4/src/pyquen1_5.f (unit = 6, file = 'stdout')
Fortran runtime error: Missing comma between descriptors
(1x,'%%                      This is PYQUEN version ',I1.1,'.',I1.1,'.',I1.1' 
```