### PR TITLE
Add missing dependency on compression libraries

### DIFF
--- a/scram-tools.file/tools/hepmc3/hepmc3.xml
+++ b/scram-tools.file/tools/hepmc3/hepmc3.xml
@@ -1,6 +1,11 @@
 <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
   <lib name="HepMC3"/>
   <lib name="HepMC3search"/>
+  <!-- header-only dependencies through bxzstr -->
+  <use name="bz2lib"/>
+  <use name="xz"/>
+  <use name="zlib"/>
+  <use name="zstd"/>
   <client>
     <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>


### PR DESCRIPTION
The missing dependency can be noted when building a package that depends on hepmc3 on a system with an older version of zstd.