### PR TITLE
Update xrootd version to 5.9.5

### DIFF
--- a/xrootd.spec
+++ b/xrootd.spec
@@ -68,3 +68,4 @@ make install
 %post
 %{relocateConfig}bin/xrootd-config
 %{relocateConfig}lib64/cmake/XRootD/XRootDConfig.cmake
+%{relocateConfig}lib64/cmake/XRootD/uninstall.cmake

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.9.4
+### RPM external xrootd 5.9.5
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 


### PR DESCRIPTION
Bugfixes
- [XrdMacaroons] Fix double free bug when reading macaroon secret (https://github.com/xrootd/xrootd/issues/2797)
- [Python] Use with statement to ensure VERSION file is closed
- [XrdHttp] Do not set iscollection property to 1 for executable files
- [XrdHttp] Perform minimal host validation in XrdHttpReq::Redir()
- [XrdHttp] Re-encode resource when appending opaque information
- [XrdHttp] Use strtoll in XrdHttpReq::ProcessHTTPReq()
- [XrdHttpTpc] Set CURLOPT_SSLVERSION to at least TLSv1.2