### PR TITLE
[Do not merge]Change config file download URLs in rivet.spec

### DIFF
--- a/rivet.spec
+++ b/rivet.spec
@@ -18,8 +18,8 @@ Patch1: rivet-2.7.0
 
 # Update config.{guess,sub} to detect aarch64 and ppc64le
 rm -f %{_tmppath}/config.{sub,guess}
-curl -L -k -s -o %{_tmppath}/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
-curl -L -k -s -o %{_tmppath}/config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+curl -L -k -s -o %{_tmppath}/config.guess 'http://cmsrep.cern.ch/cmssw/download/config/config.guess'
+curl -L -k -s -o %{_tmppath}/config.sub 'http://cmsrep.cern.ch/cmssw/download/config/config.sub'
 for CONFIG_GUESS_FILE in $(find $RPM_BUILD_DIR -name 'config.guess')
 do
   rm -f $CONFIG_GUESS_FILE


### PR DESCRIPTION
Updated URLs for config.guess and config.sub to point to cmsrep.