### PR TITLE
Update configtag version to V09-09-05

### DIFF
--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-09-04
+%define configtag       V09-09-05
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
This fixes the cyclic dependency for cuda/rocm dlink generation rule. By default gmake drops such a dependency [a] but this update makes sure that our build rules do not add such dependency

[a]
```
gmake: Circular tmp/el8_amd64_gcc13/cache/cuda_dlink/RecoTrackerLSTCoreCudaAsync <- tmp/el8_amd64_gcc13/cache/cuda_dlink/RecoTrackerLSTCoreCudaAsync dependency dropped.
gmake: Circular tmp/el8_amd64_gcc13/cache/rocm_dlink/RecoTrackerLSTCoreROCmAsync <- tmp/el8_amd64_gcc13/cache/rocm_dlink/RecoTrackerLSTCoreROCmAsync dependency dropped.
```