### PR TITLE
[16.0][BuildRules] Fix for ordering of scram based tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-08-12
+%define configtag       V09-08-13
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of #10456