### PR TITLE
[16.0.X] Update tag for HLTrigger-HLTfilters to V00-02-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,7 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
-HLTrigger-HLTfilters=V00-01-00
+HLTrigger-HLTfilters=V00-02-00
 PhysicsTools-PyTorch=V00-01-00
 PhysicsTools-PyTorchAlpaka=V00-01-00
 PhysicsTools-PyTorchAlpakaTest=V00-01-00


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmsdist/pull/10372 to CMSSW_16_0_X (needed by https://github.com/cms-sw/cmssw/pull/50271)

Move HLTrigger-HLTfilters data to new tag, see
https://github.com/cms-data/HLTrigger-HLTfilters/pull/2