### PR TITLE
Updated root to tip of branch v6-36-00-patches

### DIFF
--- a/root.spec
+++ b/root.spec
@@ -3,8 +3,8 @@
 ## INITENV SET ROOTSYS %{i}
 ## INCLUDE compilation_flags
 ## INCLUDE cpp-standard
-%define tag 8d5dabd439ade453ba85136390e10554582e5cf6
-%define branch cms/v6-36-00-patches/0f0848ab623
+%define tag 4fbe34700bb4936e9529d5f88fcc93d6cec115ff
+%define branch cms/v6-36-00-patches/122aa7ce3fa
 
 %define github_user cms-sw
 Source: git+https://github.com/%{github_user}/root.git?obj=%{branch}/%{tag}&export=%{n}-%{realversion}&output=/%{n}-%{realversion}-%{tag}.tgz


### PR DESCRIPTION
@makortel , this contains a fix mentioned https://github.com/cms-sw/cmssw/issues/51607#issuecomment-5165551178 .
This PR contains https://github.com/root-project/root/compare/0f0848ab623...122aa7ce3fa changes on top of what we already have in ROOT 6.36 default IBs.  Let me know if you have any objections updating ROT 6.36 for 20.1.X.  If needed, we can back port it to 17.0.X and 20.0.X too