### PR TITLE
Updated root to tip of branch v6-36-00-patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag 648365bd39f374e413e66e9617efab74010e1f28
-%define branch cms/v6-36-00-patches/76518d41544
+%define tag 43dcdffefe0928e97a035bc3ffb15872050ac8d7
+%define branch cms/v6-36-00-patches/105c8e77c7a
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
This Includes https://github.com/root-project/root/compare/76518d41544...105c8e77c7a root changes on top of what we already have in 17.0.X builds. Most of these changes are related to root http/httpsniff . There one change related to ROOT IO https://github.com/root-project/root/commit/105c8e77c7a1c3cf6caab8341838cb649cbe29a5 