### PR TITLE
Remove JetFlavourInfo.h from fwlite build set

### DIFF
--- a/fwlite_build_set.file
+++ b/fwlite_build_set.file
@@ -139,7 +139,6 @@ SimDataFormats/CrossingFrame
 SimDataFormats/DigiSimLinks
 SimDataFormats/EncodedEventId
 SimDataFormats/GeneratorProducts
-SimDataFormats/JetMatching/interface/JetFlavourInfo.h
 SimDataFormats/PileupSummaryInfo
 SimDataFormats/RPCDigiSimLink
 SimDataFormats/RandomEngine


### PR DESCRIPTION
After https://github.com/cms-sw/cmssw/pull/33189 , there is no need to explicitly checkout SimDataFormats/JetMatching/interface/JetFlavourInfo.h in fwlite build