### PR TITLE
python 3.14: scram and build rules changes

### DIFF
--- a/SCRAMV1.spec
+++ b/SCRAMV1.spec
@@ -1,8 +1,8 @@
-### RPM lcg SCRAMV1 V3_00_94
+### RPM lcg SCRAMV1 V3_00_95
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX
 
-%define tag 2ffbf93d2196f5b60b9f1454f68013d4530d5048
+%define tag 21a9cd17bdeb37d0ad4a42b3bcbbc4597a65aa2a
 %define branch SCRAMV3
 %define github_user cms-sw
 %define shared_dir share/%{pkgcategory}/SCRAMV1/%{realversion}

--- a/scram-project-build.file
+++ b/scram-project-build.file
@@ -56,7 +56,7 @@ BuildRequires: dwz
 %endif
 
 %if "%{?configtag:set}" != "set"
-%define configtag       V09-09-08
+%define configtag       V09-09-09
 %endif
 
 %if "%{?buildarch:set}" != "set"


### PR DESCRIPTION
For Python 3.14 we need the following changes
scram: https://github.com/cms-sw/SCRAM/commit/21a9cd17bdeb37d0ad4a42b3bcbbc4597a65aa2a
build rules: https://github.com/cms-sw/cmssw-config/commit/424a74a570c8d69e740a76c20fb1aa4afd513215

These changes should work with old python 3X versions too.