### PR TITLE
Extend rocm support in ucx

### DIFF
--- a/ucx.spec
+++ b/ucx.spec
@@ -64,14 +64,21 @@ Requires: xpmem
   CFLAGS="%{selected_microarch}" \
   CXXFLAGS="%{selected_microarch}" \
 %endif
-  CPPFLAGS="-I$NUMACTL_ROOT/include" \
-  LDFLAGS="-L$NUMACTL_ROOT/lib"
+  CPPFLAGS="-I$NUMACTL_ROOT/include%{!?without_rocm: -I$ROCR_RUNTIME_ROOT/include/hsa}" \
+  LDFLAGS="-L$NUMACTL_ROOT/lib%{!?without_rocm: -L$ROCR_RUNTIME_ROOT/lib64}"
 
 %build
 make %{makeprocesses} V=1
 
 %install
 make install V=1
+
+%if 0%{!?without_rocm:1}
+# configure warns, but doesn't stop, if the ROCm support cannot be enabled.
+# Check explicitly that the rocm UCT and UCM modules have been built.
+test -f %{i}/lib/ucx/libuct_rocm.so
+test -f %{i}/lib/ucx/libucm_rocm.so
+%endif
 
 # remove pkg-config to avoid rpm-generated dependency on /usr/bin/pkg-config
 rm -rf %{i}/lib/pkgconfig


### PR DESCRIPTION


The flag `--with-rocm=$ROCM_HIP_ROOT` we had in `ucx.spec` does not seem to be enough to make the `rocm` transports available to UCX (see [1]). This prevents UCX from knowing about AMD GPU pointers which prevents us from using it to do RDMA with AMD GPUs.

In this case, the `./configure` command would print

```
checking for hsa.h... no
configure: WARNING: ROCm not found
```

which is very easy to miss.


This PR 
- Adds the Include and Library flags that UCX needs to build the rocm UCT and UCM modules 
- Adds a quick test to check for the generated rocm modules. This is just to allow us to realize if this gets broken in future UCX version upgrades, etc.


---
[1]

The rocm support can be checked with `ucx_info -b`.

Before this PR

```
[...]
#define UCX_MODULE_SUBDIR         "ucx"
#define VERSION                   "1.21"
#define restrict                  __restrict__
#define test_MODULES              ":module"
#define ucm_MODULES               ":cuda"
#define ucs_MODULES               ""
#define uct_MODULES               ":cuda:ib:rdmacm:cma:xpmem"
#define uct_cuda_MODULES          ":gdrcopy"
#define uct_ib_MODULES            ":mlx5:efa"
#define uct_ib_mlx5_MODULES       ":gda"
#define uct_rocm_MODULES          ""
#define ucx_perftest_MODULES      ":cuda"
```

And after

```
#define UCX_MODULE_SUBDIR         "ucx"
#define VERSION                   "1.21"
#define restrict                  __restrict__
#define test_MODULES              ":module"
#define ucm_MODULES               ":cuda:rocm"
#define ucs_MODULES               ""
#define uct_MODULES               ":cuda:ib:rdmacm:rocm:cma:xpmem"
#define uct_cuda_MODULES          ":gdrcopy"
#define uct_ib_MODULES            ":mlx5:efa"
#define uct_ib_mlx5_MODULES       ":gda"
#define uct_rocm_MODULES          ""
#define ucx_perftest_MODULES      ":cuda:rocm:mad"
```




@fwyzard FYI