### PR TITLE
Drop ROOT GLEW root

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -11,7 +11,7 @@ Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&expo
 
 BuildRequires: cmake ninja
 
-Requires: gsl libjpeg-turbo libpng libtiff giflib pcre2 python3 fftw3 xz xrootd libxml2 zlib davix tbb OpenBLAS py3-numpy lz4 freetype zstd json
+Requires: curl gsl libjpeg-turbo libpng libtiff giflib pcre2 python3 fftw3 xz xrootd libxml2 zlib davix tbb OpenBLAS py3-numpy lz4 freetype zstd json
 %{!?without_cuda:Requires: cuda}
 
 %ifos linux

--- a/scram-tools.file/tools/root/rootglew.xml
+++ b/scram-tools.file/tools/root/rootglew.xml
@@ -1,4 +1,0 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
-  <info url="http://root.cern.ch/root/"/>
-  <lib name="GLEW"/>
-</tool>

--- a/scram-tools.file/tools/root/rootrgl.xml
+++ b/scram-tools.file/tools/root/rootrgl.xml
@@ -1,7 +1,6 @@
 <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
   <info url="http://root.cern.ch/root/"/>
   <lib name="RGL"/>
-  <use name="rootglew"/>
   <use name="rootgui"/>
   <use name="rootinteractive"/>
   <use name="rootgraphics"/>

--- a/scram-tools.file/tools/root/rootrgl.xml
+++ b/scram-tools.file/tools/root/rootrgl.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="RGL"/>
   <use name="rootgui"/>


### PR DESCRIPTION
Latest root has remove the buildin glew ( https://github.com/root-project/root/pull/20013 ). This PR proposes to drop the `rootglew` tool from cmssw