### PR TITLE
Update CLUEstering to version `2.12.0`

### DIFF
--- a/CLUEstering.spec
+++ b/CLUEstering.spec
@@ -1,4 +1,4 @@
-### RPM external CLUEstering 2.11.0
+### RPM external CLUEstering 2.12.0
 ## NOCOMPILER
 
 Source: https://gitlab.cern.ch/kalos/%{n}/-/archive/%{realversion}/%{n}-%{realversion}.tar.gz


### PR DESCRIPTION
This PR updates CLUEstering to the latest release, which contains new features needed for the reconstruction in TICL.

FYI: @waredjeb @mmarriot @felicepantaleo 