### PR TITLE
sherpa: disable building sherpa examples and manual

### DIFF
--- a/sherpa-disable-manual.patch
+++ b/sherpa-disable-manual.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile.am b/Makefile.am
+index 599ed4b..a7fac96 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -19,9 +19,7 @@ SUBDIRS       = \
+ 		PHOTONS++ \
+ 		SHRiMPS \
+ 		SHERPA \
+-		AddOns \
+-		Manual \
+-		Examples
++		AddOns
+ 
+ EXTRA_DIST = GUIDELINES
+ 
+diff --git a/configure.ac b/configure.ac
+index 5d2660e..7da4a97 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -220,12 +220,6 @@ AC_CONFIG_FILES([ATOOLS/Math/Makefile \
+ 	  SHERPA/Run/Makefile \
+           SHERPA/Run/Sherpa-config \
+ 	  SHERPA/Makefile \
+-	  Manual/Makefile \
+-          Manual/sherpa-completion \
+-	  Examples/Makefile \
+-	  Examples/API/ME2-Python/test.py \
+-	  Examples/API/Events/test.py \
+-	  Examples/API/MPIEvents/test.py \
+ 	  AddOns/Python/Makefile \
+ 	  AddOns/Analysis/Tools/Makefile \
+ 	  AddOns/Analysis/Main/Makefile \

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -5,11 +5,16 @@ BuildRequires: mcfm swig autotools
 Patch0: sherpa-2.2.16-hepmcshort
 #Avoid calling setenv: https://gitlab.com/sherpa-team/sherpa/-/commit/6ead62d7a2758612f8965fb5b61df8c012cf9cae.diff
 Patch1: sherpa-setenv
+#Disable build Manual and Examples
+Patch2: sherpa-disable-manual
 
 %{!?without_openloops:Requires: openloops}
 
 %prep
 %setup -q -n sherpa-%{realversion}
+%patch0 -p1
+%patch1 -p1
+%patch2 -p1
 
 autoreconf -i --force
 
@@ -17,13 +22,6 @@ autoreconf -i --force
 %ifarch x86_64
   ARCH_CMSPLATF="-m64"
 %endif
-
-%ifos darwin
-perl -p -i -e 's|-rdynamic||g' configure AddOns/Analysis/Scripts/Makefile.in
-%endif
-
-%patch0 -p1
-%patch1 -p1
 
 %build
 export PYTHON=$(which python3)
@@ -57,7 +55,6 @@ sed -i -e 's|^#!/.*|#!/usr/bin/env python3|' %{i}/bin/Sherpa-generate-model
 %{relocateConfig}lib/python%{cms_python3_major_minor_version}/site-packages/ufo_interface/sconstruct_template
 %{relocateConfig}bin/make2scons
 %{relocateConfig}share/SHERPA-MC/makelibs
-%{relocateConfig}share/SHERPA-MC/sherpa-completion
 %{relocateConfig}bin/Sherpa-config
 %{relocateConfig}bin/Sherpa-generate-model
 %{relocateConfig}include/SHERPA-MC/ATOOLS/Org/CXXFLAGS*.H


### PR DESCRIPTION
Sherpa manual and examples failed[]a to build for RISCV64, this PR proposes to drop building and shipping sherpa manual and examples

[a]
```
Sherpa.texi:32: @menu reference to nonexistent node `Command line'
Sherpa.texi:33: @menu reference to nonexistent node `Input structure'
Sherpa.texi:34: @menu reference to nonexistent node `Parameters'
Sherpa.texi:36: @menu reference to nonexistent node `Tips and Tricks'
Sherpa.texi:37: @menu reference to nonexistent node `Scale variations'
Sherpa.texi:38: @menu reference to nonexistent node `Customization'
Sherpa.texi:40: @menu reference to nonexistent node `Examples'
Sherpa.texi:42: @menu reference to nonexistent node `Getting help'
Sherpa.texi:44: @menu reference to nonexistent node `Authors'
Sherpa.texi:45: @menu reference to nonexistent node `Copying'
Sherpa.texi:47: @menu reference to nonexistent node `References'
Sherpa.texi:48: @menu reference to nonexistent node `Index'
Starting.texi:7: @menu reference to nonexistent node `Cross section determination'
make[2]: *** [Makefile:603: Sherpa.info] Error 1
make[2]: Leaving directory '/scratch/home/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/fc42_riscv64_gcc15/external/sherpa/2.2.16-6b4169b9995b1f15849571ba1233a694/external+sherpa+2.2.16-6b4169b9995b1f15849571ba1233a694-1-build/sherpa-2.2.16/Manual'
make[1]: *** [Makefile:591: all-recursive] Error 1
make[1]: Leaving directory '/scratch/home/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/fc42_riscv64_gcc15/external/sherpa/2.2.16-6b4169b9995b1f15849571ba1233a694/external+sherpa+2.2.16-6b4169b9995b1f15849571ba1233a694-1-build/sherpa-2.2.16'
make: *** [Makefile:517: all] Error 2

```