### PR TITLE
Prevent a deadlock in ROCm

### DIFF
--- a/patches/rocm-systems-issue10529.patch
+++ b/patches/rocm-systems-issue10529.patch
@@ -1,0 +1,36 @@
+commit 7e4352963e725c5ec3ef2bc541dcb3255dc2ecd3 (HEAD -> therock-7.14-issue10529, fwyzard/therock-7.14-issue10529)
+Author: Andrea Bocci <andrea.bocci@cern.ch>
+Date:   Fri Aug 21 12:25:16 2026 +0200
+
+    Prevent a deadlock between hipEventSynchronize and hipMallocAsync
+    
+    hipMallocAsync may try to acquire the device lock while it holds the memory
+    pool lock, if the pool needs to allocate more memory.
+    
+    hipEventSynchronize will try to acquire the memory pool lock while holding the
+    device lock, to free the unused memory in the pool.
+    
+    This may cause a deadlock if the two operations happen on different threads at
+    the same time.
+    
+    This change makes MemoryPool::ReleaseFreedMemory (called by hipEventSynchronize)
+    return immediately if it cannot acquire the pool lock.
+
+diff --git a/projects/clr/hipamd/src/hip_mempool_impl.cpp b/projects/clr/hipamd/src/hip_mempool_impl.cpp
+index 0983241188..0dc99953ef 100644
+--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
++++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
+@@ -339,7 +339,12 @@ void MemoryPool::ReleaseAllMemory() {
+ 
+ // ================================================================================================
+ void MemoryPool::ReleaseFreedMemory() {
+-  std::scoped_lock lock(lock_pool_ops_);
++  // Do not block if the lock cannot be acquired, to avoid a deadlock if a different thread holds
++  // the pool lock and tries to acquire the device lock, e.g. hipMallocAsync requesting new memory.
++  std::unique_lock lock(lock_pool_ops_, std::try_to_lock);
++  if (! lock.owns_lock()) {
++    return;
++  }
+ 
+   free_heap_.ReleaseAllMemory();
+ }

--- a/rocm/rocm-hip.spec
+++ b/rocm/rocm-hip.spec
@@ -4,9 +4,11 @@
 ## INITENV SET HIP_PATH %{i}
 ## INITENV SET HIP_CLANG_PATH ${ROCM_LLVM_ROOT}/lib/llvm/bin
 ## INITENV HIP_PLATFORM amd
+Patch0: patches/rocm-systems-issue10529
 BuildRequires: py3-CppHeaderParser
 Requires: rocm-llvm rocm-core rocr-runtime rocprofiler-register numactl python3 rocm-comgr
 Provides: perl(URI::Escape)
+%define ROCMPostPrep patch -p3 -i %{PATCH0}
 %define rocm_project clr
 %define cmake_args -DHIP_COMMON_DIR=${ROCM_SOURCES_ROOT}/rocm-systems/projects/hip -DHIP_PLATFORM=amd -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF -DHIP_INSTALLS_HIPCC=ON -DHIPCC_BIN_DIR=${ROCM_LLVM_ROOT}/bin -DCMAKE_C_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang -DCMAKE_CXX_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang++ -DCMAKE_INSTALL_LIBDIR=lib -DHSA_PATH=${HSA_ROCR_ROOT} -DROCM_PATH=${ROCM_LLVM_ROOT} -DDEVICE_LIB_PATH=${ROCM_LLVM_ROOT}/amdgcn/bitcode -DLLVM_DIR=${ROCM_LLVM_ROOT}/lib/llvm/lib/cmake/llvm -DCMAKE_BUILD_TYPE=RelWithDebInfo
 ## INCLUDE rocm/systems-build

--- a/rocm/rocm-hip.spec
+++ b/rocm/rocm-hip.spec
@@ -8,5 +8,5 @@ BuildRequires: py3-CppHeaderParser
 Requires: rocm-llvm rocm-core rocr-runtime rocprofiler-register numactl python3 rocm-comgr
 Provides: perl(URI::Escape)
 %define rocm_project clr
-%define cmake_args -DHIP_COMMON_DIR=${ROCM_SOURCES_ROOT}/rocm-systems/projects/hip -DHIP_PLATFORM=amd -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF -DHIP_INSTALLS_HIPCC=ON -DHIPCC_BIN_DIR=${ROCM_LLVM_ROOT}/bin -DCMAKE_C_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang -DCMAKE_CXX_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang++ -DCMAKE_INSTALL_LIBDIR=lib -DHSA_PATH=${HSA_ROCR_ROOT} -DROCM_PATH=${ROCM_LLVM_ROOT} -DDEVICE_LIB_PATH=${ROCM_LLVM_ROOT}/amdgcn/bitcode -DLLVM_DIR=${ROCM_LLVM_ROOT}/lib/llvm/lib/cmake/llvm
+%define cmake_args -DHIP_COMMON_DIR=${ROCM_SOURCES_ROOT}/rocm-systems/projects/hip -DHIP_PLATFORM=amd -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF -DHIP_INSTALLS_HIPCC=ON -DHIPCC_BIN_DIR=${ROCM_LLVM_ROOT}/bin -DCMAKE_C_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang -DCMAKE_CXX_COMPILER=${ROCM_LLVM_ROOT}/bin/amdclang++ -DCMAKE_INSTALL_LIBDIR=lib -DHSA_PATH=${HSA_ROCR_ROOT} -DROCM_PATH=${ROCM_LLVM_ROOT} -DDEVICE_LIB_PATH=${ROCM_LLVM_ROOT}/amdgcn/bitcode -DLLVM_DIR=${ROCM_LLVM_ROOT}/lib/llvm/lib/cmake/llvm -DCMAKE_BUILD_TYPE=RelWithDebInfo
 ## INCLUDE rocm/systems-build


### PR DESCRIPTION
Prevent a deadlock between `hipEventSynchronize` and `hipMallocAsync`.

`hipMallocAsync` may try to acquire the device lock while it holds the memory pool lock, if the pool needs to allocate more memory.

`hipEventSynchronize` will try to acquire the memory pool lock while holding the device lock, to free the unused memory in the pool.

This may cause a deadlock if the two operations happen on different threads at the same time.

This change makes `MemoryPool::ReleaseFreedMemory` (called by `hipEventSynchronize`) return immediately if it cannot acquire the pool lock.

We also build `libamdhip64.so` with debug symbols.