### PR TITLE
Update xz 5.8.3, python 3.12.13 and allow to build pkgs in debug mode

### DIFF
--- a/acts.spec
+++ b/acts.spec
@@ -68,7 +68,7 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_CXX_FLAGS="-fPIC $CMS_EIGEN_CXX_FLAGS %{arch_build_flags} %{selected_microarch} %{lto_build_flags}" \
   -DCMAKE_AR="$GCC_ROOT/bin/gcc-ar" \
   -DCMAKE_RANLIB="$GCC_ROOT/bin/gcc-ranlib" \
-  -DCMAKE_BUILD_TYPE="Release" \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX="%{i}" \
   -DCMAKE_SKIP_INSTALL_RPATH="ON" \
 %if 0%{!?without_cuda:1}

--- a/c-blosc.spec
+++ b/c-blosc.spec
@@ -10,7 +10,7 @@ BuildRequires: ninja cmake
 rm -rf ../build ; mkdir ../build; cd ../build
 cmake ../%{n}-%{realversion} \
  -G Ninja \
- -DCMAKE_BUILD_TYPE=Release \
+ -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
  -DCMAKE_INSTALL_PREFIX:STRING=%{i} \
  -DDEACTIVATE_LZ4:BOOL=OFF \
  -DDEACTIVATE_SNAPPY:BOOL=ON \

--- a/c-blosc2.spec
+++ b/c-blosc2.spec
@@ -10,7 +10,7 @@ BuildRequires: ninja cmake
 rm -rf ../build ; mkdir ../build; cd ../build
 cmake ../%{n}-%{realversion} \
  -G Ninja \
- -DCMAKE_BUILD_TYPE=Release \
+ -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
  -DCMAKE_INSTALL_PREFIX:STRING=%{i} \
  -DDEACTIVATE_ZLIB:BOOL=OFF \
  -DDEACTIVATE_ZSTD:BOOL=OFF \

--- a/cepgen.spec
+++ b/cepgen.spec
@@ -27,7 +27,7 @@ export ROOTSYS=${ROOT_ROOT}
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DBoost_NO_SYSTEM_PATHS=ON \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}"
 
@@ -35,7 +35,7 @@ ninja -v %{makeprocesses}
 
 %install
 cd ../build
-ninja %{makeprocesses} install
+ninja -v %{makeprocesses} install
 
 case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
 rm -f %i/lib/libCepGen*-[A-Z]*-%realversion.$so

--- a/clang-uml.spec
+++ b/clang-uml.spec
@@ -25,7 +25,7 @@ cd ../build
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
 %ifarch aarch64
   -DCMAKE_CXX_FLAGS="-Wno-sign-compare" \
 %endif
@@ -37,4 +37,4 @@ ninja -v %{makeprocesses}
 
 %install
 cd ../build
-ninja %{makeprocesses} install
+ninja -v %{makeprocesses} install

--- a/clhep.spec
+++ b/clhep.spec
@@ -19,14 +19,14 @@ cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCLHEP_BUILD_CXXSTD="-std=c++%{cms_cxx_standard}" \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCLHEP_BUILD_STATIC_LIBS=OFF
 
 ninja -v %{makeprocesses}
 
 %install
 cd ../build
-ninja %{makeprocesses} install
+ninja -v %{makeprocesses} install
 
 case $(uname) in Darwin ) so=dylib ;; * ) so=so ;; esac
 rm -f %i/lib/libCLHEP-[A-Z]*-%realversion.$so

--- a/davix.spec
+++ b/davix.spec
@@ -19,16 +19,17 @@ Requires: libxml2 libuuid curl
 rm -rf ../build; mkdir ../build; cd ../build
 cmake ../%{n}-%{realversion} \
  -DCMAKE_INSTALL_PREFIX="%{i}" \
+ -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
  -DEMBEDDED_LIBCURL=FALSE \
  -DDAVIX_TESTS=False \
  -DUUID_LIBRARY="${LIBUUID_ROOT}/lib64/libuuid.%{soext}" \
  -DCMAKE_PREFIX_PATH="${LIBXML2_ROOT};${LIBUUID_ROOT};${CURL_ROOT}"
 
-make VERBOSE=1 %{makeprocesses}
+make %{makeprocesses} VERBOSE=1
 
 %install
 cd ../build
-make install
+make install  VERBOSE=1
 
 %post
 %{relocateConfig}lib64/pkgconfig/davix.pc

