### PR TITLE
helper macros for install/removing data package

### DIFF
--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -337,6 +337,33 @@ fi
     rm -f download.url;\
   fi
 
+#Move contents of a package in to shared/package/version path and replace the original with symlinks
+%define install_shared_data_package \
+  LOCAL_PKG=${RPM_INSTALL_PREFIX}/%{pkgrel} \
+  SHARE_PKG=${RPM_INSTALL_PREFIX}/share/%{pkgcategory}/%{n}/%{realversion} \
+  cd ${LOCAL_PKG} \
+  mkdir -p ${SHARE_PKG}/.links \
+  touch ${SHARE_PKG}/.links/arch-%{cmsplatf}-%{v} \
+  cd ${LOCAL_PKG} \
+  for path in $(ls | grep -v '^etc$') ; do \
+    if [ ! -e ${SHARE_PKG}/${path} ] ; then \
+      mv ${path} ${SHARE_PKG}/${path} \
+    else \
+      chmod -R u+w ${path} \
+      rm -rf ${path} \
+    fi \
+    ln -s ../../../../share/%{pkgcategory}/%{n}/%{realversion}/${path} ${path} \
+  done
+
+#cleanup contents of shared data package
+%define uninstall_shared_data_package \
+  SHARE_PKG=${RPM_INSTALL_PREFIX}/share/%{pkgcategory}/%{n}/%{realversion} \
+  rm -f ${SHARE_PKG}/.links/arch-%{cmsplatf}-%{v} \
+  if [ $(find ${SHARE_PKG}/.links -name 'arch-*' -type f | wc -l) -eq 0 ] ; then \
+    chmod -R u+w ${SHARE_PKG} \
+    rm -rf ${SHARE_PKG} \
+  fi
+
 #Enable debug mode for cmssw packages, e.g debug root, geant4, etc
 %if "%{?cms_debug_packages:set}" == "set"
 %define is_debug_build() %(if echo %{cms_debug_packages} | tr , '\\n' | grep -q '^%{1}$' ; then echo 1 ; else echo 0; fi)


### PR DESCRIPTION
This PR adds couple of helper macros which can use usd as
```
%post
%{install_shared_data_package}

%postun
%{uninstall_shared_data_package}
```

to make a copy of data package into share area and if all the references to shared data package are removed then also delete the shared package.

I have locally tested these macros using a testdata package (with some debug output ) and these work as expected

- Building/Installing same `realversion` multiple time
1. New `relversion` build
```
RPM installation stderr testdata:
Deploying: /build/muz/bld-time/w/share/external/testdata/v11/.links/arch-el8_amd64_gcc13-v11-62a15cf9e5e5e56c4aba77b9c299823c
mv bar /build/muz/bld-time/w/share/external/testdata/v11/bar
mv bla /build/muz/bld-time/w/share/external/testdata/v11/bla
mv foo /build/muz/bld-time/w/share/external/testdata/v11/foo
```

2. Rebuilding again i.e. `realversion` remain the same
```
RPM installation stderr testdata:
Deploying: /build/muz/bld-time/w/share/external/testdata/v11/.links/arch-el8_amd64_gcc13-v11-032866d66313672c6d52d27be3983aab
Already exists /build/muz/bld-time/w/share/external/testdata/v11/bar
Already exists /build/muz/bld-time/w/share/external/testdata/v11/bla
Already exists /build/muz/bld-time/w/share/external/testdata/v11/foo
```

3. Rebuilding again i.e. `realversion` remain the same
```
RPM installation stderr testdata:
Deploying: /build/muz/bld-time/w/share/external/testdata/v11/.links/arch-el8_amd64_gcc13-v11-1075c3e4c4537645d856fc1d8351c0f9
Already exists /build/muz/bld-time/w/share/external/testdata/v11/bar
Already exists /build/muz/bld-time/w/share/external/testdata/v11/bla
Already exists /build/muz/bld-time/w/share/external/testdata/v11/foo
```

For three different builds of same data package version, we end up with a single copy of it in `share` path.

- Removing installed shared data package
```
> cmspkg -a el8_amd64_gcc13 remove -y --delete-dir external+testdata+v11-1075c3e4c4537645d856fc1d8351c0f9
Removing package external+testdata+v11-1075c3e4c4537645d856fc1d8351c0f9
Uninstall /build/muz/bld-time/w/share/external/testdata/v11/.links/-arch-el8_amd64_gcc13-v11-1075c3e4c4537645d856fc1d8351c0f9
Not cleaning up shared installation
Removed external+testdata+v11-1075c3e4c4537645d856fc1d8351c0f9
```

```
> cmspkg -a el8_amd64_gcc13 remove -y --delete-dir external+testdata+v11-032866d66313672c6d52d27be3983aab
Removing package external+testdata+v11-032866d66313672c6d52d27be3983aab
Uninstall /build/muz/bld-time/w/share/external/testdata/v11/.links/-arch-el8_amd64_gcc13-v11-032866d66313672c6d52d27be3983aab
Not cleaning up shared installation
Removed external+testdata+v11-032866d66313672c6d52d27be3983aab
```

```
> cmspkg -a el8_amd64_gcc13 remove -y --delete-dir external+testdata+v11-62a15cf9e5e5e56c4aba77b9c299823c
Removing package external+testdata+v11-62a15cf9e5e5e56c4aba77b9c299823c
Uninstall /build/muz/bld-time/w/share/external/testdata/v11/.links/-arch-el8_amd64_gcc13-v11-62a15cf9e5e5e56c4aba77b9c299823c
Uninstall shared: /build/muz/bld-time/w/share/external/testdata/v11
Removed external+testdata+v11-62a15cf9e5e5e56c4aba77b9c299823c
```