### PR TITLE
Upgrade EvtGen to v03.00.00

### DIFF
--- a/evtgen-3.0.0.patch
+++ b/evtgen-3.0.0.patch
@@ -1,0 +1,20 @@
++++ a/R03-00-00/src/EvtGenExternal/EvtSherpaPhotons.cpp.orig	2026-05-22 11:42:50.932434652 -0500 
++++ b/R03-00-00/src/EvtGenExternal/EvtSherpaPhotons.cpp	2026-05-22 11:42:23.583029106 -0500
+@@ -40,6 +40,7 @@
+ #include <cstring>
+ #include <iostream>
+ #include <vector>
++#include <mutex>
+ 
+ using std::endl;
+
++++ a/R03-00-00/EvtGenExternal/EvtSherpaPhotons.hh.orig	2026-05-22 11:42:50.932434652 -0500 
++++ b/R03-00-00/EvtGenExternal/EvtSherpaPhotons.hh	2026-05-22 11:42:23.583029106 -0500
+@@ -32,6 +32,7 @@
+ #include "SHERPA/Main/Sherpa.H"
+ 
+ #include <string>
++#include <mutex>
+ 
+ class EvtParticle;
+ class EvtAbsExternalGen;

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -21,7 +21,7 @@ Patch0: evtgen-3.0.0
 
 %prep
 %setup -q -n %{n}-%{realversion}
-%patch0 -p1
+%patch0 -p2
 
 %build
 rm -rf ../build

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -1,10 +1,5 @@
-### RPM external evtgen 2.0.0
-
-%define tag bcb7af4d35bf66a01c08fa4f8fffb623b7e24c59
-%define branch cms/%realversion
-%define github_user cms-externals
-
-Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+### RPM external evtgen 03.00.00-beta1
+Source: http://www.hepforge.org/archive/evtgen/EvtGen-%{realversion}.tar.gz
 
 BuildRequires: cmake
 
@@ -14,23 +9,17 @@ Requires: pythia8
 Requires: tauolapp
 Requires: photospp
 
-# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=40267
-# libgfortranbegin.a is finally removed and was obsolete since GCC 4.5
-#Patch0: evtgen-1.6.0-configure-new-gcc
-Patch0: evtgen-2.0.0
-
 %define keep_archives true
 
 %prep
-%setup -q -n %{n}-%{realversion}
-%patch0 -p1
+%setup -q -n EvtGen
 
 %build
 rm -rf ../build
 mkdir ../build
 cd ../build
 
-cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../%{n}-%{realversion} \
+cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../EvtGen/R03-00-00-beta1\
       -DEVTGEN_HEPMC3:BOOL=OFF -DHEPMC2_ROOT_DIR:PATH=$HEPMC_ROOT \
       -DEVTGEN_PYTHIA:BOOL=ON  -DPYTHIA8_ROOT_DIR:PATH=$PYTHIA8_ROOT \
       -DEVTGEN_PHOTOS:BOOL=ON  -DPHOTOSPP_ROOT_DIR:PATH=$PHOTOSPP_ROOT \

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -1,5 +1,10 @@
 ### RPM external evtgen 03.00.00
-Source: http://www.hepforge.org/archive/evtgen/EvtGen-%{realversion}.tar.gz
+
+%define tag d9f0979162c7b1e226c6bbfdfd9f9acca85d5617
+%define branch cms/%realversion
+%define github_user cms-externals
+
+Source: git+https://github.com/%{github_user}/%{n}.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
 
 BuildRequires: cmake
 

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -1,4 +1,4 @@
-### RPM external evtgen 03.00.00-beta1
+### RPM external evtgen 03.00.00
 Source: http://www.hepforge.org/archive/evtgen/EvtGen-%{realversion}.tar.gz
 
 BuildRequires: cmake
@@ -6,22 +6,27 @@ BuildRequires: cmake
 Requires: cmake
 Requires: hepmc
 Requires: pythia8
+Requires: sherpa
 Requires: tauolapp
 Requires: photospp
+
+Patch0: evtgen-3.0.0
 
 %define keep_archives true
 
 %prep
 %setup -q -n EvtGen
+%patch0 -p1
 
 %build
 rm -rf ../build
 mkdir ../build
 cd ../build
 
-cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../EvtGen/R03-00-00-beta1\
+cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../EvtGen/R03-00-00\
       -DEVTGEN_HEPMC3:BOOL=OFF -DHEPMC2_ROOT_DIR:PATH=$HEPMC_ROOT \
       -DEVTGEN_PYTHIA:BOOL=ON  -DPYTHIA8_ROOT_DIR:PATH=$PYTHIA8_ROOT \
+      -DEVTGEN_SHERPA3:BOOL=OFF -DEVTGEN_SHERPA:BOOL=ON  -DSHERPA_ROOT_DIR:PATH=$SHERPA_ROOT \
       -DEVTGEN_PHOTOS:BOOL=ON  -DPHOTOSPP_ROOT_DIR:PATH=$PHOTOSPP_ROOT \
       -DEVTGEN_TAUOLA:BOOL=ON  -DTAUOLAPP_ROOT_DIR:PATH=$TAUOLAPP_ROOT
 

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -20,7 +20,7 @@ Patch0: evtgen-3.0.0
 %define keep_archives true
 
 %prep
