### PR TITLE
Updated TOoLLiP to version 3.1.0.

### DIFF
--- a/TOoLLiP.spec
+++ b/TOoLLiP.spec
@@ -1,4 +1,4 @@
-### RPM external TOoLLiP 1.0.1
+### RPM external TOoLLiP 3.1.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
Updated TOoLLiP to version 3.1.0:
- TOoLLiP continuous development folder is [here](https://github.com/cms-hls4ml/TOoLLiP);
- CMSSW pull request to integrate this new version lives [here](https://github.com/cms-sw/cmssw/pull/51057). A description on how this model was validated is attached to the pull request description.