### PR TITLE
Pythia 8.317

### DIFF
--- a/pythia8.spec
+++ b/pythia8.spec
@@ -1,4 +1,4 @@
-### RPM external pythia8 316
+### RPM external pythia8 317
 
 Source: https://pythia.org/download/pythia83/%{n}%{realversion}.tgz
 
@@ -7,7 +7,7 @@ Requires: hepmc hepmc3 lhapdf
 %prep
 %setup -q -n %{n}%{realversion}
 
-./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-hepmc3=${HEPMC3_ROOT} --with-lhapdf6=${LHAPDF_ROOT} --enable-mg5mes
+./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-hepmc3=${HEPMC3_ROOT} --with-lhapdf6=${LHAPDF_ROOT} --with-mg5mes
 
 %build
 make %makeprocesses


### PR DESCRIPTION
Pythia 8.317 brings improvements to DIS, toponium and hadronization weights: https://pythia.org/history/

Validation plots made by Martins: https://mklevs.web.cern.ch/plots/pythia_regression_testing_rivet_comparison_8.316_8.317_yodamerge/
-> no difference beyond statistical fluctuations

Also correct the flag to enable MG5 ME corrections for Vincia (thanks to @DickyChant)