### PR TITLE
[17.0] Use a per-thread default stream for CUDA code

### DIFF
--- a/cuda-flags.file
+++ b/cuda-flags.file
@@ -15,7 +15,7 @@
 %define nvcc_flags_stdcxx -std=c++%{cms_cxx_standard}
 
 # generate optimised code
-%define nvcc_flags_opt -O3
+%define nvcc_flags_opt -O3 --default-stream per-thread
 
 # generate debugging information for device code
 %define nvcc_flags_debug --generate-line-info --source-in-ptx --display-error-number


### PR DESCRIPTION
From `nvcc --help`:
```
--default-stream {legacy|null|per-thread}           (-default-stream)           
        Specify the stream that CUDA commands from the compiled program will be sent
        to by default.
                
        legacy
                The CUDA legacy stream (per context, implicitly synchronizes with
                other streams).
                
        per-thread
                A normal CUDA stream (per thread, does not implicitly
                synchronize with other streams).
                
        'null' is a deprecated alias for 'legacy'.
                
        Allowed values for this option:  'legacy','null','per-thread'.
        Default value:  'legacy'.
```