### PR TITLE
Revert "[15.1.X] Update L1TSC4NGJetModel.spec to v1.0.1"

### DIFF
--- a/L1TSC4NGJetModel.spec
+++ b/L1TSC4NGJetModel.spec
@@ -1,4 +1,4 @@
-### RPM external L1TSC4NGJetModel 1.0.1
+### RPM external L1TSC4NGJetModel 0.0.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Reverts cms-sw/cmsdist#10474

@Chriisbrown , I am reverting it for 15.1.X as it was suppose to go in 17.0.X only. You can open a new backport PR if this is needed for old release cycles