### PR TITLE
[ROOT6] Updated root to tip of branch master

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -198,3 +198,4 @@ rm -rf build
 %{relocateConfig}etc/notebook/jupyter_notebook_config.py
 %{relocateConfig}include/RConfigOptions.h
 %{relocateConfig}include/compiledata.h
+%{relocateConfig}etc/cppinterop/CppInterOp/BuildInfo.inc

--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag 262b518fea463b15282562ecff3f244a1a6b795b
-%define branch cms/master/6bf5355cc45
+%define tag 23c0d170be02ee51b362d710ea197645bb9e9956
+%define branch cms/master/f44097696ef
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
https://github.com/root-project/root/pull/22765 is merged so this should fix the issue with creation of `cuda.pcm` but I am afraid that due https://github.com/root-project/root/pull/22744 change we might not be able to properly use root ( see https://github.com/cms-sw/cmsdist/pull/10706#issuecomment-4892516073 )