-%setup -q -n EvtGen
+%setup -q -n %{n}-%{realversion}
 %patch0 -p1
 
 %build
@@ -28,7 +28,7 @@ rm -rf ../build
 mkdir ../build
 cd ../build
 
-cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../EvtGen/R03-00-00\
+cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../%{n}-%{realversion} \
       -DEVTGEN_HEPMC3:BOOL=OFF -DHEPMC2_ROOT_DIR:PATH=$HEPMC_ROOT \
       -DEVTGEN_PYTHIA:BOOL=ON  -DPYTHIA8_ROOT_DIR:PATH=$PYTHIA8_ROOT \
       -DEVTGEN_SHERPA3:BOOL=OFF -DEVTGEN_SHERPA:BOOL=ON  -DSHERPA_ROOT_DIR:PATH=$SHERPA_ROOT \

--- a/pythia8-evtgen3.patch
+++ b/pythia8-evtgen3.patch
@@ -1,0 +1,42 @@
+--- a/include/Pythia8Plugins/EvtGen.h.orig	2026-01-20 15:52:30.000000000 -0600
++++ b/include/Pythia8Plugins/EvtGen.h	2026-05-18 14:10:47.647205823 -0500
+@@ -36,9 +36,15 @@
+   // Return a random number.
+   double random() {if (rndmPtr) return rndmPtr->flat(); else return -1.0;}
+ 
++  void setSeed(unsigned long int seed) override {lastSeedVal = seed;}
++  unsigned long int lastSeed() const override {return lastSeedVal;}
++
+   // The random number pointer.
+   Rndm *rndmPtr;
+ 
++private:
++  unsigned long int lastSeedVal{0};
++
+ };
+ 
+ //==========================================================================
+@@ -434,12 +440,11 @@
+ 
+   // Loop over the EvtGen entries.
+   if (!pythiaPtr) return;
+-  EvtDecayTable *egTable = EvtDecayTable::getInstance();
+-  if (!egTable) return;
++  EvtDecayTable &egTable = EvtDecayTable::getInstance();
+   for (int iEntry = 0; iEntry < (int)EvtPDL::entries(); ++iEntry) {
+     EvtId egId = EvtPDL::getEntry(iEntry);
+     int   pyId = EvtPDL::getStdHep(egId);
+-    if (egTable->getNModes(egId) == 0) continue;
++    if (egTable.getNModes(egId) == 0) continue;
+     if (excIds.find(pyId) != excIds.end()) continue;
+ 
+     // Stop Pythia from decaying the particle and include in decay set.
+@@ -462,7 +467,7 @@
+     if (!final) continue;
+ 
+     // Get the signal and background decay modes.
+-    vector<EvtParticleDecayList> egList = egTable->getDecayTable();
++    vector<EvtParticleDecayList> egList = egTable.getDecayTable();
+     int sigIdx = egId.getAlias();
+     int bkgIdx = EvtPDL::evtIdFromStdHep(pyId).getAlias();
+     if (sigIdx > (int)egList.size() || bkgIdx > (int)egList.size()) continue;

--- a/pythia8.spec
+++ b/pythia8.spec
@@ -4,8 +4,11 @@ Source: https://pythia.org/download/pythia83/%{n}%{realversion}.tgz
 
 Requires: hepmc hepmc3 lhapdf
 
+Patch0: pythia8-evtgen3
+
 %prep
 %setup -q -n %{n}%{realversion}
+%patch0 -p1
 
 ./configure --prefix=%i --enable-shared --with-hepmc2=${HEPMC_ROOT} --with-hepmc3=${HEPMC3_ROOT} --with-lhapdf6=${LHAPDF_ROOT} --with-mg5mes
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -34,8 +34,13 @@ export PYTHON=$(which python3)
             --enable-pyext \
             --enable-ufo \
             ${OPENLOOPS_ROOT+--enable-openloops=$OPENLOOPS_ROOT} \
+            --enable-mpi \
             --with-sqlite3=$SQLITE_ROOT \
             --enable-analysis \
+            CC="mpicc" \
+            CXX="mpicxx" \
+            MPICXX="mpicxx" \
+            FC="mpifort" \
             CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF -O2 -std=c++0x -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$RIVET_ROOT/include" \
             LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib"
 

--- a/sherpa.spec
+++ b/sherpa.spec
@@ -34,13 +34,8 @@ export PYTHON=$(which python3)
             --enable-pyext \
             --enable-ufo \
             ${OPENLOOPS_ROOT+--enable-openloops=$OPENLOOPS_ROOT} \
-            --enable-mpi \
             --with-sqlite3=$SQLITE_ROOT \
             --enable-analysis \
-            CC="mpicc" \
-            CXX="mpicxx" \
-            MPICXX="mpicxx" \
-            FC="mpifort" \
             CXXFLAGS="-fuse-cxa-atexit $ARCH_CMSPLATF -O2 -std=c++0x -I$LHAPDF_ROOT/include -I$BLACKHAT_ROOT/include -I$RIVET_ROOT/include" \
             LDFLAGS="-ldl -L$BLACKHAT_ROOT/lib/blackhat -L$QD_ROOT/lib"
 


### PR DESCRIPTION
This commits upgrade EvtGen to v03.00.00, which
- is now thread-safe, allowing multithreading in production
- adds new final state photon radiation models in Sherpa/Photon++ and Vincia
- includes new physics models and decay table implemented by Belle 2