### PR TITLE
[16_0_X] Update AXOL1TL to v6.0.4 (backport)

### DIFF
--- a/AXOL1TL.spec
+++ b/AXOL1TL.spec
@@ -1,4 +1,4 @@
-### RPM external AXOL1TL 6.0.3
+### RPM external AXOL1TL 6.0.4
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
This updates to the newest model with threshold fixes for the second menu as described in [this JIRA ticket](https://its.cern.ch/jira/browse/CMSLITDPG-1511)

Release: https://github.com/cms-hls4ml/AXOL1TL/releases/tag/v6.0.4

Thresholds and workflows with the newest model have been tested.

This is a backport of https://github.com/cms-sw/cmsdist/pull/10399