### PR TITLE
eigen: Update to upstream version 5.0.1

### DIFF
--- a/eigen.spec
+++ b/eigen.spec
@@ -1,11 +1,8 @@
-### RPM external eigen c1d637433e3b3f9012b226c2c9125c494b470ae6
+### RPM external eigen 5.0.1
 ## INITENV +PATH PKG_CONFIG_PATH %{i}/share/pkgconfig
 ## NOCOMPILER
 ## INCLUDE cpp-standard
-%define tag b25e86af3379e35cd267d337693684dcdbdfd5d1
-%define branch cms/master/%{realversion}
-%define github_user cms-externals
-Source: git+https://github.com/%{github_user}/eigen-git-mirror.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz
+Source: git+https://gitlab.com/libeigen/eigen.git?tag=%{realversion}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}.tgz
 BuildRequires: cmake
 
 %prep


### PR DESCRIPTION
Eigen 3.5.0/5.0.0 added the necessary device header for CMSSW. Test to see if the CMS eigen fork can be dropped in favor of upstream.

**Note:**
Eigen 3.5.0/5.0.0 made fixed size matrices and arrays [trivially_default_constructible](https://gitlab.com/libeigen/eigen/-/merge_requests/1696). This uncovered two unused Eigen::Vector/Matrix variables in RecoTracker/PixelTrackFitting and is fixed in [CMSSW!51453](https://github.com/cms-sw/cmssw/pull/51453).