### PR TITLE
[15.1][BuildRules] Fix for ordering of scram based tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-08-10
+%define configtag       V09-08-13
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of #10456 
Also contain fixes backported from https://github.com/cms-sw/cmsdist/pull/10154 and https://github.com/cms-sw/cmsdist/pull/10148