### PR TITLE
[ROOT639] Disable stripping of ROOT's `libCling.so`

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -56,6 +56,7 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_CXX_COMPILER=g++ \
   -DCMAKE_Fortran_COMPILER=gfortran \
   -DCMAKE_LINKER=ld \
+  -DCMAKE_STRIP=/usr/bin/true \
   -DCMAKE_VERBOSE_MAKEFILE=TRUE \
   -Droot7=ON \
   -Dfail-on-missing=ON \


### PR DESCRIPTION
https://github.com/root-project/root/commit/4731fd56e2f682b318f3b620d876a066f1e1ec12 automatically strips `libCling.so` in Release builds. To turn it off, define `CMAKE_STRIP=/usr/bin/true`, which is no-op.