### PR TITLE
[20_0_X] Update hls4mlEmulatorExtras to v1.1.7 (backport)

### DIFF
--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.1.6
+### RPM external hls4mlEmulatorExtras 1.1.7
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 

--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.1.4
+### RPM external hls4mlEmulatorExtras 1.1.5
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 

--- a/hls4mlEmulatorExtras.spec
+++ b/hls4mlEmulatorExtras.spec
@@ -1,4 +1,4 @@
-### RPM external hls4mlEmulatorExtras 1.1.5
+### RPM external hls4mlEmulatorExtras 1.1.6
 Source: https://github.com/cms-hls4ml/%{n}/archive/refs/tags/v%{realversion}.tar.gz
 BuildRequires: gmake
 


### PR DESCRIPTION
update hls4mlEmulatorExtras to [v1.1.7](https://github.com/cms-hls4ml/hls4mlEmulatorExtras/releases/tag/v1.1.7)
adds fix for early model destruction https://github.com/cms-hls4ml/hls4mlEmulatorExtras/issues/7 as included in https://github.com/cms-hls4ml/hls4mlEmulatorExtras/pull/8 (avoid early dlclose call). Spotted in https://github.com/cms-sw/cmssw/pull/51633

Also adds fix to shared pointer type mismatch found [here](https://github.com/cms-sw/cmsdist/pull/10770#issuecomment-5218468633) and other bugs as mentioned below. Verified compilation.

Backport of https://github.com/cms-sw/cmsdist/pull/10770