### PR TITLE
Update the Acts build

### DIFF
--- a/acts.spec
+++ b/acts.spec
@@ -23,6 +23,7 @@ Requires: fastjet
 Requires: geant4
 Requires: json
 Requires: python3
+Requires: py3-pybind11
 Requires: root
 Requires: xerces-c
 %{!?without_cuda:Requires: cuda}
@@ -77,6 +78,7 @@ cmake ../%{n}-%{realversion} \
   -DBUILD_SHARED_LIBS="ON" \
   -DACTS_NLOHMANNJSON_SOURCE="" \
   -DACTS_USE_SYSTEM_NLOHMANN_JSON="ON" \
+  -DACTS_USE_SYSTEM_PYBIND11="ON" \
   -DACTS_BUILD_PLUGIN_ACTSVG="ON" \
   -DACTS_BUILD_PLUGIN_FASTJET="ON" \
   -DACTS_BUILD_PLUGIN_JSON="ON" \
@@ -85,6 +87,7 @@ cmake ../%{n}-%{realversion} \
   -DACTS_BUILD_PLUGIN_GEANT4="ON" \
   -DACTS_BUILD_PLUGIN_TRACCC="ON" \
   -DACTS_ENABLE_LOG_FAILURE_THRESHOLD="ON" \
+  -DACTSVG_USE_SYSTEM_PYBIND11="ON" \
   -DCOVFIE_PLATFORM_CPU="ON" \
   -DCOVFIE_PLATFORM_CUDA="%{cuda_enabled}" \
   -DCOVFIE_PLATFORM_HIP="%{rocm_enabled}" \

--- a/acts.spec
+++ b/acts.spec
@@ -1,4 +1,5 @@
 ### RPM external acts v44.0.1
+## INITENV +PATH PYTHON3PATH %{i}/python
 ## INCLUDE microarch_flags
 ## INCLUDE cuda-flags
 ## INCLUDE rocm-flags
@@ -10,12 +11,11 @@
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 Source99: scram-tools.file/tools/eigen/env
 
-# Do not build the Acts and Traccc tests
-%define build_test 0
+# Build the Acts and Traccc tests
+%define build_test 1
 
 BuildRequires: cmake gmake
 Requires: boost
-Requires: bz2lib
 Requires: dd4hep
 Requires: eigen
 Requires: expat
@@ -24,13 +24,17 @@ Requires: json
 Requires: python3
 Requires: root
 Requires: xerces-c
-Requires: zlib
 %{!?without_cuda:Requires: cuda}
 %{!?without_rocm:Requires: rocm}
 %if %{build_test}
 # These are ony used to build the examples and unit tests
 Requires: hepmc3
 Requires: tbb
+# These are used through hepmc3, and need to be available to CMake
+Requires: bz2lib
+Requires: zlib
+Requires: zstd
+Requires: xz
 %endif
 
 %prep
@@ -110,15 +114,10 @@ make %{makeprocesses} VERBOSE=1
 cd ../build
 make install VERBOSE=1
 
-%if %{build_test}
-# download the traccc test data file to the .../data directory
-mkdir -p %{i}/data
-./_deps/traccc-src/data/traccc_data_get_files.sh -o %{i}/data
-%endif
-
 # remove the scripts used to set the Acts environment variables
 rm %{i}/bin/this_acts.sh
 rm %{i}/bin/this_acts_withdeps.sh
+rm %{i}/python/setup.sh
 
 %post
 %{relocateConfig}lib64/cmake/*/*.cmake

--- a/acts.spec
+++ b/acts.spec
@@ -19,6 +19,7 @@ Requires: boost
 Requires: dd4hep
 Requires: eigen
 Requires: expat
+Requires: fastjet
 Requires: geant4
 Requires: json
 Requires: python3
@@ -77,6 +78,7 @@ cmake ../%{n}-%{realversion} \
   -DACTS_NLOHMANNJSON_SOURCE="" \
   -DACTS_USE_SYSTEM_NLOHMANN_JSON="ON" \
   -DACTS_BUILD_PLUGIN_ACTSVG="ON" \
+  -DACTS_BUILD_PLUGIN_FASTJET="ON" \
   -DACTS_BUILD_PLUGIN_JSON="ON" \
   -DACTS_BUILD_PLUGIN_ROOT="ON" \
   -DACTS_BUILD_PLUGIN_DD4HEP="ON" \

--- a/actsdata.spec
+++ b/actsdata.spec
@@ -1,0 +1,11 @@
+### RPM external actsdata v10
+## NOCOMPILER
+
+%define archive traccc-data-%{realversion}.tar.gz
+Source: no-cmssdt-cache+https://acts.web.cern.ch/traccc/data/%{archive}
+AutoReqProv: no
+
+# unpack the source archive under ${RPM_INSTALL_PREFIX}/share/package during the
+# rpm installation, and create symlinks to ${RPM_INSTALL_PREFIX}/arch/package
+%define unpack_at_install 1
+## INCLUDE data/shared-data-package

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -10,6 +10,7 @@ Requires: TOPO
 Requires: CICADA
 Requires: OpenBLAS
 Requires: acts
+Requires: actsdata
 %if %{enable_vecgeom}
 Requires: celeritas
 %endif

--- a/scram-tools.file/tools/acts/acts-fastjet.xml
+++ b/scram-tools.file/tools/acts/acts-fastjet.xml
@@ -1,0 +1,6 @@
+<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+  <info url="https://acts.readthedocs.io/en/latest/plugins/plugins.html"/>
+  <lib name="ActsPluginFastJet"/>
+  <use name="acts-core"/>
+  <use name="fastjet"/>
+</tool>

--- a/scram-tools.file/tools/actsdata/actsdata.xml
+++ b/scram-tools.file/tools/actsdata/actsdata.xml
@@ -1,0 +1,8 @@
+<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+  <!-- set the environment for the Traccc test data -->
+  <info url="https://github.com/acts-project/traccc/"/>
+  <client>
+    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
+  </client>
+  <runtime name="TRACCC_TEST_DATA_DIR" value="$@TOOL_BASE@"/>
+</tool>


### PR DESCRIPTION
Update the Acts build:
  - include the Traccc test data in a dedicated package;
  - use pybind11 from the CMS distribution;
  - build the Acts FastJet plug-in;
  - build the Acts and Traccc tests.
