### PR TITLE
Update dasgoclient version to v02.04.53

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define dasgoclient_tag v02.04.52
+%define dasgoclient_tag v02.04.53
 ### RPM cms dasgoclient %{dasgoclient_tag}.rev%{version_suffix}
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX


### PR DESCRIPTION
This is change in triggered by the das2go code base upgrade and new version release of [v4.7.42](https://github.com/dmwm/das2go/releases/tag/v4.7.42). The new version fixes:  https://github.com/dmwm/das2go/issues/70

It is not backwards compatible, since new backend data providers maps were needed. The respective change in the mapping has been provided with:   https://github.com/dmwm/DASMaps/pull/47 