### PR TITLE
[py312]Revert lhapdf to 6.4.0

### DIFF
--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -1,4 +1,4 @@
-### RPM external lhapdf 6.5.4
+### RPM external lhapdf 6.4.0
 %define setsversion 6.5.1c
 
 Source: http://www.hepforge.org/archive/lhapdf/LHAPDF-%{realversion}.tar.gz
@@ -33,9 +33,8 @@ rm -f pdfsets.index
 cp -f %{_sourcedir}/lhapdf_pdfsetsindex pdfsets.index
 cd -
 
-# Remove all libtool archives and docs
+# Remove all libtool archives
 find %{i} -name '*.la' -exec rm -f {} \;
-rm -rf %{i}/share/doc
 
 %post
 %{relocateConfig}bin/lhapdf-config

--- a/lhapdf.spec
+++ b/lhapdf.spec
@@ -17,6 +17,9 @@ PYTHON=$(which python3) \
   ./configure --prefix=%{i} \
   --enable-python
 
+# Delete wrappers/python/lhapdf.cpp and re-generate with newer cython
+rm -f wrappers/python/lhapdf.cpp
+
 %build
 make all %makeprocesses 
 
@@ -33,8 +36,9 @@ rm -f pdfsets.index
 cp -f %{_sourcedir}/lhapdf_pdfsetsindex pdfsets.index
 cd -
 
-# Remove all libtool archives
+# Remove all libtool archives and docs
 find %{i} -name '*.la' -exec rm -f {} \;
+rm -rf %{i}/share/doc
 
 %post
 %{relocateConfig}bin/lhapdf-config


### PR DESCRIPTION
Trying reverting LHAPDF to version 6.4.0 for Python 3.12 IBs. This is same as https://github.com/cms-sw/cmsdist/pull/8869 . This is a workaround for https://github.com/cms-sw/cmssw/issues/43526 unless we get a proper fix. 

Failing workflow 132.0 now runs fine with this update
```
> cat cmdLog
# in: new going to execute cd 132.0_LM9p
 export CMSSW_USE_IBEOS=true
 cmsDriver.py LM9p_8TeV_cff  --relval 25000,100 -s GEN,SIM -n 10 --conditions auto:run1_mc \
 --beamspot Realistic8TeVCollision --datatier GEN-SIM --eventcontent RAWSIM \
 --fileout file:step1.root  --nThreads 4

# in: new going to execute cd 132.0_LM9p
 export CMSSW_USE_IBEOS=true
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake --datatier GEN-SIM-DIGI-RAW-HLTDEBUG \
  --eventcontent FEVTDEBUGHLT --conditions auto:run1_mc -n 100  --filein  file:step1.root  \
  --fileout file:step2.root  --nThreads 4
 
# in: new going to execute cd 132.0_LM9p
 export CMSSW_USE_IBEOS=true
 cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@standardValidationNoHLT+@miniAODValidation,DQM:@standardDQMFakeHLT+@miniAODDQM \
  --conditions auto:run1_mc --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO \
  --eventcontent RECOSIM,MINIAODSIM,DQM -n 100  --filein  file:step2.root  \
  --fileout file:step3.root  --nThreads 4

> cat runall-report-step123-.log 
132.0_LM9p Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Mar 31 14:57:16 2026-date Tue Mar 31 14:54:09 2026; exit: 0 0 0
1 1 1 tests passed, 0 0 0 failed
```