### PR TITLE
FWLite: Added HeterogeneousCore/AlpakaCore dependency

### DIFF
--- a/fwlite_build_set.file
+++ b/fwlite_build_set.file
@@ -129,6 +129,7 @@ Geometry/CaloGeometry
 Geometry/CommonDetUnit
 Geometry/CommonTopologies
 Geometry/GEMGeometry
+HeterogeneousCore/AlpakaCore
 HeterogeneousCore/AlpakaInterface
 HeterogeneousCore/TrivialSerialisation
 PhysicsTools/FWLite


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/50503 Added HeterogeneousCore/AlpakaCore dependency  which causes fwlite build to fail with error
```
src/HeterogeneousCore/TrivialSerialisation/plugins/alpaka/GenericClonerPortable.cc:41:10: fatal error: HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataSentry.h: No such file or directory
   41 | #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataSentry.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```