### PR TITLE
[acts][gcc15] Added missing cassert header

### DIFF
--- a/acts.spec
+++ b/acts.spec
@@ -5,7 +5,7 @@
 ## INCLUDE rocm-flags
 ## INCLUDE geant4-deps
 
-%define tag         1af234d8a
+%define tag         30fb4ea
 %define branch      cms/%{realversion}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
Thsi fixes the build errors for GCC 15 (https://cmssdt.cern.ch/SDT/jenkins-artifacts/build-any-ib/CMSSW_16_1_X_2026-03-26-1100/el9_amd64_gcc15/236656/external/acts/v44.0.1-f12da733e9c835128ff05b2ded4003bd/log)