### PR TITLE
fwlite: delete Heterogeneous*/*/plugins

### DIFF
--- a/fwlite.spec
+++ b/fwlite.spec
@@ -16,7 +16,7 @@ Requires: fwlite-tool-conf
 %define patchsrc3 rm -f src/FWCore/MessageLogger/python/MessageLogger_cfi.py
 
 # delete Dataformats/*/plugins directory
-%define patchsrc4 rm -rf src/DataFormats/*/plugins
+%define patchsrc4 rm -rf src/DataFormats/*/plugins src/Heterogeneous*/*/plugins
 
 %define source1 git://github.com/cms-sw/cmssw.git?protocol=https&obj=%{branch}/%{gitcommit}&module=%{cvssrc}&export=%{srctree}&output=/src.tar.gz
 


### PR DESCRIPTION
As discussed in Core SW meeting and https://github.com/cms-sw/cmsdist/pull/10814 , this PR proposes to not build `Heterogeneous*/*/plugins` . Note that we already do not build `DataFormats/*/plugins`