### PR TITLE
Address the issues that are causing the RISCV IBs to fail.

### DIFF
--- a/pip/matplotlib.file
+++ b/pip/matplotlib.file
@@ -1,5 +1,5 @@
 Requires: py3-numpy py3-pillow py3-pybind11 freetype qhull
-BuildRequires: cmake ninja
+BuildRequires: cmake ninja patchelf
 Patch0: patches/pip/matplotlib-freetype-slc7
 %define PipPreBuild \
   export CFLAGS="-I${FREETYPE_ROOT}/include/freetype2   -I${LIBPNG_ROOT}/include/libpng16 -I${QHULL_ROOT}/include" \

--- a/pip/tables.file
+++ b/pip/tables.file
@@ -4,5 +4,5 @@ Requires: py3-blosc2 py3-typing-extensions
 Requires: openmpi
 Patch0: patches/pip/tables-blosc2-max-dim
 Patch1: patches/pip/tables-cblosc-cpp23
-%define PipPreBuild export CFLAGS="-pthread -I${C_BLOSC2_ROOT}/include -I${C_BLOSC_ROOT}/inlcude -I${BZ2LIB_ROOT}/include"; export LDFLAGS="-L${C_BLOSC2_ROOT}/lib64 -L${C_BLOSC_ROOT}/lib64 -L${BZ2LIB_ROOT}/lib"  export HDF5_DIR=${HDF5_ROOT} CC="mpicc"; export DISABLE_AVX2=true ; export BLOSC2_DIR="${C_BLOSC2_ROOT}"; export CMAKE_ARGS="-DCMAKE_PREFIX_PATH='%{cmake_prefix_path}'"
+%define PipPreBuild export CFLAGS="-pthread -I${C_BLOSC2_ROOT}/include -I${C_BLOSC_ROOT}/inlcude -I${BZ2LIB_ROOT}/include"; export LDFLAGS="-L${C_BLOSC2_ROOT}/lib64 -L${C_BLOSC_ROOT}/lib64 -L${BZ2LIB_ROOT}/lib"  export HDF5_DIR=${HDF5_ROOT} CC="mpicc"; export DISABLE_AVX2=true ; export DISABLE_SSE2=true ; export BLOSC2_DIR="${C_BLOSC2_ROOT}"; export CMAKE_ARGS="-DCMAKE_PREFIX_PATH='%{cmake_prefix_path}'"
 %define PipBuildOptions  -C "--hdf5=${HDF5_ROOT}" -C "--bzip2=${BZ2LIB_ROOT}"


### PR DESCRIPTION
With these changes I was able to build RISCV IBs using QEMU emulation layer. Since the RISCV node is down for now. Let's test these changes in AMD64 before we merge.