### PR TITLE
Update GPU architectures

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -2,8 +2,8 @@
 ## INCLUDE cpp-standard
 # define the CUDA compilation flags in a way that can be shared by SCRAM-based and regular tools
 
-# build support for Pascal (6.x), Volta (7.0), Turing (7.5), Ampere (8.x), Lovelace (8.9) and Hopper (9.0)
-%define cuda_arch 60 70 75 80 89 90
+# build support for Volta (7.0), Turing (7.5), Ampere (8.x), Lovelace (8.9), Hopper (9.0) and Blackwell (10.0, 12.0)
+%define cuda_arch 70 75 80 89 90 100 120
 
 # LIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES style for listing the supported CUDA compute architectures
 %define omptarget_cuda_archs %(echo $(for ARCH in %cuda_arch; do echo "$ARCH"; done) | sed -e"s/ /,/g")

--- a/rocm-flags.file
+++ b/rocm-flags.file
@@ -1,8 +1,8 @@
 ### FILE rocm-flags
 # define the ROCm compilation flags in a way that can be shared by SCRAM-based and regular tools
 
-# build support for Instinct MI100 (gfx908), Instinct MI210/MI250X (gfx90a), Instinct MI300X (gfx942), Radeon Pro W6800 (gfx1030), Radeon Pro W7800/W7900 (gfx1100), and Radeon Pro W7600 (gfx1102)
-%define rocm_archs gfx908:sramecc+ gfx90a:sramecc+ gfx942:sramecc+ gfx1030 gfx1100 gfx1102
+# build support for Instinct MI210/MI250X (gfx90a), Instinct MI300X (gfx942), Radeon Pro W7800/W7900 (gfx1100), and Radeon Pro W7600 (gfx1102)
+%define rocm_archs gfx90a:sramecc+ gfx942:sramecc+ gfx1100 gfx1102
 
 # LLVM/hipcc style for listing the supported ROCm compute architectures
 %define hipcc_flags_rocm_archs %(echo $(for ARCH in %rocm_archs; do echo "--offload-arch=$ARCH"; done))


### PR DESCRIPTION
#### NVIDIA CUDA
  - drop support for Pascal (sm 6.0);
  - add support for Blackwell (sm 10.0 and 12.0).

#### AMD ROCm
  - drop support for Instinct MI100 (gfx908) and Radeon Pro W6800 (gfx1030).