### PR TITLE
[14.2][BuildRules] Fix for ordering of scram based tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -51,7 +51,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-05-03-03
+%define configtag       V09-05-03-04
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of #10456