### PR TITLE
Fix PyTorch ROCm library linking

### DIFF
--- a/scram-tools.file/tools/py3-torch-rocm/pytorch-rocm.xml
+++ b/scram-tools.file/tools/py3-torch-rocm/pytorch-rocm.xml
@@ -1,10 +1,12 @@
-<tool revision="3">
+<tool revision="4">
   <client>
     <environment name="INCLUDE" default="$TOOL_BASE/include"/>
     <environment name="INCLUDE" default="$TOOL_BASE/include/torch/csrc/api/include"/>
     <environment name="LIBDIR" default="$TOOL_BASE/lib"/>
   </client>
   <flags SKIP_TOOL_SYMLINKS="1"/>
+  <flags FORCE_LINK="1"/>
+  <flags LDFLAGS="-L$TOOL_BASE/lib"/>
   <use name="pytorch"/>
   <use name="rocm"/>
   <lib name="torch_hip"/>


### PR DESCRIPTION
#### PR description

This PR adds two additional linker settings:

- `FORCE_LINK` ensures that the ROCm backend library is kept in the final dependency chain even when no symbol from it is referenced directly.
- `-L$TOOL_BASE/lib` gives priority to the libraries shipped with the ROCm PyTorch package when linking a ROCm target. This ensures that `libtorch_hip`, `libtorch_cpu`, `libc10`, etc. all come from the same ROCm PyTorch build, instead of accidentally mixing ROCm-specific libraries with the generic PyTorch libraries.
