### PR TITLE
Improved xml toolfile and automatically add the tool name, version and install path

### DIFF
--- a/cmsswdata.file
+++ b/cmsswdata.file
@@ -6,26 +6,25 @@
 
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/cmsswdata.xml
-  <tool name="cmsswdata" version="%v" revision="1">
-    <client>
-      <environment name="CMSSWDATA_BASE" default="%{cmsroot}/%{cmsplatf}/%{pkgcategory}"/>
-      <environment name="CMSSW_DATA_PATH" default="$CMSSWDATA_BASE"/>
+<tool name="cmsswdata" version="%{realversion}" path="%{i}" revision="2">
+  <client>
+    <environment name="CMSSW_DATA_PATH" default="$TOOL_BASE"/>
 EOF_TOOLFILE
 
 cat << \EOF_TOOLFILE > %i/searchpath.xml
-    </client>
-    <runtime name="CMSSW_DATA_PATH" value="$CMSSWDATA_BASE" type="path"/>
+  </client>
+  <runtime name="CMSSW_DATA_PATH" value="$TOOL_BASE" type="path"/>
 EOF_TOOLFILE
 
 for toolbase in `echo %pkgreqs | tr ' ' '\n' | grep 'cms/data-'` ; do
   toolver=`basename $toolbase`
   pack=`echo $toolbase | cut -d/ -f2 | sed 's|data-||;s|-|/|'`
   echo "    <flags CMSSW_DATA_PACKAGE=\"$pack=$toolver\"/>" >> %i/etc/scram.d/cmsswdata.xml
-  echo "    <runtime name=\"CMSSW_SEARCH_PATH\" default=\"%{cmsroot}/%{cmsplatf}/$toolbase\" type=\"path\"/>" >> %i/searchpath.xml
+  echo "  <runtime name=\"CMSSW_SEARCH_PATH\" default=\"%{cmsroot}/%{cmsplatf}/$toolbase\" type=\"path\"/>" >> %i/searchpath.xml
 done
 
 cat %i/searchpath.xml >> %i/etc/scram.d/cmsswdata.xml
-echo "  </tool>"      >> %i/etc/scram.d/cmsswdata.xml
+echo "</tool>"      >> %i/etc/scram.d/cmsswdata.xml
 rm -f %i/searchpath.xml
 chmod a+r %i/etc/scram.d/cmsswdata.xml
 

--- a/geant4data.spec
+++ b/geant4data.spec
@@ -18,10 +18,7 @@ Requires: geant4-G4INCL
 
 mkdir -p %i/etc/scram.d
 cat << \EOF_TOOLFILE >%i/etc/scram.d/geant4data.xml
-<tool name="geant4data" version="%v" revision="1">
-  <client>
-    <environment name="GEANT4DATA_BASE" default="%{cmsroot}/%{cmsplatf}/%{pkgcategory}"/>
-  </client>
+<tool name="geant4data" version="%{realversion}" path="%{i}" revision="2">
 EOF_TOOLFILE
 
 for tool in `echo %requiredtools | tr ' ' '\n' | grep 'geant4-'` ; do

--- a/scram-tools.file/bin/fix_tool_variables
+++ b/scram-tools.file/bin/fix_tool_variables
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+my $file = shift or die "Usage: $0 file.xml\n";
+open my $fh, "<", $file or die "Cannot open $file: $!";
+my @lines = <$fh>;
+close $fh;
+
+my $do_tool_line = 1;
+for (@lines) {
+  # Expand @VAR@
+  s/\@([A-Za-z0-9_-]+)\@/$ENV{$1}/ge;
+
+  # Process <tool ...>
+  if ($do_tool_line && /^\s*<tool\b/o) {
+    $do_tool_line = 0;
+    my $insert = "";
+    my $tool_root = $ENV{TOOL_ROOT};
+    $insert .= qq{ name="$ENV{TOOL_FILENAME}"} unless / name=/;
+    $insert .= qq{ version="$ENV{TOOL_REALVERSION}"} unless / version=/;
+    $insert .= qq{ path="$tool_root"} if $tool_root && !/ path=/;
+    s/<tool\b/<tool$insert/ if $insert;
+  }
+}
+
+open my $out, ">", $file or die "Cannot write $file: $!";
+print $out @lines;
+close $out;

--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -6,25 +6,16 @@ function copy_tools (){
         bxml=$(basename $xml)
         export TOOL_FILENAME=$(echo $bxml | sed 's|.xml$||')
         export TOOL_BASE=$(echo $TOOL_FILENAME | tr 'a-z-' 'A-Z_')_BASE
+        export TOOL_REALVERSION=$(echo $TOOL_VERSION | sed -re 's|-[a-f0-9]{32}$||')
         [ -f ${TOOLFILES_INSTALL_DIR}/tools/selected/$bxml ] && continue
         [ -f ${TOOLFILES_INSTALL_DIR}/tools/available/$bxml ] && continue
         cp $xml ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
-        perl -i -pe '
-          s/\@([A-Za-z0-9_-]+)\@/$ENV{$1}/ge;
-          if (/^\s*<tool\b/) {
-            my $insert = "";
-            $insert .= qq{ name="$ENV{TOOL_FILENAME}"}   unless / name=/;
-            $insert .= qq{ version="$ENV{TOOL_VERSION}"} unless / version=/;
-            $insert .= qq{ path="$ENV{TOOL_ROOT}"}    if $ENV{TOOL_ROOT}    && !/ path=/;
-            s/<tool\b/<tool$insert/ if $insert;
-          }
-        ' "$TOOLFILES_INSTALL_DIR/tools/selected/$bxml"
+        $SCRAM_TOOLS_BIN_DIR/fix_tool_variables "$TOOLFILES_INSTALL_DIR/tools/selected/$bxml"
         echo "  Copied $bxml"
     done
 }
 export TOOL_ROOT=$1
 export TOOL_VERSION=$2
-export TOOL_REALVERSION=$(echo $2 | sed -re 's|-[a-f0-9]{32}$||')
 export TOOLFILES_INSTALL_DIR=$3
 export TOOL=$4
 export SCRAM_TOOLS_BIN_DIR=$(dirname $(realpath ${0}))

