### PR TITLE
[13.1][BuildRules] Fix for ordering of scram based tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -55,7 +55,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-00-01
+%define configtag       V09-00-01-01
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/10456