### PR TITLE
Update L1TSC4NGJet model to v2.0.0

### DIFF
--- a/L1TSC4NGJetModel.spec
+++ b/L1TSC4NGJetModel.spec
@@ -1,4 +1,4 @@
-### RPM external L1TSC4NGJetModel 1.0.1
+### RPM external L1TSC4NGJetModel 2.0.0
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 Requires: hls4mlEmulatorExtras hls
 BuildRequires: gmake


### PR DESCRIPTION
This PR updates the L1NGJet Model cms-dist to the v2.0.0 [tag](https://github.com/cms-hls4ml/L1TSC4NGJetModel/releases/tag/v2.0.0) which now includes the v2.0.0 model wrapper which makes the model emulator wrapper more generic allowing for different numbers of inputs being used in the NGJet model

This PR has a corresponding PR to CMSSW [here](https://github.com/cms-sw/cmssw/pull/51267)

This PR does not change the model itself and only the wrapper, no changes are expected in the model output compared to the previous v1.0.1 model

The performance plots of this model are found [here](https://cms-l1t-jet-tagger.web.cern.ch/TrainTagger/branches/generic-emulator-update/baseline_5param_extended_trk/latest/) notable the emulator matching plots [here](https://cms-l1t-jet-tagger.web.cern.ch/TrainTagger/branches/generic-emulator-update/baseline_5param_extended_trk/latest/plots/emulation/)
