### PR TITLE
[DD4Hep] Update to v01-37 with fixes for ROOT6/GCC15/LLVM22

### DIFF
--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -1,5 +1,5 @@
-### RPM external dd4hep v01-31-0x
-%define tag 4990888b50e29a5dc0ff65fc3a6fdf17205192a5
+### RPM external dd4hep v01-37x
+%define tag ed75e7e233b068cbe2cd5eb50a82a80da27ad99b
 %define branch master
 %define github_user AIDASoft
 


### PR DESCRIPTION
This PR proposes to udpate DD4Hep to latest version `v01-37` plus some updates/fixes for for newer compilers ( GCC15/16) and LLVM22.

FYI , @cms-sw/simulation-l2 @cms-sw/geometry-l2