### PR TITLE
GCC 16: disable array-bound check

### DIFF
--- a/scram-tools.file/tools/gcc/env.sh
+++ b/scram-tools.file/tools/gcc/env.sh
@@ -43,7 +43,7 @@ GCC_CXXFLAGS="$GCC_CXXFLAGS -Xassembler --compress-debug-sections"
 #FIXME: GCC 12/13/14 workaround
 if [[ "$GCC_VERSION" =~ ^12\.[23]\. ]] ; then
   GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"
-elif [[ "$GCC_VERSION" =~ ^1[345]\. ]] ; then
+elif [[ "$GCC_VERSION" =~ ^1[3456]\. ]] ; then
   GCC_CXXFLAGS="$GCC_CXXFLAGS -Wno-error=array-bounds -Warray-bounds"  
 fi
 


### PR DESCRIPTION
In GCC 16 we also see false-positive
```
 array subscript 'struct LoadableDummyProvider[0]' is partly outside array bounds of 'unsigned char[104]' [-Werror=array-bounds=]
 array subscript 'struct ModuleHolderT[0]' is partly outside array bounds of 'unsigned char[24]' [-Werror=array-bounds=]
 array subscript 'struct ModuleHolderT[0]' is partly outside array bounds of 'unsigned char[32]' [-Werror=array-bounds=]
 array subscript 'struct _Sp_counted_ptr_inplace[0]' is partly outside array bounds of 'unsigned char[104]' [-Werror=array-bounds=]
 array subscript 'struct _Sp_counted_ptr_inplace[0]' is partly outside array bounds of 'unsigned char[24]' [-Werror=array-bounds=]
 array subscript 'struct _Sp_counted_ptr_inplace[0]' is partly outside array bounds of 'unsigned char[32]' [-Werror=array-bounds=]
 array subscript 'struct _Sp_counted_ptr_inplace[0]' is partly outside array bounds of 'unsigned char[56]' [-Werror=array-bounds=]
```

This PR proposes that just like GCC 13-15, we use `-Wno-error=array-bound`