### PR TITLE
improved data package install/uninstall and size check macros

### DIFF
--- a/data/shared-data-package.file
+++ b/data/shared-data-package.file
@@ -1,0 +1,43 @@
+## NOCOMPILER
+AutoReqProv: no
+
+%pre
+%{?package_pre_pre}
+%if 0%{?unpack_at_install}
+%check_data_package_size
+%endif
+%{?package_post_pre}
+
+%prep
+%{?package_pre_prep}
+%{?package_post_prep}
+
+%build
+%{?package_pre_build}
+%{?package_post_build}
+
+%install
+%{?package_pre_install}
+%if 0%{?unpack_at_install}
+  archive=$(basename %{SOURCE0})
+  cp %{SOURCE0} %{i}/
+  %calculate_data_package_size %{SOURCE0} %{n}-rpm.macros
+  echo "%data_package_archive ${archive}" >> %{n}-rpm.macros
+%else
+  tar -xzf %{SOURCE0} -C %{i}
+%endif
+%{?package_post_install}
+
+%post
+%{?package_pre_post}
+%if 0%{?unpack_at_install}
+  %install_data_package ${RPM_INSTALL_PREFIX}/%{pkgrel}/%{data_package_archive}
+%else
+  %install_data_package
+%endif
+%{?package_post_post}
+
+%postun
+%{?package_pre_postun}
+%uninstall_data_package
+%{?package_post_postun}

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -337,29 +337,63 @@ fi
     rm -f download.url;\
   fi
 
+###########################################
+# Helper macros for shared data packages
+# #########################################
+
+#Preinstall checks to make sure we have enough disk before installing data package
+#Should be used by share data packages which unpack their contents during %post
+%define check_data_package_size \
+  if [ "${IGNORE_PRE_SIZE_CHECKS}" != "1" ] ; then \
+    if [ "%{?required_data_package_size_mb}" != "" ] ; then \
+      AVAILABLE_MB=$(df -Pm ${RPM_INSTALL_PREFIX} | awk 'NR==2 {print $4}') \
+      if (( AVAILABLE_MB < %{required_data_package_size_mb} )); then \
+        echo "ERROR: Not enough disk space for extraction. Available disk ${AVAILABLE_MB}MB but package required %{required_data_package_size_mb}MB" \
+        exit 1 \
+      fi \
+    fi \
+  fi
+
+#Calculate the size of unpacked data package (safety factor size=actual_size*2)
+#Should be used by share data packages which unpack their contents during %post
+%define calculate_data_package_size() \
+  mkdir -p ${TMPDIR}/%{n}-tmpdir \
+  tar xzf %{1} -C ${TMPDIR}/%{n}-tmpdir \
+  size=$(du -sm ${TMPDIR}/%{n}-tmpdir | awk '{print $1}') \
+  echo "%%required_data_package_size_mb $((1 + size * 2))" > %{2} \
+  rm -rf ${TMPDIR}/%{n}-tmpdir
+
 #Move contents of a package in to shared/package/version path and replace the original with symlinks
-%define install_shared_data_package \
+%define install_data_package() \
   ARCH_PKG=${RPM_INSTALL_PREFIX}/%{pkgrel} \
   SHARE_PKG=${RPM_INSTALL_PREFIX}/share/%{pkgcategory}/%{n}/%{realversion} \
   if [ ! -d ${SHARE_PKG} ]  ; then \
     mkdir -p ${SHARE_PKG}/.links \
-    find ${ARCH_PKG} -mindepth 1 -maxdepth 1 ! -name 'etc' -exec mv -t ${SHARE_PKG} {} + \
+    if [ "%{?1}" != "" ] ; then \
+      tar xzf %{1} -C ${SHARE_PKG} \
+    else \
+      find ${ARCH_PKG} -mindepth 1 -maxdepth 1 ! -name 'etc' -exec mv -t ${SHARE_PKG} {} + \
+    fi \
   else \
     chmod -R u+rwX ${ARCH_PKG} \
     find ${ARCH_PKG} -mindepth 1 -maxdepth 1 ! -name 'etc' -exec rm -rf {} + \
   fi \
+  [ "%{?1}" != "" ] && rm -f %{1} \
   pushd ${ARCH_PKG} \
     ln -s ../../../../share/%{pkgcategory}/%{n}/%{realversion}/* . \
   popd \
   touch ${SHARE_PKG}/.links/arch-%{cmsplatf}-%{v}
 
 #cleanup contents of shared data package
-%define uninstall_shared_data_package \
+%define uninstall_data_package \
   SHARE_PKG=${RPM_INSTALL_PREFIX}/share/%{pkgcategory}/%{n}/%{realversion} \
   rm -f ${SHARE_PKG}/.links/arch-%{cmsplatf}-%{v} \
   if ! find ${SHARE_PKG}/.links -name 'arch-*' -type f -print -quit | grep -q . ; then \
     chmod -R u+rwX ${SHARE_PKG} && rm -rf ${SHARE_PKG} \
   fi
+
+#############################################################
+#############################################################
 
 #Enable debug mode for cmssw packages, e.g debug root, geant4, etc
 %if "%{?cms_debug_packages:set}" == "set"


### PR DESCRIPTION
This PR updates the rpm macros for managing shared data package. It also contains a helper spec file template which one can use to build data packages which are then installed in share/package path e.g.  

- Following data package unpacks its contents during the rpm build phase and then at the rpm install time its contents are move to share/package directory and symlinks are created in the actual arch/package directory 
```
### RPM external testdata v1.0
Source: https://foo.bar/foo-%{realversion}.tar.gz
## INCLUDE data/shared-data-package
```

- Following data package unpacks its contents during rpm install time in to share/package path and then create symlinks for arch/package
```
### RPM external testdata-tar v1.0
Source: https://foo.bar/foo-%{realversion}.tar.gz
%define unpack_at_install 1
## INCLUDE data/shared-data-package
```

a ref for each installation is stored in share/package/.links path. At n-install time this ref is deleted and once there is no more ref left then actual share/package is deleted too.

For packages which unpacks its content during the RPM install time, we also calculate the required disk size for installation (by unpacking the tar file and calculating its size in MB) and feed this information to `rpmbuild`  so that package's pre-install can make sure that there is enough disk available before starting the installation.