### PR TITLE
[13.2][BuildRules] Fix for ordering of scram based tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-01-03-01
+%define configtag       V09-01-03-02
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/10456