### PR TITLE
create rpm.macros file in known TMPDIR instead of builddir

### DIFF
--- a/data/shared-data-package.file
+++ b/data/shared-data-package.file
@@ -24,8 +24,8 @@ AutoReqProv: no
 %if 0%{?unpack_at_install}
   archive=$(basename %{SOURCE0})
   cp %{SOURCE0} %{i}/
-  %calculate_data_package_size %{SOURCE0} %{n}-rpm.macros
-  echo "%data_package_archive ${archive}" >> %{n}-rpm.macros
+  %calculate_data_package_size %{SOURCE0} $TMPDIR/%{n}-rpm.macros
+  echo "%data_package_archive ${archive}" >> $TMPDIR/%{n}-rpm.macros
 %else
   mkdir -p %{i}/%{?data_directory}
   tar -xzf %{SOURCE0} -C %{i}/%{?data_directory}


### PR DESCRIPTION
create `pkg-rpm.macros` in known `$TMPDIR` directory instead of `%_builddir` which can be different in different rpm versions. `$TMPDIR` is set by `cmsBuild` so creating the file under it means `cmsBuild` can read and use it.

This should fix the rpm isntall errors (https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-8e024f/52292/external_checks/unknown/ ) seen in the GCC15 builds where `%_builddir` is different due to newer version of RPM.