### PR TITLE
Add perfetto external (v56.1)

### DIFF
--- a/cmssw-tools.spec
+++ b/cmssw-tools.spec
@@ -163,6 +163,7 @@ Requires: xtd
 %ifos linux
 Requires: openldap
 Requires: gperftools
+Requires: perfetto
 %{!?without_cuda:Requires: cuda cuda-compatible-runtime gdrcopy cudnn}
 
 Requires: alpaka

--- a/perfetto.spec
+++ b/perfetto.spec
@@ -1,0 +1,21 @@
+### RPM external perfetto 56.1
+## INCLUDE cpp-standard
+
+# The Perfetto C++ tracing SDK is published per release as a self-contained
+# amalgamation (perfetto.h + perfetto.cc), with no dependencies beyond the C++
+# standard library and pthread.
+Source0: https://github.com/google/perfetto/releases/download/v%{realversion}/perfetto-cpp-sdk-src.zip
+
+%prep
+# The zip has no top-level directory; create one and unpack into it.
+%setup -q -c -n %{n}-%{realversion}
+
+%build
+mkdir -p %{i}/lib %{i}/include
+# Compile the amalgamation into a shared library (a single translation unit).
+g++ -std=c++%{cms_cxx_standard} -O2 -fPIC -pthread -DNDEBUG -Wno-redundant-move \
+    -shared -Wl,-soname,libperfetto.so \
+    -o %{i}/lib/libperfetto.so perfetto.cc -lpthread
+
+%install
+cp -p perfetto.h %{i}/include/perfetto.h

--- a/scram-tools.file/tools/perfetto/perfetto.xml
+++ b/scram-tools.file/tools/perfetto/perfetto.xml
@@ -1,0 +1,10 @@
+<tool revision="1">
+  <info url="https://perfetto.dev"/>
+  <lib name="perfetto"/>
+  <client>
+    <environment name="INCLUDE" default="$TOOL_BASE/include"/>
+    <environment name="LIBDIR"  default="$TOOL_BASE/lib"/>
+  </client>
+  <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path"/>
+  <use name="root_cxxdefaults"/>
+</tool>


### PR DESCRIPTION
Adds the Perfetto C++ tracing SDK as an external, for PerfTools/Perfetto
(in-process Perfetto tracing for cmsRun).

- Source: the official per-release amalgamation perfetto-cpp-sdk-src.zip from the
  GitHub release v56.1 (latest stable). It is exactly perfetto.h + perfetto.cc and
  has no dependencies beyond the C++ standard library and pthread (protobuf/abseil
  are vendored inside the amalgamation).
- %build compiles the single-TU amalgamation into libperfetto.so.
- Tool exports <lib name="perfetto"/> + INCLUDE/LIBDIR; wired into cmssw-tools.spec.

Verified locally (el8_amd64_gcc13, gcc 13): downloaded v56.1, compiled to a 4.96 MB
libperfetto.so with only system shared deps, registered the SCRAM tool, and built +
ran a package using <use name="perfetto"/>

@makortel @fwyzard @rovere fyi