### PR TITLE
[PY314] Update python3 to 3.14.6

### DIFF
--- a/patches/pip/grpcio-absl-path.patch
+++ b/patches/pip/grpcio-absl-path.patch
@@ -1,46 +1,11 @@
-diff --git a/setup.py b/setup.py
-index 72e13c8..832ae73 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -37,7 +37,6 @@ import sys
- import sysconfig
- 
- import _metadata
--import pkg_resources
- from setuptools import Extension
- from setuptools.command import egg_info
- 
-@@ -473,22 +472,6 @@ if "linux" in sys.platform or "darwin" in sys.platform:
-     DEFINE_MACROS += (("PyMODINIT_FUNC", pymodinit),)
-     DEFINE_MACROS += (("GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK", 1),)
- 
--# By default, Python3 distutils enforces compatibility of
--# c plugins (.so files) with the OSX version Python was built with.
--# We need OSX 10.10, the oldest which supports C++ thread_local.
--# Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
--if "darwin" in sys.platform:
--    mac_target = sysconfig.get_config_var("MACOSX_DEPLOYMENT_TARGET")
--    if mac_target:
--        mac_target = pkg_resources.parse_version(str(mac_target))
--        if mac_target < pkg_resources.parse_version("10.10.0"):
--            os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.10"
--            os.environ["_PYTHON_HOST_PLATFORM"] = re.sub(
--                r"macosx-[0-9]+\.[0-9]+-(.+)",
--                r"macosx-10.10-\1",
--                sysconfig.get_platform(),
--            )
--
- 
- def cython_extensions_and_necessity():
-     cython_module_files = [
---- a/setup.py	2024-02-14 12:21:26.788212443 +0100
-+++ b/setup.py	2024-02-14 14:00:46.036665638 +0100
-@@ -378,7 +378,7 @@
-     EXTENSION_LIBRARIES += ("re2",)
+@@ -394,7 +394,7 @@ if BUILD_WITH_SYSTEM_RE2:
  if BUILD_WITH_SYSTEM_ABSL:
      EXTENSION_LIBRARIES += tuple(
--        lib.stem[3:] for lib in pathlib.Path("/usr").glob("lib*/libabsl_*.so")
-+        lib.stem[3:] for lib in pathlib.Path(os.getenv("ABSEIL_CPP_ROOT")).glob("lib*/libabsl_*.so")
+         lib.stem[3:]
+-        for lib in sorted(pathlib.Path("/usr").glob("lib*/libabsl_*.so"))
++        for lib in sorted(pathlib.Path(os.getenv("ABSEIL_CPP_ROOT")).glob("lib*/libabsl_*.so"))
      )
- 
+
  DEFINE_MACROS = (("_WIN32_WINNT", 0x600),)

--- a/patches/pip/numpy-f2py-wrapper.file
+++ b/patches/pip/numpy-f2py-wrapper.file
@@ -1,0 +1,6 @@
+#!/bin/bash
+export PYTHONPATH="$PYTHON3PATH${PYTHONPATH:+:$PYTHONPATH}"
+# -P: don't prepend cwd to sys.path. f2py is invoked from inside arbitrary
+# package source trees (e.g. scipy's own "scipy/" dir, which has its own
+# signal/ subpackage); without -P that shadows the stdlib "signal" module.
+exec python3 -P -m numpy.f2py "$@"

--- a/pip/astroid.file
+++ b/pip/astroid.file
@@ -1,3 +1,3 @@
-Requires: py3-typed-ast py3-typing-extensions
+Requires: py3-typing-extensions
 Requires: py3-lazy-object-proxy py3-six py3-wrapt py3-singledispatch
 Requires: py3-pytest-runner

--- a/pip/backports-zstd.file
+++ b/pip/backports-zstd.file
@@ -1,6 +1,0 @@
-Requires: zstd
-%define pip_name backports.zstd
-%define PipWheelOptions --config-settings=--build-option=--system-zstd
-%define PipPreBuild \
-  export CPPFLAGS="-I${ZSTD_ROOT}/include" \
-  export LDFLAGS="-L${ZSTD_ROOT}/lib"

--- a/pip/grpcio-tools.file
+++ b/pip/grpcio-tools.file
@@ -1,4 +1,3 @@
-Patch0: patches/pip/grpcio-tools-pkg_resources
 Requires: py3-protobuf py3-grpcio
 %define PipPreBuild \
   export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=%{compiling_processes}

--- a/pip/grpcio.file
+++ b/pip/grpcio.file
@@ -1,7 +1,7 @@
 ## INCLUDE cpp-standard
 %define patchsrc0 \
-  grep 'std=c++14' setup.py \
-  sed -i -e 's|std=c++14|std=c++%{cms_cxx_standard}|g' setup.py
+  grep 'std=c++17' setup.py \
+  sed -i -e 's|std=c++17|std=c++%{cms_cxx_standard}|g' setup.py
 Patch0: patches/pip/grpcio-absl-path
 %define PipPreBuild \
   export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=%{compiling_processes}; \
@@ -14,4 +14,4 @@ Patch0: patches/pip/grpcio-absl-path
   export CXXFLAGS="-I${RE2_ROOT}/include -I${ZLIB_ROOT}/include -I${ABSEIL_CPP_ROOT}/include -I${PYTHON3_ROOT}/include/python3.%{cms_python3_minor_version}" ;\
   export CFLAGS="-I${RE2_ROOT}/include   -I${ZLIB_ROOT}/include -I${ABSEIL_CPP_ROOT}/include -I${PYTHON3_ROOT}/include/python3.%{cms_python3_minor_version}"
 
-Requires: py3-six re2 zlib abseil-cpp
+Requires: py3-six re2 zlib abseil-cpp py3-typing-extensions

--- a/pip/luigi.file
+++ b/pip/luigi.file
@@ -1,2 +1,9 @@
 BuildRequires: py3-hatchling py3-hatch-fancy-pypi-readme
 Requires: py3-tornado py3-python-daemon py3-python-dateutil py3-tenacity
+
+# 3.8.1 is the latest release and still declares python_requires '<3.14,>=3.10',
+# so pip refuses it with "requires a different Python: 3.14.6 not in
+# '<3.14,>=3.10'". luigi is pure Python; the bound is a declaration, not a
+# technical limit. Drop these overrides once upstream ships a 3.14-capable release.
+%define PipWheelOptions --ignore-requires-python
+%define PipInstallOptions --ignore-requires-python

--- a/pip/numpy.file
+++ b/pip/numpy.file
@@ -1,7 +1,6 @@
 BuildRequires: py3-meson-python cms-ninja
 Requires: py3-cython
 Requires: zlib OpenBLAS
-Patch0: patches/pip/numpy-f2py-main
 
 %define patchsrc \
 cat > site.cfg <<EOF \
@@ -21,16 +20,30 @@ atlas_dirs = $OPENBLAS_ROOT/lib\
 fcompiler=gnu95\
 EOF
 
+#f2py is invoked from arbitrary build directories, so keep the interpreter's own
+#stdlib/site-packages ahead of the caller's cwd and PYTHONPATH entries. Applied
+#here rather than as a patch: numpy reorders these imports between releases.
+%define patchsrc0 \
+cat >> numpy/f2py/__init__.py <<'EOF' \
+\
+import sys as _cms_sys \
+_cms_zip = [_i for _i, _p in enumerate(_cms_sys.path) if _p.endswith(".zip")] \
+_cms_cut = _cms_zip[0] if _cms_zip else 0 \
+_cms_sys.path[:] = _cms_sys.path[_cms_cut:] + _cms_sys.path[:_cms_cut] \
+del _cms_sys, _cms_zip, _cms_cut \
+EOF
+
 %define source0 https://github.com/numpy/numpy/releases/download/v%{realversion}/numpy-%{realversion}.tar.gz
 %define PipPreBuild export NPY_NUM_BUILD_JOBS=%{compiling_processes}
 
 %define PipPostBuild \
   mkdir -p %{i}/c-api \
-  numpy_core=$(ls -d %{i}/lib/python*/site-packages/numpy/core | sed 's|%{i}/|../|') \
+  numpy_core=$(ls -d %{i}/lib/python*/site-packages/numpy/_core 2>/dev/null || true) \
+  [ -d "${numpy_core}/include" ] || numpy_core=$(ls -d %{i}/lib/python*/site-packages/numpy/core) \
+  numpy_core=$(echo "${numpy_core}" | sed 's|%{i}/|../|') \
   ln -s ${numpy_core} %{i}/c-api/core \
   echo "#!/bin/bash" > %{i}/bin/f2py \
   echo "echo \$PYTHONPATH" >> %{i}/bin/f2py \
-  echo "python3 -m numpy.f2py \\$*" >> %{i}/bin/f2py \
   chmod +x %{i}/bin/f2py
 #  ln -s ${numpy_core} %{i}/c-api/core
 

--- a/pip/numpy.file
+++ b/pip/numpy.file
@@ -1,10 +1,7 @@
 BuildRequires: py3-meson-python cms-ninja
 Requires: py3-cython
 Requires: zlib OpenBLAS
-<<<<<<< Updated upstream
-=======
 Source1: patches/pip/numpy-f2py-wrapper
->>>>>>> Stashed changes
 
 %define patchsrc \
 cat > site.cfg <<EOF \

--- a/pip/numpy.file
+++ b/pip/numpy.file
@@ -1,6 +1,10 @@
 BuildRequires: py3-meson-python cms-ninja
 Requires: py3-cython
 Requires: zlib OpenBLAS
+<<<<<<< Updated upstream
+=======
+Source1: patches/pip/numpy-f2py-wrapper
+>>>>>>> Stashed changes
 
 %define patchsrc \
 cat > site.cfg <<EOF \
@@ -42,8 +46,7 @@ EOF
   [ -d "${numpy_core}/include" ] || numpy_core=$(ls -d %{i}/lib/python*/site-packages/numpy/core) \
   numpy_core=$(echo "${numpy_core}" | sed 's|%{i}/|../|') \
   ln -s ${numpy_core} %{i}/c-api/core \
-  echo "#!/bin/bash" > %{i}/bin/f2py \
-  echo "echo \$PYTHONPATH" >> %{i}/bin/f2py \
+  cp %{_sourcedir}/numpy-f2py-wrapper %{i}/bin/f2py \
   chmod +x %{i}/bin/f2py
 #  ln -s ${numpy_core} %{i}/c-api/core
 

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -42,7 +42,9 @@ babel==2.18.0
 backcall==0.2.0
 backports-entry-points-selectable==1.3.0
 backports-tarfile==1.2.0
-backports-zstd==1.6.0
+# backports-zstd removed: it backports Python 3.14's compression.zstd to older
+# interpreters and its setup.py raises "RuntimeError: Unsupported Python version"
+# on 3.14 by design. Use the stdlib compression.zstd module instead.
 barectf==3.1.2
 beautifulsoup4==4.15.0
 beniget==0.5.0
@@ -143,8 +145,11 @@ google-auth==2.55.2
 google-auth-oauthlib==1.4.0
 google-pasta==0.2.0
 # NO_AUTO_UPDATE:2: update together with TF
-grpcio==1.60.1
-grpcio-tools==1.60.1
+# 1.60.1 fails to build on Python 3.14: the bundled Cython-generated cygrpc.cpp
+# calls _PyLong_AsByteArray(), which gained extra parameters in CPython 3.14.
+# 1.78.0 is what tensorflow 2.21.0 requirements_lock_3_14.txt pins.
+grpcio==1.82.0
+grpcio-tools==1.82.0
 h11==0.16.0
 hatch-fancy-pypi-readme==25.1.0
 hatch-jupyter-builder==0.9.1
@@ -152,8 +157,11 @@ hatch-nodejs-version==0.4.0
 hatch-requirements-txt==0.4.1
 hatch-vcs==0.5.0
 hatchling==1.31.0
-# NO_AUTO_UPDATE: version >= 3.15.0 requires Python 3.10; version 3.14.0 has hardcoded numpy>2 deps
-h5py==3.13.0
+# NO_AUTO_UPDATE: update together with TF. Both old reasons to hold at 3.13.0 are
+# now moot: we are on Python 3.14 (>= 3.10) and on numpy 2.x. tensorflow 2.21.0
+# setup.py.tpl requires 'h5py ~= 3.15.1' when sys.version_info.minor > 13, so
+# 3.13.0 would fail py3-tensorflow's pip check on 3.14.
+h5py==3.15.1
 hepdata-lib==0.21.0
 hepdata-validator==0.3.6
 hist==2.10.1
@@ -181,8 +189,11 @@ janus==2.0.0
 jaraco-classes==3.4.0
 jaraco-functools==4.5.0
 jaraco-context==6.1.2
-jax==0.9.0.1
-jaxlib==0.9.0.1
+# NO_AUTO_UPDATE:2: jaxlib is installed from a prebuilt wheel (see jaxlib.file).
+# 0.9.0.1 publishes no cp314 wheel, so the build picked cp312 and pip refused it
+# with "not a supported wheel on this platform". cp314 wheels start at 0.10.0.
+jax==0.11.0
+jaxlib==0.11.0
 jedi==0.20.0
 jeepney==0.9.0
 Jinja2==3.1.6
@@ -266,7 +277,14 @@ nvidia-ml-py==13.610.43
 numexpr==2.14.1
 # setuptools version <64 is needed by numpy: https://github.com/pypa/setuptools/issues/3549
 # NO_AUTO_UPDATE: update together with tensorflow
-numpy==1.26.4
+# 1.26.x supports Python <= 3.12 only and predates the numpy 2 ABI, which broke
+# pandas 3.0.3 ("numpy.core.multiarray failed to import" during the aotriton
+# CMake configure). 2.4.2 is what tensorflow 2.21.0 requirements_lock_3_14.txt
+# pins; its requirements.in floor for 3.14 is numpy>=2.2.6.
+# NOTE: numpy 2 renamed numpy/core to numpy/_core -- see the c-api symlink in
+# numpy.file, which tensorflow's third_party/cms/numpy.BUILD globs as
+# c-api/core/include.
+numpy==2.4.2
 # NO_AUTO_UPDATE:1
 orjson==3.11.5
 onnx==1.22.0
@@ -459,7 +477,10 @@ tqdm==4.68.4
 traitlets==5.15.1
 triton==3.7.1
 trove-classifiers==2026.6.1.19
-typed-ast==1.5.5
+# typed-ast removed: abandoned upstream (last release 1.5.5, 2023) and it vendors
+# CPython AST internals, so it no longer compiles ("unknown type name
+# 'PyFutureFeatures'"). Obsolete since Python 3.8 -- use ast.parse(type_comments=True).
+# Its only consumer here was astroid, which has not needed it for years.
 types-python-dateutil==2.9.0.20260518
 typing-extensions==4.16.0
 typing-inspection==0.4.2

--- a/pip/tensorflow-io-gcs-filesystem.file
+++ b/pip/tensorflow-io-gcs-filesystem.file
@@ -1,2 +1,9 @@
 %define source0 git+https://github.com/tensorflow/io?obj=master/v%{realversion}&export=%{n}-%{realversion}&output=/source.tar.gz
 Patch0: patches/pip/py3-tensorflow-io-gcs-filesystem
+
+# 0.37.1 (Jul 2024) is the latest release and declares python_requires
+# '<3.13,>=3.7'; there is no 3.13/3.14 release. pip refuses it on 3.14 with
+# "requires a different Python: 3.14.6 not in '<3.13,>=3.7'". We build from git
+# source anyway, so override the declared bound on both wheel and install.
+%define PipWheelOptions --ignore-requires-python
+%define PipInstallOptions --ignore-requires-python

--- a/python3.spec
+++ b/python3.spec
@@ -1,4 +1,4 @@
-### RPM external python3 3.12.13
+### RPM external python3 3.14.6
 ## INITENV +PATH PATH %{i}/bin
 ## INITENV +PATH LD_LIBRARY_PATH %{i}/lib
 ## INITENV SETV PYTHON3_LIB_SITE_PACKAGES lib/python%{pythonv}/site-packages

--- a/python3.spec
+++ b/python3.spec
@@ -46,7 +46,6 @@ make %{makeprocesses}
 make %{makeprocesses} install
 sed -i -e "s|^#!.*python%{pythonv} *$|#!/usr/bin/env python%{python_major}|" %{i}/bin/* %{i}/lib/python*/*.py
 sed -i -e 's|^#!/.*|#!/usr/bin/env python%{pythonv}m|' %{i}/lib/python*/config-*/python-config.py
-sed -i -e 's|^#! */usr/local/bin/python|#!/usr/bin/env python|' %{i}/lib/python*/cgi.py
 
 # is executable, but does not start with she-bang so not valid
 # executable; this avoids problems with rpm 4.8+ find-requires

--- a/python_tools.spec
+++ b/python_tools.spec
@@ -4,8 +4,7 @@ Source: none
 
 Requires: root curl python3 xrootd llvm hdf5 yoda opencv triton-inference-client
 Requires: professor2 rivet frontier_client onnxruntime openldap pacparser
-Requires: mille 
-Requires: py3-backports-zstd
+Requires: mille
 Requires: py3-multidict
 Requires: py3-anyio
 Requires: py3-sniffio

--- a/tensorflow-sources.spec
+++ b/tensorflow-sources.spec
@@ -1,6 +1,6 @@
 ### RPM external tensorflow-sources 2.21.0
-%define tag         a64812892be30f3f2d01cdb6fd25a1aa2983a894
-%define branch      cms/v%{realversion}
+%define tag         00a969e5ce3a2606b8f28621bb20273bef470cd0
+%define branch      cms/v%{realversion}-py314
 %define github_user akritkbehera
 %define build_type opt
 %define pythonOnly no


### PR DESCRIPTION
Since TF is updated we can try to update Python 3.14.6 cleanly. We will run tests for TF IBs for now.