--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -5,16 +5,16 @@ function copy_tools (){
     for xml in $(find $1 -type f -name "*.xml") ; do
         bxml=$(basename $xml)
         export TOOL_FILENAME=$(echo $bxml | sed 's|.xml$||')
-	export TOOL_BASE=$(echo $TOOL_FILENAME | tr 'a-z-' 'A-Z_')_BASE
+        export TOOL_BASE=$(echo $TOOL_FILENAME | tr 'a-z-' 'A-Z_')_BASE
         [ -f ${TOOLFILES_INSTALL_DIR}/tools/selected/$bxml ] && continue
         [ -f ${TOOLFILES_INSTALL_DIR}/tools/available/$bxml ] && continue
         cp $xml ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
-	perl -i -pe '
+        perl -i -pe '
           s/\@([A-Za-z0-9_-]+)\@/$ENV{$1}/ge;
           if (/^\s*<tool\b/) {
             my $insert = "";
-	    $insert .= qq{ name="$ENV{TOOL_FILENAME}"}   unless / name=/;
-	    $insert .= qq{ version="$ENV{TOOL_VERSION}"} unless / version=/;
+            $insert .= qq{ name="$ENV{TOOL_FILENAME}"}   unless / name=/;
+            $insert .= qq{ version="$ENV{TOOL_VERSION}"} unless / version=/;
             $insert .= qq{ path="$ENV{TOOL_ROOT}"}    if $ENV{TOOL_ROOT}    && !/ path=/;
             s/<tool\b/<tool$insert/ if $insert;
           }
@@ -24,7 +24,7 @@ function copy_tools (){
 }
 export TOOL_ROOT=$1
 export TOOL_VERSION=$2
-export TOOL_REALVERSION=$(echo $2 | sed -i -e 's|-[a-f0-9]32$||')
+export TOOL_REALVERSION=$(echo $2 | sed -re 's|-[a-f0-9]{32}$||')
 export TOOLFILES_INSTALL_DIR=$3
 export TOOL=$4
 export SCRAM_TOOLS_BIN_DIR=$(dirname $(realpath ${0}))

--- a/scram-tools.file/bin/get_tools
+++ b/scram-tools.file/bin/get_tools
@@ -4,17 +4,27 @@
 function copy_tools (){
     for xml in $(find $1 -type f -name "*.xml") ; do
         bxml=$(basename $xml)
-	    export TOOL_FILENAME=$(echo $bxml | sed 's|.xml$||')
-		export TOOL_BASE=$(echo $TOOL_FILENAME | tr 'a-z-' 'A-Z_')_BASE
+        export TOOL_FILENAME=$(echo $bxml | sed 's|.xml$||')
+	export TOOL_BASE=$(echo $TOOL_FILENAME | tr 'a-z-' 'A-Z_')_BASE
         [ -f ${TOOLFILES_INSTALL_DIR}/tools/selected/$bxml ] && continue
         [ -f ${TOOLFILES_INSTALL_DIR}/tools/available/$bxml ] && continue
         cp $xml ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
-        perl -p -i -e 's|\@([a-zA-Z0-9_-]*)\@|$ENV{$1}|g' ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
+	perl -i -pe '
+          s/\@([A-Za-z0-9_-]+)\@/$ENV{$1}/ge;
+          if (/^\s*<tool\b/) {
+            my $insert = "";
+	    $insert .= qq{ name="$ENV{TOOL_FILENAME}"}   unless / name=/;
+	    $insert .= qq{ version="$ENV{TOOL_VERSION}"} unless / version=/;
+            $insert .= qq{ path="$ENV{TOOL_ROOT}"}    if $ENV{TOOL_ROOT}    && !/ path=/;
+            s/<tool\b/<tool$insert/ if $insert;
+          }
+        ' "$TOOLFILES_INSTALL_DIR/tools/selected/$bxml"
         echo "  Copied $bxml"
     done
 }
 export TOOL_ROOT=$1
 export TOOL_VERSION=$2
+export TOOL_REALVERSION=$(echo $2 | sed -i -e 's|-[a-f0-9]32$||')
 export TOOLFILES_INSTALL_DIR=$3
 export TOOL=$4
 export SCRAM_TOOLS_BIN_DIR=$(dirname $(realpath ${0}))

--- a/scram-tools.file/bin/get_vectorized_tools
+++ b/scram-tools.file/bin/get_vectorized_tools
@@ -3,6 +3,7 @@
 
 export TOOL_ROOT=$1
 export TOOL_VERSION=$2
+export TOOL_REALVERSION=$(echo $TOOL_VERSION | sed -re 's|-[a-f0-9]{32}$||')
 export TOOLFILES_INSTALL_DIR=$3
 export SCRAM_TOOLS_BIN_DIR=$(dirname $(realpath ${0}))
 export SCRAM_TOOL_SOURCE_DIR=$(realpath ${SCRAM_TOOLS_BIN_DIR}/../tools)/$4
@@ -18,5 +19,5 @@ if [ -f $xml ] ; then
   [ -f ${TOOLFILES_INSTALL_DIR}/tools/available/$bxml ] && continue
   cp ${xml} ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
   export TOOL_VECTORIZATION_KEY=$(echo $5 | tr '[a-z-]' '[A-Z_]')
-  perl -p -i -e 's|\@([^@]*)\@|$ENV{$1}|g' ${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}
+  $SCRAM_TOOLS_BIN_DIR/fix_tool_variables "${TOOLFILES_INSTALL_DIR}/tools/selected/${bxml}"
 fi

--- a/scram-tools.file/tools/AXOL1TL/axol1tl.xml
+++ b/scram-tools.file/tools/AXOL1TL/axol1tl.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/CICADA/cicada.xml
+++ b/scram-tools.file/tools/CICADA/cicada.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/CLUEstering/CLUEstering.xml
+++ b/scram-tools.file/tools/CLUEstering/CLUEstering.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <use name="alpaka"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/CSCTrackFinderEmulation/csctrackfinderemulation.xml
+++ b/scram-tools.file/tools/CSCTrackFinderEmulation/csctrackfinderemulation.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="CSCTrackFinderEmulation"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="CSC_TRACK_FINDER_DATA_DIR" default="$@TOOL_BASE@/data/"/>
-  <runtime name="CMSSW_SEARCH_PATH" default="$@TOOL_BASE@/data" type="path"/>
+  <runtime name="CSC_TRACK_FINDER_DATA_DIR" default="$TOOL_BASE/data/"/>
+  <runtime name="CMSSW_SEARCH_PATH" default="$TOOL_BASE/data" type="path"/>
 </tool>

--- a/scram-tools.file/tools/EMTF_NN/emtf_nn.xml
+++ b/scram-tools.file/tools/EMTF_NN/emtf_nn.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/L1METML/l1metml.xml
+++ b/scram-tools.file/tools/L1METML/l1metml.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/L1TSC4NGJetModel/l1tsc4ngjetmodel.xml
+++ b/scram-tools.file/tools/L1TSC4NGJetModel/l1tsc4ngjetmodel.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/L1TSC82ProngJetModel/l1tsc82prongjetmodel.xml
+++ b/scram-tools.file/tools/L1TSC82ProngJetModel/l1tsc82prongjetmodel.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR"      default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/OpenBLAS/openblas.xml
+++ b/scram-tools.file/tools/OpenBLAS/openblas.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="openblas"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
   <runtime name="OPENBLAS_NUM_THREADS" value="1"/>
 </tool>

--- a/scram-tools.file/tools/OpenBLAS/vectorized.tmpl
+++ b/scram-tools.file/tools/OpenBLAS/vectorized.tmpl
@@ -1,6 +1,6 @@
-<tool name="openblas_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="openblas_@TOOL_VECTORIZATION@" revision="2">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
-    <environment name="@TOOL_VECTORIZATION_KEY@_BINDIR" default="@TOOL_ROOT@/bin"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_BINDIR" default="$TOOL_BASE/bin"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/TOPO/topo.xml
+++ b/scram-tools.file/tools/TOPO/topo.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/TOoLLiP/toollip.xml
+++ b/scram-tools.file/tools/TOoLLiP/toollip.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/abseil-cpp/abseil-cpp.xml
+++ b/scram-tools.file/tools/abseil-cpp/abseil-cpp.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/abseil/abseil-cpp"/>
   <lib name="absl_bad_any_cast_impl"/>
   <lib name="absl_bad_optional_access"/>
@@ -60,8 +60,7 @@
   <lib name="absl_time"/>
   <lib name="absl_time_zone"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"  default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"  default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/acts/acts-common.xml
+++ b/scram-tools.file/tools/acts/acts-common.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <!-- common tool that defines the directories and common flags for all Acts tool -->
   <info url="https://acts.readthedocs.io/en/latest/index.html"/>
   <flags CXXFLAGS="-Wno-missing-braces"/>
   <flags CXXFLAGS="-DACTS_ENABLE_LOG_FAILURE_THRESHOLD"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/acts/acts-core.xml
+++ b/scram-tools.file/tools/acts/acts-core.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/index.html"/>
   <lib name="ActsCore"/>
   <use name="acts-common"/>

--- a/scram-tools.file/tools/acts/acts-covfie.xml
+++ b/scram-tools.file/tools/acts/acts-covfie.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/plugins/plugins.html"/>
   <lib name="ActsPluginCovfie"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/acts-dd4hep.xml
+++ b/scram-tools.file/tools/acts/acts-dd4hep.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/plugins/dd4hep.html"/>
   <lib name="ActsPluginDD4hep"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/acts-detray.xml
+++ b/scram-tools.file/tools/acts/acts-detray.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/acts-project/detray"/>
   <lib name="ActsPluginDetray"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/acts-fastjet.xml
+++ b/scram-tools.file/tools/acts/acts-fastjet.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/plugins/plugins.html"/>
   <lib name="ActsPluginFastJet"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/acts-geant4.xml
+++ b/scram-tools.file/tools/acts/acts-geant4.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/plugins/geant4.html"/>
   <lib name="ActsPluginGeant4"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/acts-json.xml
+++ b/scram-tools.file/tools/acts/acts-json.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/plugins/json.html"/>
   <lib name="ActsPluginJson"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/acts-root.xml
+++ b/scram-tools.file/tools/acts/acts-root.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/plugins/root.html"/>
   <lib name="ActsPluginRoot"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/acts-svg.xml
+++ b/scram-tools.file/tools/acts/acts-svg.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://acts.readthedocs.io/en/latest/plugins/plugins.html"/>
   <lib name="ActsPluginActSVG"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/actsvg.xml
+++ b/scram-tools.file/tools/acts/actsvg.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/acts-project/actsvg/blob/main/README.md"/>
   <lib name="actsvg_core"/>
   <lib name="actsvg_meta"/>

--- a/scram-tools.file/tools/acts/covfie.xml
+++ b/scram-tools.file/tools/acts/covfie.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://covfie.readthedocs.io/en/latest/"/>
   <use name="acts-common"/>
 </tool>

--- a/scram-tools.file/tools/acts/detray.xml
+++ b/scram-tools.file/tools/acts/detray.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/acts-project/detray/blob/main/README.md"/>
   <use name="acts-common"/>
   <use name="json"/>

--- a/scram-tools.file/tools/acts/traccc-cuda.xml
+++ b/scram-tools.file/tools/acts/traccc-cuda.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/acts-project/traccc/"/>
   <lib name="traccc_cuda"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/traccc-io.xml
+++ b/scram-tools.file/tools/acts/traccc-io.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/acts-project/traccc/"/>
   <lib name="traccc_io"/>
   <use name="acts-core"/>
   <use name="acts-json"/>
   <use name="traccc"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/acts/traccc-performance.xml
+++ b/scram-tools.file/tools/acts/traccc-performance.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/acts-project/traccc/"/>
   <lib name="traccc_performance"/>
   <use name="acts-core"/>

--- a/scram-tools.file/tools/acts/traccc.xml
+++ b/scram-tools.file/tools/acts/traccc.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/acts-project/traccc/"/>
   <lib name="traccc_core"/>
   <use name="acts-common"/>

--- a/scram-tools.file/tools/acts/vecmem-cuda.xml
+++ b/scram-tools.file/tools/acts/vecmem-cuda.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="github.com/acts-project/vecmem/blob/main/README.md"/>
   <lib name="vecmem_cuda"/>
   <use name="cuda"/>

--- a/scram-tools.file/tools/acts/vecmem-rocm.xml
+++ b/scram-tools.file/tools/acts/vecmem-rocm.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="github.com/acts-project/vecmem/blob/main/README.md"/>
   <lib name="vecmem_hip"/>
   <use name="rocm"/>

--- a/scram-tools.file/tools/acts/vecmem.xml
+++ b/scram-tools.file/tools/acts/vecmem.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="github.com/acts-project/vecmem/blob/main/README.md"/>
   <lib name="vecmem_core"/>
   <use name="acts-common"/>

--- a/scram-tools.file/tools/actsdata/actsdata.xml
+++ b/scram-tools.file/tools/actsdata/actsdata.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <!-- set the environment for the Traccc test data -->
   <info url="https://github.com/acts-project/traccc/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="TRACCC_TEST_DATA_DIR" value="$@TOOL_BASE@"/>
+  <runtime name="TRACCC_TEST_DATA_DIR" value="$TOOL_BASE"/>
 </tool>

--- a/scram-tools.file/tools/alpaka/alpaka-cuda.xml
+++ b/scram-tools.file/tools/alpaka/alpaka-cuda.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <use name="alpaka"/>
   <use name="cuda"/>
   <!-- host comiplation should run with ALPAKA_HOST_ONLY defined -->

--- a/scram-tools.file/tools/alpaka/alpaka-rocm.xml
+++ b/scram-tools.file/tools/alpaka/alpaka-rocm.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <use name="alpaka"/>
   <use name="rocm"/>
   <!-- host comiplation should run with ALPAKA_HOST_ONLY defined -->

--- a/scram-tools.file/tools/alpaka/alpaka-serial.xml
+++ b/scram-tools.file/tools/alpaka/alpaka-serial.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <use name="alpaka"/>
   <flags CXXFLAGS="-DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED"/>
   <flags GENREFLEX_CPPFLAGS="-DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED"/>

--- a/scram-tools.file/tools/alpaka/alpaka-tbb.xml
+++ b/scram-tools.file/tools/alpaka/alpaka-tbb.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <use name="alpaka"/>
   <use name="tbb"/>
   <flags CXXFLAGS="-DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED"/>

--- a/scram-tools.file/tools/alpaka/alpaka.xml
+++ b/scram-tools.file/tools/alpaka/alpaka.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <!-- set ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 for host, device, and dictionaries -->

--- a/scram-tools.file/tools/alpgen/alpgen.xml
+++ b/scram-tools.file/tools/alpgen/alpgen.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/blackhat/blackhat.xml
+++ b/scram-tools.file/tools/blackhat/blackhat.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
 <lib name="Ampl_eval"/>
 <lib name="BG"/>
 <lib name="BH"/>
@@ -15,10 +15,9 @@
 <lib name="assembly"/>
 <lib name="ratext"/>
 <client>
-<environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$@TOOL_BASE@/lib/blackhat"/>
-<environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+<environment name="LIBDIR" default="$TOOL_BASE/lib/blackhat"/>
+<environment name="INCLUDE" default="$TOOL_BASE/include"/>
 </client>
 <use name="qd"/>
-<runtime name="WORKER_DATA_PATH" value="$@TOOL_BASE@/share/blackhat/datafiles/" type="path"/>
+<runtime name="WORKER_DATA_PATH" value="$TOOL_BASE/share/blackhat/datafiles/" type="path"/>
 </tool>

--- a/scram-tools.file/tools/boost/boost.xml
+++ b/scram-tools.file/tools/boost/boost.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_THREAD_LIB@"/>
   <lib name="@BOOST_DATE_TIME_LIB@"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="boost_header"/>
 </tool>

--- a/scram-tools.file/tools/boost/boost_chrono.xml
+++ b/scram-tools.file/tools/boost/boost_chrono.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_CHRONO_LIB@"/>
   <use name="boost_system"/>

--- a/scram-tools.file/tools/boost/boost_filesystem.xml
+++ b/scram-tools.file/tools/boost/boost_filesystem.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_FILESYSTEM_LIB@"/>
   <use name="boost_system"/>

--- a/scram-tools.file/tools/boost/boost_header.xml
+++ b/scram-tools.file/tools/boost/boost_header.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.boost.org"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="sockets"/>

--- a/scram-tools.file/tools/boost/boost_iostreams.xml
+++ b/scram-tools.file/tools/boost/boost_iostreams.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_IOSTREAMS_LIB@"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/boost/boost_mpi.xml
+++ b/scram-tools.file/tools/boost/boost_mpi.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_MPI_LIB@"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/boost/boost_program_options.xml
+++ b/scram-tools.file/tools/boost/boost_program_options.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_PROGRAM_OPTIONS_LIB@"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/boost/boost_python.xml
+++ b/scram-tools.file/tools/boost/boost_python.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_PYTHON_LIB@"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="boost_header"/>
   <use name="python3"/>

--- a/scram-tools.file/tools/boost/boost_regex.xml
+++ b/scram-tools.file/tools/boost/boost_regex.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_REGEX_LIB@"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/boost/boost_serialization.xml
+++ b/scram-tools.file/tools/boost/boost_serialization.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_SERIALIZATION_LIB@"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/boost/boost_system.xml
+++ b/scram-tools.file/tools/boost/boost_system.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="@BOOST_SYSTEM_LIB@"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/boost/boost_test.xml
+++ b/scram-tools.file/tools/boost/boost_test.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.boost.org"/>
   <lib name="boost_unit_test_framework"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/bz2lib/bz2lib.xml
+++ b/scram-tools.file/tools/bz2lib/bz2lib.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://sources.redhat.com/bzip2/"/>
   <lib name="bz2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/c-ares/c-ares.xml
+++ b/scram-tools.file/tools/c-ares/c-ares.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://c-ares.org/"/>
   <lib name="cares"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>
 

--- a/scram-tools.file/tools/c-blosc/c-blosc.xml
+++ b/scram-tools.file/tools/c-blosc/c-blosc.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="blosc"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"     default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"     default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"      default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/c-blosc2/c-blosc2.xml
+++ b/scram-tools.file/tools/c-blosc2/c-blosc2.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="blosc2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/catch2/catch2.xml
+++ b/scram-tools.file/tools/catch2/catch2.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <lib name="Catch2Main"/>
   <lib name="Catch2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"     default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"     default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"      default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/ccache/ccache-ccompiler.xml
+++ b/scram-tools.file/tools/ccache/ccache-ccompiler.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-ccompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="CC" value="$@TOOL_BASE@/bin/gcc"/>
+      <environment name="CC" value="$TOOL_BASE/bin/gcc"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/ccache/ccache-cxxcompiler.xml
+++ b/scram-tools.file/tools/ccache/ccache-cxxcompiler.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-cxxcompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="CXX" value="$@TOOL_BASE@/bin/c++"/>
+      <environment name="CXX" value="$TOOL_BASE/bin/c++"/>
       <environment name="BUILDENV_CCACHE_BASEDIR" value="$LOCALTOP" handler="warn"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/ccache/ccache-f77compiler.xml
+++ b/scram-tools.file/tools/ccache/ccache-f77compiler.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-f77compiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="FC" value="$@TOOL_BASE@/bin/gfortran"/>
+      <environment name="FC" value="$TOOL_BASE/bin/gfortran"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/celeritas/celeritas.xml
+++ b/scram-tools.file/tools/celeritas/celeritas.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="4">
+<tool revision="5">
   <info url="https://github.com/celeritas-project/celeritas"/>
   <lib name="accel"/>
   <lib name="celeritas"/>
@@ -6,9 +6,8 @@
   <lib name="corecel"/>
   <lib name="g4vg"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
   <flags CXXFLAGS="-Wno-error=missing-braces"/>
   <use name="geant4core"/>

--- a/scram-tools.file/tools/cepgen/cepgen.xml
+++ b/scram-tools.file/tools/cepgen/cepgen.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://cepgen.hepforge.org/"/>
   <lib name="CepGen"/>
   <lib name="CepGenHepMC2"/>
@@ -7,12 +7,11 @@
   <lib name="CepGenProcesses"/>
   <lib name="CepGenPythia6"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-  <runtime name="CEPGEN_PATH" value="$@TOOL_BASE@/share/CepGen"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+  <runtime name="CEPGEN_PATH" value="$TOOL_BASE/share/CepGen"/>
   <use name="gsl"/>
   <use name="OpenBLAS"/>
   <use name="hepmc"/>

--- a/scram-tools.file/tools/clang-uml/clang-uml.xml
+++ b/scram-tools.file/tools/clang-uml/clang-uml.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/bkryza/clang-uml/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <use name="yaml-cpp"/>
   <use name="zlib"/>
 </tool>

--- a/scram-tools.file/tools/classlib/classlib.xml
+++ b/scram-tools.file/tools/classlib/classlib.xml
@@ -1,9 +1,8 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://cmsmac01.cern.ch/~lat/exports/"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
       <flags CPPDEFINES="__STDC_LIMIT_MACROS"/>
       <flags CPPDEFINES="__STDC_FORMAT_MACROS"/>
       <lib name="classlib"/>

--- a/scram-tools.file/tools/clhep/clhep.xml
+++ b/scram-tools.file/tools/clhep/clhep.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://wwwinfo.cern.ch/asd/lhc++/clhep"/>
   <lib name="CLHEP"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="clhepheader"/>
 </tool>

--- a/scram-tools.file/tools/clhep/clhepheader.xml
+++ b/scram-tools.file/tools/clhep/clhepheader.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://wwwinfo.cern.ch/asd/lhc++/clhep"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"    default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE"    default="$TOOL_BASE/include"/>
   </client>
-  <flags ROOTCLING_ARGS="-moduleMapFile=$@TOOL_BASE@/include/module.modulemap"/>
-  <runtime name="CLHEP_PARAM_PATH" value="$@TOOL_BASE@"/>
+  <flags ROOTCLING_ARGS="-moduleMapFile=$TOOL_BASE/include/module.modulemap"/>
+  <runtime name="CLHEP_PARAM_PATH" value="$TOOL_BASE"/>
   <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/clue/clue.xml
+++ b/scram-tools.file/tools/clue/clue.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <use name="alpaka"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/cmssw/cmssw.xml
+++ b/scram-tools.file/tools/cmssw/cmssw.xml
@@ -1,20 +1,19 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="scram" revision="2">
+<tool type="scram" revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/biglib/$SCRAM_ARCH"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/$SCRAM_ARCH"/>
-    <environment name="CMSSW_BINDIR" default="$@TOOL_BASE@/bin/$SCRAM_ARCH"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/src"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/$SCRAM_ARCH/include" handler="warn"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/biglib/$SCRAM_ARCH"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib/$SCRAM_ARCH"/>
+    <environment name="CMSSW_BINDIR" default="$TOOL_BASE/bin/$SCRAM_ARCH"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/src"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/$SCRAM_ARCH/include" handler="warn"/>
   </client>
-  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/biglib/$SCRAM_ARCH" type="path"/>
-  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/biglib/$SCRAM_ARCH" type="path"/>
+  <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="RIVET_ANALYSIS_PATH"      value="$LOCALTOP/lib/$SCRAM_ARCH" type="path"/>
   <runtime name="PATH"       value="$CMSSW_BINDIR" type="path"/>
-  <runtime name="PYTHON3PATH" value="$@TOOL_BASE@/lib/$SCRAM_ARCH" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@/src" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@/include/$SCRAM_ARCH/include" type="path" handler="warn"/>
-  <runtime name="CMSSW_FULL_RELEASE_BASE" value="$@TOOL_BASE@"/>
+  <runtime name="PYTHON3PATH" value="$TOOL_BASE/lib/$SCRAM_ARCH" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$TOOL_BASE/src" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$TOOL_BASE/include/$SCRAM_ARCH/include" type="path" handler="warn"/>
+  <runtime name="CMSSW_FULL_RELEASE_BASE" value="$TOOL_BASE"/>
   @CXXMODULE_DATA@
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/collier/collier.xml
+++ b/scram-tools.file/tools/collier/collier.xml
@@ -1,5 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/conifer/conifer.xml
+++ b/scram-tools.file/tools/conifer/conifer.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="json"/>
 </tool>

--- a/scram-tools.file/tools/coral/coral.xml
+++ b/scram-tools.file/tools/coral/coral.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="scram" revision="2">
+<tool type="scram" revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/$SCRAM_ARCH/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/LCG"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/$SCRAM_ARCH/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/LCG"/>
   </client>
-  <runtime name="PYTHON3PATH" default="$@TOOL_BASE@/$SCRAM_ARCH/python" type="path"/>
-  <runtime name="PYTHON3PATH" default="$@TOOL_BASE@/$SCRAM_ARCH/lib" type="path"/>
+  <runtime name="PYTHON3PATH" default="$TOOL_BASE/$SCRAM_ARCH/python" type="path"/>
+  <runtime name="PYTHON3PATH" default="$TOOL_BASE/$SCRAM_ARCH/lib" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/cppunit/cppunit.xml
+++ b/scram-tools.file/tools/cppunit/cppunit.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="cppunit"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/cpu_features/cpu_features.xml
+++ b/scram-tools.file/tools/cpu_features/cpu_features.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/google/cpu_features"/>
   <lib name="cpu_features"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
+++ b/scram-tools.file/tools/cuda-compatible-runtime/cuda-compatible-runtime.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://gitlab.cern.ch/cms-patatrack/cuda-compatible-runtime/"/>
   <use name="cuda"/>
   <use name="cuda-stubs"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/cuda/cuda-cublas.xml
+++ b/scram-tools.file/tools/cuda/cuda-cublas.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/cublas/index.html"/>
   <use name="cuda"/>
   <lib name="cublas"/>

--- a/scram-tools.file/tools/cuda/cuda-cufft.xml
+++ b/scram-tools.file/tools/cuda/cuda-cufft.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/cufft/index.html"/>
   <use name="cuda"/>
   <lib name="cufft"/>

--- a/scram-tools.file/tools/cuda/cuda-curand.xml
+++ b/scram-tools.file/tools/cuda/cuda-curand.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/curand/index.html"/>
   <use name="cuda"/>
   <lib name="curand"/>

--- a/scram-tools.file/tools/cuda/cuda-cusolver.xml
+++ b/scram-tools.file/tools/cuda/cuda-cusolver.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/cusolver/index.html"/>
   <use name="cuda"/>
   <lib name="cusolver"/>

--- a/scram-tools.file/tools/cuda/cuda-cusparse.xml
+++ b/scram-tools.file/tools/cuda/cuda-cusparse.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/cusparse/index.html"/>
   <use name="cuda"/>
   <lib name="cusparse"/>

--- a/scram-tools.file/tools/cuda/cuda-gcc-support.xml
+++ b/scram-tools.file/tools/cuda/cuda-gcc-support.xml
@@ -1,2 +1,2 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
 </tool>

--- a/scram-tools.file/tools/cuda/cuda-interface.xml
+++ b/scram-tools.file/tools/cuda/cuda-interface.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR"              default="$@TOOL_BASE@/bin"/>
-    <environment name="LIBDIR"              default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE"             default="$@TOOL_BASE@/include"/>
+    <environment name="BINDIR"              default="$TOOL_BASE/bin"/>
+    <environment name="LIBDIR"              default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE"             default="$TOOL_BASE/include"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
   <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$LIBDIR"  type="path"/>

--- a/scram-tools.file/tools/cuda/cuda-npp.xml
+++ b/scram-tools.file/tools/cuda/cuda-npp.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/npp/index.html"/>
   <use name="cuda"/>
   <lib name="nppial"/>

--- a/scram-tools.file/tools/cuda/cuda-nvgraph.xml
+++ b/scram-tools.file/tools/cuda/cuda-nvgraph.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/nvgraph/index.html"/>
   <use name="cuda"/>
   <lib name="nvgraph"/>

--- a/scram-tools.file/tools/cuda/cuda-nvjpeg.xml
+++ b/scram-tools.file/tools/cuda/cuda-nvjpeg.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/nvjpeg/index.html"/>
   <use name="cuda"/>
   <lib name="nvjpeg"/>

--- a/scram-tools.file/tools/cuda/cuda-nvml.xml
+++ b/scram-tools.file/tools/cuda/cuda-nvml.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/deploy/nvml-api/index.html"/>
   <use name="cuda-stubs"/>
   <lib name="nvidia-ml"/>

--- a/scram-tools.file/tools/cuda/cuda-nvrtc.xml
+++ b/scram-tools.file/tools/cuda/cuda-nvrtc.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/nvrtc/index.html"/>
   <use name="cuda"/>
   <lib name="nvrtc"/>

--- a/scram-tools.file/tools/cuda/cuda-stubs.xml
+++ b/scram-tools.file/tools/cuda/cuda-stubs.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <lib name="cuda"/>
   <use name="cuda-interface"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"          default="$@TOOL_BASE@/lib64/stubs"/>
+    <environment name="LIBDIR"          default="$TOOL_BASE/lib64/stubs"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
 </tool>

--- a/scram-tools.file/tools/cuda/cuda.xml
+++ b/scram-tools.file/tools/cuda/cuda.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="5">
+<tool revision="6">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <use name="cuda-interface"/>
   <use name="cuda-stubs"/>
   <lib name="cudart"/>
   <lib name="cudadevrt"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="NVCC"      default="$@TOOL_BASE@/bin/nvcc"/>
+    <environment name="NVCC"      default="$TOOL_BASE/bin/nvcc"/>
   </client>
   <flags CUDA_FLAGS="@CUDA_FLAGS@"/>
   <flags REM_CUDA_HOST_CXXFLAGS="-std=%"/>

--- a/scram-tools.file/tools/cuda/cupti.xml
+++ b/scram-tools.file/tools/cuda/cupti.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://docs.nvidia.com/cupti/Cupti/index.html"/>
   <lib name="cupti"/>
   <use name="cuda-interface"/>

--- a/scram-tools.file/tools/cuda/nvidia-drivers.xml
+++ b/scram-tools.file/tools/cuda/nvidia-drivers.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://docs.nvidia.com/cuda/index.html"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/drivers"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/drivers"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
 </tool>

--- a/scram-tools.file/tools/cuda/nvperf.xml
+++ b/scram-tools.file/tools/cuda/nvperf.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://docs.nvidia.com/cupti/Cupti/index.html"/>
   <lib name="nvperf_host"/>
   <lib name="nvperf_target"/>

--- a/scram-tools.file/tools/cudnn/cudnn.xml
+++ b/scram-tools.file/tools/cudnn/cudnn.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://docs.nvidia.com/deeplearning/cudnn/index.html"/>
   <lib name="cudnn"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
   <use name="cuda"/>
 </tool>

--- a/scram-tools.file/tools/curl/curl.xml
+++ b/scram-tools.file/tools/curl/curl.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="curl"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/dablooms/dablooms.xml
+++ b/scram-tools.file/tools/dablooms/dablooms.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="dablooms"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/das_client/das_client.xml
+++ b/scram-tools.file/tools/das_client/das_client.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/davix/davix.xml
+++ b/scram-tools.file/tools/davix/davix.xml
@@ -1,12 +1,11 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="https://dmc.web.cern.ch/projects/davix/home"/>
     <lib name="davix"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include/davix"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include/davix"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
     <use name="boost_system"/>
     <use name="libxml2"/>
   </tool>

--- a/scram-tools.file/tools/db6/db6.xml
+++ b/scram-tools.file/tools/db6/db6.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="db"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/dcap/dcap.xml
+++ b/scram-tools.file/tools/dcap/dcap.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="dcap"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/dd4hep/dd4hep-core.xml
+++ b/scram-tools.file/tools/dd4hep/dd4hep-core.xml
@@ -1,15 +1,14 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/AIDASoft/DD4hep"/>
   <lib name="DDCore" />
   <lib name="DDParsers" />
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-  <flags LISTCOMPONENTS="$@TOOL_BASE@/bin/listcomponents_dd4hep"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+  <flags LISTCOMPONENTS="$TOOL_BASE/bin/listcomponents_dd4hep"/>
   <flags cppdefines="DD4HEP_USE_GEANT4_UNITS=1"/>
   <use name="root_cxxdefaults"/>
   <use name="root"/>

--- a/scram-tools.file/tools/dd4hep/dd4hep-geant4.xml
+++ b/scram-tools.file/tools/dd4hep/dd4hep-geant4.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="DDG4-static"/>
   <use name="geant4core"/>
   <use name="dd4hep-core"/>

--- a/scram-tools.file/tools/dd4hep/dd4hep.xml
+++ b/scram-tools.file/tools/dd4hep/dd4hep.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="DDAlign" />
   <lib name="DDCond" />
   <use name="dd4hep-core"/>

--- a/scram-tools.file/tools/dip/dip-platform-dependent.xml
+++ b/scram-tools.file/tools/dip/dip-platform-dependent.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="platform-dependent"/>
   <use name="dip_interface"/>
 </tool>

--- a/scram-tools.file/tools/dip/dip.xml
+++ b/scram-tools.file/tools/dip/dip.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="dip"/>
   <use name="dip-platform-dependent"/>
   <use name="log4cplus"/>

--- a/scram-tools.file/tools/dip/dip_interface.xml
+++ b/scram-tools.file/tools/dip/dip_interface.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/dmtcp/dmtcp.xml
+++ b/scram-tools.file/tools/dmtcp/dmtcp.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://dmtcp.sourceforge.net/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/dmtcp"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib/dmtcp"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/eigen/eigen.xml
+++ b/scram-tools.file/tools/eigen/eigen.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@"   default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include/eigen3"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include/eigen3"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags CXXFLAGS="@CMS_EIGEN_CXX_FLAGS@"/>

--- a/scram-tools.file/tools/evtgen/evtgen.xml
+++ b/scram-tools.file/tools/evtgen/evtgen.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="EvtGen"/>
   <lib name="EvtGenExternal"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="EVTGENDATA" value="$@TOOL_BASE@/share/EvtGen"/>
+  <runtime name="EVTGENDATA" value="$TOOL_BASE/share/EvtGen"/>
   <use name="hepmc"/>
   <use name="pythia8"/>
   <use name="tauolapp"/>

--- a/scram-tools.file/tools/expat/expat.xml
+++ b/scram-tools.file/tools/expat/expat.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="expat"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/fastjet-contrib/fastjet-contrib-archive.xml
+++ b/scram-tools.file/tools/fastjet-contrib/fastjet-contrib-archive.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+  <tool revision="2">
     <info url="http://fastjet.hepforge.org/contrib/"/>
     <lib name="EnergyCorrelator"/>
     <lib name="GenericSubtractor"/>
@@ -9,8 +9,7 @@
     <lib name="SubjetCounting"/>
     <lib name="VariableR"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/fastjet-contrib/fastjet-contrib.xml
+++ b/scram-tools.file/tools/fastjet-contrib/fastjet-contrib.xml
@@ -1,9 +1,8 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://fastjet.hepforge.org/contrib/"/>
     <lib name="fastjetcontribfragile"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/fastjet/fastjet.xml
+++ b/scram-tools.file/tools/fastjet/fastjet.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://fastjet.fr"/>
     <lib name="fastjetplugins"/>
     <lib name="fastjettools"/>
@@ -6,9 +6,8 @@
     <lib name="siscone_spherical"/>
     <lib name="fastjet"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/fastjet/vectorized.tmpl
+++ b/scram-tools.file/tools/fastjet/vectorized.tmpl
@@ -1,5 +1,5 @@
-<tool name="fastjet_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="fastjet_@TOOL_VECTORIZATION@"  revision="1">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/fftjet/fftjet.xml
+++ b/scram-tools.file/tools/fftjet/fftjet.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="fftjet"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/fftw3/fftw3.xml
+++ b/scram-tools.file/tools/fftw3/fftw3.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="fftw3"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/flatbuffers/flatbuffers.xml
+++ b/scram-tools.file/tools/flatbuffers/flatbuffers.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="flatbuffers"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"          default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"           default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"          default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"           default="$TOOL_BASE/lib64"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/fmt/fmt.xml
+++ b/scram-tools.file/tools/fmt/fmt.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/fmtlib/fmt"/>
   <lib name="fmt"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/freetype/freetype.xml
+++ b/scram-tools.file/tools/freetype/freetype.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="freetype-cms"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/frontier_client/frontier_client.xml
+++ b/scram-tools.file/tools/frontier_client/frontier_client.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="frontier_client"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="FRONTIER_CLIENT" value="$@TOOL_BASE@/"/>
+  <runtime name="FRONTIER_CLIENT" value="$TOOL_BASE/"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="zlib"/>

--- a/scram-tools.file/tools/g4hepem/g4hepem_interface.xml
+++ b/scram-tools.file/tools/g4hepem/g4hepem_interface.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <info url="https://github.com/mnovak42/g4hepem"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/G4HepEm"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/G4HepEm"/>
   </client>
   <use name="geant4core"/>
 </tool>

--- a/scram-tools.file/tools/g4hepem/g4hepemcore.xml
+++ b/scram-tools.file/tools/g4hepem/g4hepemcore.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="g4hepem-static"/>
   <use name="g4hepem_interface"/>
 </tool>

--- a/scram-tools.file/tools/g4hepem/g4hepemstatic.xml
+++ b/scram-tools.file/tools/g4hepem/g4hepemstatic.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="g4hepem-static"/>
   <use name="g4hepem_interface"/>
 </tool>

--- a/scram-tools.file/tools/g4vg/g4vg.xml
+++ b/scram-tools.file/tools/g4vg/g4vg.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/celeritas-project/g4vg"/>
   <lib name="g4vg"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
   <use name="geant4core"/>
   <use name="vecgeom_interface"/>

--- a/scram-tools.file/tools/gbl/gbl.xml
+++ b/scram-tools.file/tools/gbl/gbl.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://www.wiki.terascale.de/index.php/GeneralBrokenLines"/>
   <lib name="GBL"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="eigen"/>
   <use name="mille"/>

--- a/scram-tools.file/tools/gbl/vectorized.tmpl
+++ b/scram-tools.file/tools/gbl/vectorized.tmpl
@@ -1,5 +1,5 @@
-<tool name="gbl_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="gbl_@TOOL_VECTORIZATION@"  revision="1">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/gcc/gcc-atomic.xml
+++ b/scram-tools.file/tools/gcc/gcc-atomic.xml
@@ -1,6 +1,5 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+  <tool revision="2">
     <lib name="atomic"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/gcc/gcc-ccompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-ccompiler.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
 %if 0%{!?use_system_gcc:1}
-      <environment name="CC" value="$@TOOL_BASE@/bin/gcc@COMPILER_NAME_SUFFIX@"/>
+      <environment name="CC" value="$TOOL_BASE/bin/gcc@COMPILER_NAME_SUFFIX@"/>
 %else
       <environment name="CC" value="gcc@COMPILER_NAME_SUFFIX@"/>
 %endif

--- a/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-cxxcompiler.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
 %if 0%{!?use_system_gcc:1}
-      <environment name="CXX" value="$@TOOL_BASE@/bin/c++@COMPILER_NAME_SUFFIX@"/>
+      <environment name="CXX" value="$TOOL_BASE/bin/c++@COMPILER_NAME_SUFFIX@"/>
 %else
       <environment name="CXX" value="c++@COMPILER_NAME_SUFFIX@"/>
 %endif
@@ -41,21 +40,21 @@
     <flags LD_UNIT="@GCC_LD_UNIT@"/>
     <runtime name="SCRAM_CXX11_ABI" value="@SCRAM_CXX11_ABI@"/>
 %if 0%{!?use_system_gcc:1}
-    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/@OS_LIB64DIR@" type="path"/>
-    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/lib" type="path"/>
-    <runtime name="COMPILER_PATH" value="$@TOOL_BASE@"/>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/@OS_LIB64DIR@" type="path"/>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/lib" type="path"/>
+    <runtime name="COMPILER_PATH" value="$TOOL_BASE"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 %if 0%{?rhel} >= 9
-    <runtime name="GPROFNG_SYSCONFDIR" value="$@TOOL_BASE@/etc"/>
+    <runtime name="GPROFNG_SYSCONFDIR" value="$TOOL_BASE/etc"/>
 %endif
     <ifrelease name="ASAN">
-      <runtime name="GCC_RUNTIME_ASAN" value="$@TOOL_BASE@/@OS_LIB64DIR@/libasan.so" type="path"/>
+      <runtime name="GCC_RUNTIME_ASAN" value="$TOOL_BASE/@OS_LIB64DIR@/libasan.so" type="path"/>
     <elif name="LSAN"/>
-      <runtime name="GCC_RUNTIME_LSAN" value="$@TOOL_BASE@/@OS_LIB64DIR@/libasan.so" type="path"/>
+      <runtime name="GCC_RUNTIME_LSAN" value="$TOOL_BASE/@OS_LIB64DIR@/libasan.so" type="path"/>
     <elif name="UBSAN"/>
-      <runtime name="GCC_RUNTIME_UBSAN" value="$@TOOL_BASE@/@OS_LIB64DIR@/libubsan.so" type="path"/>
+      <runtime name="GCC_RUNTIME_UBSAN" value="$TOOL_BASE/@OS_LIB64DIR@/libubsan.so" type="path"/>
     <elif name="TSAN"/>
-      <runtime name="GCC_RUNTIME_TSAN" value="$@TOOL_BASE@/@OS_LIB64DIR@/libtsan.so" type="path"/>
+      <runtime name="GCC_RUNTIME_TSAN" value="$TOOL_BASE/@OS_LIB64DIR@/libtsan.so" type="path"/>
     </ifrelease>
 %endif
   </tool>

--- a/scram-tools.file/tools/gcc/gcc-f77compiler.xml
+++ b/scram-tools.file/tools/gcc/gcc-f77compiler.xml
@@ -1,10 +1,9 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <lib name="gfortran"/>
     <lib name="m"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
 %if 0%{!?use_system_gcc:1}
-      <environment name="FC" default="$@TOOL_BASE@/bin/gfortran"/>
+      <environment name="FC" default="$TOOL_BASE/bin/gfortran"/>
 %else
       <environment name="FC" default="gfortran"/>
 %endif

--- a/scram-tools.file/tools/gcc/gcc-plugin.xml
+++ b/scram-tools.file/tools/gcc/gcc-plugin.xml
@@ -1,9 +1,8 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+  <tool revision="2">
     <lib name="cc1plugin cp1plugin"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@GCC_PLUGIN_DIR@"/>
-      <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
-      <environment name="LIBDIR"    default="$@TOOL_BASE@"/>
+      <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+      <environment name="LIBDIR"    default="$TOOL_BASE"/>
     </client>
 %if 0%{?use_system_gcc:1}
     <flags SKIP_TOOL_SYMLINKS="1"/>

--- a/scram-tools.file/tools/gcc/no-array-bounds-flag.xml
+++ b/scram-tools.file/tools/gcc/no-array-bounds-flag.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="1.0" revision="1">
+<tool version="1.0" revision="2">
   <!-- work around a GCC bug that makes LTO ignore diagnostic #pragma:
     - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80922
     - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109916

--- a/scram-tools.file/tools/gcc/ofast-flag.xml
+++ b/scram-tools.file/tools/gcc/ofast-flag.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="1.0" revision="1">
+  <tool version="1.0" revision="2">
     <flags CXXFLAGS="-Ofast -fno-reciprocal-math"/>
     <ifarch match="ppc64le|amd64|x86_64">
       <flags CXXFLAGS="-mrecip=none"/>

--- a/scram-tools.file/tools/gcc/sanitizer-flags-asan.xml
+++ b/scram-tools.file/tools/gcc/sanitizer-flags-asan.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="1.0" revision="1">
+  <tool version="1.0" revision="2">
     <ifrelease name="ASAN">
       <flags CPPDEFINES="CMS_ADDRESS_SANITIZER"/>
       <flags CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address"/>

--- a/scram-tools.file/tools/gcc/sanitizer-flags-ubsan.xml
+++ b/scram-tools.file/tools/gcc/sanitizer-flags-ubsan.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="1.0" revision="1">
+  <tool version="1.0" revision="2">
     <ifrelease name="UBSAN">
       <flags CPPDEFINES="CMS_UNDEFINED_SANITIZER"/>
       <flags CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>

--- a/scram-tools.file/tools/gdb/gdb.xml
+++ b/scram-tools.file/tools/gdb/gdb.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gdbm/gdbm.xml
+++ b/scram-tools.file/tools/gdbm/gdbm.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="gdbm"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/gdrcopy/gdrcopy.xml
+++ b/scram-tools.file/tools/gdrcopy/gdrcopy.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="gdrapi"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/geant4-parfullcms/geant4-parfullcms.xml
+++ b/scram-tools.file/tools/geant4-parfullcms/geant4-parfullcms.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-    <runtime name="GEANT4_PARFULLCMS_CONFIG_DIR" value="$@TOOL_BASE@/share/ParFullCMS" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+    <runtime name="GEANT4_PARFULLCMS_CONFIG_DIR" value="$TOOL_BASE/share/ParFullCMS" type="path"/>
     <runtime name="G4FORCENUMBEROFTHREADS" value="max"/>
   </tool>

--- a/scram-tools.file/tools/geant4/geant4.xml
+++ b/scram-tools.file/tools/geant4/geant4.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://geant4.web.cern.ch/geant4/"/>
   <use name="geant4core"/>
   <use name="geant4vis"/>

--- a/scram-tools.file/tools/geant4/geant4_interface.xml
+++ b/scram-tools.file/tools/geant4/geant4_interface.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://geant4.web.cern.ch/geant4/"/>
   <flags CXXFLAGS="-ftls-model=global-dynamic -pthread"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/Geant4"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/Geant4"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <flags cppdefines="GNU_GCC G4V9"/>

--- a/scram-tools.file/tools/geant4/geant4core.xml
+++ b/scram-tools.file/tools/geant4/geant4core.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="G4digits_hits"/>
   <lib name="G4error_propagation"/>
   <lib name="G4event"/>
@@ -22,8 +22,7 @@
   <lib name="G4analysis"/>
   <lib name="G4ptl"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
     <environment name="G4LIB" value="$LIBDIR"/>
   </client>
   <flags cppdefines="GNU_GCC G4V9"/>

--- a/scram-tools.file/tools/geant4/geant4static.xml
+++ b/scram-tools.file/tools/geant4/geant4static.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="geant4-static"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64/archive"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64/archive"/>
   </client>
   <use name="geant4_interface"/>
 </tool>

--- a/scram-tools.file/tools/geant4/geant4vis.xml
+++ b/scram-tools.file/tools/geant4/geant4vis.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="G4FR"/>
   <lib name="G4modeling"/>
   <lib name="G4RayTracer"/>

--- a/scram-tools.file/tools/giflib/giflib.xml
+++ b/scram-tools.file/tools/giflib/giflib.xml
@@ -1,12 +1,11 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://giflib.sourceforge.net"/>
     <lib name="gif"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/git-lfs/git-lfs.xml
+++ b/scram-tools.file/tools/git-lfs/git-lfs.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://git-lfs.com/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/git/git.xml
+++ b/scram-tools.file/tools/git/git.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://git-scm.com"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-  <runtime name="PATH" value="$@TOOL_BASE@/libexec/git-core" type="path"/>
-  <runtime name="GIT_TEMPLATE_DIR" value="$@TOOL_BASE@/share/git-core/templates" type="path"/>
-  <runtime name="GIT_SSL_CAINFO" value="$@TOOL_BASE@/share/ssl/certs/ca-bundle.crt" type="path"/>
-  <runtime name="GIT_EXEC_PATH" value="$@TOOL_BASE@/libexec/git-core" type="path"/>
-  <runtime name="PERL5LIB" value="$@TOOL_BASE@@PERL5LIB_PATH@" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/libexec/git-core" type="path"/>
+  <runtime name="GIT_TEMPLATE_DIR" value="$TOOL_BASE/share/git-core/templates" type="path"/>
+  <runtime name="GIT_SSL_CAINFO" value="$TOOL_BASE/share/ssl/certs/ca-bundle.crt" type="path"/>
+  <runtime name="GIT_EXEC_PATH" value="$TOOL_BASE/libexec/git-core" type="path"/>
+  <runtime name="PERL5LIB" value="$TOOL_BASE@PERL5LIB_PATH@" type="path"/>
 </tool>

--- a/scram-tools.file/tools/glimpse/glimpse.xml
+++ b/scram-tools.file/tools/glimpse/glimpse.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gmake/gmake.xml
+++ b/scram-tools.file/tools/gmake/gmake.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gnuplot/gnuplot.xml
+++ b/scram-tools.file/tools/gnuplot/gnuplot.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://gnuplot.sourceforge.net"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/google-benchmark/google-benchmark-main.xml
+++ b/scram-tools.file/tools/google-benchmark/google-benchmark-main.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/google/benchmark"/>
   <lib name="benchmark_main"/>
   <use name="google-benchmark"/>

--- a/scram-tools.file/tools/google-benchmark/google-benchmark.xml
+++ b/scram-tools.file/tools/google-benchmark/google-benchmark.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/google/benchmark"/>
   <lib name="benchmark"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE"     default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"      default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE"     default="$TOOL_BASE/include"/>
   </client>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/google-test/google-test-main.xml
+++ b/scram-tools.file/tools/google-test/google-test-main.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://google.github.io/googletest/"/>
   <lib name="gtest_main"/>
   <use name="google-test"/>

--- a/scram-tools.file/tools/google-test/google-test.xml
+++ b/scram-tools.file/tools/google-test/google-test.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://google.github.io/googletest/"/>
   <lib name="gtest"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE"     default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"      default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE"     default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/gosam/gosam.xml
+++ b/scram-tools.file/tools/gosam/gosam.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
   <runtime name="PATH" default="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gosamcontrib/gosamcontrib.xml
+++ b/scram-tools.file/tools/gosamcontrib/gosamcontrib.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="GOSAMCONTRIB_PATH" value="$@TOOL_BASE@" type="path"/>
-  <runtime name="ROOT_PATH" value="$@TOOL_BASE@" type="path"/>
+  <runtime name="GOSAMCONTRIB_PATH" value="$TOOL_BASE" type="path"/>
+  <runtime name="ROOT_PATH" value="$TOOL_BASE" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gperftools/gperf.xml
+++ b/scram-tools.file/tools/gperftools/gperf.xml
@@ -1,3 +1,3 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <use name="gperf_profiler"/>
 </tool>

--- a/scram-tools.file/tools/gperftools/gperf_interface.xml
+++ b/scram-tools.file/tools/gperftools/gperf_interface.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"       default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"        default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"       default="$TOOL_BASE/include"/>
   </client>
   <use name="libunwind"/>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/gperftools/gperf_profiler.xml
+++ b/scram-tools.file/tools/gperftools/gperf_profiler.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="profiler"/>
   <use name="gperf_interface"/>
 </tool>

--- a/scram-tools.file/tools/gperftools/gperf_tcmalloc_and_profiler.xml
+++ b/scram-tools.file/tools/gperftools/gperf_tcmalloc_and_profiler.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="tcmalloc_and_profiler"/>
   <use name="gperf_interface"/>
 </tool>

--- a/scram-tools.file/tools/gperftools/tcmalloc.xml
+++ b/scram-tools.file/tools/gperftools/tcmalloc.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="tcmalloc"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR"        default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/gperftools/tcmalloc_minimal.xml
+++ b/scram-tools.file/tools/gperftools/tcmalloc_minimal.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="tcmalloc_minimal"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"                default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR"                default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/graphviz/graphviz.xml
+++ b/scram-tools.file/tools/graphviz/graphviz.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.research.att.com/sw/tools/graphviz/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <use name="expat"/>
   <use name="zlib"/>
   <use name="libjpeg-turbo"/>

--- a/scram-tools.file/tools/grpc/grpc.xml
+++ b/scram-tools.file/tools/grpc/grpc.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/grpc/grpc"/>
   <lib name="grpc"/>
   <lib name="grpc++"/>
   <lib name="grpc++_reflection"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <flags SYSTEM_INCLUDE="1"/>
   <use name="protobuf"/>

--- a/scram-tools.file/tools/gsl/gsl.xml
+++ b/scram-tools.file/tools/gsl/gsl.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.gnu.org/software/gsl/gsl.html"/>
   <lib name="gsl"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <use name="OpenBLAS"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/hdf5/hdf5.xml
+++ b/scram-tools.file/tools/hdf5/hdf5.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://support.hdfgroup.org/HDF5/"/>
   <lib name="hdf5"/>
   <lib name="hdf5_hl"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="mpi"/>
 </tool>

--- a/scram-tools.file/tools/heaptrack/heaptrack.xml
+++ b/scram-tools.file/tools/heaptrack/heaptrack.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="https://invent.kde.org/sdk/heaptrack/"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/hector/hector.xml
+++ b/scram-tools.file/tools/hector/hector.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.fynu.ucl.ac.be/themes/he/ggamma/hector/"/>
   <lib name="Hector"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/hepmc/hepmc.xml
+++ b/scram-tools.file/tools/hepmc/hepmc.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="HepMCfio"/>
   <lib name="HepMC"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="hepmc_headers"/>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@TOOL_BASE@/include" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$TOOL_BASE/include" type="path"/>
 </tool>

--- a/scram-tools.file/tools/hepmc/hepmc_headers.xml
+++ b/scram-tools.file/tools/hepmc/hepmc_headers.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH"  value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/hepmc3/hepmc3.xml
+++ b/scram-tools.file/tools/hepmc3/hepmc3.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="HepMC3"/>
   <lib name="HepMC3search"/>
   <!-- header-only dependencies through bxzstr -->
@@ -7,10 +7,9 @@
   <use name="zlib"/>
   <use name="zstd"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@TOOL_BASE@/include" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$TOOL_BASE/include" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/heppdt/heppdt.xml
+++ b/scram-tools.file/tools/heppdt/heppdt.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="HepPDT"/>
   <lib name="HepPID"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="HEPPDT_PARAM_PATH" value="$@TOOL_BASE@"/>
+  <runtime name="HEPPDT_PARAM_PATH" value="$TOOL_BASE"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/herwig7/herwig7.xml
+++ b/scram-tools.file/tools/herwig7/herwig7.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="HerwigAPI"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/Herwig"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib/Herwig"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
-  <runtime name="HERWIGPATH" value="$@TOOL_BASE@/share/Herwig"/>
+  <runtime name="HERWIGPATH" value="$TOOL_BASE/share/Herwig"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <runtime name="PATH" default="$BINDIR" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/highfive/highfive.xml
+++ b/scram-tools.file/tools/highfive/highfive.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/BlueBrain/HighFive"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="boost"/>

--- a/scram-tools.file/tools/hls/hls.xml
+++ b/scram-tools.file/tools/hls/hls.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/Xilinx/HLS_arbitrary_Precision_Types"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
+++ b/scram-tools.file/tools/hls4mlEmulatorExtras/hls4mlemulatorextras.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="emulator_interface"/>
   <use name="sockets"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/hwloc/hwloc.xml
+++ b/scram-tools.file/tools/hwloc/hwloc.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="hwloc"/>
   <client>
-    <environment name="@TOOL_BASE@"  default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"     default="$@TOOL_BASE@/include/hwloc"/>
-    <environment name="LIBDIR"      default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"     default="$TOOL_BASE/include/hwloc"/>
+    <environment name="LIBDIR"      default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 %if 0%{!?without_cuda:1}%{!?without_rocm:1}
-  <runtime name="HWLOC_PLUGINS_PATH" value="$@TOOL_BASE@/lib/hwloc" type="path"/>
+  <runtime name="HWLOC_PLUGINS_PATH" value="$TOOL_BASE/lib/hwloc" type="path"/>
 %endif
 </tool>

--- a/scram-tools.file/tools/hydjet/hydjet.xml
+++ b/scram-tools.file/tools/hydjet/hydjet.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="hydjet"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="pyquen"/>
   <use name="pythia6"/>

--- a/scram-tools.file/tools/hydjet2/hydjet2.xml
+++ b/scram-tools.file/tools/hydjet2/hydjet2.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="hydjet2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="CMSSW_SEARCH_PATH" default="$@TOOL_BASE@/data" type="path"/>
+  <runtime name="CMSSW_SEARCH_PATH" default="$TOOL_BASE/data" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="pyquen"/>
   <use name="pythia6"/>

--- a/scram-tools.file/tools/icc/icc-ccompiler.xml
+++ b/scram-tools.file/tools/icc/icc-ccompiler.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-ccompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@/installation" handler="warn"/>
-      <environment name="CC" value="$@TOOL_BASE@/bin/intel64/icc" handler="warn"/>
+      <environment name="CC" value="$TOOL_BASE/bin/intel64/icc" handler="warn"/>
     </client>
     <architecture name="_mic_">
       <flags CFLAGS="-mmic"/>

--- a/scram-tools.file/tools/icc/icc-cxxcompiler.xml
+++ b/scram-tools.file/tools/icc/icc-cxxcompiler.xml
@@ -1,9 +1,8 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-cxxcompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@/installation" handler="warn"/>
-      <environment name="CXX" value="$@TOOL_BASE@/bin/intel64/icpc" handler="warn"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/compiler/lib/intel64"/>
+      <environment name="CXX" value="$TOOL_BASE/bin/intel64/icpc" handler="warn"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/compiler/lib/intel64"/>
     </client>
     <flags REM_CXXFLAGS="-felide-constructors"/>
     <flags REM_CXXFLAGS="-ftree-vectorize"/>
@@ -22,6 +21,6 @@
       <flags CXXFLAGS="-mmic"/>
       <flags LDFLAGS="-mmic"/>
     </architecture>
-    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/compiler/lib/intel64" type="path" handler="warn"/>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin/intel64" type="path" handler="warn"/>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/compiler/lib/intel64" type="path" handler="warn"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin/intel64" type="path" handler="warn"/>
   </tool>

--- a/scram-tools.file/tools/icc/icc-f77compiler.xml
+++ b/scram-tools.file/tools/icc/icc-f77compiler.xml
@@ -1,15 +1,14 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-f77compiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@/ifort" handler="warn"/>
-      <environment name="FC" default="$@TOOL_BASE@/bin/intel64/ifort" handler="warn"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/compiler/lib/intel64" handler="warn"/>
+      <environment name="FC" default="$TOOL_BASE/bin/intel64/ifort" handler="warn"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/compiler/lib/intel64" handler="warn"/>
     </client>
     <flags REM_FFLAGS="-fno-second-underscore"/>
     <architecture name="_mic_">
       <flags FFLAGS="-mmic"/>
     </architecture>
-    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/compiler/lib/intel64" type="path" handler="warn"/>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/compiler/lib/intel64" type="path" handler="warn"/>
     <lib name="ifcore"/>
     <lib name="ifport"/>
   </tool>

--- a/scram-tools.file/tools/icc/intel-license.xml
+++ b/scram-tools.file/tools/icc/intel-license.xml
@@ -1,3 +1,3 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+  <tool revision="2">
     <runtime name="INTEL_LICENSE_FILE" value="28518@lxlicen01.cern.ch,28518@lxlicen02.cern.ch,28518@lxlicen03.cern.ch" handler="warn"/>
   </tool>

--- a/scram-tools.file/tools/icx/icx-ccompiler.xml
+++ b/scram-tools.file/tools/icx/icx-ccompiler.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-ccompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@/installation" handler="warn"/>
-      <environment name="CC" value="$@TOOL_BASE@/bin/icx" handler="warn"/>
+      <environment name="CC" value="$TOOL_BASE/bin/icx" handler="warn"/>
     </client>
     <architecture name="_mic_">
       <flags CFLAGS="-mmic"/>

--- a/scram-tools.file/tools/icx/icx-cxxcompiler.xml
+++ b/scram-tools.file/tools/icx/icx-cxxcompiler.xml
@@ -1,9 +1,8 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-cxxcompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@/installation" handler="warn"/>
-      <environment name="CXX" value="$@TOOL_BASE@/bin/icpx" handler="warn"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="CXX" value="$TOOL_BASE/bin/icpx" handler="warn"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
     </client>
     <flags REM_CXXFLAGS="-felide-constructors"/>
     <flags REM_CXXFLAGS="-ftree-vectorize"/>
@@ -24,6 +23,6 @@
       <flags CXXFLAGS="-mmic"/>
       <flags LDFLAGS="-mmic"/>
     </architecture>
-    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/lib" type="path" handler="warn"/>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path" handler="warn"/>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/lib" type="path" handler="warn"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path" handler="warn"/>
   </tool>

--- a/scram-tools.file/tools/icx/icx-f77compiler.xml
+++ b/scram-tools.file/tools/icx/icx-f77compiler.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-f77compiler"/>
     <client>
 %if 0%{!?use_system_gcc:1}

--- a/scram-tools.file/tools/igprof/igprof.xml
+++ b/scram-tools.file/tools/igprof/igprof.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://igprof.sourceforge.net/"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/intel-vtune/intel-vtune.xml
+++ b/scram-tools.file/tools/intel-vtune/intel-vtune.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@INTEL_VTUNE_INSTALLDIR@"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin64"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin64"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin64" type="path"/>
-  <runtime name="VTUNE_PROFILER_DIR" value="$@TOOL_BASE@"/>
-  <runtime name="VTUNE_PROFILER_2025_DIR" value="$@TOOL_BASE@"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin64" type="path"/>
+  <runtime name="VTUNE_PROFILER_DIR" value="$TOOL_BASE"/>
+  <runtime name="VTUNE_PROFILER_2025_DIR" value="$TOOL_BASE"/>
 </tool>

--- a/scram-tools.file/tools/isal/isal.xml
+++ b/scram-tools.file/tools/isal/isal.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/intel/isa-l/wiki"/>
   <lib name="isal"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="eigen"/>
 </tool>

--- a/scram-tools.file/tools/ittnotify/ittnotify.xml
+++ b/scram-tools.file/tools/ittnotify/ittnotify.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
  <lib name="ittnotify"/>
  <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
  </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   </tool>

--- a/scram-tools.file/tools/jemalloc-debug/jemalloc-debug.xml
+++ b/scram-tools.file/tools/jemalloc-debug/jemalloc-debug.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="jemalloc-debug"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"        default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"        default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/jemalloc-prof/jemalloc-prof.xml
+++ b/scram-tools.file/tools/jemalloc-prof/jemalloc-prof.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="jemalloc-prof"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"        default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"        default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/jemalloc/jemalloc.xml
+++ b/scram-tools.file/tools/jemalloc/jemalloc.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="jemalloc"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"        default="$@TOOL_BASE@/lib"/>
-    <environment name="BINDIR"        default="$@TOOL_BASE@/bin"/>
-    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"        default="$TOOL_BASE/lib"/>
+    <environment name="BINDIR"        default="$TOOL_BASE/bin"/>
+    <environment name="INCLUDE"        default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <runtime name="PATH" value="$BINDIR" type="path" />

--- a/scram-tools.file/tools/json/json.xml
+++ b/scram-tools.file/tools/json/json.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/ktjet/ktjet.xml
+++ b/scram-tools.file/tools/ktjet/ktjet.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://hepforge.cedar.ac.uk/ktjet"/>
   <lib name="KtEvent"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <flags cppdefines="KTDOUBLEPRECISION"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/lcov/lcov.xml
+++ b/scram-tools.file/tools/lcov/lcov.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://ltp.sourceforge.net/coverage/lcov.php"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/lhapdf/lhapdf.xml
+++ b/scram-tools.file/tools/lhapdf/lhapdf.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="LHAPDF"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="LHAPDF_DATA_PATH" value="$@TOOL_BASE@/share/LHAPDF"/>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="LHAPDF_DATA_PATH" value="$TOOL_BASE/share/LHAPDF"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libfabric/libfabric.xml
+++ b/scram-tools.file/tools/libfabric/libfabric.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="fabric"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"         default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"        default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libffi/libffi.xml
+++ b/scram-tools.file/tools/libffi/libffi.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="ffi"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libjpeg-turbo/libjpeg-turbo.xml
+++ b/scram-tools.file/tools/libjpeg-turbo/libjpeg-turbo.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://libjpeg-turbo.virtualgl.org"/>
   <lib name="jpeg"/>
   <lib name="turbojpeg"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libpciaccess/libpciaccess.xml
+++ b/scram-tools.file/tools/libpciaccess/libpciaccess.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="libpciaccess"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"            default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"           default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"            default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"           default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libpng/libpng.xml
+++ b/scram-tools.file/tools/libpng/libpng.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.libpng.org/"/>
   <lib name="png"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libtiff/libtiff.xml
+++ b/scram-tools.file/tools/libtiff/libtiff.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.libtiff.org/"/>
   <lib name="tiff"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libungif/libungif.xml
+++ b/scram-tools.file/tools/libungif/libungif.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://sourceforge.net/projects/libungif"/>
   <lib name="ungif"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libunwind/libunwind.xml
+++ b/scram-tools.file/tools/libunwind/libunwind.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="unwind"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libuuid/libuuid.xml
+++ b/scram-tools.file/tools/libuuid/libuuid.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="uuid"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/libxml2/libxml2.xml
+++ b/scram-tools.file/tools/libxml2/libxml2.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://xmlsoft.org/"/>
   <lib name="xml2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/libxml2"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/libxml2"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/libxslt/libxslt.xml
+++ b/scram-tools.file/tools/libxslt/libxslt.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://xmlsoft.org/libxslt"/>
   <lib name="xslt"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/libxslt"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/libxslt"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/libzmq/libzmq.xml
+++ b/scram-tools.file/tools/libzmq/libzmq.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://zeromq.org"/>
   <lib name="zmq"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/llvm/iwyu-cxxcompiler.xml
+++ b/scram-tools.file/tools/llvm/iwyu-cxxcompiler.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="llvm-cxxcompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="CXX" value="$@TOOL_BASE@/bin/include-what-you-use"/>
+      <environment name="CXX" value="$TOOL_BASE/bin/include-what-you-use"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-analyzer-ccompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-analyzer-ccompiler.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="llvm-ccompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="CC" value="$@TOOL_BASE@/bin/ccc-analyzer"/>
+      <environment name="CC" value="$TOOL_BASE/bin/ccc-analyzer"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-analyzer-cxxcompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-analyzer-cxxcompiler.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="llvm-cxxcompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="CXX" value="$@TOOL_BASE@/bin/c++-analyzer"/>
+      <environment name="CXX" value="$TOOL_BASE/bin/c++-analyzer"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-ccompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-ccompiler.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="2">
+  <tool type="compiler" revision="3">
     <use name="gcc-ccompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="CC" value="$@TOOL_BASE@/bin/clang"/>
+      <environment name="CC" value="$TOOL_BASE/bin/clang"/>
     </client>
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-cxxcompiler.xml
@@ -1,8 +1,7 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="2">
+  <tool type="compiler" revision="3">
     <use name="gcc-cxxcompiler"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="CXX" value="$@TOOL_BASE@/bin/clang++"/>
+      <environment name="CXX" value="$TOOL_BASE/bin/clang++"/>
     </client>
     # drop flags not supported by llvm
     # -Wno-non-template-friend removed since it's not supported, yet, by llvm.
@@ -33,6 +32,6 @@
     <flags CXXFLAGS="-Wno-tautological-type-limit-compare"/>
     <flags CXXFLAGS="-Wno-vla-cxx-extension"/>
     <flags CXXFLAGS="-fsized-deallocation"/>
-    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$@TOOL_BASE@/lib64" type="path"/>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="@OS_RUNTIME_LDPATH_NAME@" value="$TOOL_BASE/lib64" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/llvm/llvm-f77compiler.xml
+++ b/scram-tools.file/tools/llvm/llvm-f77compiler.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" type="compiler" revision="1">
+  <tool type="compiler" revision="2">
     <use name="gcc-f77compiler"/>
     <client>
 %if 0%{!?use_system_gcc:1}

--- a/scram-tools.file/tools/llvm/llvm.xml
+++ b/scram-tools.file/tools/llvm/llvm.xml
@@ -1,9 +1,8 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <lib name="clang"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>
     <flags LDFLAGS="-Wl,-undefined -Wl,suppress"/>
     <flags CXXFLAGS="-D_DEBUG -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS"/>

--- a/scram-tools.file/tools/llvm/pyclang.xml
+++ b/scram-tools.file/tools/llvm/pyclang.xml
@@ -1,5 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/log4cplus/log4cplus.xml
+++ b/scram-tools.file/tools/log4cplus/log4cplus.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="log4cplusS"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE"        default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"         default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/lwtnn/lwtnn.xml
+++ b/scram-tools.file/tools/lwtnn/lwtnn.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/lwtnn/lwtnn"/>
   <lib name="lwtnn"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="eigen"/>

--- a/scram-tools.file/tools/lwtnn/vectorized.tmpl
+++ b/scram-tools.file/tools/lwtnn/vectorized.tmpl
@@ -1,6 +1,6 @@
-<tool name="lwtnn_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="lwtnn_@TOOL_VECTORIZATION@" revision="2">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="@TOOL_VECTORIZATION_KEY@_PATH" value="@TOOL_ROOT@/bin" type="path"/>
+  <runtime name="@TOOL_VECTORIZATION_KEY@_PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/lz4/lz4.xml
+++ b/scram-tools.file/tools/lz4/lz4.xml
@@ -1,12 +1,11 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="https://github.com/lz4/lz4"/>
     <lib name="lz4"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/madgraph5amcatnlo/madgraph5amcatnlo.xml
+++ b/scram-tools.file/tools/madgraph5amcatnlo/madgraph5amcatnlo.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@" type="path"/>
-  <runtime name="ROOT_PATH" value="$@TOOL_BASE@" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$TOOL_BASE" type="path"/>
+  <runtime name="ROOT_PATH" value="$TOOL_BASE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="gosamcontrib"/>
 </tool>

--- a/scram-tools.file/tools/mctester/mctester.xml
+++ b/scram-tools.file/tools/mctester/mctester.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="HEPEvent"/>
   <lib name="HepMCEvent"/>
   <lib name="MCTester"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/md5/md5.xml
+++ b/scram-tools.file/tools/md5/md5.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://tls.mbed.org/md5-source-code"/>
    <lib name="cms-md5"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>  
 </tool>

--- a/scram-tools.file/tools/mille/mille.xml
+++ b/scram-tools.file/tools/mille/mille.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://millepede.pages.desy.de/Mille/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <lib name="Mille2"/>
   <lib name="MilleC"/>
   <use name="sockets"/>

--- a/scram-tools.file/tools/millepede/millepede.xml
+++ b/scram-tools.file/tools/millepede/millepede.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://millepede.pages.desy.de/millepede-ii/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <use name="sockets"/>
   <use name="pcre"/>
   <use name="root"/>

--- a/scram-tools.file/tools/mozsearch/mozsearch.xml
+++ b/scram-tools.file/tools/mozsearch/mozsearch.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="1.0" revision="2">
+<tool version="1.0" revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR"         default="$TOOL_BASE/lib64"/>
   </client>
   <flags INDEX_FLAGS="
     -Xclang -load

--- a/scram-tools.file/tools/mpi/mpi.xml
+++ b/scram-tools.file/tools/mpi/mpi.xml
@@ -1,3 +1,3 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <use name="openmpi"/>
 </tool>

--- a/scram-tools.file/tools/mpich/mpich.xml
+++ b/scram-tools.file/tools/mpich/mpich.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="mpi"/>
   <lib name="mpicxx"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"     default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"    default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"     default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"    default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/mxnet-predict/mxnet-predict.xml
+++ b/scram-tools.file/tools/mxnet-predict/mxnet-predict.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="mxnet"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="openblas"/>
   <flags SYSTEM_INCLUDE="1"/>

--- a/scram-tools.file/tools/numactl/numactl.xml
+++ b/scram-tools.file/tools/numactl/numactl.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="numa"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-  <runtime name="MANPATH" value="$@TOOL_BASE@/share/man" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+  <runtime name="MANPATH" value="$TOOL_BASE/share/man" type="path"/>
 </tool>

--- a/scram-tools.file/tools/onnxruntime/onnxruntime.xml
+++ b/scram-tools.file/tools/onnxruntime/onnxruntime.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="onnxruntime"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="protobuf"/>
   <use name="cuda"/>

--- a/scram-tools.file/tools/opencl-cpp/opencl-cpp.xml
+++ b/scram-tools.file/tools/opencl-cpp/opencl-cpp.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.khronos.org/registry/cl/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="opencl"/>
 </tool>

--- a/scram-tools.file/tools/opencl/opencl.xml
+++ b/scram-tools.file/tools/opencl/opencl.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://www.khronos.org/opencl/"/>
   <lib name="OpenCL"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/opencv/opencv.xml
+++ b/scram-tools.file/tools/opencv/opencv.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="opencv_core"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
   <use name="libpng"/>
   <use name="libjpeg-turbo"/>

--- a/scram-tools.file/tools/opencv/vectorized.tmpl
+++ b/scram-tools.file/tools/opencv/vectorized.tmpl
@@ -1,6 +1,6 @@
-<tool name="opencv_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="opencv_@TOOL_VECTORIZATION@"  revision="1">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
-    <environment name="@TOOL_VECTORIZATION_KEY@_BINDIR" default="@TOOL_ROOT@/bin"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_BINDIR" default="$TOOL_BASE/bin"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/openldap/openldap.xml
+++ b/scram-tools.file/tools/openldap/openldap.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="db6"/>
 </tool>

--- a/scram-tools.file/tools/openloops/openloops.xml
+++ b/scram-tools.file/tools/openloops/openloops.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
 <client>
-<environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-<runtime name="CMS_OPENLOOPS_PREFIX" value="$@TOOL_BASE@" type="path"/>
+<environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+<runtime name="CMS_OPENLOOPS_PREFIX" value="$TOOL_BASE" type="path"/>
 </client>
 </tool>

--- a/scram-tools.file/tools/openmpi/openmpi.xml
+++ b/scram-tools.file/tools/openmpi/openmpi.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="4">
+<tool revision="5">
   <lib name="mpi"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-  <runtime name="OPAL_PREFIX" value="$@TOOL_BASE@"/>
-  <runtime name="PMIX_PREFIX" value="$@TOOL_BASE@"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+  <runtime name="OPAL_PREFIX" value="$TOOL_BASE"/>
+  <runtime name="PMIX_PREFIX" value="$TOOL_BASE"/>
   <runtime name="OMPI_MCA_accelerator" value="null"/>
 %if "%{?HFI_NO_BACKTRACE:set}" == "set"
   <runtime name="HFI_NO_BACKTRACE" value="%{HFI_NO_BACKTRACE}"/>

--- a/scram-tools.file/tools/oracle-fake/oracle.xml
+++ b/scram-tools.file/tools/oracle-fake/oracle.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="clntsh"/>
   @OS_LIBS@
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     <environment name="ORACLE_ADMINDIR" value="@ORACLE_ENV_ROOT@/etc"/>
-    <environment name="LIBDIR" value="$@TOOL_BASE@/lib"/>
-    <environment name="BINDIR" value="$@TOOL_BASE@/bin"/>
-    <environment name="INCLUDE" value="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" value="$TOOL_BASE/lib"/>
+    <environment name="BINDIR" value="$TOOL_BASE/bin"/>
+    <environment name="INCLUDE" value="$TOOL_BASE/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="TNS_ADMIN" default="$ORACLE_ADMINDIR"/>

--- a/scram-tools.file/tools/oracle-fake/oracleocci.xml
+++ b/scram-tools.file/tools/oracle-fake/oracleocci.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="occi"/>
   <use name="oracle"/>
 </tool>

--- a/scram-tools.file/tools/oracle/oracle.xml
+++ b/scram-tools.file/tools/oracle/oracle.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="clntsh"/>
   @OS_LIBS@
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     <environment name="ORACLE_ADMINDIR" value="@ORACLE_ENV_ROOT@/etc"/>
-    <environment name="LIBDIR" value="$@TOOL_BASE@/lib"/>
-    <environment name="BINDIR" value="$@TOOL_BASE@/bin"/>
-    <environment name="INCLUDE" value="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" value="$TOOL_BASE/lib"/>
+    <environment name="BINDIR" value="$TOOL_BASE/bin"/>
+    <environment name="INCLUDE" value="$TOOL_BASE/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="TNS_ADMIN" default="$ORACLE_ADMINDIR"/>

--- a/scram-tools.file/tools/oracle/oracleocci.xml
+++ b/scram-tools.file/tools/oracle/oracleocci.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="occi"/>
   <use name="oracle"/>
 </tool>

--- a/scram-tools.file/tools/pacparser/pacparser.xml
+++ b/scram-tools.file/tools/pacparser/pacparser.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://code.google.com/p/pacparser/"/>
   <lib name="pacparser"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/pcm_util/pcm_util.xml
+++ b/scram-tools.file/tools/pcm_util/pcm_util.xml
@@ -1,14 +1,13 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/clhep" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/boost" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/tinyxml2" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/cuda" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/tbb" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/HepMC" type="path"/>
-  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$@TOOL_BASE@/lib/pybind11" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$TOOL_BASE/lib/clhep" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$TOOL_BASE/lib/boost" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$TOOL_BASE/lib/tinyxml2" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$TOOL_BASE/lib/cuda" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$TOOL_BASE/lib/tbb" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$TOOL_BASE/lib/HepMC" type="path"/>
+  <runtime name="CLING_PREBUILT_MODULE_PATH" value="$TOOL_BASE/lib/pybind11" type="path"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@HEPMC_ROOT@/include/hepmc.modulemap" type="path" handler="warn"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@CLHEP_ROOT@/include/clhep.modulemap" type="path" handler="warn"/>
   <runtime name="CLING_MODULEMAP_FILES" value="@TBB_ROOT@/include/module.modulemap" type="path" handler="warn"/>

--- a/scram-tools.file/tools/pcre/pcre.xml
+++ b/scram-tools.file/tools/pcre/pcre.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.pcre.org"/>
   <lib name="pcre"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/pcre2/pcre2.xml
+++ b/scram-tools.file/tools/pcre2/pcre2.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.pcre.org"/>
   <lib name="pcre2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/photospp/photospp.xml
+++ b/scram-tools.file/tools/photospp/photospp.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <lib name="Photospp"/>
   <lib name="PhotosppHepMC"/>
   <lib name="PhotosppHepMC3"/>
   <lib name="PhotosppHEPEVT"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="hepmc"/>
   <use name="hepmc3"/>

--- a/scram-tools.file/tools/professor2/professor2.xml
+++ b/scram-tools.file/tools/professor2/professor2.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
 <client>
-<environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-<environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+<environment name="LIBDIR" default="$TOOL_BASE/lib"/>
 </client>
 <use name="py3-numpy"/>
 <use name="root"/>
 <use name="yoda"/>
 <use name="eigen"/>
-<runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+<runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/protobuf/protobuf.xml
+++ b/scram-tools.file/tools/protobuf/protobuf.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="protobuf"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/py3-correctionlib/correctionlib.xml
+++ b/scram-tools.file/tools/py3-correctionlib/correctionlib.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="correctionlib"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/@PYTHON3_LIB_SITE_PACKAGES@/correctionlib/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/@PYTHON3_LIB_SITE_PACKAGES@/correctionlib/lib"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/@PYTHON3_LIB_SITE_PACKAGES@/correctionlib/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/@PYTHON3_LIB_SITE_PACKAGES@/correctionlib/lib"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
   </client>
   <runtime name="PATH" default="$BINDIR" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-dxr/py3-dxr.xml
+++ b/scram-tools.file/tools/py3-dxr/py3-dxr.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-numpy/numpy-c-api.xml
+++ b/scram-tools.file/tools/py3-numpy/numpy-c-api.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="npymath"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/c-api/core/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/c-api/core/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/c-api/core/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/c-api/core/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/py3-numpy/py3-numpy.xml
+++ b/scram-tools.file/tools/py3-numpy/py3-numpy.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-pybind11/py3-pybind11.xml
+++ b/scram-tools.file/tools/py3-pybind11/py3-pybind11.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/@PYTHON3_LIB_SITE_PACKAGES@/pybind11/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/@PYTHON3_LIB_SITE_PACKAGES@/pybind11/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/py3-tensorflow/py3-tensorflow.xml
+++ b/scram-tools.file/tools/py3-tensorflow/py3-tensorflow.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/py3-tensorflow/tensorflow-includes.xml
+++ b/scram-tools.file/tools/py3-tensorflow/tensorflow-includes.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/@PYTHON3_LIB_SITE_PACKAGES@/tensorflow/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/@PYTHON3_LIB_SITE_PACKAGES@/tensorflow/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/py3-torch-cuda/pytorch-cuda-links.xml
+++ b/scram-tools.file/tools/py3-torch-cuda/pytorch-cuda-links.xml
@@ -1,5 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="CUDA_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="CUDA_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/py3-torch-cuda/pytorch-cuda.xml
+++ b/scram-tools.file/tools/py3-torch-cuda/pytorch-cuda.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torch/csrc/api/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/torch/csrc/api/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
   <use name="pytorch"/>

--- a/scram-tools.file/tools/py3-torch-rocm/pytorch-rocm.xml
+++ b/scram-tools.file/tools/py3-torch-rocm/pytorch-rocm.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torch/csrc/api/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="PYTHONDIR" default="$@TOOL_BASE@/lib/python@PYTHON3V@/site-packages"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/torch/csrc/api/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="PYTHONDIR" default="$TOOL_BASE/lib/python@PYTHON3V@/site-packages"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
   <runtime name="LD_LIBRARY_PATH" value="$LIBDIR" type="path"/>

--- a/scram-tools.file/tools/py3-torch/pytorch.xml
+++ b/scram-tools.file/tools/py3-torch/pytorch.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="4">
+<tool revision="5">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torch/csrc/api/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/torch/csrc/api/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <lib name="torch"/>
   <lib name="torch_cpu"/>

--- a/scram-tools.file/tools/py3-torch/torch-interface.xml
+++ b/scram-tools.file/tools/py3-torch/torch-interface.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <use name="protobuf"/>
   <use name="zlib"/>
 </tool>

--- a/scram-tools.file/tools/pyquen/pyquen.xml
+++ b/scram-tools.file/tools/pyquen/pyquen.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="pyquen"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="pythia6"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/pythia6/pydata.xml
+++ b/scram-tools.file/tools/pythia6/pydata.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
   <ifos value="linux">
-    <flags LDFLAGS="$@TOOL_BASE@/lib/pydata.o"/>
+    <flags LDFLAGS="$TOOL_BASE/lib/pydata.o"/>
   </ifos>
   <flags NO_RECURSIVE_EXPORT="1"/>
 </tool>

--- a/scram-tools.file/tools/pythia6/pythia6.xml
+++ b/scram-tools.file/tools/pythia6/pythia6.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <lib name="pythia6"/>
   <lib name="pythia6_dummy"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="lhapdf"/>
   <use name="pythia6_headers"/>

--- a/scram-tools.file/tools/pythia6/pythia6_headers.xml
+++ b/scram-tools.file/tools/pythia6/pythia6_headers.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/pythia6/pythia6_pdfdummy.xml
+++ b/scram-tools.file/tools/pythia6/pythia6_pdfdummy.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="pythia6_pdfdummy"/>
   <flags NO_RECURSIVE_EXPORT="1"/>
 </tool>

--- a/scram-tools.file/tools/pythia8/pythia8.xml
+++ b/scram-tools.file/tools/pythia8/pythia8.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="pythia8"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PYTHIA8DATA" value="$@TOOL_BASE@/share/Pythia8/xmldoc"/>
+  <runtime name="PYTHIA8DATA" value="$TOOL_BASE/share/Pythia8/xmldoc"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="hepmc3"/>

--- a/scram-tools.file/tools/python/python.xml
+++ b/scram-tools.file/tools/python/python.xml
@@ -1,14 +1,13 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="python@PYTHONV@"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/python@PYTHONV@"/>
-    <environment name="PYTHON_COMPILE" default="$@TOOL_BASE@/lib/python@PYTHONV@/compileall.py"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/python@PYTHONV@"/>
+    <environment name="PYTHON_COMPILE" default="$TOOL_BASE/lib/python@PYTHONV@/compileall.py"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="PYTHON_VALGRIND_SUPP" value="$@TOOL_BASE@/share/valgrind/valgrind-python.supp" type="path"/>
+  <runtime name="PYTHON_VALGRIND_SUPP" value="$TOOL_BASE/share/valgrind/valgrind-python.supp" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/python3/python3.xml
+++ b/scram-tools.file/tools/python3/python3.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="python@PYTHON3V@"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/python@PYTHON3V@"/>
-    <environment name="PYTHON3_COMPILE" default="$@TOOL_BASE@/lib/python@PYTHON3V@/compileall.py"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/python@PYTHON3V@"/>
+    <environment name="PYTHON3_COMPILE" default="$TOOL_BASE/lib/python@PYTHON3V@/compileall.py"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <use name="sockets"/>
 </tool>

--- a/scram-tools.file/tools/python_tools/python_tools.xml
+++ b/scram-tools.file/tools/python_tools/python_tools.xml
@@ -1,2 +1,2 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
 </tool>

--- a/scram-tools.file/tools/pytorch-cluster/pytorch-cluster.xml
+++ b/scram-tools.file/tools/pytorch-cluster/pytorch-cluster.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torchcluster/"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/torchcluster/"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchcluster"/>

--- a/scram-tools.file/tools/pytorch-custom-ops/pytorch-custom-ops.xml
+++ b/scram-tools.file/tools/pytorch-custom-ops/pytorch-custom-ops.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="1.0" revision="2">
+<tool version="1.0" revision="3">
     <use name="pytorch"/>
     <use name="pytorch-scatter"/>
     <use name="pytorch-cluster"/>

--- a/scram-tools.file/tools/pytorch-scatter/pytorch-scatter.xml
+++ b/scram-tools.file/tools/pytorch-scatter/pytorch-scatter.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torchscatter/"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/torchscatter/"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchscatter"/>

--- a/scram-tools.file/tools/pytorch-sparse/pytorch-sparse.xml
+++ b/scram-tools.file/tools/pytorch-sparse/pytorch-sparse.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/torchsparse/"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/torchsparse/"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <use name="pytorch"/>
   <lib name="torchsparse"/>

--- a/scram-tools.file/tools/qd/qd.xml
+++ b/scram-tools.file/tools/qd/qd.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="qdmod"/>
   <lib name="qd"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/qd/qd_f_main.xml
+++ b/scram-tools.file/tools/qd/qd_f_main.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="qd_f_main"/>
   <use name="qd"/>
 </tool>

--- a/scram-tools.file/tools/rdma-core/libibumad.xml
+++ b/scram-tools.file/tools/rdma-core/libibumad.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
   <use name="rdma-core"/>
   <lib name="ibumad"/>

--- a/scram-tools.file/tools/rdma-core/libibverbs.xml
+++ b/scram-tools.file/tools/rdma-core/libibverbs.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
   <use name="rdma-core"/>
   <lib name="ibverbs"/>

--- a/scram-tools.file/tools/rdma-core/librdmacm.xml
+++ b/scram-tools.file/tools/rdma-core/librdmacm.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
   <use name="rdma-core"/>
   <use name="libibverbs"/>

--- a/scram-tools.file/tools/rdma-core/rdma-core.xml
+++ b/scram-tools.file/tools/rdma-core/rdma-core.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/linux-rdma/rdma-core/blob/master/README.md"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"         default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"         default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE"        default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="VERBS_CONFIG_DIR" value="$@TOOL_BASE@/etc/libibverbs.d" type="path"/>
+  <runtime name="VERBS_CONFIG_DIR" value="$TOOL_BASE/etc/libibverbs.d" type="path"/>
 </tool>

--- a/scram-tools.file/tools/re2/re2.xml
+++ b/scram-tools.file/tools/re2/re2.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/google/re2"/>
   <lib name="re2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>
 

--- a/scram-tools.file/tools/rivet/rivet.xml
+++ b/scram-tools.file/tools/rivet/rivet.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="Rivet"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-  <runtime name="RIVET_DATA_PATH" value="$@TOOL_BASE@/share/Rivet" type="path"/>
-  <runtime name="PDFPATH" default="$@TOOL_BASE@/share" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+  <runtime name="RIVET_DATA_PATH" value="$TOOL_BASE/share/Rivet" type="path"/>
+  <runtime name="PDFPATH" default="$TOOL_BASE/share" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="hepmc"/>
   <use name="fastjet"/>

--- a/scram-tools.file/tools/rivet/vectorized.tmpl
+++ b/scram-tools.file/tools/rivet/vectorized.tmpl
@@ -1,6 +1,6 @@
-<tool name="rivet_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="rivet_@TOOL_VECTORIZATION@"  revision="1">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="@TOOL_VECTORIZATION_KEY@_PATH" value="@TOOL_ROOT@/bin" type="path"/>
+  <runtime name="@TOOL_VECTORIZATION_KEY@_PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/rocm/rocm-rccl.xml
+++ b/scram-tools.file/tools/rocm/rocm-rccl.xml
@@ -1,5 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
-  <info url="https://rocm.docs.amd.com/projects/rccl/en/docs-@TOOL_VERSION@/"/>
+<tool revision="2">
+  <info url="https://rocm.docs.amd.com/projects/rccl/en/docs-@TOOL_REALVERSION@/"/>
   <use name="rocm"/>
   <lib name="rccl"/>
 </tool>

--- a/scram-tools.file/tools/rocm/rocm-rocprofiler-sdk.xml
+++ b/scram-tools.file/tools/rocm/rocm-rocprofiler-sdk.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/index.html"/>
   <use name="rocm"/>
   <lib name="rocprofiler-sdk-roctx"/>

--- a/scram-tools.file/tools/rocm/rocm-rocrand.xml
+++ b/scram-tools.file/tools/rocm/rocm-rocrand.xml
@@ -1,5 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
-  <info url="https://rocm.docs.amd.com/projects/rocRAND/en/docs-@TOOL_VERSION@/"/>
+<tool revision="2">
+  <info url="https://rocm.docs.amd.com/projects/rocRAND/en/docs-@TOOL_REALVERSION@/"/>
   <use name="rocm"/>
   <lib name="hiprand"/>
   <lib name="rocrand"/>

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -1,17 +1,16 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="7">
-  <info url="https://rocm.docs.amd.com/en/docs-@TOOL_VERSION@/"/>
+<tool revision="8">
+  <info url="https://rocm.docs.amd.com/en/docs-@TOOL_REALVERSION@/"/>
   <lib name="amdhip64"/>
   <lib name="hsa-runtime64"/>
   <lib name="rocm_smi64"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="HIPCC"     default="$@TOOL_BASE@/bin/hipcc"/>
-    <environment name="BINDIR"    default="$@TOOL_BASE@/bin"/>
-    <environment name="LIBDIR"    default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"   default="$@TOOL_BASE@/include"/>
+    <environment name="HIPCC"     default="$TOOL_BASE/bin/hipcc"/>
+    <environment name="BINDIR"    default="$TOOL_BASE/bin"/>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
   </client>
   <flags CPPDEFINES="__HIP_PLATFORM_HCC__ __HIP_PLATFORM_AMD__"/>
-  <flags ROCM_FLAGS="--rocm-path=$@TOOL_BASE@"/>
+  <flags ROCM_FLAGS="--rocm-path=$TOOL_BASE"/>
   <flags ROCM_FLAGS="@ROCM_FLAGS@"/>
   <flags ROCM_FLAGS="-fgpu-rdc"/>
   <flags ROCM_FLAGS="-Wno-pass-failed"/>
@@ -24,7 +23,7 @@
   <!-- use -isystem instead of -I to silence warnings in the HIP/ROCm headers -->
   <flags SYSTEM_INCLUDE="1"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="HSA_XNACK" value="1"/>
   <use name="fmt"/>
 </tool>

--- a/scram-tools.file/tools/root/histfactory.xml
+++ b/scram-tools.file/tools/root/histfactory.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="HistFactory"/>
   <use name="roofitcore"/>

--- a/scram-tools.file/tools/root/roofit.xml
+++ b/scram-tools.file/tools/root/roofit.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="RooFit"/>
   <use name="roofitcore"/>

--- a/scram-tools.file/tools/root/roofitcore.xml
+++ b/scram-tools.file/tools/root/roofitcore.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="RooFitCore"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="ROOFITSYS" value="$@TOOL_BASE@/"/>
+  <runtime name="ROOFITSYS" value="$TOOL_BASE/"/>
   <use name="rootcore"/>
   <use name="roothistmatrix"/>
   <use name="rootgpad"/>

--- a/scram-tools.file/tools/root/roostats.xml
+++ b/scram-tools.file/tools/root/roostats.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="RooStats"/>
   <use name="roofitcore"/>

--- a/scram-tools.file/tools/root/root.xml
+++ b/scram-tools.file/tools/root/root.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://root.cern.ch/root/"/>
   <use name="rootphysics"/>
   <flags GENREFLEX_FAILES_ON_WARNS="-failOnWarnings"/>

--- a/scram-tools.file/tools/root/root_interface.xml
+++ b/scram-tools.file/tools/root/root_interface.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <client>
-    <environment name="@TOOL_BASE@"     default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"                 default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"                  default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"                 default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"                  default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="PATH"                          value="$@TOOL_BASE@/bin" type="path"/>
-  <runtime name="ROOTSYS"                       value="$@TOOL_BASE@/"/>
+  <runtime name="PATH"                          value="$TOOL_BASE/bin" type="path"/>
+  <runtime name="ROOTSYS"                       value="$TOOL_BASE/"/>
   <runtime name="ROOT_TTREECACHE_SIZE"          value="0"/>
   <runtime name="ROOT_TTREECACHE_PREFILL"       value="0"/>
   <runtime name="ROOT_INCLUDE_PATH"             value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/root/rootcling.xml
+++ b/scram-tools.file/tools/root/rootcling.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Core"/>
   <flags OVERRIDABLE_FLAGS="ROOTCLING_ARGS"/>

--- a/scram-tools.file/tools/root/rootcore.xml
+++ b/scram-tools.file/tools/root/rootcore.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Tree"/>
   <lib name="Net"/>

--- a/scram-tools.file/tools/root/rootdataframe.xml
+++ b/scram-tools.file/tools/root/rootdataframe.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="ROOTDataFrame"/>
   <use name="rootcore"/>

--- a/scram-tools.file/tools/root/rooteg.xml
+++ b/scram-tools.file/tools/root/rooteg.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="EG"/>
   <use name="rootgraphics"/>

--- a/scram-tools.file/tools/root/rooteve.xml
+++ b/scram-tools.file/tools/root/rooteve.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Eve"/>
   <use name="rootgeompainter"/>

--- a/scram-tools.file/tools/root/rootfoam.xml
+++ b/scram-tools.file/tools/root/rootfoam.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Foam"/>
   <use name="roothistmatrix"/>

--- a/scram-tools.file/tools/root/rootged.xml
+++ b/scram-tools.file/tools/root/rootged.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Ged"/>
   <use name="rootgui"/>

--- a/scram-tools.file/tools/root/rootgeom.xml
+++ b/scram-tools.file/tools/root/rootgeom.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Geom"/>
   <use name="rootrio"/>

--- a/scram-tools.file/tools/root/rootgeompainter.xml
+++ b/scram-tools.file/tools/root/rootgeompainter.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="GeomPainter"/>
   <use name="rootgeom"/>

--- a/scram-tools.file/tools/root/rootglew.xml
+++ b/scram-tools.file/tools/root/rootglew.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="GLEW"/>
 </tool>

--- a/scram-tools.file/tools/root/rootgpad.xml
+++ b/scram-tools.file/tools/root/rootgpad.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Gpad"/>
   <lib name="Graf"/>

--- a/scram-tools.file/tools/root/rootgraphics.xml
+++ b/scram-tools.file/tools/root/rootgraphics.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="TreePlayer"/>
   <lib name="Graf3d"/>

--- a/scram-tools.file/tools/root/rootgui.xml
+++ b/scram-tools.file/tools/root/rootgui.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Gui"/>
   <use name="rootgpad"/>

--- a/scram-tools.file/tools/root/rootguihtml.xml
+++ b/scram-tools.file/tools/root/rootguihtml.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="GuiHtml"/>
   <use name="rootgui"/>

--- a/scram-tools.file/tools/root/roothistmatrix.xml
+++ b/scram-tools.file/tools/root/roothistmatrix.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1"> 
+<tool revision="2"> 
   <info url="http://root.cern.ch/root/"/>
   <lib name="Hist"/>
   <lib name="Matrix"/>

--- a/scram-tools.file/tools/root/roothistpainter.xml
+++ b/scram-tools.file/tools/root/roothistpainter.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="HistPainter"/>
   <use name="roothistmatrix"/>

--- a/scram-tools.file/tools/root/roothtml.xml
+++ b/scram-tools.file/tools/root/roothtml.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Html"/>
   <use name="rootgpad"/>

--- a/scram-tools.file/tools/root/rootimt.xml
+++ b/scram-tools.file/tools/root/rootimt.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Imt"/>
   <use name="rootthread"/>

--- a/scram-tools.file/tools/root/rootinteractive.xml
+++ b/scram-tools.file/tools/root/rootinteractive.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Gui"/>
   <use name="libjpeg-turbo"/>

--- a/scram-tools.file/tools/root/rootmath.xml
+++ b/scram-tools.file/tools/root/rootmath.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="GenVector"/>
   <lib name="MathMore"/>

--- a/scram-tools.file/tools/root/rootmathcore.xml
+++ b/scram-tools.file/tools/root/rootmathcore.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="MathCore"/>
   <use name="rootcling"/>

--- a/scram-tools.file/tools/root/rootminuit.xml
+++ b/scram-tools.file/tools/root/rootminuit.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Minuit"/>
   <use name="rootgpad"/>

--- a/scram-tools.file/tools/root/rootminuit2.xml
+++ b/scram-tools.file/tools/root/rootminuit2.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Minuit2"/>
   <use name="rootgpad"/>

--- a/scram-tools.file/tools/root/rootmlp.xml
+++ b/scram-tools.file/tools/root/rootmlp.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="MLP"/>
   <use name="rootgraphics"/>

--- a/scram-tools.file/tools/root/rootntuple.xml
+++ b/scram-tools.file/tools/root/rootntuple.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="ROOTNTuple"/>
   <use name="rootvecops"/>

--- a/scram-tools.file/tools/root/rootphysics.xml
+++ b/scram-tools.file/tools/root/rootphysics.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Physics"/>
   <use name="roothistmatrix"/>

--- a/scram-tools.file/tools/root/rootpy.xml
+++ b/scram-tools.file/tools/root/rootpy.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <use name="rootgraphics"/>
 </tool>

--- a/scram-tools.file/tools/root/rootpymva.xml
+++ b/scram-tools.file/tools/root/rootpymva.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="PyMVA"/>
   <use name="roottmva"/>

--- a/scram-tools.file/tools/root/rootrflx.xml
+++ b/scram-tools.file/tools/root/rootrflx.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
   <ifarchitecture name="_amd64_">
     <flags GENREFLEX_GCCXMLOPT="-m64"/>
   </ifarchitecture>
   <flags GENREFLEX_CPPFLAGS="-DCMS_DICT_IMPL -D_REENTRANT -DGNUSOURCE -D__STRICT_ANSI__"/>
-  <runtime name="GENREFLEX" value="$@TOOL_BASE@/bin/rootcling"/>
+  <runtime name="GENREFLEX" value="$TOOL_BASE/bin/rootcling"/>
   <flags OVERRIDABLE_FLAGS="GENREFLEX_CPPFLAGS"/>
   <use name="root_interface"/>
   <use name="rootcling"/>

--- a/scram-tools.file/tools/root/rootrgl.xml
+++ b/scram-tools.file/tools/root/rootrgl.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="RGL"/>
   <use name="rootglew"/>

--- a/scram-tools.file/tools/root/rootrint.xml
+++ b/scram-tools.file/tools/root/rootrint.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Rint"/>
   <use name="rootcling"/>

--- a/scram-tools.file/tools/root/rootrio.xml
+++ b/scram-tools.file/tools/root/rootrio.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="RIO"/>
   <use name="rootcling"/>

--- a/scram-tools.file/tools/root/rootsmatrix.xml
+++ b/scram-tools.file/tools/root/rootsmatrix.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Smatrix"/>
   <use name="rootcling"/>

--- a/scram-tools.file/tools/root/rootspectrum.xml
+++ b/scram-tools.file/tools/root/rootspectrum.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Spectrum"/>
   <use name="roothistmatrix"/>

--- a/scram-tools.file/tools/root/rootthread.xml
+++ b/scram-tools.file/tools/root/rootthread.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="Thread"/>
   <use name="rootrio"/>

--- a/scram-tools.file/tools/root/roottmva.xml
+++ b/scram-tools.file/tools/root/roottmva.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="TMVA"/>
   <use name="rootmlp"/>

--- a/scram-tools.file/tools/root/rootvecops.xml
+++ b/scram-tools.file/tools/root/rootvecops.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="ROOTVecOps"/>
   <use name="rootcore"/>

--- a/scram-tools.file/tools/root/rootx11.xml
+++ b/scram-tools.file/tools/root/rootx11.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="@ROOT_GX11_LIB@"/>
   <use name="rootcling"/>

--- a/scram-tools.file/tools/root/rootxml.xml
+++ b/scram-tools.file/tools/root/rootxml.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="XMLParser"/>
   <use name="rootcore"/>

--- a/scram-tools.file/tools/root/rootxmlio.xml
+++ b/scram-tools.file/tools/root/rootxmlio.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://root.cern.ch/root/"/>
   <lib name="XMLIO"/>
   <use name="rootrio"/>

--- a/scram-tools.file/tools/ruff/ruff.xml
+++ b/scram-tools.file/tools/ruff/ruff.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://docs.astral.sh/ruff/"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
 </tool>
 

--- a/scram-tools.file/tools/scitokens-cpp/scitokens-cpp.xml
+++ b/scram-tools.file/tools/scitokens-cpp/scitokens-cpp.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="SciTokens"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="sqlite"/>
   <use name="libuuid"/>

--- a/scram-tools.file/tools/sherpa/sherpa.xml
+++ b/scram-tools.file/tools/sherpa/sherpa.xml
@@ -1,18 +1,17 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="SherpaMain"/>
   <lib name="ToolsMath"/>
   <lib name="ToolsOrg"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/SHERPA-MC"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/SHERPA-MC"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib/SHERPA-MC"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/SHERPA-MC"/>
   </client>
-  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$@TOOL_BASE@/include" type="path"/>
-  <runtime name="SHERPA_SHARE_PATH" value="$@TOOL_BASE@/share/SHERPA-MC" type="path"/>
-  <runtime name="SHERPA_INCLUDE_PATH" value="$@TOOL_BASE@/include/SHERPA-MC" type="path"/>
+  <runtime name="CMSSW_FWLITE_INCLUDE_PATH" value="$TOOL_BASE/include" type="path"/>
+  <runtime name="SHERPA_SHARE_PATH" value="$TOOL_BASE/share/SHERPA-MC" type="path"/>
+  <runtime name="SHERPA_INCLUDE_PATH" value="$TOOL_BASE/include/SHERPA-MC" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="SHERPA_LIBRARY_PATH" value="$@TOOL_BASE@/lib/SHERPA-MC" type="path"/>
+  <runtime name="SHERPA_LIBRARY_PATH" value="$TOOL_BASE/lib/SHERPA-MC" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="HepMC"/>
   <use name="HepMC3"/>

--- a/scram-tools.file/tools/sigcpp/sigcpp.xml
+++ b/scram-tools.file/tools/sigcpp/sigcpp.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="sigc-3.0"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/sigc++-3.0"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/sigc++-3.0"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/sloccount/sloccount.xml
+++ b/scram-tools.file/tools/sloccount/sloccount.xml
@@ -1,7 +1,6 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://www.dwheeler.com/sloccount/"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   </tool>

--- a/scram-tools.file/tools/sqlite/sqlite.xml
+++ b/scram-tools.file/tools/sqlite/sqlite.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="sqlite3"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/starlight/starlight.xml
+++ b/scram-tools.file/tools/starlight/starlight.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="Starlib"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="clhep"/>

--- a/scram-tools.file/tools/systemtools/opengl.xml
+++ b/scram-tools.file/tools/systemtools/opengl.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="system" revision="1">
+  <tool version="system" revision="2">
     <lib name="GL"/>
     <lib name="GLU"/>
     <use name="x11"/>

--- a/scram-tools.file/tools/systemtools/openssl.xml
+++ b/scram-tools.file/tools/systemtools/openssl.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="system" revision="1">
+  <tool version="system" revision="2">
     <lib name="ssl"/>
     <lib name="crypto"/>
   </tool>

--- a/scram-tools.file/tools/systemtools/resolv.xml
+++ b/scram-tools.file/tools/systemtools/resolv.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="system" revision="1">
+  <tool version="system" revision="2">
     <lib name="resolv"/>
     <flags FORCE_LINK="1"/>
   </tool>

--- a/scram-tools.file/tools/systemtools/root_cxxdefaults.xml
+++ b/scram-tools.file/tools/systemtools/root_cxxdefaults.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
 %if 0%{!?use_system_gcc:1}
   <runtime name="ROOT_GCC_TOOLCHAIN" value="@GCC_ROOT@" type="path"/>
 %endif

--- a/scram-tools.file/tools/systemtools/sockets.xml
+++ b/scram-tools.file/tools/systemtools/sockets.xml
@@ -1,4 +1,4 @@
-  <tool name="@TOOL_FILENAME@" version="system" revision="1">
+  <tool version="system" revision="2">
     <lib name="crypt"/>
     <lib name="dl"/>
     <lib name="rt"/>

--- a/scram-tools.file/tools/systemtools/x11.xml
+++ b/scram-tools.file/tools/systemtools/x11.xml
@@ -1,3 +1,3 @@
-  <tool name="@TOOL_FILENAME@" version="system" revision="1">
+  <tool version="system" revision="2">
     <use name="sockets"/>
   </tool>

--- a/scram-tools.file/tools/tauolapp/tauolapp.xml
+++ b/scram-tools.file/tools/tauolapp/tauolapp.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="TauolaCxxInterface"/>
   <lib name="TauolaFortran"/>
   <lib name="TauolaTauSpinner"/>
   <lib name="TauolaHepMC"/>
   <lib name="TauolaHEPEVT"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/tbb/tbb.xml
+++ b/scram-tools.file/tools/tbb/tbb.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://threadingbuildingblocks.org"/>
   <lib name="tbb"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"   default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"  default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"   default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"  default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/tbb/tbbbind.xml
+++ b/scram-tools.file/tools/tbb/tbbbind.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://threadingbuildingblocks.org"/>
   <use name="tbb"/>
   <lib name="tbbbind_2_0"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE"      default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR"       default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"      default="$TOOL_BASE/include"/>
   </client>
   <flags SYSTEM_INCLUDE="1"/>
 </tool>

--- a/scram-tools.file/tools/tensorflow-xla-runtime/tensorflow-xla-runtime.xml
+++ b/scram-tools.file/tools/tensorflow-xla-runtime/tensorflow-xla-runtime.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <lib name="tf_xla_runtime"/>
 

--- a/scram-tools.file/tools/tensorflow-xla-runtime/vectorized.tmpl
+++ b/scram-tools.file/tools/tensorflow-xla-runtime/vectorized.tmpl
@@ -1,5 +1,5 @@
-<tool name="tensorflow-xla-runtime_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="tensorflow-xla-runtime_@TOOL_VECTORIZATION@" revision="2">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/tensorflow/tensorflow-cc.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow-cc.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="tensorflow_cc"/>
   <use name="tensorflow-framework"/>
   <use name="eigen"/>

--- a/scram-tools.file/tools/tensorflow/tensorflow-framework.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow-framework.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <lib name="tensorflow_framework"/>
   <use name="tensorflow"/>
   <use name="giflib"/>

--- a/scram-tools.file/tools/tensorflow/tensorflow.xml
+++ b/scram-tools.file/tools/tensorflow/tensorflow.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="KERAS_BACKEND" value="tensorflow"/>
   <runtime name="TF_CPP_MIN_LOG_LEVEL" value="3"/>

--- a/scram-tools.file/tools/tensorflow/vectorized.tmpl
+++ b/scram-tools.file/tools/tensorflow/vectorized.tmpl
@@ -1,5 +1,5 @@
-<tool name="tensorflow_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="tensorflow_@TOOL_VECTORIZATION@"  revision="1">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/thepeg/thepeg.xml
+++ b/scram-tools.file/tools/thepeg/thepeg.xml
@@ -1,12 +1,11 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="ThePEG"/>
   <lib name="LesHouches"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib/ThePEG"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib/ThePEG"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="THEPEGPATH" value="$@TOOL_BASE@/share/ThePEG"/>
+  <runtime name="THEPEGPATH" value="$TOOL_BASE/share/ThePEG"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="lhapdf"/>

--- a/scram-tools.file/tools/tinyxml2/tinyxml2.xml
+++ b/scram-tools.file/tools/tinyxml2/tinyxml2.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/leethomason/tinyxml2"/>
   <lib name="tinyxml2"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/> 
 </tool>

--- a/scram-tools.file/tools/tkonlinesw-fake/tkonlinesw.xml
+++ b/scram-tools.file/tools/tkonlinesw-fake/tkonlinesw.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.cern.ch/"/>
   <lib name="ICUtils"/>
   <lib name="Fed9UUtils"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" value="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" value="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" value="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" value="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <flags CXXFLAGS="-DCMS_TK_64BITS"/>

--- a/scram-tools.file/tools/tkonlinesw-fake/tkonlineswdb.xml
+++ b/scram-tools.file/tools/tkonlinesw-fake/tkonlineswdb.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.cern.ch/"/>
   <lib name="DeviceDescriptions"/>
   <lib name="Fed9UDeviceFactory"/>

--- a/scram-tools.file/tools/tkonlinesw/tkonlinesw.xml
+++ b/scram-tools.file/tools/tkonlinesw/tkonlinesw.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://www.cern.ch/"/>
   <lib name="ICUtils"/>
   <lib name="Fed9UUtils"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" value="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" value="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" value="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" value="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <flags CXXFLAGS="-DCMS_TK_64BITS"/>

--- a/scram-tools.file/tools/tkonlinesw/tkonlineswdb.xml
+++ b/scram-tools.file/tools/tkonlinesw/tkonlineswdb.xml
@@ -1,4 +1,4 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="http://www.cern.ch/"/>
   <lib name="DeviceDescriptions"/>
   <lib name="Fed9UDeviceFactory"/>

--- a/scram-tools.file/tools/triton-inference-client/triton-inference-client.xml
+++ b/scram-tools.file/tools/triton-inference-client/triton-inference-client.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/triton-inference-server/client"/>
   <lib name="grpcclient"/> 
   <lib name="tritoncommonmodelconfig"/> 
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"  default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"  default="$TOOL_BASE/lib"/>
   </client>
   <use name="protobuf"/>
   <use name="grpc"/>

--- a/scram-tools.file/tools/ucx/ucx.xml
+++ b/scram-tools.file/tools/ucx/ucx.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <lib name="ucp"/>
   <lib name="uct"/>
   <lib name="ucs"/>
   <lib name="ucm"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"  default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"   default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"  default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"   default="$TOOL_BASE/lib"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="UCX_HANDLE_ERRORS" value="none"/>
 </tool>

--- a/scram-tools.file/tools/utm/utm.xml
+++ b/scram-tools.file/tools/utm/utm.xml
@@ -1,15 +1,14 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="tmeventsetup"/>
   <lib name="tmtable"/>
   <lib name="tmxsd"/>
   <lib name="tmgrammar"/>
   <lib name="tmutil"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
-  <runtime name="UTM_XSD_DIR" value="$@TOOL_BASE@"/>
+  <runtime name="UTM_XSD_DIR" value="$TOOL_BASE"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/valgrind/valgrind.xml
+++ b/scram-tools.file/tools/valgrind/valgrind.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
-  <runtime name="VALGRIND_LIB" value="$@TOOL_BASE@/libexec/valgrind"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
+  <runtime name="VALGRIND_LIB" value="$TOOL_BASE/libexec/valgrind"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/vdt/vdt.xml
+++ b/scram-tools.file/tools/vdt/vdt.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="vdt"/>
   <use name="vdt_headers"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/vdt/vdt_headers.xml
+++ b/scram-tools.file/tools/vdt/vdt_headers.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/vecgeom/vecgeom.xml
+++ b/scram-tools.file/tools/vecgeom/vecgeom.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://gitlab.cern.ch/VecGeom/VecGeom"/>
   <lib name="vecgeom"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
   <use name="vecgeom_interface"/>
 </tool>

--- a/scram-tools.file/tools/vecgeom/vecgeom_interface.xml
+++ b/scram-tools.file/tools/vecgeom/vecgeom_interface.xml
@@ -1,11 +1,10 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <info url="https://gitlab.cern.ch/VecGeom/VecGeom"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/VecGeom"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/VecGeom"/>
   </client>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@/include" type="path"/>
-  <runtime name="ROOT_INCLUDE_PATH" value="$@TOOL_BASE@/include/VecGeom" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$TOOL_BASE/include" type="path"/>
+  <runtime name="ROOT_INCLUDE_PATH" value="$TOOL_BASE/include/VecGeom" type="path"/>
   <use name="root_cxxdefaults"/>
 </tool>

--- a/scram-tools.file/tools/vecgeom/vectorized.tmpl
+++ b/scram-tools.file/tools/vecgeom/vectorized.tmpl
@@ -1,5 +1,5 @@
-<tool name="vecgeom_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="vecgeom_@TOOL_VECTORIZATION@"  revision="1">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib64"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/xerces-c/xerces-c.xml
+++ b/scram-tools.file/tools/xerces-c/xerces-c.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://xml.apache.org/xerces-c/"/>
   <lib name="xerces-c"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/xgboost/xgboost.xml
+++ b/scram-tools.file/tools/xgboost/xgboost.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="xgboost"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="BINDIR" default="$@TOOL_BASE@/bin"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="BINDIR" default="$TOOL_BASE/bin"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="PATH" value="$BINDIR" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>

--- a/scram-tools.file/tools/xpmem/xpmem.xml
+++ b/scram-tools.file/tools/xpmem/xpmem.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="xpmem"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"    default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR"     default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE"    default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"     default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/xrdcl-record/xrdcl-record.xml
+++ b/scram-tools.file/tools/xrdcl-record/xrdcl-record.xml
@@ -1,6 +1,5 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
   </client>
-  <runtime name="XRDCL_RECORDER_PLUGIN" value="$@TOOL_BASE@/lib64/libXrdClRecorder-5.so"/>
+  <runtime name="XRDCL_RECORDER_PLUGIN" value="$TOOL_BASE/lib64/libXrdClRecorder-5.so"/>
 </tool>

--- a/scram-tools.file/tools/xrootd/xrootd.xml
+++ b/scram-tools.file/tools/xrootd/xrootd.xml
@@ -1,13 +1,12 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="3">
+<tool revision="4">
   <lib name="XrdUtils"/>
   <lib name="XrdCl"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/xrootd"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include/xrootd/private"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/xrootd"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include/xrootd/private"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
-  <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>
   <use name="isal"/>

--- a/scram-tools.file/tools/xtd/xtd.xml
+++ b/scram-tools.file/tools/xtd/xtd.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="1">
+<tool revision="2">
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE"        default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE"        default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
 </tool>

--- a/scram-tools.file/tools/xtensor/xtensor.xml
+++ b/scram-tools.file/tools/xtensor/xtensor.xml
@@ -1,8 +1,7 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/QuantStack/xtensor"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="xtl"/>
 </tool>

--- a/scram-tools.file/tools/xtl/xtl.xml
+++ b/scram-tools.file/tools/xtl/xtl.xml
@@ -1,7 +1,6 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/QuantStack/xtl"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/xz/xz.xml
+++ b/scram-tools.file/tools/xz/xz.xml
@@ -1,12 +1,11 @@
-  <tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+  <tool revision="3">
     <info url="http://tukaani.org/xz/"/>
     <lib name="lzma"/>
     <client>
-      <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-      <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-      <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+      <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+      <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     </client>
-    <runtime name="PATH" value="$@TOOL_BASE@/bin" type="path"/>
+    <runtime name="PATH" value="$TOOL_BASE/bin" type="path"/>
     <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
     <use name="root_cxxdefaults"/>
   </tool>

--- a/scram-tools.file/tools/yaml-cpp/yaml-cpp.xml
+++ b/scram-tools.file/tools/yaml-cpp/yaml-cpp.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="https://github.com/jbeder/yaml-cpp/"/>
   <lib name="yaml-cpp"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib64"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/yoda/yoda.xml
+++ b/scram-tools.file/tools/yoda/yoda.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="YODA"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <use name="root_cxxdefaults"/>
-  <runtime name="PATH"       value="$@TOOL_BASE@/bin" type="path"/>
+  <runtime name="PATH"       value="$TOOL_BASE/bin" type="path"/>
 </tool>

--- a/scram-tools.file/tools/zlib/vectorized.tmpl
+++ b/scram-tools.file/tools/zlib/vectorized.tmpl
@@ -1,5 +1,5 @@
-<tool name="zlib_@TOOL_VECTORIZATION@" version="@TOOL_VERSION@" revision="1">
+<tool name="zlib_@TOOL_VECTORIZATION@" revision="2">
   <client>
-    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="@TOOL_ROOT@/lib"/>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
 </tool>

--- a/scram-tools.file/tools/zlib/zlib.xml
+++ b/scram-tools.file/tools/zlib/zlib.xml
@@ -1,9 +1,8 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <lib name="z"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram-tools.file/tools/zstd/zstd.xml
+++ b/scram-tools.file/tools/zstd/zstd.xml
@@ -1,10 +1,9 @@
-<tool name="@TOOL_FILENAME@" version="@TOOL_VERSION@" revision="2">
+<tool revision="3">
   <info url="http://https://facebook.github.io/zstd"/>
   <lib name="zstd"/>
   <client>
-    <environment name="@TOOL_BASE@" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR" default="$@TOOL_BASE@/lib"/>
-    <environment name="INCLUDE" default="$@TOOL_BASE@/include"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
   </client>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
   <use name="root_cxxdefaults"/>

--- a/scram/tool-conf-src.file
+++ b/scram/tool-conf-src.file
@@ -40,7 +40,7 @@ for tool in %requiredtools %{?use_system_gcc:gcc}; do
   uctool=`echo $tool | tr '[a-z-]' '[A-Z_]'`
   toolbase=`eval echo \\$${uctool}_ROOT`
   toolver=`eval echo \\$${uctool}_VERSION`
-  while [ $(jobs -r -p | wc -l) -gt %compiling_processes ] ; do sleep 0.05; done
+  while [ $(jobs -r -p | wc -l) -gt %compiling_processes ] ; do sleep 0.01; done
   %{_sourcedir}/scram-tools/bin/get_tools "$toolbase" "$toolver" %i "${tool}" &
 done
 %{_sourcedir}/scram-tools/bin/get_tools "" "system" %i "systemtools"
@@ -55,7 +55,7 @@ for vec in %{package_vectorization}; do \
     uctool=`echo $tool | tr '[a-z-]' '[A-Z_]'`
     toolbase=`eval echo \\$${uctool}_${ucvec}_ROOT`
     toolver=`eval echo \\$${uctool}_${ucvec}_VERSION`
-    while [ $(jobs -r -p | wc -l) -gt %compiling_processes ] ; do sleep 0.05; done
+    while [ $(jobs -r -p | wc -l) -gt %compiling_processes ] ; do sleep 0.01; done
     %{_sourcedir}/scram-tools/bin/get_vectorized_tools "$toolbase" "$toolver" %i "${tool}" "${vec}" &
   done
   wait
@@ -164,25 +164,40 @@ if [ -f ${pth} ] ; then
 fi
 %endif
 %endif
-
 echo '</tool>' >> %{i}/tools/selected/python-paths.xml
+
+function pytool_content() {
+  local pkg=$1
+  pk_name=$(echo $pkg | cut -d/ -f2 | tr '[A-Z]' '[a-z]')
+  if [ -f %{i}/tools/selected/${pk_name}.xml ] ; then return ; fi
+  pk_ver=$(echo $pkg | cut -d/ -f3 | sed -re 's|-[a-f0-9]{32}$||')
+  echo "<tool name=\"$pk_name\" version=\"$pk_ver\" path=\"%{cmsroot}/%{cmsplatf}/$pkg\" revision=\"1\">" > %{i}/tools/selected/${pk_name}.xml
+  if [ -e %{cmsroot}/%{cmsplatf}/$pkg/bin ] ; then
+    echo "  <runtime name=\"PATH\" value=\"\$TOOL_BASE/bin\" type=\"path\"/>" >> %{i}/tools/selected/${pk_name}.xml
+  fi
+  echo -e "</tool>" >> %{i}/tools/selected/${pk_name}.xml
+}
+
+function tool_content() {
+  tool=$(basename $xml)
+  echo "cat << \\EOF_TOOLFILE >> %%{i}/tools/${type}/${tool}" > ${xml}.tmp
+  cat $xml                     >> ${xml}.tmp
+  echo -e "\nEOF_TOOLFILE\n"   >> ${xml}.tmp
+  grep -v '^\s*$' ${xml}.tmp > $xml
+  rm -f ${xml}.tmp
+}
 
 ALL_PY_BIN=""
 ALL_PY_BIN_PKGS=""
 for pkg in  $(echo %{allpkgreqs} | tr ' ' '\n' | grep '/py[23]-') ; do
-  pk_name=$(echo $pkg | cut -d/ -f2 | tr '[A-Z]' '[a-z]')
-  if [ -f %{i}/tools/selected/${pk_name}.xml ] ; then continue ; fi
-  pk_ver=$(echo $pkg | cut -d/ -f3)
-  client_content=""
+  while [ $(jobs -r -p | wc -l) -gt %compiling_processes ] ; do sleep 0.01; done
+  pytool_content $pkg &
   if [ -e %{cmsroot}/%{cmsplatf}/$pkg/bin ] ; then
     for b in $(ls %{cmsroot}/%{cmsplatf}/$pkg/bin) ; do
       ALL_PY_BIN="${ALL_PY_BIN} ${b}"
       ALL_PY_BIN_PKGS="${ALL_PY_BIN_PKGS} ${b}:${pk_name}"
     done
-    uctool=`echo ${pk_name} | tr '[a-z-]' '[A-Z_]'`
-    client_content="  <client>\n    <environment name=\"${uctool}_BASE\" default=\"%{cmsroot}/%{cmsplatf}/$pkg\"/>\n  </client>\n  <runtime name=\"PATH\" value=\"\$${uctool}_BASE/bin\" type=\"path\"/>\n"
   fi
-  echo -e "<tool name=\"$pk_name\" version=\"$pk_ver\" revision=\"1\">\n${client_content}</tool>" > %{i}/tools/selected/${pk_name}.xml
 done
 DUP_BIN=$(echo "${ALL_PY_BIN}" | tr ' ' '\n' | grep -v '__pycache__' | sort | uniq -c | sed 's|^\s*||' | grep -v '^1 ' | sed 's|^.* ||')
 
@@ -195,21 +210,14 @@ if [ "${DUP_BIN}" != "" ] ; then
   exit 1
 fi
 set -x
+
 if [ -e %{i}/tools/selected/cuda-gcc-support.xml ] ; then
   if [ "%{cuda_gcc_support}" != "true" ] ; then
     rm -f %{i}/tools/selected/cuda-gcc-support.xml
     echo "WARNING: CUDA does not support this GCC version, removing cuda-gcc-support.xml tool file"
   fi
 fi
-
-function tool_content() {
-  tool=$(basename $xml)
-  echo "cat << \\EOF_TOOLFILE >> %%{i}/tools/${type}/${tool}" > ${xml}.tmp
-  cat $xml                     >> ${xml}.tmp
-  echo -e "\nEOF_TOOLFILE\n"   >> ${xml}.tmp
-  grep -v '^\s*$' ${xml}.tmp > $xml
-  rm -f ${xml}.tmp
-}
+wait
 
 mkdir -p %{i}/tools
 for type in selected available ; do
@@ -217,7 +225,7 @@ for type in selected available ; do
   touch %{i}/tools/${type}.tmpl
   [ -d %{i}/tools/${type} ] || continue
   for xml in $(ls %{i}/tools/${type}/*.xml) ; do
-    while [ $(jobs -r -p | wc -l) -gt %compiling_processes ] ; do sleep 0.05; done
+    while [ $(jobs -r -p | wc -l) -gt %compiling_processes ] ; do sleep 0.01; done
     tool_content $xml &
   done
   wait


### PR DESCRIPTION
This cleans up the scram toolfile definition. No more `@TOOL_BASE@` or `@TOOL_ROOT@` in tool files. when these toolfiles are generated then now we add `< tool path="%i"...>` which then `scram` can use to set the `UpperCaseTool_BASE` (mostly used by cmssw build rules) and `$TOOL_BASE`. We now can use `$TOOL_BASE`  within the toolfile to refer to the installation path of the tool