### PR TITLE
Set build time env so that edmPluginRefresh can find gpu-backend specfic libs

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-09-00
+%define configtag       V09-09-01
 %endif
 
 %if "%{?buildarch:set}" != "set"
@@ -250,7 +250,7 @@ gzip -f %i/etc/dependencies/*.out
 %endif
 
 
-eval `%scramcmd run -sh`
+eval `USER_SCRAM_RUNTIME_TYPE=BUILD %scramcmd run -sh`
 for cmd in edmPluginRefresh ; do
   cmdpath=`which $cmd 2> /dev/null || echo ""`
   if [ "X$cmdpath" != X ] ; then


### PR DESCRIPTION
When we build cmssw then after the build we set cmssw env and run `edmPluginRefresh` once for each lib directory to get the final `edmplugincache`. This have worked fine but now with GPU backend specific libraries (e.g. touch/rocm, toch/cuda etc.) the cmssw env on build node does not add the GPU backend libraries in LD_LIBRARY_PATH as on build node we do not have any gou available. For new this causes edm plugin for gpu backend missing from the `edmplugincache` e.g. in PY312 IBs, where we have separate pytorch libs for cpu and cuda, we only see [a] i.e. missing `alpaka_cuda_async` plugins and this causes one unit test to fail [b] for PY312 IBs.

This PR allows to set build time env so that `edmPluginRefresh` can find all libs.

[a]
```
Singularity> grep torchtest::DataSource $CMSSW_RELEASE_BASE/lib/el8_amd64_gcc13/.edmplugincache
pluginPhysicsToolsPyTorchAlpakaTestPluginsPortableROCmAsync.so alpaka_rocm_async::torchtest::DataSource CMS%EDM%Framework%Module
pluginPhysicsToolsPyTorchAlpakaTestPluginsPortableROCmAsync.so alpaka_rocm_async::torchtest::DataSource CMS%EDM%Framework%ParameterSet%Description
pluginPhysicsToolsPyTorchAlpakaTestPluginsPortableSerialSync.so alpaka_serial_sync::torchtest::DataSource CMS%EDM%Framework%Module
pluginPhysicsToolsPyTorchAlpakaTestPluginsPortableSerialSync.so alpaka_serial_sync::torchtest::DataSource CMS%EDM%Framework%ParameterSet%Description
pluginPhysicsToolsPyTorchAlpakaTestPluginsPortableSerialSync.so torchtest::DataSource@alpaka CMS%EDM%Framework%ParameterSet%Description
```

[b] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc13/CMSSW_16_1_PY312_X_2026-03-10-2300/gpu/nvidia_h100/unitTestLogs/PhysicsTools/PyTorchAlpakaTest#/
```
----- Begin Fatal Exception 11-Mar-2026 12:32:43 CET-----------------------
An exception of category 'PluginNotFound' occurred while
   [0] Constructing the EventProcessor
Exception Message:
Unable to find plugin 'torchtest::DataSource@alpaka' in category 'CMS EDM Framework Module'. Please check spelling of name.
   Additional Info:
      [a] These alternative types were tried: alpaka_cuda_async::torchtest::DataSource
----- End Fatal Exception -------------------------------------------------
```