### PR TITLE
[prmon]Build and deploy prmon along with cmssw-tools

### DIFF
--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -1,7 +1,7 @@
-### RPM cms cmssw-tools 5.0
+### RPM cms cmssw-tools 6.0
 # With cmsBuild, change the above version only when a new tool is added
 
-## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cms-cat cmssw-osenv cms-git-tools SCRAMV2
+## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cms-cat cmssw-osenv cms-git-tools SCRAMV2 prmon
 ## UPLOAD_DEPENDENCIES dqmgui
 ## INCLUDE vecgeom-opt
 

--- a/prmon/README.md
+++ b/prmon/README.md
@@ -1,5 +1,0 @@
-# Process Monitor (prmon)
-
-The [PRocess MONitor](https://github.com/HSF/prmon) is a small stand alone program that can monitor the resource consumption of a process and its children. This is useful in the context of the WLCG/HSF working group to evaluate the costs and performance of HEP workflows in WLCG. In a previous incarnation (MemoryMonitor) it has been used by ATLAS for some time to gather data on resource consumption by production jobs. One of its most useful features is to use smaps to correctly calculate the Proportional Set Size in the group of processes monitored, which is a much better indication of the true memory consumption of a group of processes where children share many pages.
-
-This was requested by Submission Infrastructure (SI) L2 area.

--- a/prmon/README.md
+++ b/prmon/README.md
@@ -1,0 +1,5 @@
+# Process Monitor (prmon)
+
+The [PRocess MONitor](https://github.com/HSF/prmon) is a small stand alone program that can monitor the resource consumption of a process and its children. This is useful in the context of the WLCG/HSF working group to evaluate the costs and performance of HEP workflows in WLCG. In a previous incarnation (MemoryMonitor) it has been used by ATLAS for some time to gather data on resource consumption by production jobs. One of its most useful features is to use smaps to correctly calculate the Proportional Set Size in the group of processes monitored, which is a much better indication of the true memory consumption of a group of processes where children share many pages.
+
+This was requested by Submission Infrastructure (SI) L2 area.

--- a/prmon/doc.txt
+++ b/prmon/doc.txt
@@ -1,0 +1,11 @@
+- Requested, AddedBy: 
+  Marco Mascheroni:  CMs Offline and Computing Submission Infrastructure (SI) L2 area
+
+- PR:
+  https://github.com/cms-sw/cmsdist/pull/10379
+
+- Description:
+  The [PRocess MONitor](https://github.com/HSF/prmon) is a small stand alone program that can monitor the resource consumption of a process and its children. This is useful in the context of the WLCG/HSF working group to evaluate the costs and performance of HEP workflows in WLCG. In a previous incarnation (MemoryMonitor) it has been used by ATLAS for some time to gather data on resource consumption by production jobs. One of its most useful features is to use smaps to correctly calculate the Proportional Set Size in the group of processes monitored, which is a much better indication of the true memory consumption of a group of processes where children share many pages.
+
+- Documentation
+  https://github.com/HSF/prmon

--- a/prmon/prmon-env.csh.file
+++ b/prmon/prmon-env.csh.file
@@ -1,0 +1,12 @@
+#####################################################
+# **************** IMPORTANT NOTE ***************** #
+# Increament Revision for every change              #
+#####################################################
+#CMSDIST_FILE_REVISION=1
+
+set latest_prmon=`ls -d @CMS_PATH@/share/\`uname -m\`/cms/prmon/v*/bin | sort | tail -1`
+if ( $?PATH ) then
+    setenv PATH "${latest_prmon}:$PATH"
+else
+    setenv PATH "${latest_prmon}"
+endif

--- a/prmon/prmon-env.sh.file
+++ b/prmon/prmon-env.sh.file
@@ -1,0 +1,8 @@
+#####################################################
+# **************** IMPORTANT NOTE ***************** #
+# Increament Revision for every change              #
+#####################################################
+#CMSDIST_FILE_REVISION=1
+
+latest_prmon=$(ls -d @CMS_PATH@/share/$(uname -m)/cms/prmon/v*/bin | sort | tail -1)
+export PATH="${latest_prmon}${PATH:+:$PATH}"

--- a/prmon/spec
+++ b/prmon/spec
@@ -1,0 +1,40 @@
+############## IMPORTANT ########################################
+#Always update the order_version below to point to latest date
+#order_version is of form vYYYYMMDDnn 
+#Increment nn if we had to patch and release it on same day
+#This provides a static build of prmon tool so we deploy it under
+#<CMS_PATH>/share/$(uname -m)/ so that it can use used for all OS/GCC
+#################################################################
+BuildRequires: cmake gmake
+%define prmon_tag 3.2.0
+%define build_type static-gnu115-opt
+%define order_version v2026022600
+
+### RPM cms prmon %{order_version}.%{prmon_tag}
+Source0: https://github.com/HSF/prmon/releases/download/v%{prmon_tag}/prmon_%{prmon_tag}_%{_arch}-%{build_type}.tar.gz
+Source1: prmon/prmon-env.sh
+Source2: prmon/prmon-env.csh
+
+%prep
+%setup -b 0 -n %{n}_%{prmon_tag}_%{_arch}-%{build_type}
+
+%build
+%install
+mkdir %{i}/etc
+rsync -a ./ %{i}/
+sed -e 's|@CMS_PATH@|%{cmsroot}|' %{_sourcedir}/prmon-env.sh  > %{i}/etc/prmon-env.sh
+sed -e 's|@CMS_PATH@|%{cmsroot}|' %{_sourcedir}/prmon-env.csh > %{i}/etc/prmon-env.csh
+
+%post
+%{relocateConfig}/etc/prmon*
+
+
+cd ${RPM_INSTALL_PREFIX}
+prmon_dir=share/%{_arch}/%{pkgcategory}/%{n}/%{order_version}
+if [ ! -d ${prmon_dir} ] ; then
+  mkdir -p ${prmon_dir}
+  rpath=$(echo "$prmon_dir" | sed 's|[^/][^/]*|..|g')
+  ln -s ${rpath}/%{pkgrel}/bin ${prmon_dir}/bin
+fi
+%common_revision_script %{pkgrel}/etc/prmon-env.sh  share/etc/profile.d/S99prmon-env.sh
+%common_revision_script %{pkgrel}/etc/prmon-env.csh share/etc/profile.d/S99prmon-env.csh


### PR DESCRIPTION
Submission Infrastructure (SI) requested to include [prmon](https://github.com/HSF/prmon) in our env. This is used for monitoring a running process.  It is build as a static executable to we can build it once for x86_64, aarch64 and riscv64 and then we can use it for any <os>_<arch>_<compiler>. Though it is deployed under normal `<CMS>/$SCRAM_ARCH/cms/prmon/<version>` but then at post install time it gets copied under `<CMS>/share/$(uname -m)/cms/prmon/<version>` so that it can be used by any $SCRAM_ARCH.