### PR TITLE
Adding P2 L1T NNVtx

### DIFF
--- a/NNVtx.spec
+++ b/NNVtx.spec
@@ -1,4 +1,4 @@
-### RPM external NNVtx 1.0.0
+### RPM external NNVtx 1.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/NNVtx.spec
+++ b/NNVtx.spec
@@ -1,0 +1,14 @@
+### RPM external NNVtx 1.0.0
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
+Requires: hls4mlEmulatorExtras hls
+BuildRequires: gmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+make %{makeprocesses} EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT} HLS_ROOT=${HLS_ROOT}
+
+%install
+make PREFIX=%{i} install
+

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -1,4 +1,4 @@
-### RPM cms cmssw-tools 6.0
+### RPM cms cmssw-tools 7.0
 # With cmsBuild, change the above version only when a new tool is added
 
 ## INSTALL_DEPENDENCIES cmsLHEtoEOSManager gcc-fixincludes cms-cat cmssw-osenv cms-git-tools SCRAMV2
@@ -90,6 +90,7 @@ Requires: libfabric
 Requires: openmpi
 Requires: mpich
 Requires: mpi
+Requires: NNVtx
 Requires: sigcpp
 Requires: sqlite
 Requires: tauolapp

--- a/scram-tools.file/tools/NNVtx/nnvtx.xml
+++ b/scram-tools.file/tools/NNVtx/nnvtx.xml
@@ -1,0 +1,5 @@
+<tool revision="2">
+  <client>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/NNVtx/nnvtx.xml
+++ b/scram-tools.file/tools/NNVtx/nnvtx.xml
@@ -1,4 +1,4 @@
-<tool revision="2">
+<tool revision="1">
   <client>
     <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>


### PR DESCRIPTION
Adding into cmsdist the spec file for the Phase-2 Level-1 Trigger NNVtx Vertex Reconstruction.
The hls4ml files are kept here: https://github.com/cms-hls4ml/NNVtx
The gitlab page is here: https://gitlab.cern.ch/ml_l1/l1-vertex-finding