### PR TITLE
Update OpenMPI to v5.0.10 [16.0.x]

### DIFF
--- a/openmpi.spec
+++ b/openmpi.spec
@@ -1,4 +1,4 @@
-### RPM external openmpi 5.0.9
+### RPM external openmpi 5.0.10
 ## INCLUDE openmpi-opt
 ## INITENV SET OPAL_PREFIX %{i}
 ## INITENV SET PMIX_PREFIX %{i}


### PR DESCRIPTION
See https://docs.open-mpi.org/en/v5.0.x/release-notes/changelog/v5.0.x.html for the changes in the 5.0.x release series.

#### Backport status

Backport of #10418 to 16.0.x for online NGT tests.