### PR TITLE
bump adept to v0.3.5

### DIFF
--- a/adept.spec
+++ b/adept.spec
@@ -1,4 +1,4 @@
-### RPM external adept v0.3.4
+### RPM external adept v0.3.5
 %define tag %{realversion}
 %define branch master
 %define github_user apt-sim


### PR DESCRIPTION
The version bump includes an important fix for CMSSW, so it would be good to get it in right away.