### PR TITLE
[BuildRules] Fix for ordering of scram based tools in dev area based on patch release

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-09-01
+%define configtag       V09-09-02
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This includes the fix https://github.com/cms-sw/cmssw-config/commit/1eaf3eb4cc10db6105c4c0f2e596c215c5927a30 which should use the correct order for SCRAM based tools.

https://github.com/cms-sw/cmssw-config/commit/1eaf3eb4cc10db6105c4c0f2e596c215c5927a30 change should be back ported to old release cycles too