### PR TITLE
Update py3-protobuf version 5.29.6

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -287,8 +287,7 @@ prettytable==3.17.0
 prometheus-client==0.24.1
 prompt_toolkit==3.0.52
 propcache==0.4.1
-#NO_AUTO_UPDATE:1: Update together with Tensorflow
-protobuf==5.28.0
+protobuf==5.29.6
 prwlock==0.4.1
 psutil==7.2.2
 ptyprocess==0.7.0


### PR DESCRIPTION
Updated protobuf version from 5.28.0 to 5.29.6. New version includes some security fixes