### PR TITLE
Update xrootd to version 6.0.2

### DIFF
--- a/libzip.spec
+++ b/libzip.spec
@@ -1,0 +1,29 @@
+### RPM external libzip 1.11.4
+Source: https://github.com/nih-at/libzip/releases/download/v%{realversion}/libzip-%{realversion}.tar.gz
+BuildRequires: cmake gmake
+Requires: zlib zstd
+Requires: bz2lib
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+cmake \
+  -S %{_builddir}/%{n}-%{realversion} \
+  -B %{_builddir}/build \
+  -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_PREFIX_PATH=%{cmake_prefix_path} \
+  -DENABLE_COMMONCRYPTO=OFF \
+  -DENABLE_GNUTLS=OFF \
+  -DENABLE_MBEDTLS=OFF \
+  -DENABLE_WINDOWS_CRYPTO=OFF \
+  -DBUILD_EXAMPLES=OFF \
+  -DBUILD_DOC=OFF
+
+make -C %{_builddir}/build %{makeprocesses}
+
+%install
+make -C %{_builddir}/build %{makeprocesses} install
+
+%post
+%{relocateConfig}lib64/pkgconfig/libzip.pc

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -1,4 +1,4 @@
-### RPM external xrootd 5.9.5
+### RPM external xrootd 6.0.2
 ## INITENV +PATH LD_LIBRARY_PATH %i/lib64
 ## INITENV +PATH PYTHON3PATH %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 
@@ -8,7 +8,7 @@
 %define github_user xrootd
 Source: https://github.com/xrootd/xrootd/releases/download/v%{realversion}/%{n}-%{realversion}.tar.gz
 
-BuildRequires: cmake gmake autotools py3-pip
+BuildRequires: cmake gmake autotools py3-pip libzip
 Requires: zlib libuuid curl davix
 Requires: python3 py3-setuptools
 Requires: libxml2
@@ -56,7 +56,7 @@ cmake ../%n-%{realversion} \
   -DENABLE_XRDEC=TRUE \
   -DCMAKE_CXX_FLAGS="-I${LIBUUID_ROOT}/include" \
   -DCMAKE_SHARED_LINKER_FLAGS="-L${LIBUUID_ROOT}/lib64" \
-  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
+  -DCMAKE_PREFIX_PATH="%{cmake_prefix_path};$LIBZIP_ROOT"
 
 make %makeprocesses VERBOSE=1
 


### PR DESCRIPTION
backport of #10562

Update XRootD to version 6.0.2. This was integrated in DEVEL IBs a month ago and we have not seen any issues. So lets backport it for default 20.1.X builds