### PR TITLE
Build `libamdhip64.so` with debug symbols

### DIFF
--- a/rocm/rocm-hip.spec
+++ b/rocm/rocm-hip.spec
@@ -8,5 +8,5 @@ BuildRequires: py3-CppHeaderParser
 Requires: rocm-llvm rocm-core rocr-runtime rocprofiler-register numactl python3 rocm-comgr
 Provides: perl(URI::Escape)
 %define rocm_project clr
-%define cmake_args -DHIP_COMMON_DIR=${ROCM_SOURCES_ROOT}/rocm-systems/projects/hip -DHIP_PLATFORM=amd -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF -DHIP_INSTALLS_HIPCC=ON -DHIPCC_BIN_DIR=${ROCM_LLVM_ROOT}/bin -DCMAKE_C_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang -DCMAKE_CXX_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang++ -DCMAKE_INSTALL_LIBDIR=lib -DHSA_PATH=${HSA_ROCR_ROOT} -DROCM_PATH=${ROCM_LLVM_ROOT} -DDEVICE_LIB_PATH=${ROCM_LLVM_ROOT}/amdgcn/bitcode -DLLVM_DIR=${ROCM_LLVM_ROOT}/lib/llvm/lib/cmake/llvm
+%define cmake_args -DHIP_COMMON_DIR=${ROCM_SOURCES_ROOT}/rocm-systems/projects/hip -DHIP_PLATFORM=amd -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF -DHIP_INSTALLS_HIPCC=ON -DHIPCC_BIN_DIR=${ROCM_LLVM_ROOT}/bin -DCMAKE_C_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang -DCMAKE_CXX_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang++ -DCMAKE_INSTALL_LIBDIR=lib -DHSA_PATH=${HSA_ROCR_ROOT} -DROCM_PATH=${ROCM_LLVM_ROOT} -DDEVICE_LIB_PATH=${ROCM_LLVM_ROOT}/amdgcn/bitcode -DLLVM_DIR=${ROCM_LLVM_ROOT}/lib/llvm/lib/cmake/llvm -DCMAKE_BUILD_TYPE=RelWithDebInfo
 ## INCLUDE rocm/systems-build


### PR DESCRIPTION
The size increase is order of 30MB, if there is no impact on the runtime performance I would actually suggest to keep this.