### PR TITLE
cleanup rocm-rocprofiler-systems to avoid linking against system bz2lib

### DIFF
--- a/dyninst/DyninstConfig-DyninstTarget.cmake.file
+++ b/dyninst/DyninstConfig-DyninstTarget.cmake.file
@@ -1,0 +1,10 @@
+if(NOT TARGET Dyninst::Dyninst)
+    add_library(Dyninst::Dyninst INTERFACE IMPORTED)
+    message(STATUS "Adding additional target Dyninst::Dyninst")
+    target_link_libraries(Dyninst::Dyninst
+        INTERFACE
+            Dyninst::dyninstAPI
+            Dyninst::parseAPI
+            Dyninst::instructionAPI
+            Dyninst::symtabAPI)
+endif()

--- a/dyninst/spec
+++ b/dyninst/spec
@@ -1,0 +1,25 @@
+### RPM external dyninst 13.0.0
+%define keep_archives true
+Source0: https://github.com/dyninst/dyninst/archive/refs/tags/v%{realversion}.tar.gz
+Source1: dyninst/DyninstConfig-DyninstTarget.cmake
+BuildRequires: gmake cmake libiberty
+Requires: boost tbb
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+rm -rf ../build; mkdir ../build ; cd ../build
+
+cmake ../%{n}-%{realversion} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="%{i}" \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path};${LIBIBERTY_ROOT}"
+
+make %{makeprocesses} VERBOSE=1
+
+%install
+cd ../build
+make install
+test %{i}/lib/cmake/Dyninst/DyninstConfig.cmake
+cat %{_sourcedir}/DyninstConfig-DyninstTarget.cmake >> %{i}/lib/cmake/Dyninst/DyninstConfig.cmake

--- a/libiberty/spec
+++ b/libiberty/spec
@@ -1,0 +1,18 @@
+### RPM external libiberty 2.43.1
+Source: https://sourceware.org/pub/binutils/releases/binutils-%{realversion}.tar.bz2
+%define keep_archives true
+
+%prep
+%setup -n binutils-%{realversion}
+
+%build
+cd libiberty
+./configure   --prefix=%{pkginstroot} CC="gcc -fPIC" CXX="c++ -fPIC"
+make %{makeprocesses}
+
+%install
+mkdir %{pkginstroot}/lib %{pkginstroot}/include
+mv libiberty/libiberty.a %{pkginstroot}/lib/
+for h in libiberty.h demangle.h ; do
+  mv include/$h %{pkginstroot}/include/$h
+done

--- a/patches/rocprofiler-systems-elfutils.patch
+++ b/patches/rocprofiler-systems-elfutils.patch
@@ -1,0 +1,13 @@
+diff --git a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+index 1aedf49..fc10cc8 100644
+--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
++++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+@@ -186,7 +186,7 @@ else()
+         CONFIGURE_COMMAND
+             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3
+             CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3
+-            [=[LDFLAGS=-Wl,-rpath='$$ORIGIN']=] <SOURCE_DIR>/configure
++            <SOURCE_DIR>/configure
+             --enable-install-elfh --prefix=${_eu_root} --disable-libdebuginfod
+             --disable-debuginfod --enable-thread-safety ${ElfUtils_CONFIG_OPTIONS}
+             --libdir=${_eu_root}/lib

--- a/pip/plotille.file
+++ b/pip/plotille.file
@@ -1,1 +1,1 @@
-Requires: py3-uv-build
+BuildRequires: py3-uv-build

--- a/pip/textual-fspicker.file
+++ b/pip/textual-fspicker.file
@@ -1,1 +1,2 @@
-Requires: py3-uv-build py3-textual
+Requires: py3-textual
+BuildRequires: py3-uv-build

--- a/rocm-rocprofiler-sdk.spec
+++ b/rocm-rocprofiler-sdk.spec
@@ -6,6 +6,7 @@ Requires: rocm-core rocm-llvm rocr-runtime rocm-cmake rocprofiler comgr
 Requires: fmt glog sqlite py3-pybind11 aqlprofile rocprofiler-register
 Patch0: rocm-rocprofiler-sdk
 Patch1: rocm-rocprofiler-sdk-externals
+BuildRequires: cmake gmake
 
 %prep
 %setup -q -n rocprofiler-sdk-rocm-%{realversion}

--- a/rocm-rocprofiler-systems.spec
+++ b/rocm-rocprofiler-systems.spec
@@ -1,34 +1,46 @@
 ## INCLUDE rocm-config
 ### RPM external rocm-rocprofiler-systems %{rocm_version_num}
