### PR TITLE
change cryptography order to avoid Dependabot alerts

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -82,9 +82,9 @@ contextlib2==21.6.0
 contextvars==2.4
 coverage==7.13.4
 cppy==1.3.1
+cryptography==49.0.0 ; cmsos_name!='el8'
 # NO_AUTO_UPDATE:1: cryptography>=47.0.0 requires OpenSSL 3 i.e. el9 and above
 cryptography==46.0.7 ; cmsos_name=='el8'
-cryptography==49.0.0
 cx-Oracle==8.3.0
 cycler==0.12.1
 cython==3.2.4


### PR DESCRIPTION
Lets see if this fixes Dependabot alerts for cryptography version.

Changing order in pip/requirement.txt does not rebuild any package.