### PR TITLE
Update tag for L1TriggerScouting-OnlineProcessing to V00-01-00 [`16_0_X`]

### DIFF
--- a/cmsswdata.spec
+++ b/cmsswdata.spec
@@ -5,6 +5,7 @@ Source: none
 %define BaseTool %(echo %n | tr '[a-z-]' '[A-Z_]')
 
 Requires: data-CondTools-SiPhase2Tracker
+Requires: data-L1TriggerScouting-OnlineProcessing
 Requires: data-HLTrigger-HLTfilters
 Requires: data-PhysicsTools-PyTorch
 Requires: data-PhysicsTools-PyTorchAlpaka

--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+L1TriggerScouting-OnlineProcessing=V00-01-00
 HLTrigger-HLTfilters=V00-02-00
 PhysicsTools-PyTorch=V00-01-00
 PhysicsTools-PyTorchAlpaka=V00-01-00


### PR DESCRIPTION
backport of #10503

This integrates the update in https://github.com/cms-data/L1TriggerScouting-OnlineProcessing/pull/1 into 16_0_X.

It goes along with the update in https://github.com/cms-sw/cmssw/pull/50792 (though the latter does not strictly depend on this PR, because the cms-data file in question is not tested centrally at the moment).