### PR TITLE
[12.4][BuildRules] Fix for ordering of scram based tools

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -53,7 +53,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V07-00-09
+%define configtag       V07-00-10
 %endif
 
 %if "%{?cvssrc:set}" != "set"


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmsdist/pull/10456