-
-Source0: git+https://github.com/akritkbehera/rocprofiler-systems.git?obj=release/rocm-rel-7.2/%{rocm_version}&export=%{n}&submodules=1&output=/%{n}.tar.gz
-Requires: rocm-core rocr-runtime cmake rocm-cmake rocprofiler roctracer hip libxml2
-Requires: libunwind sqlite rocm-rocprofiler-sdk amdsmi flex bison bz2lib comgr
-Provides: libbz2.so.1()(64bit)
+Source0: git+https://github.com/ROCm/rocm-systems.git?obj=release/rocm-rel-7.2/%{rocm_version}&export=rocm-systems&submodules=1&output=/rocm-systems.tar.gz
+Source1: https://github.com/ROCm/rocm-systems/commit/6276d4d7ab8350531e84a24d3db65b9f98d85eb6.patch
+Patch0: patches/rocprofiler-systems-elfutils
+Requires: rocm-core rocr-runtime rocm-cmake rocprofiler roctracer hip libxml2
+Requires: libunwind dyninst bz2lib
+Requires: sqlite rocm-rocprofiler-sdk amdsmi zlib comgr boost tbb json py3-pybind11
+BuildRequires: flex bison cmake libiberty
 
 %prep
-%setup -q -n %{n}
+%setup -q -n rocm-systems
+patch -p1 <%{_sourcedir}/6276d4d7ab8350531e84a24d3db65b9f98d85eb6.patch
+%patch0 -p1
 
 %build
 
+CPPFLAGS=-I${BZ2LIB_ROOT}/include \
+LDFLAGS=-L${BZ2LIB_ROOT}/lib \
 cmake \
   -B %{_builddir}/build \
-  -S %{_builddir}/%{n} \
+  -S %{_builddir}/rocm-systems/projects/rocprofiler-systems \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path};${LIBIBERTY_ROOT};${FLEX_ROOT};${BISON_ROOT}" \
+  -DTBB_ROOT_DIR=${TBB_ROOT} \
+  -DROCPROFSYS_USE_BFD=ON \
   -DROCPROFSYS_USE_PYTHON=ON \
-  -DROCPROFSYS_BUILD_DYNINST=ON \
-  -DROCPROFSYS_BUILD_TBB=ON \
-  -DROCPROFSYS_BUILD_BOOST=ON \
-  -DROCPROFSYS_BUILD_LIBIBERTY=ON \
+  -DROCPROFSYS_BUILD_PYTHON=OFF \
+  -DROCPROFSYS_BUILD_DYNINST=OFF \
+  -DROCPROFSYS_BUILD_TBB=OFF \
+  -DROCPROFSYS_BUILD_LIBUNWIND=OFF \
+  -DROCPROFSYS_BUILD_BOOST=OFF \
+  -DROCPROFSYS_BUILD_LIBIBERTY=OFF \
   -DROCPROFSYS_BUILD_ELFUTILS=ON \
+  -DROCPROFILER_BUILD_SQLITE3=OFF \
+  -DROCPROFSYS_BUILD_NLOHMANN_JSON=OFF \
   -DROCPROFSYS_BUILD_EXAMPLES=OFF \
   -DROCPROFSYS_BUILD_TESTING=OFF \
+  -DCMAKE_FIND_DEBUG_MODE=OFF \
   -DROCPROFSYS_USE_PAPI=OFF
 
-
-cmake --build %{_builddir}/build --parallel %{makeprocesses}
+cmake --build %{_builddir}/build --parallel %{makeprocesses} --verbose
 
 %install
 cmake --build %{_builddir}/build --target install

--- a/rocm-rocprofiler-systems.spec
+++ b/rocm-rocprofiler-systems.spec
@@ -15,8 +15,8 @@ patch -p1 <%{_sourcedir}/6276d4d7ab8350531e84a24d3db65b9f98d85eb6.patch
 
 %build
 
-CPPFLAGS=-I${BZ2LIB_ROOT}/include \
-LDFLAGS=-L${BZ2LIB_ROOT}/lib \
+export CPPFLAGS=-I${BZ2LIB_ROOT}/include
+export LDFLAGS=-L${BZ2LIB_ROOT}/lib
 cmake \
   -B %{_builddir}/build \
   -S %{_builddir}/rocm-systems/projects/rocprofiler-systems \


### PR DESCRIPTION
This PR fixes
- Avoid deploying extra python packages which are only needed at build time
- Fix rocprofiler-system to avoid linking against system bz2lib
- Make sure to use our cmake and gmake

FYI @akritkbehera 