### PR TITLE
Fix for IWYU so that it can find the correct clang header

### DIFF
--- a/llvm.spec
+++ b/llvm.spec
@@ -43,6 +43,7 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
 %endif
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lld;openmp" \
   -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+  -DIWYU_RESOURCE_RELATIVE_TO="iwyu" \
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DLLVM_LIBDIR_SUFFIX:STRING=64 \


### PR DESCRIPTION
`onclude-what-you-use` is failing in latest 16.1.X IBs with error [a]. This was due to the change in clang 2) and above there `iwyu` was looking for headers in to build path of clang. This change now allows `iwyu` to look under the runtime path of `iwyu`.

[a]
```
>> Compiling edm plugin src/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
In file included from src/Alignment/APEEstimation/plugins/ApeEstimator.cc:22:
In file included from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02932/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../include/c++/13.4.0/memory:78:
In file included from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02932/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../include/c++/13.4.0/bits/unique_ptr.h:42:
In file included from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02932/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../include/c++/13.4.0/ostream:40:
In file included from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02932/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../include/c++/13.4.0/ios:40:
In file included from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02932/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../include/c++/13.4.0/iosfwd:42:
In file included from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02932/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../include/c++/13.4.0/bits/postypes.h:40:
In file included from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02932/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../include/c++/13.4.0/cwchar:44:
/usr/include/wchar.h:35:10: fatal error: 'stddef.h' file not found
```