--- a/dd4hep.spec
+++ b/dd4hep.spec
@@ -35,7 +35,7 @@ export BOOST_ROOT
 rm -rf ../build; mkdir ../build; cd ../build
 cmake %{cmake_fixed_args} -DBUILD_SHARED_LIBS=ON -DDD4HEP_USE_GEANT4=OFF ../%{n}-%{realversion}
 make %{makeprocesses} VERBOSE=1
-make install
+make install VERBOSE=1
 
 #Building DDG4 static
 rm -rf ../build-g4; mkdir ../build-g4; cd ../build-g4

--- a/evtgen.spec
+++ b/evtgen.spec
@@ -31,6 +31,7 @@ mkdir ../build
 cd ../build
 
 cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../%{n}-%{realversion} \
+      -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
       -DEVTGEN_HEPMC3:BOOL=OFF -DHEPMC2_ROOT_DIR:PATH=$HEPMC_ROOT \
       -DEVTGEN_PYTHIA:BOOL=ON  -DPYTHIA8_ROOT_DIR:PATH=$PYTHIA8_ROOT \
       -DEVTGEN_PHOTOS:BOOL=ON  -DPHOTOSPP_ROOT_DIR:PATH=$PHOTOSPP_ROOT \
@@ -41,12 +42,12 @@ cmake -DCMAKE_INSTALL_PREFIX:PATH=%{i} ../%{n}-%{realversion} \
  perl -p -i -e "s|-shared|-dynamiclib -undefined dynamic_lookup|" make.inc
 %endif
 
-make
+make VERBOSE=1
 
 %install
 
 cd ../build
-make install
+make install VERBOSE=1
 mkdir -p %i/lib
 find %i/lib64 -name "*.*" -exec mv {} %i/lib \;
 rm -rf %i/lib64

--- a/gbl.spec
+++ b/gbl.spec
@@ -22,18 +22,18 @@ source %{_sourcedir}/env
 
 cmake ../cpp \
   -DCMAKE_INSTALL_PREFIX=%{i} \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_VERBOSE_MAKEFILE=ON \
   -DEIGEN3_INCLUDE_DIR=${EIGEN_ROOT}/include/eigen3 \
   -DSUPPORT_ROOT=False \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS %{selected_microarch}"
 
-make %{makeprocesses}
+make %{makeprocesses} VERBOSE=1
 
 %install
 cd build
-make install
+make install VERBOSE=1
 
 %post
 %{relocateConfig}GBLConfig.cmake

--- a/geant4-parfullcms.spec
+++ b/geant4-parfullcms.spec
@@ -18,10 +18,9 @@ cd build-ParFullCMS
 
 cmake .. \
   -DCMAKE_CXX_COMPILER="g++" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
   -DCMAKE_INSTALL_LIBDIR="lib" \
-  -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \
   -DBUILD_STATIC_LIBS=ON \
   -DGeant4_USE_FILE=${GEANT4_ROOT}
@@ -31,4 +30,4 @@ make %{makeprocesses} VERBOSE=1
 %install
 
 cd build-ParFullCMS
-make install
+make install VERBOSE=1

--- a/google-benchmark.spec
+++ b/google-benchmark.spec
@@ -21,7 +21,7 @@ cmake ../benchmark-%{realversion}-%{commit} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX="%{i}" \
   -DCMAKE_CXX_FLAGS="-fPIE" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
   -DBENCHMARK_DOWNLOAD_DEPENDENCIES=OFF
 

--- a/google-test.spec
+++ b/google-test.spec
@@ -21,7 +21,7 @@ cmake ../googletest-%{realversion}-%{commit} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX="%{i}" \
   -DCMAKE_CXX_FLAGS="-fPIC" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DBUILD_GMOCK=OFF
 
 ninja -v %{makeprocesses}

--- a/grpc.spec
+++ b/grpc.spec
@@ -22,7 +22,7 @@ cd ../build
 cmake ../%{n}-%{realversion} \
     -G Ninja \
     -DgRPC_INSTALL=ON \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
     -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
     -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_INSTALL_LIBDIR=lib \

--- a/heaptrack.spec
+++ b/heaptrack.spec
@@ -15,13 +15,14 @@ mkdir -p %i
 rm -rf ../build; mkdir ../build; cd ../build
 
 cmake ../%{n}-%{realversion} \
