### PR TITLE
Add DataFormats/AlpakaCommon to fwlite build set

### DIFF
--- a/fwlite_build_set.file
+++ b/fwlite_build_set.file
@@ -6,6 +6,7 @@ CondFormats/External
 CondFormats/L1TObjects
 CondFormats/RPCObjects
 CondFormats/Serialization
+DataFormats/AlpakaCommon
 DataFormats/BTauReco
 DataFormats/BeamSpot
 DataFormats/CLHEP


### PR DESCRIPTION
fixes fwlite build which are failing  with error

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/fwlite/el8_amd64_gcc13/CMSSW_16_1_X_2026-03-31-2300/HeterogeneousCore/TrivialSerialisation
```
In file included from src/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h:8,
                 from src/HeterogeneousCore/TrivialSerialisation/src/alpaka/SerialiserFactoryDevice.cc:1:
src/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Serialiser.h:8:10: fatal error: DataFormats/AlpakaCommon/interface/alpaka/DeviceProductType.h: No such file or directory
    8 | #include "DataFormats/AlpakaCommon/interface/alpaka/DeviceProductType.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from src/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h:8,
                 from src/HeterogeneousCore/TrivialSerialisation/src/alpaka/SerialiserFactoryDevice.cc:1:
src/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Serialiser.h:8:10: fatal error: DataFormats/AlpakaCommon/interface/alpaka/DeviceProductType.h: No such file or directory
    8 | #include "DataFormats/AlpakaCommon/interface/alpaka/DeviceProductType.h"

```