### PR TITLE
SCRAMV1: Fix for finding system python3

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_90
+### RPM lcg SCRAMV1 V3_00_91
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 269386003214abb8d2a6a0a8418bd338668c58c6
+%define tag 8eb7d95e0df3fb0c2c02bbd6776a5ef8815305a1
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_88
+### RPM lcg SCRAMV1 V3_00_89
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 0b8262ec55e7fba768764ee22f8bfcd470502403
+%define tag 439b15dd907cf2a03bf62268dba478baefd5b8ba
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz

--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_89
+### RPM lcg SCRAMV1 V3_00_90
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 439b15dd907cf2a03bf62268dba478baefd5b8ba
+%define tag 269386003214abb8d2a6a0a8418bd338668c58c6
 %define branch SCRAMV3
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/SCRAM.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
SCRAM change https://github.com/cms-sw/SCRAM/commit/8eb7d95e0df3fb0c2c02bbd6776a5ef8815305a1 should fix the system python3 search issue. It works now under both fedora and debian based os

[a] AlmaLinux8
```
> SCRAM_ARCH=el8_amd64_gcc13 bash -ex <dir>/SCRAM/cli/scram list ROCM
++ which python3
++ alias
++ eval declare -f
+++ declare -f
++ /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot python3
+ cmd_python3=/usr/bin/python3
+ '[' '' = '' ']'
+ export SCRAMV3_BACKUP_LD_LIBRARY_PATH=
+ SCRAMV3_BACKUP_LD_LIBRARY_PATH=
+ export LD_LIBRARY_PATH=
+ LD_LIBRARY_PATH=
++ env -i PATH=/usr/bin:/bin bash -c 'command -v python3'
+ cmd_python3=/usr/bin/python3
+ unset SCRAM_RUNTIME_TYPE
+ unset SCRAM_RTBOURNE_SET
++ dirname <dir>/SCRAM/cli/scram
+ PYTHONPATH=
+ /usr/bin/python3 <dir>/SCRAM/cli/scram.py list ROCM
```

[b] Ubuntu
```
> docker run  --rm -v /cvmfs:/cvmfs -v /tmp:/tmp -v /home:/home -v /build:/build -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group -v /afs:/afs --net=host -it ubuntu:latest bash
> apt update; apt install -y python3
> SCRAM_ARCH=el8_amd64_gcc13 bash -ex <dir>/SCRAM/cli/scram list ROCM
++ which python3
+ cmd_python3=/usr/bin/python3
+ '[' '' = '' ']'
+ export SCRAMV3_BACKUP_LD_LIBRARY_PATH=
+ SCRAMV3_BACKUP_LD_LIBRARY_PATH=
+ export LD_LIBRARY_PATH=
+ LD_LIBRARY_PATH=
++ env -i PATH=/usr/bin:/bin bash -c 'command -v python3'
+ cmd_python3=/usr/bin/python3
+ unset SCRAM_RUNTIME_TYPE
+ unset SCRAM_RTBOURNE_SET
++ dirname <dir>/SCRAM/cli/scram
+ PYTHONPATH=
+ /usr/bin/python3 <dir>/SCRAM/cli/scram.py list ROCM
```