### PR TITLE
Implement CUDA 13 flags to parallelise device-code compilation

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -30,6 +30,12 @@
 # - mark __global__ functions and function templates, and __constant__, __device__ and __managed__ variables and variable templates, with __attribute__((visibility("hidden")))
 %define nvcc_visibility_flags --static-global-template-stub=true --device-entity-has-hidden-visibility=true
 
+# parallel device code compilation, integrated with make
+# split-compile=0 tries to automatically divide heavy TUs into multiple parallel compilation units
+# threads=0 uses all available CPU cores for parallel compilation
+# jobserver allows parallel compilation to be integrated with make's jobserver, so that the number of parallel jobs is limited to the number of jobs make is allowed to run in parallel
+%define nvcc_flags_parallel_compile --split-compile 0 --threads 0 --jobserver
+
 # build support for the various compute architectures
 %define nvcc_flags_cuda_archs %(echo $(for ARCH in %cuda_arch; do echo "-gencode arch=compute_$ARCH,code=[sm_$ARCH,compute_$ARCH]"; done)) -Wno-deprecated-gpu-targets
 
@@ -51,4 +57,5 @@
 # collect all CUDA flags
 %define nvcc_cuda_flags \
   %{nvcc_flags_stdcxx} %{nvcc_flags_opt} %{nvcc_flags_debug} %{nvcc_flags_constexpr} %{nvcc_flags_lambda} %{nvcc_visibility_flags} \
-  %{nvcc_flags_cuda_archs} %{nvcc_flags_cuda_diag_suppress} %{nvcc_flags_cudafe_diag} %{nvcc_flags_gnu_version} %{nvcc_flags_cudart}
+  %{nvcc_flags_parallel_compile} %{nvcc_flags_cuda_archs} %{nvcc_flags_cuda_diag_suppress} %{nvcc_flags_cudafe_diag} \
+  %{nvcc_flags_gnu_version} %{nvcc_flags_cudart}


### PR DESCRIPTION
This PR implements a few new `nvcc` flags to speed-up device code compilation. In particular:
- [--split-compile number](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#split-compile-number-split-compile) to try and automatically divide heavy TUs into smaller chunks
- [--threads](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#threads-number-t) to allow parallel compilation of device-code TUs
- [--jobserver](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#jobserver-jobserver) to make it so both the split and the threads rely on the same jobs spawned by Make

I have performed some local measurements on a node equipped with 2 AMD EPYC 9534 using [#51085](https://github.com/cms-sw/cmssw/pull/51085) to pull about 25% of CMSSW and especially the `RecoTracker/PixelSeeding` package as one of the slowest to compile for device. I have also disabled rocm compilation to isolate the effects on the CUDA side. I attach here the results from time for each compilation step (starting from `scram b clean` before every pass):
```
Default compilation time:
real    13m16.469s
user    569m49.105s
sys     254m48.762s
Default RecoTracker/PixelSeeding compilation time:
real    9m39.174s
user    33m22.067s
sys     7m16.893s
New flags compilation time:
real    8m25.389s
user    510m24.473s
sys     107m21.013s
New flags RecoTracker/PixelSeeding compilation time:
real    2m32.060s
user    34m28.999s
sys     7m36.785s
```

Note: **Requires https://github.com/cms-sw/cmssw-config/pull/120 to be able to correctly parse the `--jobserver` flag**