+   -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
    -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE \
    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3" \
    -DCMAKE_PREFIX_PATH="${LIBUNWIND_ROOT};${BOOST_ROOT};${ZSTD_ROOT};${BZ2LIB_ROOT};${ZLIB_ROOT}" \
    -DHEAPTRACK_BUILD_GUI=off -DHEAPTRACK_USE_LIBUNWIND=on -DHEAPTRACK_BUILD_PRINT=on
-make DEBUG=1 VERBOSE=1 %makeprocesses
+make %makeprocesses DEBUG=1 VERBOSE=1
 
 %install
 cd ../build
-make %makeprocesses install
+make %makeprocesses install VERBOSE=1
 %define drop_files %i/share/man

--- a/hepmc3.spec
+++ b/hepmc3.spec
@@ -17,6 +17,7 @@ cd ../build
 
 cmake ../HepMC3-%{realversion} \
   -DCMAKE_INSTALL_PREFIX="%i" \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   -DHEPMC3_CXX_STANDARD=%{cms_cxx_standard} \
   -DHEPMC3_ENABLE_ROOTIO="OFF" \
@@ -39,4 +40,4 @@ make %{makeprocesses} VERBOSE=1
 
 %install
 cd ../build
-make install
+make install VERBOSE=1

--- a/highfive.spec
+++ b/highfive.spec
@@ -18,6 +18,7 @@ rm -rf build
 mkdir build && cd build
 
 cmake ../%{n}-%{realversion} \
+    -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
     -DCMAKE_INSTALL_PREFIX=%{i} \
     -DHIGHFIVE_EXAMPLES=OFF \
     -DCMAKE_INSTALL_PREFIX=%{i} \
@@ -26,7 +27,7 @@ cmake ../%{n}-%{realversion} \
 
 %install
 cd %{_builddir}/build
-make install
+make install VERBOSE=1
 
 %post
 %{relocateConfig}share/HighFive/CMake/HighFiveTargets.cmake

--- a/hydjet.spec
+++ b/hydjet.spec
@@ -12,9 +12,13 @@ Requires: pyquen pythia6 lhapdf
 
 %build
 
-cmake . -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_BUILD_TYPE=Release -DPYQUEN_DIR=${PYQUEN_ROOT} -DPYTHIA6_DIR=${PYTHIA6_ROOT} -DLHAPDF_ROOT_DIR=${LHAPDF_ROOT}
-cmake --build . --clean-first -- %{makeprocesses}
+cmake . -DCMAKE_INSTALL_PREFIX=%i \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
+  -DPYQUEN_DIR=${PYQUEN_ROOT} \
+  -DPYTHIA6_DIR=${PYTHIA6_ROOT} \
+  -DLHAPDF_ROOT_DIR=${LHAPDF_ROOT}
+cmake --build . --clean-first -- %{makeprocesses} VERBOSE=1
 
 %install
 
-cmake --build . --target install -- %{makeprocesses}
+cmake --build . --target install -- %{makeprocesses} VERBOSE=1

--- a/hydjet2.spec
+++ b/hydjet2.spec
@@ -13,12 +13,17 @@ Requires: pyquen pythia6 lhapdf root
 
 %build
 
-cmake . -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_BUILD_TYPE=Release -DPYQUEN_DIR=${PYQUEN_ROOT} -DPYTHIA6_DIR=${PYTHIA6_ROOT} -DLHAPDF_ROOT_DIR=${LHAPDF_ROOT} -DROOTSYS=${ROOT_ROOT}
-cmake --build . --clean-first -- %{makeprocesses}
+cmake . -DCMAKE_INSTALL_PREFIX=%i \
+   -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
+   -DPYQUEN_DIR=${PYQUEN_ROOT} \
+   -DPYTHIA6_DIR=${PYTHIA6_ROOT} \
+   -DLHAPDF_ROOT_DIR=${LHAPDF_ROOT} \
+   -DROOTSYS=${ROOT_ROOT}
+cmake --build . --clean-first -- %{makeprocesses} VERBOSE=1
 
 %install
 
