### PR TITLE
[UBSAN] Apply abseil ubsan fix

### DIFF
--- a/abseil-cpp.spec
+++ b/abseil-cpp.spec
@@ -1,11 +1,13 @@
-### RPM external abseil-cpp 20250814.1
+### RPM external abseil-cpp 20260817.0
 ## INCLUDE cpp-standard
 
 Source: https://github.com/abseil/abseil-cpp/archive/%{realversion}.tar.gz
+Patch0: patches/abseil-cpp-ubsan
 BuildRequires: cmake gmake
 
 %prep
 %setup -n %{n}-%{realversion}
+%patch0 -p1
 
 %build
 rm -rf ../build

--- a/abseil-cpp.spec
+++ b/abseil-cpp.spec
@@ -1,4 +1,4 @@
-### RPM external abseil-cpp 20260817.0
+### RPM external abseil-cpp 20250814.1
 ## INCLUDE cpp-standard
 
 Source: https://github.com/abseil/abseil-cpp/archive/%{realversion}.tar.gz

--- a/patches/abseil-cpp-ubsan.patch
+++ b/patches/abseil-cpp-ubsan.patch
@@ -1,0 +1,44 @@
+diff --git a/absl/container/internal/hash_policy_traits.h b/absl/container/internal/hash_policy_traits.h
+index e469d71..6c6627b 100644
+--- a/absl/container/internal/hash_policy_traits.h
++++ b/absl/container/internal/hash_policy_traits.h
+@@ -28,6 +28,16 @@
+ namespace absl {
+ ABSL_NAMESPACE_BEGIN
+ namespace container_internal {
++// Selects the policy-provided type-erased hash-slot function, or the generic
++// non-type-erased fallback when the policy returns nullptr.
++template <HashSlotFn kFallbackFn, HashSlotFn kPolicyFn>
++struct HashSlotFnSelector {
++  static constexpr HashSlotFn kValue = kPolicyFn;
++};
++template <HashSlotFn kFallbackFn>
++struct HashSlotFnSelector<kFallbackFn, nullptr> {
++  static constexpr HashSlotFn kValue = kFallbackFn;
++};
+ 
+ // Defines how slots are initialized/destroyed/moved.
+ template <class Policy, class = void>
+@@ -148,19 +158,9 @@ template <class Policy, class = void>
+ 
+   template <class Hash, bool kIsDefault>
+   static constexpr HashSlotFn get_hash_slot_fn() {
+-// get_hash_slot_fn may return nullptr to signal that non type erased function
+-// should be used. GCC warns against comparing function address with nullptr.
+-#if defined(__GNUC__) && !defined(__clang__)
+-#pragma GCC diagnostic push
+-// silent error: the address of * will never be NULL [-Werror=address]
+-#pragma GCC diagnostic ignored "-Waddress"
+-#endif
+-    return Policy::template get_hash_slot_fn<Hash, kIsDefault>() == nullptr
+-               ? &hash_slot_fn_non_type_erased<Hash, kIsDefault>
+-               : Policy::template get_hash_slot_fn<Hash, kIsDefault>();
+-#if defined(__GNUC__) && !defined(__clang__)
+-#pragma GCC diagnostic pop
+-#endif
++    return HashSlotFnSelector<
++        &hash_slot_fn_non_type_erased<Hash, kIsDefault>,
++        Policy::template get_hash_slot_fn<Hash, kIsDefault>()>::kValue;
+   }
+ 
+   // Whether small object optimization is enabled. True by default.


### PR DESCRIPTION
Update Abseil to version 20260817 with patch suggested https://github.com/abseil/abseil-cpp/issues/1634#issuecomment-5492146056 to avoid UBSAN build errors in CMSSW [a]

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc14/CMSSW_20_1_UBSAN_X_2026-09-07-2300/RecoTracker/TkSeedGenerator
```
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/internal/raw_hash_set.h:212,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/internal/raw_hash_map.h:27,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/flat_hash_map.h:45,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/protobuf/6.31.1-b36a2fb74ed10457e80fba31cbeb33b8/include/google/protobuf/descriptor.h:47,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/protobuf/6.31.1-b36a2fb74ed10457e80fba31cbeb33b8/include/google/protobuf/generated_message_reflection.h:26,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/tensorflow/2.21.0-fa4dd945279daec5b6f3a820caacb861/include/tensorflow/core/framework/types.pb.h:26,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/tensorflow/2.21.0-fa4dd945279daec5b6f3a820caacb861/include/tensorflow/core/framework/tensor_shape.h:22,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/tensorflow/2.21.0-fa4dd945279daec5b6f3a820caacb861/include/tensorflow/core/framework/tensor.h:28,
                 from src/PhysicsTools/TensorFlow/interface/TensorFlow.h:11,
                 from src/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc:70:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/internal/hash_policy_traits.h: In instantiation of 'static const absl::lts_20250814::container_internal::PolicyFunctions& absl::lts_20250814::container_internal::raw_hash_set<Policy, Hash, Eq, Alloc>::GetPolicyFunctions() [with Policy = absl::lts_20250814::container_internal::FlatHashSetPolicy<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Hash = absl::lts_20250814::hash_internal::Hash<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Eq = std::equal_to<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Alloc = std::allocator<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/internal/raw_hash_set.h:2264:38:   required from 'absl::lts_20250814::container_internal::raw_hash_set<Policy, Hash, Eq, Alloc>::raw_hash_set(const absl::lts_20250814::container_internal::raw_hash_set<Policy, Hash, Eq, Alloc>&, const allocator_type&) [with Policy = absl::lts_20250814::container_internal::FlatHashSetPolicy<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Hash = absl::lts_20250814::hash_internal::Hash<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Eq = std::equal_to<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Alloc = std::allocator<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; allocator_type = std::allocator<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >]'
 2264 |     Copy(common(), GetPolicyFunctions(), that.common(),
      |                    ~~~~~~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/internal/raw_hash_set.h:2315:18:   required from 'absl::lts_20250814::container_internal::raw_hash_set<Policy, Hash, Eq, Alloc>& absl::lts_20250814::container_internal::raw_hash_set<Policy, Hash, Eq, Alloc>::operator=(const absl::lts_20250814::container_internal::raw_hash_set<Policy, Hash, Eq, Alloc>&) [with Policy = absl::lts_20250814::container_internal::FlatHashSetPolicy<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Hash = absl::lts_20250814::hash_internal::Hash<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Eq = std::equal_to<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >; Alloc = std::allocator<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >]'
 2315 |     raw_hash_set tmp(that, alloc);
      |                  ^~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/flat_hash_set.h:130:28:   required from here
  130 | class ABSL_ATTRIBUTE_OWNER flat_hash_set
      |                            ^~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/internal/raw_hash_set.h:3594:72:   in 'constexpr' expansion of 'absl::lts_20250814::container_internal::hash_policy_traits<absl::lts_20250814::container_internal::FlatHashSetPolicy<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >, void>::get_hash_slot_fn<absl::lts_20250814::hash_internal::Hash<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >, true>()'
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/abseil-cpp/20250814.1-7ece1702c014212b5e6ba4308f4c25e9/include/absl/container/internal/hash_policy_traits.h:158:66: error: '(absl::lts_20250814::container_internal::TypeErasedApplyToSlotFn<absl::lts_20250814::hash_internal::Hash<std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*> >, std::pair<const google::protobuf::Message*, const google::protobuf::FieldDescriptor*>, true> == 0)' is not a constant expression
   158 |     return Policy::template get_hash_slot_fn<Hash, kIsDefault>() == nullptr

```