### PR TITLE
Update dasgoclient version to v02.04.54

### DIFF
--- a/dasgoclient.spec
+++ b/dasgoclient.spec
@@ -3,7 +3,7 @@
 #For any other change, increment version_suffix
 ##########################################
 %define version_suffix 00
-%define dasgoclient_tag v02.04.52
+%define dasgoclient_tag v02.04.54
 ### RPM cms dasgoclient %{dasgoclient_tag}.rev%{version_suffix}
 ## NOCOMPILER
 ## NO_VERSION_SUFFIX


### PR DESCRIPTION
This change is triggered by the das2go code base upgrade and new version release of [v04.07.43](https://github.com/dmwm/das2go/releases/tag/v04.07.43). The new version fixes: https://github.com/dmwm/das2go/issues/86