### PR TITLE
bug fix: make sure to fail if patchsrc not applied

### DIFF
--- a/pip/files/pyg-lib-common.file
+++ b/pip/files/pyg-lib-common.file
@@ -5,8 +5,10 @@ Requires: zlib ninja
 Patch0: patches/pip/pyg-lib
 %define source0 git+https://github.com/pyg-team/pyg-lib?obj=master/%{realversion}&export=pyg-lib-%{realversion}&submodules=1&output=/source.tar.gz
 %define patchsrc0 \
-  grep -q 'CMAKE_CXX_STANDARD 17' CMakeLists.txt && sed -i -e 's|CMAKE_CXX_STANDARD 17|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt &&\
-  grep -q 'march=native' third_party/METIS/GKlib/GKlibSystem.cmake && sed -i -e '/-march=native/d' third_party/METIS/GKlib/GKlibSystem.cmake
+  grep -q 'CMAKE_CXX_STANDARD 17' CMakeLists.txt \
+  sed -i -e 's|CMAKE_CXX_STANDARD 17|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt \
+  grep -q 'march=native' third_party/METIS/GKlib/GKlibSystem.cmake \
+  sed -i -e '/-march=native/d' third_party/METIS/GKlib/GKlibSystem.cmake
 %define build_flags -Wall -Wextra %{?arch_build_flags}
 
 %define PipPreBuildPy \

--- a/pip/files/pyg-lib-common.file
+++ b/pip/files/pyg-lib-common.file
@@ -5,8 +5,8 @@ Requires: zlib ninja
 Patch0: patches/pip/pyg-lib
 %define source0 git+https://github.com/pyg-team/pyg-lib?obj=master/%{realversion}&export=pyg-lib-%{realversion}&submodules=1&output=/source.tar.gz
 %define patchsrc0 \
-  grep -q 'CMAKE_CXX_STANDARD 17' CMakeLists.txt \
-  sed -i -e 's|CMAKE_CXX_STANDARD 17|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt \
+  grep -q 'CMAKE_CXX_STANDARD 20' CMakeLists.txt \
+  sed -i -e 's|CMAKE_CXX_STANDARD 20|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt \
   grep -q 'march=native' third_party/METIS/GKlib/GKlibSystem.cmake \
   sed -i -e '/-march=native/d' third_party/METIS/GKlib/GKlibSystem.cmake
 %define build_flags -Wall -Wextra %{?arch_build_flags}

--- a/pip/grpcio.file
+++ b/pip/grpcio.file
@@ -1,5 +1,7 @@
 ## INCLUDE cpp-standard
-%define patchsrc0 grep 'std=c++14' setup.py && sed -i -e 's|std=c++14|std=c++%{cms_cxx_standard}|g' setup.py
+%define patchsrc0 \
+  grep 'std=c++14' setup.py \
+  sed -i -e 's|std=c++14|std=c++%{cms_cxx_standard}|g' setup.py
 Patch0: patches/pip/grpcio-absl-path
 %define PipPreBuild \
   export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=%{compiling_processes}; \

--- a/pip/onnx.file
+++ b/pip/onnx.file
@@ -1,6 +1,8 @@
 ## INCLUDE cpp-standard
 Patch0: patches/pip/py3-onnx
-%define patchsrc0 grep -q 'CMAKE_CXX_STANDARD  *11' CMakeLists.txt && sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt
+%define patchsrc0 \
+  grep -q 'CMAKE_CXX_STANDARD  *11' CMakeLists.txt \
+  sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt
 Requires: cmake protobuf py3-protobuf py3-six py3-typing-extensions py3-numpy py3-pytest-runner
 Requires: py3-ml_dtypes
 %define runpath_opts -n pb -n onnx

--- a/pip/onnx.file
+++ b/pip/onnx.file
@@ -1,8 +1,5 @@
 ## INCLUDE cpp-standard
 Patch0: patches/pip/py3-onnx
-%define patchsrc0 \
-  grep -q 'CMAKE_CXX_STANDARD  *11' CMakeLists.txt \
-  sed -i -e 's|CMAKE_CXX_STANDARD  *11|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' CMakeLists.txt
 Requires: cmake protobuf py3-protobuf py3-six py3-typing-extensions py3-numpy py3-pytest-runner
 Requires: py3-ml_dtypes
 %define runpath_opts -n pb -n onnx

--- a/pip/python-ldap.file
+++ b/pip/python-ldap.file
@@ -1,4 +1,5 @@
 Requires: openldap py3-pyasn1-modules
-%define patchsrc0 sed -i -e "s|\\[_ldap\\]|[_ldap]\\ninclude_dirs = ${PYTHON3_ROOT}/include ${OPENLDAP_ROOT}/include|" setup.cfg
-%define patchsrc1 sed -i -e "s|\\[_ldap\\]|[_ldap]\\nlibrary_dirs = ${PYTHON3_ROOT}/lib ${OPENLDAP_ROOT}/lib|" setup.cfg
-%define patchsrc2 sed -i -e "s|HAVE_SASL||" setup.cfg
+%define patchsrc0 \
+  sed -i -e "s|\\[_ldap\\]|[_ldap]\\ninclude_dirs = ${PYTHON3_ROOT}/include ${OPENLDAP_ROOT}/include|" setup.cfg \
+  sed -i -e "s|\\[_ldap\\]|[_ldap]\\nlibrary_dirs = ${PYTHON3_ROOT}/lib ${OPENLDAP_ROOT}/lib|" setup.cfg \
+  sed -i -e "s|HAVE_SASL||" setup.cfg

--- a/pip/xgboost.file
+++ b/pip/xgboost.file
@@ -1,6 +1,6 @@
 Requires: py3-scipy xgboost
 %define patchsrc \
-        sed -i -e 's|^\\(  *\\)outfiles *= *super().install()|\\1return super().install()|' setup.py ;\
+        sed -i -e 's|^\\(  *\\)outfiles *= *super().install()|\\1return super().install()|' setup.py \
         sed -i -e "s|^\\(.*'use-system-libxgboost':.*\\)0[)]|\\11)|" setup.py
 
 %define PipPostInstall \


### PR DESCRIPTION
commands like ` cmd1 && cmd2` does not fail if `cmd1` fails. Proper way to run such commands is to either have `cmd1 ; cmsd2` or simply 
```
  cmd1
  cmd2
```