### PR TITLE
set env for various build system so that each package respect the build jobs count

### DIFF
--- a/libfabric.spec
+++ b/libfabric.spec
@@ -2,6 +2,7 @@
 Source: https://github.com/ofiwg/%{n}/releases/download/v%{realversion}/%{n}-%{realversion}.tar.bz2
 %{!?without_cuda:Requires: cuda gdrcopy}
 %{!?without_rocm:Requires: rocm}
+BuildRequires: autotools
 Requires: curl
 Requires: numactl
 Requires: rdma-core

--- a/ninja/ninja.sh.file
+++ b/ninja/ninja.sh.file
@@ -1,0 +1,11 @@
+#!/bin/bash
+for a in "$@"; do
+  if [[ "$a" == -j* ]]; then
+    exec ninja.exe "$@"
+  fi
+done
+args=()
+if [[ -n "${NINJA_NUM_JOBS}" ]]; then
+  args=(-j "${NINJA_NUM_JOBS}")
+fi
+exec ninja.exe "${args[@]}" "$@"

--- a/ninja/spec
+++ b/ninja/spec
@@ -1,5 +1,6 @@
-### RPM external ninja 1.11.1
+### RPM external ninja 1.13.2
 Source0: git://github.com/ninja-build/ninja.git?obj=release/v%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
+Source1: ninja/ninja.sh
 
 BuildRequires: python3 re2c
 
@@ -11,4 +12,6 @@ python3 ./configure.py --bootstrap
 
 %install
 mkdir -p %{i}/bin
-cp ninja %{i}/bin
+install ninja %{i}/bin/ninja.exe
+install %{_sourcedir}/ninja.sh %{i}/bin/ninja
+chmod +x %{i}/bin/ninja

--- a/pip/grpcio-tools.file
+++ b/pip/grpcio-tools.file
@@ -1,1 +1,3 @@
 Requires: py3-protobuf py3-grpcio
+%define PipPreBuild \
+  export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=%{compiling_processes}

--- a/pip/iminuit.file
+++ b/pip/iminuit.file
@@ -1,1 +1,2 @@
 Requires: py3-numpy py3-matplotlib py3-scipy py3-ipywidgets py3-scikit-build-core
+BuildRequires: cmake ninja

--- a/pip/scikit-learn.file
+++ b/pip/scikit-learn.file
@@ -1,4 +1,4 @@
 Requires: py3-scipy py3-joblib py3-threadpoolctl
+%define PipInstallOptions --config-settings=compile-args="-j%{compiling_processes}"
 %define PipPreBuild \
-  export SKLEARN_BUILD_PARALLEL=%{compiling_processes}; \
-  export CFLAGS="-Wno-error=incompatible-pointer-types"
+   export CFLAGS="-Wno-error=incompatible-pointer-types"

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -195,8 +195,17 @@
 %define initenv_all     %{disable_recursive_env} ; for x in %{allpkgreqs}                          .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %define initenv_direct1 %{disable_recursive_env} ; for x in %{directpkgreqs} %{builddirectpkgreqs} .; do i=%{cmsroot}/$x/%{cmsplatf}/etc/profile.d/init.sh; [ -f $i ] && . $i; done
 %endif
-%define initenv_direct  %{initenv_direct1} %{?cmsdist_package_initenv: ; %{cmsdist_package_initenv}}
-%define initenv         %{initenv_all}     %{?cmsdist_package_initenv: ; %{cmsdist_package_initenv}}
+
+%define build_system_env \
+  export CMAKE_BUILD_PARALLEL_LEVEL='%{compiling_processes}' ; \
+  export MAX_JOBS='%{compiling_processes}' ;\
+  export NINJA_NUM_JOBS='%{compiling_processes}' ;\
+  export CYTHON_NTHREADS='%{compiling_processes}' ;\
+  export MESON_NUM_PROCESSES='%{compiling_processes}' ;\
+  export CARGO_HOME="${TMPDIR}/cargo_home"
+
+%define initenv_direct  %{build_system_env} ; %{initenv_direct1} %{?cmsdist_package_initenv: ; %{cmsdist_package_initenv}}
+%define initenv         %{build_system_env} ; %{initenv_all}     %{?cmsdist_package_initenv: ; %{cmsdist_package_initenv}}
 
 %if "%{?compiling_processes:set}" == "set"
 %define makeprocesses -j %compiling_processes 


### PR DESCRIPTION
many pypi packages run `nproc` jobs to build. This is fine on small machines with 8, 16 core but on machine with hundreds of core this break build as we start to hit various limitation e.g. number of files open, number of parallel process a user can run. This PR proposes to set various environment various which build system like cmake, meson , ninja can use. In most cases e do pass `-j N` to build system but many pypi packages have different way of controlling the parallel jobs. This change will atleast control those pypi packages which use cmake or ninja to build