### PR TITLE
Add NNPuppiTauModel external spec and toolfile

### DIFF
--- a/NNPuppiTauModel.spec
+++ b/NNPuppiTauModel.spec
@@ -1,0 +1,13 @@
+### RPM external NNPuppiTauModel 1.0.0
+Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
+Requires: hls4mlEmulatorExtras hls
+BuildRequires: gmake
+
+%prep
+%setup -n %{n}-%{realversion}
+
+%build
+make %{makeprocesses} EMULATOR_EXTRAS=${HLS4MLEMULATOREXTRAS_ROOT} HLS_ROOT=${HLS_ROOT}
+
+%install
+make PREFIX=%{i} install

--- a/NNPuppiTauModel.spec
+++ b/NNPuppiTauModel.spec
@@ -1,4 +1,4 @@
-### RPM external NNPuppiTauModel 1.0.0
+### RPM external NNPuppiTauModel 1.0.1
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake

--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -67,6 +67,7 @@ Requires: EMTF_NN
 Requires: L1METML
 Requires: L1TSC4NGJetModel
 Requires: L1TSC82ProngJetModel
+Requires: NNPuppiTauModel
 Requires: lhapdf
 Requires: libjpeg-turbo
 Requires: libpng

--- a/scram-tools.file/tools/NNPuppiTauModel/nnpuppitaumodel.xml
+++ b/scram-tools.file/tools/NNPuppiTauModel/nnpuppitaumodel.xml
@@ -1,0 +1,6 @@
+<tool name="nnpuppitaumodel" version="@TOOL_VERSION@" revision="1">
+  <client>
+    <environment name="NNPUPPITAUMODEL_BASE" default="@TOOL_ROOT@"/>
+    <environment name="LIBDIR"       default="$NNPUPPITAUMODEL_BASE/lib64"/>
+  </client>
+</tool>

--- a/scram-tools.file/tools/NNPuppiTauModel/nnpuppitaumodel.xml
+++ b/scram-tools.file/tools/NNPuppiTauModel/nnpuppitaumodel.xml
@@ -1,6 +1,5 @@
-<tool name="nnpuppitaumodel" version="@TOOL_VERSION@" revision="1">
+<tool revision="1">
   <client>
-    <environment name="NNPUPPITAUMODEL_BASE" default="@TOOL_ROOT@"/>
-    <environment name="LIBDIR"       default="$NNPUPPITAUMODEL_BASE/lib64"/>
+    <environment name="LIBDIR" default="$TOOL_BASE/lib64"/>
   </client>
 </tool>


### PR DESCRIPTION
#### Summary

Adds the SCRAM build/install plumbing for the new **[cms-hls4ml/NNPuppiTauModel](https://github.com/cms-hls4ml/NNPuppiTauModel)** external package, following the same precedent already used for `L1TSC4NGJetModel`/`AXOL1TL`. This package replaces the in-tree, un-namespaced hls4ml weight arrays (`w2`, `b2`, ..., `w20`, `b20`) previously compiled directly into `L1Trigger/Phase2L1ParticleFlow`'s `TauNNIdHW`, which were vulnerable to ELF symbol interposition when multiple hls4ml models were loaded into the same process (the bug class behind cms-sw/cmssw#49632).

This is part of a 3-PR migration:
1. New external repo: [cms-hls4ml/NNPuppiTauModel](https://github.com/cms-hls4ml/NNPuppiTauModel) — the externally-built package itself.
2. **This PR** — `cmsdist` spec + toolfile so SCRAM builds/installs the new external.
3. cms-sw/cmssw#51263 — `cmssw` changes to consume it via `hls4mlEmulator::ModelLoader`/`hls4mlEmulator::Model`.

#### Changes

- **`NNPuppiTauModel.spec`** (new) — RPM spec for the external, modeled on `L1TSC4NGJetModel.spec`/`AXOL1TL.spec`: fetches the release tarball from `cms-hls4ml/NNPuppiTauModel`, builds via `make` against `hls4mlEmulatorExtras`/`hls`, installs into `$PREFIX`.
- **`scram-tools.file/tools/NNPuppiTauModel/nnpuppitaumodel.xml`** (new) — SCRAM toolfile exposing `NNPUPPITAUMODEL_BASE`/`LIBDIR` environment variables for the new external, modeled on `l1tsc4ngjetmodel.xml`.
- **`cmssw-tools.spec`** — adds `Requires: NNPuppiTauModel` alongside the existing L1-trigger model externals (`L1TSC4NGJetModel`, `L1TSC82ProngJetModel`, etc.), so it's pulled into every CMSSW release.

#### Dependencies

Requires a tagged release of [cms-hls4ml/NNPuppiTauModel](https://github.com/cms-hls4ml/NNPuppiTauModel) to exist before this can build successfully.

#### PR validation

cms-bot code-checks will perform the first real build test of the spec/toolfile/package Makefile chain. Once this external is available in an IB, `cms-sw/cmssw#51263` can build against it.
