### PR TITLE
use cryptography==46.0.7 for el8

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -82,6 +82,8 @@ contextlib2==21.6.0
 contextvars==2.4
 coverage==7.13.4
 cppy==1.3.1
+# NO_AUTO_UPDATE:1: cryptography>=47.0.0 requires OpenSSL 3 i.e. el9 and above
+cryptography==46.0.7 ; cmsos_name=='el8'
 cryptography==49.0.0
 cx-Oracle==8.3.0
 cycler==0.12.1


### PR DESCRIPTION
As `cryptography>=47.0.0` requires OpenSSL 3 i.e. el9 and above so for `el8` we use old version of cryptography.