### PR TITLE
BuildRules: Make sure to build local rocm/cuda dlink archives

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-09-03
+%define configtag       V09-09-04
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
New build rules makes sure that device link static libs (e.g. `lib*_rocm.a` and `lib*_nv.a`) of dependencies are build first before linking it to dependent package's `*_nv.o`