### PR TITLE
[17.0] Update UCX to version 1.21.0

### DIFF
--- a/cmssw-vectorization.file
+++ b/cmssw-vectorization.file
@@ -1,5 +1,5 @@
 %if "%{?package_vectorization}" != ""
-%global vectorized_packages fastjet OpenBLAS rivet gbl lwtnn opencv
+%global vectorized_packages fastjet OpenBLAS rivet gbl lwtnn opencv ucx
 %if 0%{?without_tensorflow} <= 0
 %global vectorized_packages %{vectorized_packages} tensorflow-sources tensorflow
 %endif

--- a/microarch_flags.file
+++ b/microarch_flags.file
@@ -1,13 +1,16 @@
 %ifarch x86_64
 %define default_microarch_name x86-64-v3
 %define default_microarch -march=%{default_microarch_name}
-%if "%{?override_microarch:set}" == "set"
-%define selected_microarch %{override_microarch}
+%if "%{?override_microarch_name:set}" == "set"
+%define selected_microarch_name %{override_microarch_name}
+%define selected_microarch      %{override_microarch}
 %else
+%define selected_microarch_name %{default_microarch_name}
 %define selected_microarch %{default_microarch}
 %endif
 %else
-%define default_microarch_name %{nil}
-%define selected_microarch %{nil}
-%define default_microarch %{nil}
+%define default_microarch_name  %{nil}
+%define default_microarch       %{nil}
+%define selected_microarch_name %{nil}
+%define selected_microarch      %{nil}
 %endif

--- a/scram-tools.file/tools/ucx/vectorized.tmpl
+++ b/scram-tools.file/tools/ucx/vectorized.tmpl
@@ -1,0 +1,5 @@
+<tool name="ucx_@TOOL_VECTORIZATION@"  revision="1">
+  <client>
+    <environment name="@TOOL_VECTORIZATION_KEY@_LIBDIR" default="$TOOL_BASE/lib"/>
+  </client>
+</tool>

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,4 +1,6 @@
-### RPM external ucx 1.19.0
+### RPM external ucx 1.20.1
+## INCLUDE microarch_flags
+## INCLUDE cuda-flags
 Source: https://github.com/openucx/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: autotools
 %{!?without_cuda:Requires: cuda gdrcopy}
@@ -15,6 +17,11 @@ Requires: xpmem
 
 ./configure \
   --prefix=%i \
+  --enable-mt \
+  --disable-logging \
+  --disable-debug \
+  --disable-assertions \
+  --disable-params-check \
   --disable-dependency-tracking \
   --enable-openmp \
   --enable-shared \
@@ -25,20 +32,14 @@ Requires: xpmem
   --disable-doxygen-html \
   --enable-compiler-opt \
   --enable-cma \
-  --enable-mt \
   --with-pic \
   --with-gnu-ld \
-%ifarch x86_64
-  --with-march=x86-64-v2 \
-  --with-sse41 \
-  --with-sse42 \
-  --without-avx \
-%endif
   --without-go \
   --without-java \
 %if 0%{!?without_cuda:1}
   --with-cuda=$CUDA_ROOT \
   --with-gdrcopy=$GDRCOPY_ROOT \
+  --with-nvcc-gencode='%{nvcc_flags_cuda_archs}' \
 %else
   --without-cuda \
   --without-gdrcopy \
@@ -59,14 +60,18 @@ Requires: xpmem
   --without-knem \
   --with-xpmem=$XPMEM_ROOT \
   --without-ugni \
+%ifarch x86_64
+  CFLAGS="%{selected_microarch}" \
+  CXXFLAGS="%{selected_microarch}" \
+%endif
   CPPFLAGS="-I$NUMACTL_ROOT/include" \
   LDFLAGS="-L$NUMACTL_ROOT/lib"
 
 %build
-make %{makeprocesses} 
+make %{makeprocesses} V=1
 
 %install
-make install
+make install V=1
 
 # remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
 rm -rf %{i}/lib/pkgconfig

--- a/ucx.spec
+++ b/ucx.spec
@@ -1,7 +1,7 @@
-### RPM external ucx 1.20.1
+### RPM external ucx 1.21.0
 ## INCLUDE microarch_flags
 ## INCLUDE cuda-flags
-Source: https://github.com/openucx/%{n}/archive/refs/tags/v%{realversion}.tar.gz
+Source: git+https://github.com/openucx/%{n}.git?obj=master/v%{realversion}&export=%{n}-%{realversion}&submodules=1&output=/%{n}-%{realversion}.tgz
 BuildRequires: autotools
 %{!?without_cuda:Requires: cuda gdrcopy}
 Requires: numactl

--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -43,7 +43,7 @@ def packages(virtual_packages, *args):
         err = True
       vpkg = "%s_%s" % (pkg, v)
       spec =     ["%define vectorized_package {0}".format(v)]
-      spec.append("%define default_pkgname {0}".format(v))
+      spec.append("%define default_pkgname {0}".format(pkg))
       spec.append("%define override_microarch {0}".format(VALID_TARGETS[v]))
       spec.append("cmd:sed -e 's|\(^###  *RPM  *[^\s]*\)  *{0} |\\1 {1} |;s|%{{n}}|{0}|g;' {2}/{0}.spec".format(pkg, vpkg, opts.cmsdist))
       virtual_packages[vpkg] = spec[:]

--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -21,6 +21,7 @@ if machine() == "x86_64":
     "lwtnn",
     "opencv",
     "pytorch",
+    "ucx",
   ]
   VALID_TARGETS = {
     "nehalem":     "-march=nehalem",
@@ -43,6 +44,7 @@ def packages(virtual_packages, *args):
         err = True
       vpkg = "%s_%s" % (pkg, v)
       spec =     ["%define vectorized_package {0}".format(v)]
+      spec.append("%define override_microarch_name {0}".format(v))
       spec.append("%define default_pkgname {0}".format(pkg))
       spec.append("%define override_microarch {0}".format(VALID_TARGETS[v]))
       spec.append("cmd:sed -e 's|\(^###  *RPM  *[^\s]*\)  *{0} |\\1 {1} |;s|%{{n}}|{0}|g;' {2}/{0}.spec".format(pkg, vpkg, opts.cmsdist))

--- a/vectorization/cmsdist_packages.py
+++ b/vectorization/cmsdist_packages.py
@@ -43,6 +43,7 @@ def packages(virtual_packages, *args):
         err = True
       vpkg = "%s_%s" % (pkg, v)
       spec =     ["%define vectorized_package {0}".format(v)]
+      spec.append("%define default_pkgname {0}".format(v))
       spec.append("%define override_microarch {0}".format(VALID_TARGETS[v]))
       spec.append("cmd:sed -e 's|\(^###  *RPM  *[^\s]*\)  *{0} |\\1 {1} |;s|%{{n}}|{0}|g;' {2}/{0}.spec".format(pkg, vpkg, opts.cmsdist))
       virtual_packages[vpkg] = spec[:]


### PR DESCRIPTION
Enable multi-microarchitecture support in UCX.
Download the UCX sources via git, with support for git submodules.

Backport of #10663, #10671, #10673 and #10682 to 17.0.x for Run-3 studies.