### PR TITLE
[ROCM] roc/hip toolfiles needed by torch-rocm at runtime

### DIFF
--- a/scram-tools.file/tools/hipblas/hipblas.xml
+++ b/scram-tools.file/tools/hipblas/hipblas.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/hipblaslt/hipblaslt.xml
+++ b/scram-tools.file/tools/hipblaslt/hipblaslt.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/hipfft/hipfft.xml
+++ b/scram-tools.file/tools/hipfft/hipfft.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/hipsolver/hipsolver.xml
+++ b/scram-tools.file/tools/hipsolver/hipsolver.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/hipsparse/hipsparse.xml
+++ b/scram-tools.file/tools/hipsparse/hipsparse.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/hipsparselt/hipsparselt.xml
+++ b/scram-tools.file/tools/hipsparselt/hipsparselt.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/miopen/miopen.xml
+++ b/scram-tools.file/tools/miopen/miopen.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/rocblas/rocblas.xml
+++ b/scram-tools.file/tools/rocblas/rocblas.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/rocfft/rocfft.xml
+++ b/scram-tools.file/tools/rocfft/rocfft.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/rocsolver/rocsolver.xml
+++ b/scram-tools.file/tools/rocsolver/rocsolver.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/rocsparse/rocsparse.xml
+++ b/scram-tools.file/tools/rocsparse/rocsparse.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/roctracer/roctracer.xml
+++ b/scram-tools.file/tools/roctracer/roctracer.xml
@@ -1,0 +1,6 @@
+<tool revision="1">
+  <client>
+    <environment name="LIBDIR"    default="$TOOL_BASE/lib64"/>
+    <environment name="INCLUDE"   default="$TOOL_BASE/include"/>
+  </client>
+</tool>


### PR DESCRIPTION
@akritkbehera , these toolfiles are needed so that scram can add the libs from these tools in LD_LIBRARY_PATH . These libs are needed by torch-rocm. after adding these tools I wa sable to run a simple torhc-rocm test
```
Singularity> python3 ./x.py
PyTorch version: 2.11.0
Selected device: cuda
Device count: 1
Current device: 0
Device name: AMD Radeon Pro W7900
Backend: AMD ROCm
ROCm version: 7.1.26233
OK. Computed. Result: 2436.77490234375
```