### PR TITLE
ThePEG: Removed inlined Particle::parents()

### DIFF
--- a/thepeg-Particle-parents.patch
+++ b/thepeg-Particle-parents.patch
@@ -1,0 +1,32 @@
+diff --git a/EventRecord/Particle.cc b/EventRecord/Particle.cc
+index 9d72c8a..dee05fb 100644
+--- a/EventRecord/Particle.cc
++++ b/EventRecord/Particle.cc
+@@ -64,6 +64,11 @@ Particle::~Particle() {
+   theData = cEventPDPtr();
+ }
+ 
++const tParticleVector & Particle::parents() const {
++  static const tParticleVector null;
++  return hasRep() ? rep().theParents : null;
++}
++
+ void Particle::initFull() {
+   if ( theRep ) return;
+   theRep = new ParticleRep;
+diff --git a/EventRecord/Particle.h b/EventRecord/Particle.h
+index 80505c8..f26118c 100644
+--- a/EventRecord/Particle.h
++++ b/EventRecord/Particle.h
+@@ -155,10 +155,7 @@ public:
+   /**
+    * The list of parent particles.
+    */
+-  const tParticleVector & parents() const {
+-    static const tParticleVector null;
+-    return hasRep() ? rep().theParents : null;
+-  }
++  const tParticleVector & parents() const;
+ 
+   /**
+    * Return a set of neighboring particles coming from the same decay

--- a/thepeg.spec
+++ b/thepeg.spec
@@ -6,6 +6,7 @@
 Source: http://www.hepforge.org/archive/thepeg/ThePEG-%{realversion}.tar.bz2
 Patch0: LHEEventNum
 Patch1: thepeg-deprecated-warn
+Patch2: thepeg-Particle-parents
 
 Requires: lhapdf
 Requires: gsl OpenBLAS
@@ -26,6 +27,7 @@ BuildRequires: lhapdf
 %setup -q -n ThePEG-%{realversion}
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 
 # Regenerate build scripts
 autoreconf -fiv


### PR DESCRIPTION
Following suggestion at https://github.com/cms-sw/cmssw/issues/45872 , this PR proposes to patch thepeg and move inlined `Particle::parent()` in to the source file.

Fixes https://github.com/cms-sw/cmssw/issues/45872