### PR TITLE
Update jemalloc version 5.3.1

### DIFF
--- a/jemalloc-common.file
+++ b/jemalloc-common.file
@@ -1,6 +1,6 @@
-%define jemalloc_version 5.3.0
-%define tag 54eaed1d8b56b1aa528be3bdd1877e59c56fa90c
-%define branch cms/%{realversion}
+%define jemalloc_version 5.3.1
+%define tag fc5eb3f3a066cf57492e316f2d6e1ab4824ba72b
+%define branch cms/%{jemalloc_version}
 %define github_user cms-externals
 Source: git+https://github.com/%{github_user}/jemalloc.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 BuildRequires: autotools gmake


### PR DESCRIPTION
backport of #10567 

Already tested in DEVEL IBs

Update `jemalloc` release https://github.com/jemalloc/jemalloc/releases/tag/5.3.1

also include fixes for GCC 16 https://github.com/cms-externals/jemalloc/commit/fc5eb3f3a066cf57492e316f2d6e1ab4824ba72b