### PR TITLE
[17.0] Update CUDA to version 12.9.2

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -1,4 +1,4 @@
-### RPM external cuda 12.9.1
+### RPM external cuda 12.9.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 
 %define runpath_opts -m compute-sanitizer -m drivers -m nvvm


### PR DESCRIPTION
CUDA Toolkit 12.9 Update 2 includes critical cuBLAS fixes for issues that could lead to incorrect results, hangs, or invalid memory access in specific `cuBLASLtMatmul()` configurations (notably `ALGO_CONFIG_ID 66` across multiple compute capabilities), as well as a ztrmm kernel correctness issue on NVIDIA Ada and Blackwell GeForce-class GPUs.

See https://docs.nvidia.com/cuda/archive/12.9.2/cuda-toolkit-release-notes/index.html for the release notes, bug fixes and known issues.

Backport of #10609 to 17.0.x.