-cmake --build . --target install -- %{makeprocesses}
+cmake --build . --target install -- %{makeprocesses} VERBOSE=1
 
 mkdir -p %{i}/data/externals/hydjet2
 mv %{i}/share/* %{i}/data/externals/hydjet2

--- a/igprof.spec
+++ b/igprof.spec
@@ -16,12 +16,14 @@ mkdir -p %i
 rm -rf ../build; mkdir ../build; cd ../build
 
 cmake ../igprof-%{git_commit} \
-   -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+   -DCMAKE_INSTALL_PREFIX=%i \
+   -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+   -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -Wno-error=deprecated-declarations" \
    -DCMAKE_PREFIX_PATH="$LIBUNWIND_ROOT;$PCRE_ROOT"
-make DEBUG=1 VERBOSE=1 %makeprocesses
+make %makeprocesses DEBUG=1 VERBOSE=1
 
 %install
 cd ../build
-make %makeprocesses install
+make %makeprocesses install VERBOSE=1
 %define drop_files %i/share/man

--- a/libzip.spec
+++ b/libzip.spec
@@ -12,6 +12,7 @@ cmake \
   -S %{_builddir}/%{n}-%{realversion} \
   -B %{_builddir}/build \
   -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_PREFIX_PATH=%{cmake_prefix_path} \
   -DENABLE_COMMONCRYPTO=OFF \
   -DENABLE_GNUTLS=OFF \
@@ -20,10 +21,10 @@ cmake \
   -DBUILD_EXAMPLES=OFF \
   -DBUILD_DOC=OFF
 
-make -C %{_builddir}/build %{makeprocesses}
+make -C %{_builddir}/build %{makeprocesses} VERBOSE=1
 
 %install
-make -C %{_builddir}/build %{makeprocesses} install
+make -C %{_builddir}/build %{makeprocesses} install VERBOSE=1
 
 %post
 %{relocateConfig}lib64/pkgconfig/libzip.pc

--- a/llvm.spec
+++ b/llvm.spec
@@ -45,7 +45,7 @@ cmake %{_builddir}/llvm-%{realversion}-%{llvmCommit}/llvm \
   -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;compiler-rt;openmp" \
   -DIWYU_RESOURCE_RELATIVE_TO="iwyu" \
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
-  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DCMAKE_BUILD_TYPE:STRING=%{cmake_build_type} \
   -DLLVM_INSTALL_UTILS=ON \
   -DLLVM_LIBDIR_SUFFIX:STRING=64 \
   -DLLVM_BUILD_LLVM_DYLIB:BOOL=ON \

--- a/lwtnn.spec
+++ b/lwtnn.spec
@@ -25,7 +25,7 @@ cmake ../%{n}-%{realversion} \
   -DCMAKE_CXX_COMPILER="g++" \
   -DCMAKE_CXX_FLAGS="-fPIC -DBOOST_DISABLE_ASSERTS $CMS_EIGEN_CXX_FLAGS %{selected_microarch}" \
   -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DBUILTIN_BOOST=OFF \
   -DBUILTIN_EIGEN=OFF \
   -DCMAKE_PREFIX_PATH="${EIGEN_ROOT};${BOOST_ROOT}" \

--- a/mille.spec
+++ b/mille.spec
@@ -15,16 +15,18 @@ rm -rf ../build
 mkdir ../build
 cd ../build
 cmake \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -DCMAKE_Fortran_COMPILER=$(which gfortran) \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   ../%{n}-%{realversion}
+
 make  %{makeprocesses} VERBOSE=1
+
 %install
 cd ../build
-make install PREFIX=%{i}
+make install PREFIX=%{i} VERBOSE=1
 
 %post
 %{relocateConfig}milleStandaloneSetup.sh

--- a/millepede.spec
+++ b/millepede.spec
@@ -14,15 +14,17 @@ mkdir ../build
 cd ../build
 cmake \
   -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   -DLAPACK_OPENBLAS=off \
   ../%{n}-ii-%{realversion}
+
 make %{makeprocesses} VERBOSE=1
 
 %install
 cd ../build
-make install PREFIX=%{i}
+make install PREFIX=%{i} VERBOSE=1
 
 %post
 %{relocateConfig}mp2setup.sh

--- a/opencv.spec
+++ b/opencv.spec
@@ -34,7 +34,7 @@ cmake ../%{n}-%{realversion} \
     -DPYTHON3_EXECUTABLE:FILEPATH="${PYTHON3_ROOT}/bin/python3" \
     -DPYTHON3_INCLUDE_DIR:PATH="${PYTHON3_ROOT}/include/python%{cms_python3_major_minor_version}" \
     -DPYTHON3_LIBRARY:FILEPATH="${PYTHON3_ROOT}/lib/libpython%{cms_python3_major_minor_version}.so" \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
     -DCMAKE_CXX_FLAGS="$CMS_EIGEN_CXX_FLAGS %{selected_microarch}" \
     -DCMAKE_PREFIX_PATH="${LIBPNG_ROOT};${LIBTIFF_ROOT};${LIBJPEG_TURBO_ROOT};${ZLIB_ROOT};${PYTHON3_ROOT};${PY2_NUMPY_ROOT};${PY3_NUMPY_ROOT};${EIGEN_ROOT};${OPENBLAS_ROOT}"
 

--- a/protobuf.spec
+++ b/protobuf.spec
@@ -34,7 +34,7 @@ cd ../build
 cmake ../%{n}-%{realversion} \
     -G Ninja \
     -DCMAKE_INSTALL_PREFIX="%{i}" \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
     -DCMAKE_CXX_STANDARD=17 \
     -Dprotobuf_BUILD_TESTS=OFF \
     -Dprotobuf_BUILD_SHARED_LIBS=ON \

--- a/pyquen.spec
+++ b/pyquen.spec
@@ -12,9 +12,13 @@ Requires: pythia6 lhapdf
 
 %build
 
-cmake . -DCMAKE_INSTALL_PREFIX=%i -DCMAKE_BUILD_TYPE=Release -DPYTHIA6_DIR=${PYTHIA6_ROOT} -DLHAPDF_ROOT_DIR=${LHAPDF_ROOT}
-cmake --build . --clean-first -- %{makeprocesses}
+cmake . -DCMAKE_INSTALL_PREFIX=%i \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
+  -DPYTHIA6_DIR=${PYTHIA6_ROOT} \
+  -DLHAPDF_ROOT_DIR=${LHAPDF_ROOT}
+
+cmake --build . --clean-first -- %{makeprocesses} VERBOSE=1
 
 %install
 
-cmake --build . --target install -- %{makeprocesses}
+cmake --build . --target install -- %{makeprocesses} VERBOSE=1

--- a/python3.spec
+++ b/python3.spec
@@ -1,4 +1,4 @@
-### RPM external python3 3.12.4
+### RPM external python3 3.12.13
 ## INITENV +PATH PATH %{i}/bin
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib
 ## INITENV SETV PYTHON3_LIB_SITE_PACKAGES lib/python%{pythonv}/site-packages

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -17,6 +17,7 @@ cd build
 # currently there is no way to use a custom location for libnl3, so disable neighbours resolution
 cmake \
   -G Ninja \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_INSTALL_RUNDIR=/var/run \
   -DENABLE_RESOLVE_NEIGH=FALSE \

--- a/rocm-cmake.spec
+++ b/rocm-cmake.spec
@@ -9,9 +9,10 @@ Source: https://github.com/ROCm/%{n}/archive/refs/tags/%{rocm_version}.tar.gz
 cmake \
   -S %{_builddir}/%{n}-%{rocm_version} \
   -B %{_builddir}/build \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DROCM_VERSION=%{rocm_version_num}
 
-cmake --build %{_builddir}/build --parallel %{makeprocesses}
+cmake --build %{_builddir}/build --parallel %{makeprocesses} --verbose
 %install
-cmake --install %{_builddir}/build
+cmake --install %{_builddir}/build %{makeprocesses} --verbose

--- a/rocm-comgr.spec
+++ b/rocm-comgr.spec
@@ -21,7 +21,7 @@ cmake -G "Unix Makefiles" \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_C_COMPILER=$ROCM_LLVM_ROOT/lib/llvm/bin/clang \
   -DCMAKE_CXX_COMPILER=$ROCM_LLVM_ROOT/lib/llvm/bin/clang++ \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCOMGR_BUILD_SHARED_LIBS=ON \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCOMGR_STATIC_LLVM=ON \

--- a/rocm-libraries-build.file
+++ b/rocm-libraries-build.file
@@ -18,6 +18,7 @@ export HIP_DEVICE_LIB_PATH=$ROCM_LLVM_ROOT/amdgcn/bitcode
 CMAKE_ARGS=(
   -B %{_builddir}/build
   -S %{_builddir}/rocm-libraries/projects/%{n}
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX=%{i}
   -DCMAKE_C_COMPILER=$ROCM_LLVM_ROOT/bin/amdclang
   -DCMAKE_CXX_COMPILER=$ROCM_LLVM_ROOT/bin/amdclang++
@@ -32,7 +33,7 @@ cmake "${CMAKE_ARGS[@]}"
 %{?ROCMPostCMake:%ROCMPostCMake}
 
 %{?ROCMPreMake:%ROCMPreMake}
-make -C %{_builddir}/build %{makeprocesses}
+make -C %{_builddir}/build %{makeprocesses} VERBOSE=1
 %{?ROCMPostMake:%ROCMPostMake}
 
 %{?ROCMPostBuild:%ROCMPostBuild}

--- a/rocm-llvm.spec
+++ b/rocm-llvm.spec
@@ -27,7 +27,7 @@ cmake -G Ninja \
   -S %{_builddir}/%{n}-%{realversion}/llvm \
   -B %{_builddir}/build-llvm \
   -DCMAKE_INSTALL_PREFIX=%{i}/lib/llvm \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" \
@@ -55,7 +55,7 @@ ln -sf %{_builddir}/build-llvm/bin/clang++.cfg %{_builddir}/build-llvm/bin/clang
 ln -sf %{_builddir}/build-llvm/bin/clang++.cfg %{_builddir}/build-llvm/bin/$host_triple.cfg
 %endif
 
-ninja -C %{_builddir}/build-llvm %{makeprocesses}
+ninja -v -C %{_builddir}/build-llvm %{makeprocesses}
 
 cmake -G Ninja \
   -S %{_builddir}/%{n}-%{realversion}/amd/device-libs \
@@ -63,10 +63,10 @@ cmake -G Ninja \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_C_COMPILER=%{_builddir}/build-llvm/bin/clang \
   -DCMAKE_CXX_COMPILER=%{_builddir}/build-llvm/bin/clang++ \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_PREFIX_PATH="%{_builddir}/build-llvm;%{cmake_prefix_path}"
-ninja -C %{_builddir}/build-device-libs %{makeprocesses}
+ninja -v -C %{_builddir}/build-device-libs %{makeprocesses}
 
 cmake -G Ninja \
   -S  %{_builddir}/%{n}-%{realversion}/amd/hipcc \
@@ -74,16 +74,16 @@ cmake -G Ninja \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_C_COMPILER=%{_builddir}/build-llvm/bin/clang \
   -DCMAKE_CXX_COMPILER=%{_builddir}/build-llvm/bin/clang++ \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_PREFIX_PATH="%{_builddir}/build-llvm;%{cmake_prefix_path}"
-ninja  -C %{_builddir}/build-hip  %{makeprocesses}
+ninja -v -C %{_builddir}/build-hip  %{makeprocesses}
 
 %install
-ninja -C %{_builddir}/build-llvm %{makeprocesses} install
-ninja -C %{_builddir}/build-llvm/runtimes/runtimes-bins %{makeprocesses} install
-ninja -C %{_builddir}/build-llvm/runtimes/builtins-bins %{makeprocesses} install
-ninja -C %{_builddir}/build-device-libs install
-ninja -C %{_builddir}/build-hip install
+ninja -v -C %{_builddir}/build-llvm %{makeprocesses} install
+ninja -v -C %{_builddir}/build-llvm/runtimes/runtimes-bins %{makeprocesses} install
+ninja -v -C %{_builddir}/build-llvm/runtimes/builtins-bins %{makeprocesses} install
+ninja -v -C %{_builddir}/build-device-libs install
+ninja -v -C %{_builddir}/build-hip install
 
 mkdir -p %{i}/lib/llvm/bin/
 %if 0%{!?use_system_gcc:1}

--- a/rocm-rocprofiler-sdk.spec
+++ b/rocm-rocprofiler-sdk.spec
@@ -24,7 +24,7 @@ cmake \
   -B %{_builddir}/build \
   -S %{_builddir}/rocm-systems/projects/rocprofiler-sdk \
   -DCMAKE_INSTALL_PREFIX=%{i} \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -DROCPROFILER_BUILD_TESTS=OFF \
   -DROCPROFILER_BUILD_FMT=OFF \

--- a/rocm-rocprofiler-systems.spec
+++ b/rocm-rocprofiler-systems.spec
@@ -24,7 +24,7 @@ cmake \
   -B %{_builddir}/build \
   -S %{_builddir}/rocm-systems/projects/rocprofiler-systems \
   -DCMAKE_INSTALL_PREFIX=%{i} \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path};${LIBIBERTY_ROOT};${FLEX_ROOT};${BISON_ROOT}" \
   -DTBB_ROOT_DIR=${TBB_ROOT} \
   -DROCPROFSYS_USE_BFD=ON \

--- a/rocprofiler-compute.spec
+++ b/rocprofiler-compute.spec
@@ -18,7 +18,7 @@ cmake \
   -S %{_builddir}/rocm-systems/projects/%{n} \
   -B %{_builddir}/build \
   -DCMAKE_INSTALL_PREFIX=%{i} \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_PREFIX_PATH="%{cmake_prefix_path}" \
   -DCMAKE_C_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang \
   -DCMAKE_CXX_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang++ \

--- a/rocprofiler-register.spec
+++ b/rocprofiler-register.spec
@@ -21,7 +21,7 @@ sed -i -e 's|CMAKE_CXX_STANDARD  *17|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' %{
 cmake \
   -S %{_builddir}/rocm-systems/projects/%{n} \
   -B %{_builddir}/build \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   -DCMAKE_VERBOSE_MAKEFILE=TRUE \

--- a/starlight.spec
+++ b/starlight.spec
@@ -25,7 +25,7 @@ CXXFLAGS="-Wno-error=deprecated-declarations -Wno-error=deprecated-copy -Wno-err
 
 cmake ../%{n}-%{realversion} \
  -DCMAKE_INSTALL_PREFIX:PATH="%{i}" \
- -DCMAKE_BUILD_TYPE=Realease \
+ -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
  -DENABLE_CLHEP=ON \
  -DCMAKE_CXX_FLAGS="$CXXFLAGS"
 

--- a/tbb.spec
+++ b/tbb.spec
@@ -18,7 +18,7 @@ mkdir %{_builddir}/build
 
 cd %{_builddir}/build
 cmake ../%{n}-%{realversion} \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_CXX_FLAGS="-Wno-error=use-after-free -Wno-error=address -Wno-error=uninitialized" \
   -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
@@ -28,8 +28,8 @@ cmake ../%{n}-%{realversion} \
   -DTBB_CPF=ON \
   -DTBB_TEST=OFF
 
-make %{makeprocesses}
+make %{makeprocesses} VERBOSE=1
 
 %install
 cd %{_builddir}/build
-make install
+make install VERBOSE=1

--- a/tensorflow-xla-runtime.spec
+++ b/tensorflow-xla-runtime.spec
@@ -33,11 +33,12 @@ pushd xla-aot-runtime/src
 
   cmake . \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -I${TENSORFLOW_ROOT}/include" \
+    -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
     -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
     -DCMAKE_PREFIX_PATH=${ABSEIL_CPP_ROOT} \
     -DCMAKE_SHARED_LINKER_FLAGS="-L../lib -Wl,--whole-archive -l:libfft_wrapper.pic.a -Wl,--no-whole-archive -l:libfft.pic.a -l:libmutex.pic.a -l:libnsync_cpp.pic.a" \
     -DBUILD_SHARED_LIBS=ON
-  make %{makeprocesses}
+  make %{makeprocesses} VERBOSE=1
 popd
 
 %install

--- a/tkonlinesw.spec
+++ b/tkonlinesw.spec
@@ -117,13 +117,14 @@ export CXXFLAGS="-O2 -fPIC"
     cp %_sourcedir/tkonlinesw-cmake-build ./CMakeLists.txt
     make -C TrackerOnline/Fed9U/Fed9USoftware/Fed9UUtils include/Fed9UUtils.hh
     cmake . -DORACLE_ROOT=${ORACLE_ROOT} \
+      -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
 	    -DCMAKE_C_COMPILER="`which gcc`" \
 	    -DCMAKE_CXX_COMPILER="`which c++`" \
 	    -DCMAKE_LINKER=`which ld` \
 	    -DXERCES_ROOT=${XERCES_C_ROOT} \
 	    -DXERCESC=2 -DCMAKE_INSTALL_PREFIX=%i
-    make %makeprocesses
-    make install
+    make %makeprocesses VERBOSE=1
+    make install VERBOSE=1
 %endif
 
 %install

--- a/triton-inference-client.spec
+++ b/triton-inference-client.spec
@@ -42,7 +42,7 @@ TRITON_ENABLE_GPU_VALUE=%{?without_cuda:OFF}%{!?without_cuda:ON}
 cmake ${PROJ_DIR} \
     -DCMAKE_INSTALL_PREFIX="%{i}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
     -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
     -DTRITON_ENABLE_CC_HTTP=OFF \
     -DTRITON_ENABLE_CC_GRPC=ON \
@@ -63,7 +63,7 @@ rm -rf ../buildpy ; mkdir ../buildpy ; cd ../buildpy
 cmake ../%{n}-%{realversion}/src/python \
     -DCMAKE_INSTALL_PREFIX="%{i}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
     -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
     -DTRITON_ENABLE_PYTHON_HTTP=OFF \
     -DTRITON_ENABLE_PYTHON_GRPC=ON \
@@ -82,7 +82,7 @@ make %{makeprocesses} VERBOSE=1
 
 %install
 cd ../build
-make install
+make install VERBOSE=1
 cd ../buildpy
 mkdir -p %{i}/${PYTHON3_LIB_SITE_PACKAGES}
 rsync -a ./library/linux/wheel/build/lib/ %{i}/${PYTHON3_LIB_SITE_PACKAGES}/

--- a/vdt.spec
+++ b/vdt.spec
@@ -16,6 +16,7 @@ BuildRequires: cmake python3
 cmake . \
   -DCMAKE_INSTALL_PREFIX=%{i} \
   -DPYTHONLIBS_VERSION_STRING=%{cms_python3_major_minor_version} \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DPRELOAD:BOOL=ON \
 %ifarch x86_64
   -DSSE:BOOL=ON \
@@ -27,4 +28,4 @@ cmake . \
 make %{makeprocesses} VERBOSE=1
 
 %install
-make install
+make install VERBOSE=1

--- a/xrdcl-record.spec
+++ b/xrdcl-record.spec
@@ -10,7 +10,7 @@ Requires: xrootd
 %build
 rm -rf ../build; mkdir ../build ; cd ../build
 cmake ../%{n}-%{realversion} \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DCMAKE_INSTALL_PREFIX="%{i}" \
   -DCMAKE_PREFIX_PATH="${XROOTD_ROOT}" \
   -DCMAKE_VERBOSE=1 \
@@ -20,4 +20,4 @@ gmake %{makeprocesses} VERBOSE=1
 
 %install
 cd ../build
-gmake %{makeprocesses} install
+gmake %{makeprocesses} install VERBOSE=1

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -37,7 +37,7 @@ sed -i -e 's|^ *check_library_exists("uuid" "uuid_generate_random".*$|set(_have_
 rm -rf ../build; mkdir ../build; cd ../build
 cmake ../%n-%{realversion} \
   -DCMAKE_INSTALL_PREFIX=%{i} \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DFORCE_ENABLED=ON \
   -DENABLE_FUSE=FALSE \
   -DENABLE_VOMS=FALSE \
@@ -62,7 +62,7 @@ make %makeprocesses VERBOSE=1
 
 %install
 cd ../build
-make install
+make install VERBOSE=1
 %relocatePy3Shebang bin
 
 %post

--- a/xz.spec
+++ b/xz.spec
@@ -1,4 +1,4 @@
-### RPM external xz 5.6.4
+### RPM external xz 5.8.3
 Source0: http://tukaani.org/xz/xz-%{realversion}.tar.gz
 
 BuildRequires: autotools
@@ -8,10 +8,10 @@ BuildRequires: autotools
 
 %build
 ./configure CFLAGS='-fPIC -Ofast' --prefix=%{i} --disable-static --disable-nls --disable-rpath --disable-dependency-tracking --disable-doc
-make %{makeprocesses}
+make %{makeprocesses} VERBOSE=1
 
 %install
-make %{makeprocesses} install
+make %{makeprocesses} install VERBOSE=1
 
 %define strip_files %{i}/lib
 %define drop_files %{i}/share

--- a/yaml-cpp.spec
+++ b/yaml-cpp.spec
@@ -15,7 +15,7 @@ cd ../build
 cmake ../%{n}-%{realversion} \
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX:PATH="%i" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=%{cmake_build_type} \
   -DYAML_BUILD_SHARED_LIBS=ON \
   -DYAML_CPP_BUILD_TESTS=OFF
 
@@ -23,7 +23,7 @@ ninja -v %{makeprocesses}
 
 %install
 cd ../build
-ninja %{makeprocesses} install
+ninja -v %{makeprocesses} install
 
 %post
 %{relocateConfig}lib64/pkgconfig/yaml-cpp.pc


### PR DESCRIPTION
Update `xz` to latest version `5.8.3`. As python3 is also rebuild due to dependency ion xz, I propose to update python3 to latest version 3.12.13.

As this rebuild nearly all the externals (due to rebuild of `python3`) so I also propose to update the build configuration of externals to use `CMAKE_BUILD_TYPE=%{cmake_build_type}` which will allow us to configure and build a package in debug mode using `cmsBuild --define cms_debug_packages=pkg1,pkg2`