### PR TITLE
Added support for overriding c++ standard for package via command-line

### DIFF
--- a/cpp-standard.file
+++ b/cpp-standard.file
@@ -1,4 +1,10 @@
 # C++ standard to use for CMS externals
+%define default_cxx_standard 20
 %if "%{?cms_cxx_standard:set}" != "set"
-%define cms_cxx_standard 20
+%define cms_cxx_standard %{default_cxx_standard}
+%endif
+%global package_cxx_standard %{get_package_cxx_standard %cms_cxx_standard}
+%if "%{package_cxx_standard}" != "%{cms_cxx_standard}"
+%undefine cms_cxx_standard
+%define cms_cxx_standard %{package_cxx_standard}
 %endif

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -409,6 +409,9 @@ fi
 
 #############################################################
 #############################################################
+%if "%{?default_pkgname:set}" != "set"
+%define default_pkgname %{pkgname}
+%endif
 
 #Enable debug mode for cmssw packages, e.g debug root, geant4, etc
 %if "%{?cms_debug_packages:set}" == "set"
@@ -417,10 +420,16 @@ fi
 %define is_debug_build() 0
 %endif
 
-%if %{is_debug_build %{pkgname}}
+%if %{is_debug_build %{default_pkgname}}
 %define cmake_build_type Debug
 %else
 %define cmake_build_type Release
+%endif
+
+%if "%{?cms_override_standard:set}" == "set"
+%define get_package_cxx_standard() %(echo %{cms_override_standard} | tr ',' '\\n' | awk -F: '/^%{default_pkgname}:/{print $2; found=1} END{if(!found) print %{1}}')
+%else
+%define get_package_cxx_standard() %{1}
 %endif
 
 %ifnarch x86_64

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -427,7 +427,7 @@ fi
 %endif
 
 %if "%{?cms_override_standard:set}" == "set"
-%define get_package_cxx_standard() %(echo %{cms_override_standard} | tr ',' '\\n' | awk -F: '/^%{default_pkgname}:/{print $2; found=1} END{if(!found) print %{1}}')
+%define get_package_cxx_standard() %(echo %{cms_override_standard} | tr ',' '\\n' | awk -F: '/^%{default_pkgname}@/{print $2; found=1} END{if(!found) print %{1}}')
 %else
 %define get_package_cxx_standard() %{1}
 %endif

--- a/rpm-preamble.file
+++ b/rpm-preamble.file
@@ -427,7 +427,7 @@ fi
 %endif
 
 %if "%{?cms_override_standard:set}" == "set"
-%define get_package_cxx_standard() %(echo %{cms_override_standard} | tr ',' '\\n' | awk -F: '/^%{default_pkgname}@/{print $2; found=1} END{if(!found) print %{1}}')
+%define get_package_cxx_standard() %(echo %{cms_override_standard} | tr ',' '\\n' | awk -F@ '/^%{default_pkgname}@/{print $2; found=1} END{if(!found) print %{1}}')
 %else
 %define get_package_cxx_standard() %{1}
 %endif


### PR DESCRIPTION
This change allows  `--define cms_override_standard=pkgA:20,pkgB=20`  to be used on `cmsBuild` command line to override the `c++ standard` for `pkgA and pkgB` to `20`. 

this we can use to override the `pytorch` standard to `20` for CPP23 IBs so that we can enable `cuda`  