### PR TITLE
fix elfutils for el8

### DIFF
--- a/elfutils.spec
+++ b/elfutils.spec
@@ -22,5 +22,15 @@ make %{makeprocesses} V=1
 %install
 make install V=1
 
+#### FIXME: For next full rebuild fix xz to ave pkgconfig ###
+#We do not have xz/lib/pkgconfig/liblzma.pc file so lets remove liblzma from Requires and explicitly link lzma
+if grep ' liblzma' %i/lib/pkgconfig/libdw.pc ; then
+  # Remove explicit Requires of liblzma
+  sed -i -e 's| liblzma||'  %i/lib/pkgconfig/libdw.pc
+  # Added our lzma include and lib paths
+  sed -i -e "s|^Cflags: |Cflags: -I${XZ_ROOT}/include |" %i/lib/pkgconfig/libdw.pc
+  sed -i -e "s|^Libs.private: |Libs.private: -L${XZ_ROOT}/lib -llzma |" %i/lib/pkgconfig/libdw.pc
+fi
+
 %post
 %relocateConfigAll lib/pkgconfig *.pc

--- a/elfutils.spec
+++ b/elfutils.spec
@@ -6,6 +6,10 @@ Requires: zlib bz2lib xz
 
 %prep
 %setup -n %{n}-%{realversion}
+%if "%{rhel}" == "8"
+sed -i -e 's|^readelf_LDADD\s*[+]=\s*libthread.a|readelf_LDADD += libthread.a -lpthread|' src/Makefile.am
+autoreconf -fi
+%endif
 
 %build
 export CPPFLAGS="-I${ZLIB_ROOT}/include -I${BZ2LIB_ROOT}/include -I${XZ_ROOT}/include"
@@ -13,10 +17,10 @@ export LDFLAGS="-L${ZLIB_ROOT}/lib -L${BZ2LIB_ROOT}/lib -L${XZ_ROOT}/lib"
 ./configure --prefix=%{i} --disable-static --enable-install-elfh \
             --disable-libdebuginfod --disable-debuginfod \
             --enable-thread-safety --disable-nls
-make %{makeprocesses}
+make %{makeprocesses} V=1
 
 %install
-make install
+make install V=1
 
 %post
 %relocateConfigAll lib/pkgconfig *.pc

--- a/rocm-rocprofiler-systems.spec
+++ b/rocm-rocprofiler-systems.spec
@@ -4,10 +4,10 @@ Patch0: patches/rocprofiler-systems-elfutils
 Patch1: patches/rocprofiler-systems-dyninst-tbb-boost-conflict
 Requires: rocm-core rocr-runtime rocprofiler roctracer rocm-hip libxml2
 Requires: libunwind dyninst bz2lib
-Requires: sqlite rocm-rocprofiler-sdk amdsmi zlib rocm-comgr boost tbb json py3-pybind11 elfutils
+Requires: sqlite rocm-rocprofiler-sdk amdsmi zlib rocm-comgr boost tbb json py3-pybind11 elfutils xz
 BuildRequires: flex bison cmake libiberty rocm-llvm rocm-cmake
 %define rocm_project rocprofiler-systems
 %define ROCMPostPrep patch -p3 -i %{PATCH0} ; patch -p3 -i %{PATCH1}
-%define ROCMPreBuild export CPPFLAGS=-I${BZ2LIB_ROOT}/include; export LDFLAGS=-L${BZ2LIB_ROOT}/lib; export PKG_CONFIG_PATH=${ELFUTILS_ROOT}/lib/pkgconfig:/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}; perl -i -0pe 's|#include <elf-bfd\\.h>\\n#include <elfutils/libdw\\.h>|#include <elfutils/libdw.h>\\n#include <elf-bfd.h>|' %{_builddir}/rocm-systems/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
+%define ROCMPreBuild export PKG_CONFIG_PATH=${ELFUTILS_ROOT}/lib/pkgconfig:/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}; perl -i -0pe 's|#include <elf-bfd\\.h>\\n#include <elfutils/libdw\\.h>|#include <elfutils/libdw.h>\\n#include <elf-bfd.h>|' %{_builddir}/rocm-systems/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
 %define cmake_args -DCMAKE_PREFIX_PATH="%{cmake_prefix_path};${LIBIBERTY_ROOT};${FLEX_ROOT};${BISON_ROOT}" -DTBB_ROOT_DIR=${TBB_ROOT} -DROCPROFSYS_USE_BFD=ON -DROCPROFSYS_USE_PYTHON=ON -DROCPROFSYS_BUILD_PYTHON=OFF -DROCPROFSYS_BUILD_DYNINST=OFF -DROCPROFSYS_BUILD_TBB=OFF -DROCPROFSYS_BUILD_LIBUNWIND=OFF -DROCPROFSYS_BUILD_BOOST=OFF -DROCPROFSYS_BUILD_LIBIBERTY=OFF -DROCPROFSYS_BUILD_ELFUTILS=OFF -DElfUtils_ROOT_DIR=${ELFUTILS_ROOT} -DElfUtils_INCLUDEDIR=${ELFUTILS_ROOT}/include -DElfUtils_LIBRARYDIR=${ELFUTILS_ROOT}/lib -DROCPROFILER_BUILD_SQLITE3=OFF -DROCPROFSYS_BUILD_NLOHMANN_JSON=OFF -DROCPROFSYS_BUILD_EXAMPLES=OFF -DROCPROFSYS_BUILD_TESTING=OFF -DCMAKE_FIND_DEBUG_MODE=OFF -DROCPROFSYS_USE_PAPI=OFF -DPython3_ROOT_DIR=$PYTHON3_ROOT
 ## INCLUDE rocm-systems-build


### PR DESCRIPTION
This should fix the failing el8_amd64_gcc13 IBs where elfutils fails for el8 with error 
```
/build/muz/del/w/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld: libthread.a(threadlib.o): 
   undefined reference to symbol 'pthread_join@@GLIBC_2.2.5' 
/build/muz/del/w/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld: /lib64/libpthread.so.0: 
  error adding symbols: DSO missing from command line collect2: error: ld returned 1
exit status make[2]: *** [Makefile:814: readelf] Error 1 make[1]: *** [Makefile:633: all-recursive] Error 1
```

FYI @akritkbehera 