### PR TITLE
[cuda] install libnvidia-pkcs11 only for x86_64

### DIFF
--- a/cuda.spec
+++ b/cuda.spec
@@ -101,9 +101,11 @@ ln -sf libnvidia-nvvm.so.4                                                      
 # libnvidia-nvvm70.so
 cp -p %_builddir/build/drivers/libnvidia-nvvm70.so.4                            %{i}/drivers/
 ln -sf libnvidia-nvvm70.so.4                                                    %{i}/drivers/libnvidia-nvvm70.so
+%ifarch x86_64
 # libnvidia-pkcs11.so
 cp -p %_builddir/build/drivers/libnvidia-pkcs11.so.%{driversversion}            %{i}/drivers/
 ln -sf libnvidia-pkcs11.so.%{driversversion}                                    %{i}/drivers/ibnvidia-pkcs11.so
+%endif
 # libnvidia-ptxjitcompiler.so
 cp -p %_builddir/build/drivers/libnvidia-ptxjitcompiler.so.%{driversversion}    %{i}/drivers/
 ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                            %{i}/drivers/libnvidia-ptxjitcompiler.so.1

--- a/cuda.spec
+++ b/cuda.spec
@@ -101,11 +101,11 @@ ln -sf libnvidia-nvvm.so.4                                                      
 # libnvidia-nvvm70.so
 cp -p %_builddir/build/drivers/libnvidia-nvvm70.so.4                            %{i}/drivers/
 ln -sf libnvidia-nvvm70.so.4                                                    %{i}/drivers/libnvidia-nvvm70.so
-%ifarch x86_64
 # libnvidia-pkcs11.so
-cp -p %_builddir/build/drivers/libnvidia-pkcs11.so.%{driversversion}            %{i}/drivers/
-ln -sf libnvidia-pkcs11.so.%{driversversion}                                    %{i}/drivers/ibnvidia-pkcs11.so
-%endif
+if [ -f %_builddir/build/drivers/libnvidia-pkcs11.so.%{driversversion} ]; then
+  cp -p %_builddir/build/drivers/libnvidia-pkcs11.so.%{driversversion}          %{i}/drivers/
+  ln -sf libnvidia-pkcs11.so.%{driversversion}                                  %{i}/drivers/libnvidia-pkcs11.so
+fi
 # libnvidia-ptxjitcompiler.so
 cp -p %_builddir/build/drivers/libnvidia-ptxjitcompiler.so.%{driversversion}    %{i}/drivers/
 ln -sf libnvidia-ptxjitcompiler.so.%{driversversion}                            %{i}/drivers/libnvidia-ptxjitcompiler.so.1


### PR DESCRIPTION
Copy `libnvidia-pkcs11`  only if it exists ( also fix a type in the pkcs11 lib name `ibnvidia-pkcs11` -> `libnvidia-pkcs11`)
@fwyzard , looks like `libnvidia-pkcs11` is not available for aarch64.