### PR TITLE
HepMC3: Update to version 3.3.1 and enable tests

### DIFF
--- a/hepmc3.spec
+++ b/hepmc3.spec
@@ -2,7 +2,7 @@
 ## INCLUDE cpp-standard
 Source: https://gitlab.cern.ch/hepmc/HepMC3/-/archive/%{realversion}/HepMC3-%{realversion}.tar.gz
 
-BuildRequires: cmake
+BuildRequires: cmake gmake
 Requires: zlib bz2lib xz zstd
 
 %define drop_files %i/share/doc

--- a/hepmc3.spec
+++ b/hepmc3.spec
@@ -1,8 +1,9 @@
-### RPM external hepmc3 3.2.7
+### RPM external hepmc3 3.3.1
 ## INCLUDE cpp-standard
 Source: https://gitlab.cern.ch/hepmc/HepMC3/-/archive/%{realversion}/HepMC3-%{realversion}.tar.gz
 
 BuildRequires: cmake
+Requires: zlib bz2lib xz zstd
 
 %define drop_files %i/share/doc
 
@@ -19,14 +20,22 @@ cmake ../HepMC3-%{realversion} \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   -DHEPMC3_CXX_STANDARD=%{cms_cxx_standard} \
   -DHEPMC3_ENABLE_ROOTIO="OFF" \
-  -DHEPMC3_ENABLE_TEST="OFF" \
+  -DHEPMC3_ENABLE_TEST="ON" \
+  -DHEPMC3_TEST_THREADS="ON" \
+  -DHEPMC3_TEST_HEPMC2="OFF" \
+  -DHEPMC3_TEST_VALGRIND="OFF" \
+  -DHEPMC3_TEST_ZLIB="ON" \
+  -DHEPMC3_TEST_LZMA="ON" \
+  -DHEPMC3_TEST_BZIP2="ON" \
+  -DHEPMC3_TEST_ZSTD="ON" \
   -DHEPMC3_ENABLE_PYTHON="OFF" \
   -DHEPMC3_BUILD_STATIC_LIBS="OFF" \
   -DHEPMC3_BUILD_DOCS="OFF" \
   -DHEPMC3_INSTALL_INTERFACES="ON" \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -L
 
-make %{makeprocesses}
+make %{makeprocesses} VERBOSE=1
 
 %install
 cd ../build


### PR DESCRIPTION
`hepmc3` version `3.3.1` has fixed the tests for comparison tools and can now properly find and use these externals
```
-- HepMC3 test: The following packages are enabled for tests HEPMC3_TEST_PACKAGES_LIST=Threads;zlib;lzma;bzip2;zstd
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE
-- HepMC3 test: Threads library found.  Thread safety tests enabled
-- Found ZLIB: /build/muz/hepmc3/w/el8_amd64_gcc13/external/zlib/1.2.13-589f6bb51bbeba38a7adf5a10ea8a093/lib/libz.so (found version "1.2.13")
-- HepMC3 test: ZLIB library found. zlib tests enabled
-- Looking for lzma_auto_decoder in /build/muz/hepmc3/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/lib/liblzma.so
-- Looking for lzma_auto_decoder in /build/muz/hepmc3/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/lib/liblzma.so - found
-- Looking for lzma_easy_encoder in /build/muz/hepmc3/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/lib/liblzma.so
-- Looking for lzma_easy_encoder in /build/muz/hepmc3/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/lib/liblzma.so - found
-- Looking for lzma_lzma_preset in /build/muz/hepmc3/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/lib/liblzma.so
-- Looking for lzma_lzma_preset in /build/muz/hepmc3/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/lib/liblzma.so - found
-- Found LibLZMA: /build/muz/hepmc3/w/el8_amd64_gcc13/external/xz/5.6.4-b9c4ffbc390ed320a5d57fd552e29a05/lib/liblzma.so (found version "5.6.4")
-- HepMC3 test: LZMA library found.  lzma tests enabled
-- Found BZip2: /build/muz/hepmc3/w/el8_amd64_gcc13/external/bz2lib/1.0.6-d113e1c6278c07eeaff5f84db9548446/lib/libbz2.so (found version "1.0.6")
-- Looking for BZ2_bzCompressInit
-- Looking for BZ2_bzCompressInit - found
-- HepMC3 test: BZip2 library found.  BZip2 tests enabled
-- Found zstd: /build/muz/hepmc3/w/el8_amd64_gcc13/external/zstd/1.5.7-06370988946837b634b6dbd71385514f/lib/libzstd.so (Required is at least version "1.4.0")
-- Found zstd: /build/muz/hepmc3/w/el8_amd64_gcc13/external/zstd/1.5.7-06370988946837b634b6dbd71385514f/include (found suitable version "1.5.7", minimum required is "1.4.0")
-- HepMC3 test: Zstd library version 1.5.7 found.  Zstd tests enabled
```

FYI @fwyzard 