### PR TITLE
[13.0][BuildRules] Fix for ordering of scram based tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -54,7 +54,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V08-00-04
+%define configtag       V08-00-05
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/10456