### PR TITLE
Set the cuBLAS workspace configuration

### DIFF
--- a/scram-tools.file/tools/cuda/cuda-cublas.xml
+++ b/scram-tools.file/tools/cuda/cuda-cublas.xml
@@ -3,4 +3,10 @@
   <use name="cuda"/>
   <lib name="cublas"/>
   <lib name="cublasLt"/>
+  <!--
+    Set the cuBLAS workspace configuration to 8 * 16 KiB.
+    This reduces the amount of GPU memory used by cuBLAS, especially within PyTorch,
+    and ensures reproducibility of the cuBLAS results.
+  -->
+  <runtime name="CUBLAS_WORKSPACE_CONFIG" value=":16:8"/>
 </tool>


### PR DESCRIPTION
Set the cuBLAS workspace configuration to 8 × 16 KiB.

This leads to large memory savings with PyTorch, with a very small cost in performance, and ensures reproducibility of the cuBLAS results.

For more information on the impact on PyTorch, see the presentation [ML inference on GPUs in CMSSW with PyTorch](https://indico.cern.ch/event/1667896/#6-ml-inference-on-gpus-in-cmss) by @EmanueleCoradin at the [CMS developments with GPUs](https://indico.cern.ch/event/1667896/) on March 30th, 2026.

For more information on the impact on the reproducibility of the results, see the section on [Results Reproducibility](https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility) of the [cuBLAS online documentation](https://docs.nvidia.com/cuda/cublas/index.html).