### PR TITLE
Update version to 1.0.1 in L1TSC4NGJetModel.spec

### DIFF
--- a/L1TSC4NGJetModel.spec
+++ b/L1TSC4NGJetModel.spec
@@ -1,4 +1,4 @@
-### RPM external L1TSC4NGJetModel 0.0.0
+### RPM external L1TSC4NGJetModel 1.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
This PR updates the Phase-2 L1 trigger Jet Tagger model to v1.01 to use fully emulated inputs

Release: https://github.com/cms-hls4ml/L1TSC4NGJetModel/tree/main/L1TSC4NGJetModel_v1_0_1

Model tested in emulation and FW

Corresponding CMSSW PR: https://github.com/cms-sw/cmssw/pull/50174